### PR TITLE
fix Windows sealed-artifact checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+sdk/python/src/openai_codex_security/_bundled_plugin/examples/completed-scan/*.json text eol=lf


### PR DESCRIPTION
## What changed

Add the reviewed `.gitattributes` rule that keeps the bundled completed-scan JSON artifacts LF-normalized on Windows.

## Why

The monorepo portability fix ([openai/openai#1138521](https://github.com/openai/openai/pull/1138521)) was projected successfully, and package/Linux/macOS CI now passes. Copyberry omitted `.gitattributes`, so the destination's latest Windows job still rewrites the sealed JSON artifacts to CRLF and fails four contract tests with `sealed artifact changed or is missing`.

This PR supplies only the missing projected file.

## Validation

- `uv sync --project sdk/python --frozen --extra dev`
- `uv run --project sdk/python --frozen python -m pytest -q` — 118 passed
- `ruff check sdk/python`
- `ruff format --check sdk/python`
- cloned with `core.autocrlf=true`, confirmed all three completed-scan JSON files resolve to `text: set, eol: lf`
- confirmed coverage/findings SHA-256 values match `scan-manifest.json`
- ran contract tests from the Windows-style checkout — 15 passed

Latest failing run: https://github.com/openai/codex-security/actions/runs/29459495758