### PR TITLE
test: make temporary directory cleanup idempotent

### DIFF
--- a/sdk/typescript/tests-ts/config.test.ts
+++ b/sdk/typescript/tests-ts/config.test.ts
@@ -25,7 +25,9 @@ const temporaryDirectories: string[] = [];
 
 afterEach(async () => {
   await Promise.all(
-    temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true })),
+    temporaryDirectories
+      .splice(0)
+      .map((path) => rm(path, { recursive: true, force: true })),
   );
 });
 

--- a/sdk/typescript/tests-ts/contract.test.ts
+++ b/sdk/typescript/tests-ts/contract.test.ts
@@ -22,7 +22,9 @@ const temporaryDirectories: string[] = [];
 
 afterEach(async () => {
   await Promise.all(
-    temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true })),
+    temporaryDirectories
+      .splice(0)
+      .map((path) => rm(path, { recursive: true, force: true })),
   );
 });
 

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -44,7 +44,9 @@ const testPosix = process.platform === "win32" ? test.skip : test;
 
 afterEach(async () => {
   await Promise.all(
-    temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true })),
+    temporaryDirectories
+      .splice(0)
+      .map((path) => rm(path, { recursive: true, force: true })),
   );
 });
 

--- a/sdk/typescript/tests-ts/targets.test.ts
+++ b/sdk/typescript/tests-ts/targets.test.ts
@@ -25,7 +25,9 @@ const temporaryDirectories: string[] = [];
 
 afterEach(async () => {
   await Promise.all(
-    temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true })),
+    temporaryDirectories
+      .splice(0)
+      .map((path) => rm(path, { recursive: true, force: true })),
   );
 });
 
@@ -48,6 +50,11 @@ function git(repo: string, ...args: string[]): string {
 }
 
 describe("scan target normalization", () => {
+  test("tolerates a temporary repository removed before cleanup", async () => {
+    const repo = await repository();
+    await rm(join(repo, ".."), { recursive: true });
+  });
+
   test("normalizes repository and path targets", async () => {
     const repo = await repository();
     expect(await normalizeTarget(repo, "repository")).toEqual({


### PR DESCRIPTION
## Summary

Fix the intermittent macOS post-merge CI failure from #4 by making tracked temporary-directory cleanup idempotent across the TypeScript test suites.

The failed `node-ci` run reported `ENOENT` from `tests-ts/targets.test.ts:27` while `afterEach` removed a temporary repository that was already gone. The same non-idempotent cleanup pattern also existed in the config, contract, and runtime suites; auth/API already use `force: true`.

## Changes

- Add `force: true` to the four affected `afterEach` cleanup hooks.
- Add a regression that deliberately removes a tracked temporary repository before cleanup, reproducing the prior failure without the fix.
- Keep production/runtime behavior unchanged.

## Validation

- Regression fails before the fix with the same `ENOENT` and passes 30 repeated runs after it.
- Affected suites: **70 passed, 0 failed**.
- Full TypeScript suite: **149 passed, 1 intentional integration skip, 0 failed**.
- Typecheck, Prettier, build, `git diff --check` passed.
- Packed and inspected the npm artifact: **146 entries validated**.

Follow-up to #4.