### PR TITLE
feat: reuse Codex sign-in for security scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,22 @@ scans also require a host Python interpreter. Docker and Python are not needed
 to install the package or run
 `--help` and `--version`.
 
-Standard repository and path scans run through the OpenAI Agents SDK by
-default. Set `OPENAI_API_KEY` or `CODEX_API_KEY` before scanning. Diff and deep
-scans continue to use Codex and can also reuse an existing file-backed Codex
-sign-in.
+Standard repository and path scans run through the OpenAI Agents SDK with an
+API key, or Codex with a stored sign-in. Diff and deep scans continue to use
+Codex.
 
 ## Install and scan
 
 ```bash
 npm install @openai/codex-security@beta
+npx codex-security login
 npx codex-security scan /path/to/repo
 ```
+
+On a remote or headless machine, use `npx codex-security login --device-auth`.
+For CI, set `OPENAI_API_KEY` or `CODEX_API_KEY`. See the
+[TypeScript SDK and CLI reference](sdk/typescript/README.md#authentication)
+for stored API keys, enterprise access tokens, and login status.
 
 Scan a subset of a repository or write machine-readable results:
 
@@ -57,7 +62,7 @@ stable across checkouts without colliding across monorepo services; bounded
 results are copied to the requested output directory. SDK tracing and sensitive
 debug logging are suppressed, and repository instruction files such as
 `AGENTS.md` are treated as untrusted scan input.
-Docker must be running for the default Agents engine. Use
+Docker must be running when the Agents engine is selected. Use
 `--engine codex` to run the existing Codex-backed standard scan when needed;
 diff, working-tree, deep, `--codex`, and native Windows scans select it
 automatically.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Scan a subset of a repository or write machine-readable results:
 
 ```bash
 npx codex-security scan /path/to/repo --path src --path tests
+# With OPENAI_API_KEY or CODEX_API_KEY set (Agents):
 npx codex-security scan /path/to/repo --path src --model gpt-5.6 --reasoning-effort high
 npx codex-security scan /path/to/repo --diff origin/main --json
 npx codex-security scan /path/to/repo --output-dir /path/outside/repo/results

--- a/README.md
+++ b/README.md
@@ -11,12 +11,11 @@ The SDK and CLI require Node.js 22 or later. Standard Agents scans require a
 running Docker daemon and a host Python 3 interpreter for the SDK PTY bridge;
 the default sandbox image includes Python for the bundled scan helpers. Codex
 scans also require a host Python interpreter. Docker and Python are not needed
-to install the package or run
-`--help` and `--version`.
+to install the package or run `--help` and `--version`.
 
-Standard repository and path scans run through the OpenAI Agents SDK with an
-API key, or Codex with a stored sign-in. Diff and deep scans continue to use
-Codex.
+On macOS and Linux, standard repository and path scans use OpenAI Agents SDK
+with an API key and Codex with a stored sign-in. Diff, working-tree, deep,
+`--codex`, and native Windows scans use Codex.
 
 ## Install and scan
 
@@ -28,8 +27,8 @@ npx codex-security scan /path/to/repo
 
 On a remote or headless machine, use `npx codex-security login --device-auth`.
 For CI, set `OPENAI_API_KEY` or `CODEX_API_KEY`. See the
-[TypeScript SDK and CLI reference](sdk/typescript/README.md#authentication)
-for stored API keys, enterprise access tokens, and login status.
+[authentication guide](sdk/typescript/README.md#authentication) for stored API
+keys, enterprise access tokens, and login status.
 
 Scan a subset of a repository or write machine-readable results:
 
@@ -45,27 +44,19 @@ The output directory must be outside the scanned repository. When SARIF is produ
 `<scan-dir>/exports/results.sarif`. Use `npx codex-security scan --help` for all
 target, output, and runtime options.
 
-The Agents engine stages the requested tracked, regular-file scope and the
-bundled scan skills/helpers into a network-disabled `node:22-bookworm` Docker
-workspace using a credential-free staging subprocess, mounts them read-only,
-exposes the SDK shell tool with context compaction, and delegates one bounded
-scan worker. Path scans include
-applicable ancestor `SECURITY.md` files while
-excluding unrelated source files. Local edits to tracked files are included; untracked/ignored files,
-submodule contents, symlinks, hard-linked source/custom-plugin files, intent-to-add files, unstaged deletions, sparse-checkout paths absent
-from the worktree, common local credential stores/key material (including `.config`, shell profiles/histories/caches, alternate-VCS metadata, `.envrc`/`.flaskenv`, Composer/Bundler/Gradle/Bazel/Bun credentials, Terraform CLI/state, Databricks, dbt, Snowflake/SnowSQL, gsutil, deployment/ML CLI stores, Sentry/authinfo, browser/keychain/password databases, common database/client RC files, and bounded credential-shaped and nested Docker/AWS/Azure/OAuth/service-account JSON, exported token/kubeconfig/CSV files, and extensionless SSH keys), and Git credentials/history (including incomplete/headless tracked nested repositories) are excluded. Credential-directory roots/descendants, empty targets, Git-config includes, Git-shaped targets (including an ambiguous tracked-worktree root), and
-unversioned directories containing `.gitignore` files or nested Git worktrees fail closed; bundled content-addressable installs are supported. Use the Codex engine when a path
-contains only untracked or ignored files. Ambient OpenAI/Codex API keys and
-Docker-configured proxy credentials are not forwarded to the scan shell; host Git, staging, and Docker subprocesses receive a minimal credential-free environment, reject target-controlled Docker configuration, path-shaped Docker helper names, and Docker/PTY helpers resolving into the target, and suppress unsafe PTY loader overrides. A sanitized,
-one-way-hashed remote and relative-scope identity keeps finding fingerprints
-stable across checkouts without colliding across monorepo services; bounded
-results are copied to the requested output directory. SDK tracing and sensitive
-debug logging are suppressed, and repository instruction files such as
-`AGENTS.md` are treated as untrusted scan input.
-Docker must be running when the Agents engine is selected. Use
-`--engine codex` to run the existing Codex-backed standard scan when needed;
-diff, working-tree, deep, `--codex`, and native Windows scans select it
-automatically.
+The Agents engine stages tracked, regular files and bundled scan helpers, then
+mounts them read-only in a network-disabled Docker workspace. Local edits to
+tracked files are included; untracked or ignored files, submodules, symlinks,
+Git history, and common credential stores are excluded. Path scans include
+applicable ancestor `SECURITY.md` files. Unsafe or ambiguous targets fail
+before a scan starts, and repository instructions such as `AGENTS.md` remain
+untrusted input.
+
+The scan shell does not receive ambient API keys or Docker proxy credentials.
+Host Git, staging, and Docker subprocesses use a minimal credential-free
+environment. Staged content remains trusted local input. Use `--engine codex`
+when a path contains only untracked or ignored files, or when Docker is
+unavailable.
 
 ## TypeScript SDK
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -61,6 +61,7 @@ ChatGPT sign-in.
 ```bash
 npx codex-security scan /path/to/repository
 npx codex-security scan /path/to/repository --path src --path tests
+# With OPENAI_API_KEY or CODEX_API_KEY set (Agents):
 npx codex-security scan /path/to/repository --path src --model gpt-5.6 --reasoning-effort high
 npx codex-security scan /path/to/repository --diff origin/main --json
 npx codex-security scan /path/to/repository --output-dir /path/outside/repository/results

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -2,9 +2,10 @@
 
 TypeScript SDK and CLI for running Codex Security scans. The package is
 ESM-only, includes TypeScript declarations, and installs the `codex-security`
-executable. Standard repository/path scans use OpenAI Agents SDK with an API
-key or the aligned `@openai/codex` runtime with a stored sign-in. Codex also
-handles diff, deep, and explicit Codex-backed scans.
+executable. On macOS and Linux, standard repository/path scans use OpenAI
+Agents SDK with an API key and the aligned `@openai/codex` runtime with a
+stored sign-in. Codex also handles diff, working-tree, deep, `--codex`, and
+native Windows scans.
 
 > [!WARNING]
 > Codex Security is in beta. APIs, CLI options, and output formats may change.
@@ -50,9 +51,10 @@ Check or remove the stored sign-in with `npx codex-security login status` and
 sign-in. If Codex stores credentials in the system keyring, run
 `npx codex-security login` once before scanning.
 
-An environment API key takes precedence over a stored sign-in. Standard
-repository/path scans use Agents with an API key and Codex with a stored
-sign-in. Unset the API key to use your ChatGPT sign-in.
+An environment API key takes precedence over a stored sign-in. On macOS and
+Linux, standard repository/path scans use Agents with an API key and Codex with
+a stored sign-in. Unset both `OPENAI_API_KEY` and `CODEX_API_KEY` to use your
+ChatGPT sign-in.
 
 ## CLI
 
@@ -71,31 +73,22 @@ repository and path targets. The output directory must be outside the scanned
 repository. When SARIF is produced, it is written to
 `<scan-dir>/exports/results.sarif`.
 
-The Agents engine stages the requested tracked, regular-file scope
-and the plugin into the SDK Docker workspace using a credential-free staging
-subprocess, mounts them read-only, disables network access, and exposes the SDK
-shell tool with context compaction before
-delegating one bounded worker. Local edits to tracked files are
-included; untracked/ignored files, submodule contents, symlinks, hard-linked source/custom-plugin files, intent-to-add files, unstaged
-deletions, sparse-checkout paths absent from the worktree, common local credential stores/key material (including `.config`, shell profiles/histories/caches, alternate-VCS metadata, `.envrc`/`.flaskenv`, Composer/Bundler/Gradle/Bazel/Bun credentials, Terraform CLI/state, Databricks, dbt, Snowflake/SnowSQL, gsutil, deployment/ML CLI stores, Sentry/authinfo, browser/keychain/password databases, common database/client RC files, and bounded credential-shaped and nested Docker/AWS/Azure/OAuth/service-account JSON, exported token/kubeconfig/CSV files, and extensionless SSH keys), Git credentials/history (including incomplete/headless tracked nested repositories),
-and unrelated plugin-checkout files are excluded. Path scans also include
-applicable ancestor `SECURITY.md` files and exclude unrelated source files.
-Credential-directory roots/descendants, empty targets, Git-config includes, Git-shaped targets (including an ambiguous tracked-worktree root), and unversioned directories containing `.gitignore` files or nested Git worktrees fail closed; bundled content-addressable installs are supported. Use the Codex engine when
-a path contains only untracked or ignored files. Ambient OpenAI/Codex API keys
-and Docker-configured proxy credentials are not forwarded to the scan shell; host Git, staging, and Docker subprocesses receive a minimal credential-free environment, reject target-controlled Docker configuration, path-shaped Docker helper names, and Docker/PTY helpers resolving into the target, and suppress unsafe PTY loader overrides. Inputs and
-results are size/type bounded before handoff. The standard `security-scan`
-skill runs with one serialized delegated ranking worker and preserves the
-existing pool-plan, receipt, and canonical output contract. A stable one-way-hashed,
-credential-free remote and relative-scope identity is bound during validation
-when available, while SDK tracing and sensitive debug logging are suppressed.
-Repository instruction files such as `AGENTS.md` are treated as untrusted scan
-input.
+The Agents engine stages tracked, regular files and bundled scan helpers, then
+mounts them read-only in a network-disabled Docker workspace. Local edits to
+tracked files are included; untracked or ignored files, submodules, symlinks,
+Git history, and common credential stores are excluded. Path scans include
+applicable ancestor `SECURITY.md` files. Unsafe or ambiguous targets fail
+before a scan starts, and repository instructions such as `AGENTS.md` remain
+untrusted input.
 
-This intentionally keeps staging small: Git-backed targets are treated as
-directory snapshots, so history/advisory lookup is unavailable; staged
-directories omit common `.env` and key files but remain a trusted-local input.
-Docker-host resource limits apply. `--model`, `--reasoning-effort`,
-`--max-turns`, and `--worker-max-turns` control the Agents workflow.
+The scan shell does not receive ambient API keys or Docker proxy credentials.
+Host Git, staging, and Docker subprocesses use a minimal credential-free
+environment. Git-backed targets are directory snapshots, so history and
+advisory lookup are unavailable; staged content remains trusted local input.
+Use `--engine codex` when a path contains only untracked or ignored files, or
+when Docker is unavailable. `--model`,
+`--reasoning-effort`, `--max-turns`, and `--worker-max-turns` control the
+Agents workflow.
 
 The sandbox uses a writable temporary home/cache without exposing host home
 directories. Docker workspaces default to `~/.cache/codex-security/sandboxes`, which works with

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -2,9 +2,9 @@
 
 TypeScript SDK and CLI for running Codex Security scans. The package is
 ESM-only, includes TypeScript declarations, and installs the `codex-security`
-executable. Standard repository/path scans use OpenAI Agents SDK by default;
-the aligned `@openai/codex` runtime remains available for diff, deep, and
-explicit Codex-backed scans.
+executable. Standard repository/path scans use OpenAI Agents SDK with an API
+key or the aligned `@openai/codex` runtime with a stored sign-in. Codex also
+handles diff, deep, and explicit Codex-backed scans.
 
 > [!WARNING]
 > Codex Security is in beta. APIs, CLI options, and output formats may change.
@@ -22,9 +22,37 @@ sandbox image includes Python for the bundled scan helpers.
 `--python` and `pythonPath` select an in-container interpreter for Agents
 scans or a host interpreter for Codex scans.
 
-Before a standard repository/path scan, set `OPENAI_API_KEY` or
-`CODEX_API_KEY`. File-backed Codex sign-in remains available for
-`--engine codex`, diff, and deep scans.
+## Authentication
+
+For local use, sign in with ChatGPT:
+
+```bash
+npx codex-security login
+npx codex-security scan .
+```
+
+On a remote or headless machine, use device authentication:
+
+```bash
+npx codex-security login --device-auth
+```
+
+For CI, set `OPENAI_API_KEY` or `CODEX_API_KEY`. To store an API key or
+enterprise access token instead, pass it on stdin:
+
+```bash
+printenv OPENAI_API_KEY | npx codex-security login --with-api-key
+printenv CODEX_ACCESS_TOKEN | npx codex-security login --with-access-token
+```
+
+Check or remove the stored sign-in with `npx codex-security login status` and
+`npx codex-security logout`. Codex Security reuses an existing file-based Codex
+sign-in. If Codex stores credentials in the system keyring, run
+`npx codex-security login` once before scanning.
+
+An environment API key takes precedence over a stored sign-in. Standard
+repository/path scans use Agents with an API key and Codex with a stored
+sign-in. Unset the API key to use your ChatGPT sign-in.
 
 ## CLI
 
@@ -43,7 +71,7 @@ repository and path targets. The output directory must be outside the scanned
 repository. When SARIF is produced, it is written to
 `<scan-dir>/exports/results.sarif`.
 
-The default Agents engine stages the requested tracked, regular-file scope
+The Agents engine stages the requested tracked, regular-file scope
 and the plugin into the SDK Docker workspace using a credential-free staging
 subprocess, mounts them read-only, disables network access, and exposes the SDK
 shell tool with context compaction before

--- a/sdk/typescript/compatibility/PARITY_MATRIX.md
+++ b/sdk/typescript/compatibility/PARITY_MATRIX.md
@@ -41,31 +41,31 @@ contracts. The SDK is asynchronous and uses camelCase option and result names.
 
 ## CLI flags and arguments
 
-| Surface                        | CLI behavior                                                                       |
-| ------------------------------ | ---------------------------------------------------------------------------------- |
-| no arguments                   | Print root help to stdout and exit 0                                               |
-| `-h`, `--help`                 | Print root help and exit 0                                                         |
-| `--version`                    | Print SDK version and bundled plugin version to stdout; exit 0 without Python      |
-| `login [OPTIONS]`              | Delegate ChatGPT, device, API-key, and access-token login to bundled Codex         |
-| `login status`                 | Show the stored sign-in available to Codex Security                                |
-| `logout`                       | Remove the stored sign-in available to Codex Security                              |
-| `scan [repository]`            | Repository defaults to the current directory                                       |
-| repeatable `--path PATH`       | Path-only scan; mutually exclusive with diff/working-tree                          |
-| `--diff BASE`                  | Ref diff using `--head` or `HEAD`                                                  |
-| `--working-tree`               | Staged and unstaged changes using `--base` or `HEAD`                               |
-| `--head REF`                   | Valid only with `--diff`                                                           |
-| `--base REF`                   | Valid only with `--working-tree`                                                   |
-| `--mode standard\|deep`        | Deep rejects diff targets                                                          |
-| `--engine agents\|codex`       | API-key repo/path scans default to Agents; stored sign-in/diff/deep defaults Codex |
-| `--model MODEL`                | Agents model, default `gpt-5.6`                                                    |
-| `--reasoning-effort EFFORT`    | Agents reasoning effort, default `high`                                            |
-| `--max-turns N`                | Agents coordinator turn limit, default `200`                                       |
-| `--worker-max-turns N`         | Agents per-worker turn limit, default `100`                                        |
-| `--output-dir DIR`             | Must be absent or empty and outside the repository; preserved on interruption      |
-| `--plugin-path PATH`           | Plugin directory or safe ZIP override                                              |
-| repeatable `--codex KEY=VALUE` | Parse TOML literals, reject duplicate/conflicting/owned keys                       |
-| `--json`                       | Machine JSON only on stdout; progress/errors on stderr                             |
-| `--python PATH`                | Intentional additive v0 option for the explicit plugin runtime boundary            |
+| Surface                        | CLI behavior                                                                  |
+| ------------------------------ | ----------------------------------------------------------------------------- |
+| no arguments                   | Print root help to stdout and exit 0                                          |
+| `-h`, `--help`                 | Print root help and exit 0                                                    |
+| `--version`                    | Print SDK version and bundled plugin version to stdout; exit 0 without Python |
+| `login [OPTIONS]`              | Delegate ChatGPT, device, API-key, and access-token login to bundled Codex    |
+| `login status`                 | Show the stored sign-in available to Codex Security                           |
+| `logout`                       | Remove the stored sign-in available to Codex Security                         |
+| `scan [repository]`            | Repository defaults to the current directory                                  |
+| repeatable `--path PATH`       | Path-only scan; mutually exclusive with diff/working-tree                     |
+| `--diff BASE`                  | Ref diff using `--head` or `HEAD`                                             |
+| `--working-tree`               | Staged and unstaged changes using `--base` or `HEAD`                          |
+| `--head REF`                   | Valid only with `--diff`                                                      |
+| `--base REF`                   | Valid only with `--working-tree`                                              |
+| `--mode standard\|deep`        | Deep rejects diff targets                                                     |
+| `--engine agents\|codex`       | Repo/path: Agents with key; sign-in/diff/working-tree/deep/Windows: Codex     |
+| `--model MODEL`                | Agents model, default `gpt-5.6`                                               |
+| `--reasoning-effort EFFORT`    | Agents reasoning effort, default `high`                                       |
+| `--max-turns N`                | Agents coordinator turn limit, default `200`                                  |
+| `--worker-max-turns N`         | Agents per-worker turn limit, default `100`                                   |
+| `--output-dir DIR`             | Must be absent or empty and outside the repository; preserved on interruption |
+| `--plugin-path PATH`           | Plugin directory or safe ZIP override                                         |
+| repeatable `--codex KEY=VALUE` | Parse TOML literals, reject duplicate/conflicting/owned keys                  |
+| `--json`                       | Machine JSON only on stdout; progress/errors on stderr                        |
+| `--python PATH`                | Intentional additive v0 option for the explicit plugin runtime boundary       |
 
 ## Output, exit, and signal contract
 

--- a/sdk/typescript/compatibility/PARITY_MATRIX.md
+++ b/sdk/typescript/compatibility/PARITY_MATRIX.md
@@ -46,6 +46,9 @@ contracts. The SDK is asynchronous and uses camelCase option and result names.
 | no arguments                   | Print root help to stdout and exit 0                                               |
 | `-h`, `--help`                 | Print root help and exit 0                                                         |
 | `--version`                    | Print SDK version and bundled plugin version to stdout; exit 0 without Python      |
+| `login [OPTIONS]`              | Delegate ChatGPT, device, API-key, and access-token login to bundled Codex         |
+| `login status`                 | Show the stored sign-in available to Codex Security                                |
+| `logout`                       | Remove the stored sign-in available to Codex Security                              |
 | `scan [repository]`            | Repository defaults to the current directory                                       |
 | repeatable `--path PATH`       | Path-only scan; mutually exclusive with diff/working-tree                          |
 | `--diff BASE`                  | Ref diff using `--head` or `HEAD`                                                  |
@@ -53,7 +56,7 @@ contracts. The SDK is asynchronous and uses camelCase option and result names.
 | `--head REF`                   | Valid only with `--diff`                                                           |
 | `--base REF`                   | Valid only with `--working-tree`                                                   |
 | `--mode standard\|deep`        | Deep rejects diff targets                                                          |
-| `--engine agents\|codex`       | Standard repo/path defaults to Agents; diff/deep/`--codex`/Win32 defaults to Codex |
+| `--engine agents\|codex`       | API-key repo/path scans default to Agents; stored sign-in/diff/deep defaults Codex |
 | `--model MODEL`                | Agents model, default `gpt-5.6`                                                    |
 | `--reasoning-effort EFFORT`    | Agents reasoning effort, default `high`                                            |
 | `--max-turns N`                | Agents coordinator turn limit, default `200`                                       |

--- a/sdk/typescript/compatibility/golden/root-help.txt
+++ b/sdk/typescript/compatibility/golden/root-help.txt
@@ -1,8 +1,10 @@
-usage: codex-security [-h] [--version] {scan} ...
+usage: codex-security [-h] [--version] {scan,login,logout} ...
 
-positional arguments:
-  {scan}
+commands:
+  {scan,login,logout}
     scan      Run a Codex Security scan.
+    login     Sign in with ChatGPT or store credentials.
+    logout    Remove the stored sign-in.
 
 options:
   -h, --help  show this help message and exit

--- a/sdk/typescript/compatibility/golden/scan-help.txt
+++ b/sdk/typescript/compatibility/golden/scan-help.txt
@@ -31,8 +31,9 @@ options:
   --python PATH         Plugin Python interpreter (in-container for Docker).
   --engine {agents,codex}
                         Execution engine. Repository/path standard scans
-                        default to Agents SDK; diff/deep, --codex, and native
-                        Windows scans default to Codex. Agents stages tracked files only.
+                        default to Agents SDK with an API key. Stored sign-in,
+                        diff/deep, --codex, and native Windows scans use Codex.
+                        Agents stages tracked files only.
   --model MODEL         Agents SDK model (default: gpt-5.6).
   --reasoning-effort EFFORT
                         Agents SDK reasoning effort: none, minimal, low,

--- a/sdk/typescript/compatibility/golden/scan-help.txt
+++ b/sdk/typescript/compatibility/golden/scan-help.txt
@@ -30,9 +30,10 @@ options:
                         of the bundled plugin.
   --python PATH         Plugin Python interpreter (in-container for Docker).
   --engine {agents,codex}
-                        Execution engine. Repository/path standard scans
-                        default to Agents SDK with an API key. Stored sign-in,
-                        diff/deep, --codex, and native Windows scans use Codex.
+                        Standard repository/path scans use Agents with an API
+                        key on macOS/Linux and Codex with a stored sign-in. Diff,
+                        working-tree, deep, --codex, and native Windows scans
+                        use Codex.
                         Agents stages tracked files only.
   --model MODEL         Agents SDK model (default: gpt-5.6).
   --reasoning-effort EFFORT

--- a/sdk/typescript/src/agents.ts
+++ b/sdk/typescript/src/agents.ts
@@ -297,7 +297,7 @@ export class AgentsSecurity {
       const apiKey = environmentApiKey(this.#dependencies.environment);
       if (apiKey === null) {
         throw new AuthenticationRequiredError(
-          "Agents SDK scans require OPENAI_API_KEY or CODEX_API_KEY. File-backed Codex authentication is available only with the Codex engine.",
+          "The Agents engine requires an API key. Set OPENAI_API_KEY or CODEX_API_KEY, or use --engine codex to scan with your Codex sign-in.",
         );
       }
       const workspaceRoot = await dockerWorkspaceRoot(

--- a/sdk/typescript/src/agents.ts
+++ b/sdk/typescript/src/agents.ts
@@ -73,6 +73,7 @@ import {
 } from "./errors.js";
 import { ScanResult, type TurnResultMetadata } from "./result.js";
 import {
+  environmentApiKey,
   pluginMetadata,
   prepareOutputDir,
   requireModelSafeOutputDir,
@@ -2226,14 +2227,6 @@ async function resolveCreatablePath(candidate: string): Promise<string> {
       current = parent;
     }
   }
-}
-
-function environmentApiKey(environment: ProcessEnvironment): string | null {
-  for (const name of ["OPENAI_API_KEY", "CODEX_API_KEY"]) {
-    const value = environmentValue(environment, name);
-    if (value !== undefined) return value;
-  }
-  return null;
 }
 
 function environmentValue(

--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -304,8 +304,9 @@ export class CodexSecurity {
       }
       if (!runtime.credentialsAvailable) {
         throw new AuthenticationRequiredError(
-          "The isolated Codex home has no reusable authentication. Set OPENAI_API_KEY or " +
-            "CODEX_API_KEY, call a login method, or use file-backed Codex authentication.",
+          "No credentials were found. Run 'codex-security login', use " +
+            "'codex-security login --device-auth' on a remote or headless machine, or set " +
+            "OPENAI_API_KEY or CODEX_API_KEY for CI.",
         );
       }
       const python = await (

--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -36,6 +36,7 @@ import {
   bootstrapPlugin,
   cleanupSdkDirectory,
   createIsolatedHome,
+  environmentApiKey,
   importAmbientAuth,
   pluginExecutionEnvironment,
   prepareOutputDir,
@@ -1102,15 +1103,6 @@ class EventLog<T> {
     for (const waiter of this.#waiters) waiter();
     this.#waiters.clear();
   }
-}
-
-function environmentApiKey(environment: ProcessEnvironment): string | null {
-  for (const requested of ["OPENAI_API_KEY", "CODEX_API_KEY"]) {
-    for (const [name, value] of Object.entries(environment)) {
-      if (name.toUpperCase() === requested && value) return value;
-    }
-  }
-  return null;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -763,8 +763,10 @@ export class CodexSecurity {
         environment: processEnvironment,
         signal,
       });
-      const ambientHome =
-        processEnvironment["CODEX_HOME"] ?? join(homedir(), ".codex");
+      const configuredHome = processEnvironment["CODEX_HOME"];
+      const ambientHome = configuredHome?.trim()
+        ? configuredHome
+        : join(homedir(), ".codex");
       const credentialsAvailable = await initialCredentialsAvailable(
         processEnvironment,
         ambientHome,

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -3,7 +3,7 @@
 import { spawn } from "node:child_process";
 import { realpathSync, statSync, writeSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { cwd } from "node:process";
 import { pathToFileURL } from "node:url";
 import { parse as parseToml } from "smol-toml";
@@ -118,11 +118,18 @@ const DEFAULT_DEPENDENCIES: CliDependencies = {
   hasReusableCodexSignIn: () => hasReusableCodexSignIn(),
   runCodex: async (args) => {
     const command = resolveCodexCommand();
+    const configuredHome = process.env["CODEX_HOME"];
     const invocation = spawn(
       command.command,
       [...command.prefixArgs, ...args],
       {
-        env: process.env,
+        env:
+          configuredHome === undefined
+            ? process.env
+            : {
+                ...process.env,
+                CODEX_HOME: resolve(expandHome(configuredHome)),
+              },
         cwd: homedir(),
         stdio: "inherit",
         windowsHide: true,

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -119,18 +119,18 @@ const DEFAULT_DEPENDENCIES: CliDependencies = {
   runCodex: async (args) => {
     const command = resolveCodexCommand();
     const configuredHome = process.env["CODEX_HOME"];
+    const environment = { ...process.env };
+    if (configuredHome?.trim()) {
+      environment["CODEX_HOME"] = resolve(expandHome(configuredHome));
+    } else {
+      delete environment["CODEX_HOME"];
+    }
     const invocation = spawn(
       command.command,
       [...command.prefixArgs, ...args],
       {
-        env:
-          configuredHome === undefined
-            ? process.env
-            : {
-                ...process.env,
-                CODEX_HOME: resolve(expandHome(configuredHome)),
-              },
-        cwd: parse(homedir()).root,
+        env: environment,
+        cwd: parse(process.execPath).root,
         stdio: "inherit",
         windowsHide: true,
       },
@@ -680,10 +680,13 @@ export function hasReusableCodexSignIn(
   if (environmentApiKey(environment) !== null) {
     return false;
   }
+  const configuredHome = environment["CODEX_HOME"];
   try {
     return statSync(
       join(
-        expandHome(environment["CODEX_HOME"] ?? join(homedir(), ".codex")),
+        expandHome(
+          configuredHome?.trim() ? configuredHome : join(homedir(), ".codex"),
+        ),
         "auth.json",
       ),
     ).isFile();

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 
-import { realpathSync, writeSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { realpathSync, statSync, writeSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { cwd } from "node:process";
 import { pathToFileURL } from "node:url";
 import { parse as parseToml } from "smol-toml";
@@ -13,6 +16,7 @@ import { CodexSecurity, type ScanOptions } from "./api.js";
 import type { CodexSecurityConfig, JsonObject, JsonValue } from "./config.js";
 import { CodexSecurityError, ScanInterruptedError } from "./errors.js";
 import type { ScanResult } from "./result.js";
+import { expandHome, resolveCodexCommand } from "./runtime.js";
 import { DiffTarget, type ScanMode, type ScanTarget } from "./targets.js";
 import { BUNDLED_PLUGIN_VERSION, VERSION } from "./version.js";
 
@@ -82,6 +86,8 @@ interface CliDependencies {
   removeSignalListener(signal: SignalName, listener: () => void): void;
   writeSynchronously(stream: Writable, value: string): void;
   forceExit(signal: SignalName): void;
+  hasReusableCodexSignIn(): boolean;
+  runCodex(args: readonly string[]): number;
 }
 
 const DEFAULT_DEPENDENCIES: CliDependencies = {
@@ -105,15 +111,34 @@ const DEFAULT_DEPENDENCIES: CliDependencies = {
     writeSync(stream.fd, value);
   },
   forceExit: (signal) => process.kill(process.pid, signal),
+  hasReusableCodexSignIn: () => hasReusableCodexSignIn(),
+  runCodex: (args) => {
+    const command = resolveCodexCommand();
+    const invocation = spawnSync(
+      command.command,
+      [...command.prefixArgs, ...args],
+      {
+        env: process.env,
+        stdio: "inherit",
+        windowsHide: true,
+      },
+    );
+    if (invocation.error !== undefined) throw invocation.error;
+    if (invocation.signal === "SIGINT") return 130;
+    if (invocation.signal === "SIGTERM") return 143;
+    return invocation.status ?? 1;
+  },
 };
 
 export function rootHelp(): string {
   return [
-    "usage: codex-security [-h] [--version] {scan} ...",
+    "usage: codex-security [-h] [--version] {scan,login,logout} ...",
     "",
-    "positional arguments:",
-    "  {scan}",
+    "commands:",
+    "  {scan,login,logout}",
     "    scan      Run a Codex Security scan.",
+    "    login     Sign in with ChatGPT or store credentials.",
+    "    logout    Remove the stored sign-in.",
     "",
     "options:",
     "  -h, --help  show this help message and exit",
@@ -156,8 +181,9 @@ export function scanHelp(): string {
     "  --python PATH         Plugin Python interpreter (in-container for Docker).",
     "  --engine {agents,codex}",
     "                        Execution engine. Repository/path standard scans",
-    "                        default to Agents SDK; diff/deep, --codex, and native",
-    "                        Windows scans default to Codex. Agents stages tracked files only.",
+    "                        default to Agents SDK with an API key. Stored sign-in,",
+    "                        diff/deep, --codex, and native Windows scans use Codex.",
+    "                        Agents stages tracked files only.",
     "  --model MODEL         Agents SDK model (default: gpt-5.6).",
     "  --reasoning-effort EFFORT",
     "                        Agents SDK reasoning effort: none, minimal, low,",
@@ -201,6 +227,14 @@ export async function main(
   if (rootOption === "--version") {
     output.write(`${versionText()}\n`);
     return 0;
+  }
+  if (argv[0] === "login" || argv[0] === "logout") {
+    return dependencies.runCodex([
+      argv[0],
+      "-c",
+      'cli_auth_credentials_store="file"',
+      ...argv.slice(1),
+    ]);
   }
   if (argv[0] !== "scan") {
     return usageError(`invalid choice: ${argv[0]}`, rootHelp(), errorOutput);
@@ -309,7 +343,11 @@ async function runScan(
   let failure: unknown;
   try {
     const target = targetFromArguments(arguments_);
-    const engine = scanEngineFor(arguments_, dependencies.platform());
+    const engine = scanEngineFor(
+      arguments_,
+      dependencies.platform(),
+      dependencies.hasReusableCodexSignIn,
+    );
     const config: CodexSecurityConfig | AgentsSecurityConfig =
       engine === "agents"
         ? {
@@ -564,6 +602,7 @@ export function targetFromArguments(
 function scanEngineFor(
   arguments_: ParsedScanArguments,
   platform: NodeJS.Platform,
+  hasReusableCodexSignIn: () => boolean,
 ): ScanEngine {
   const implicitCodex =
     arguments_.mode === "deep" ||
@@ -572,7 +611,9 @@ function scanEngineFor(
     arguments_.codex.length > 0;
   const engine =
     arguments_.engine ??
-    (implicitCodex || platform === "win32" ? "codex" : "agents");
+    (implicitCodex || platform === "win32" || hasReusableCodexSignIn()
+      ? "codex"
+      : "agents");
   if (engine === "agents" && platform === "win32") {
     throw new CodexSecurityError(
       "The Agents SDK sandbox does not support native Windows host paths; use --engine codex or run the Agents engine from WSL.",
@@ -595,6 +636,31 @@ function scanEngineFor(
     );
   }
   return engine;
+}
+
+export function hasReusableCodexSignIn(
+  environment: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (
+    Object.entries(environment).some(
+      ([name, value]) =>
+        (name.toUpperCase() === "OPENAI_API_KEY" ||
+          name.toUpperCase() === "CODEX_API_KEY") &&
+        Boolean(value),
+    )
+  ) {
+    return false;
+  }
+  try {
+    return statSync(
+      join(
+        expandHome(environment["CODEX_HOME"] ?? join(homedir(), ".codex")),
+        "auth.json",
+      ),
+    ).isFile();
+  } catch {
+    return false;
+  }
 }
 
 function positiveOptionValue(value: string, option: string): number {

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -120,10 +120,11 @@ const DEFAULT_DEPENDENCIES: CliDependencies = {
     const command = resolveCodexCommand();
     const configuredHome = process.env["CODEX_HOME"];
     const environment = { ...process.env };
+    for (const name of Object.keys(environment)) {
+      if (name.toUpperCase() === "CODEX_HOME") delete environment[name];
+    }
     if (configuredHome?.trim()) {
       environment["CODEX_HOME"] = resolve(expandHome(configuredHome));
-    } else {
-      delete environment["CODEX_HOME"];
     }
     const invocation = spawn(
       command.command,

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -216,9 +216,10 @@ export function scanHelp(): string {
     "                        of the bundled plugin.",
     "  --python PATH         Plugin Python interpreter (in-container for Docker).",
     "  --engine {agents,codex}",
-    "                        Execution engine. Repository/path standard scans",
-    "                        default to Agents SDK with an API key. Stored sign-in,",
-    "                        diff/deep, --codex, and native Windows scans use Codex.",
+    "                        Standard repository/path scans use Agents with an API",
+    "                        key on macOS/Linux and Codex with a stored sign-in. Diff,",
+    "                        working-tree, deep, --codex, and native Windows scans",
+    "                        use Codex.",
     "                        Agents stages tracked files only.",
     "  --model MODEL         Agents SDK model (default: gpt-5.6).",
     "  --reasoning-effort EFFORT",
@@ -263,6 +264,9 @@ export async function main(
   if (rootOption === "--version") {
     output.write(`${versionText()}\n`);
     return 0;
+  }
+  if (argv[0] === "login" && argv[1] === "help") {
+    return await dependencies.runCodex(argv);
   }
   if (argv[0] === "login" || argv[0] === "logout") {
     return await dependencies.runCodex([

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -3,7 +3,7 @@
 import { spawn } from "node:child_process";
 import { realpathSync, statSync, writeSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { join, parse, resolve } from "node:path";
 import { cwd } from "node:process";
 import { pathToFileURL } from "node:url";
 import { parse as parseToml } from "smol-toml";
@@ -130,7 +130,7 @@ const DEFAULT_DEPENDENCIES: CliDependencies = {
                 ...process.env,
                 CODEX_HOME: resolve(expandHome(configuredHome)),
               },
-        cwd: homedir(),
+        cwd: parse(homedir()).root,
         stdio: "inherit",
         windowsHide: true,
       },

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { realpathSync, statSync, writeSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -16,7 +16,11 @@ import { CodexSecurity, type ScanOptions } from "./api.js";
 import type { CodexSecurityConfig, JsonObject, JsonValue } from "./config.js";
 import { CodexSecurityError, ScanInterruptedError } from "./errors.js";
 import type { ScanResult } from "./result.js";
-import { expandHome, resolveCodexCommand } from "./runtime.js";
+import {
+  environmentApiKey,
+  expandHome,
+  resolveCodexCommand,
+} from "./runtime.js";
 import { DiffTarget, type ScanMode, type ScanTarget } from "./targets.js";
 import { BUNDLED_PLUGIN_VERSION, VERSION } from "./version.js";
 
@@ -87,7 +91,7 @@ interface CliDependencies {
   writeSynchronously(stream: Writable, value: string): void;
   forceExit(signal: SignalName): void;
   hasReusableCodexSignIn(): boolean;
-  runCodex(args: readonly string[]): number;
+  runCodex(args: readonly string[]): Promise<number>;
 }
 
 const DEFAULT_DEPENDENCIES: CliDependencies = {
@@ -112,21 +116,46 @@ const DEFAULT_DEPENDENCIES: CliDependencies = {
   },
   forceExit: (signal) => process.kill(process.pid, signal),
   hasReusableCodexSignIn: () => hasReusableCodexSignIn(),
-  runCodex: (args) => {
+  runCodex: async (args) => {
     const command = resolveCodexCommand();
-    const invocation = spawnSync(
+    const invocation = spawn(
       command.command,
       [...command.prefixArgs, ...args],
       {
         env: process.env,
+        cwd: homedir(),
         stdio: "inherit",
         windowsHide: true,
       },
     );
-    if (invocation.error !== undefined) throw invocation.error;
-    if (invocation.signal === "SIGINT") return 130;
-    if (invocation.signal === "SIGTERM") return 143;
-    return invocation.status ?? 1;
+    let requestedSignal: SignalName | null = null;
+    const onInterrupt = (): void => {
+      requestedSignal = "SIGINT";
+      invocation.kill("SIGINT");
+    };
+    const onTerminate = (): void => {
+      requestedSignal = "SIGTERM";
+      invocation.kill("SIGTERM");
+    };
+    process.on("SIGINT", onInterrupt);
+    process.on("SIGTERM", onTerminate);
+    try {
+      return await new Promise<number>((resolve, reject) => {
+        invocation.once("error", reject);
+        invocation.once("exit", (status, signal) => {
+          resolve(
+            requestedSignal === "SIGINT" || signal === "SIGINT"
+              ? 130
+              : requestedSignal === "SIGTERM" || signal === "SIGTERM"
+                ? 143
+                : status ?? 1,
+          );
+        });
+      });
+    } finally {
+      process.off("SIGINT", onInterrupt);
+      process.off("SIGTERM", onTerminate);
+    }
   },
 };
 
@@ -229,11 +258,11 @@ export async function main(
     return 0;
   }
   if (argv[0] === "login" || argv[0] === "logout") {
-    return dependencies.runCodex([
+    return await dependencies.runCodex([
       argv[0],
+      ...argv.slice(1),
       "-c",
       'cli_auth_credentials_store="file"',
-      ...argv.slice(1),
     ]);
   }
   if (argv[0] !== "scan") {
@@ -641,14 +670,7 @@ function scanEngineFor(
 export function hasReusableCodexSignIn(
   environment: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  if (
-    Object.entries(environment).some(
-      ([name, value]) =>
-        (name.toUpperCase() === "OPENAI_API_KEY" ||
-          name.toUpperCase() === "CODEX_API_KEY") &&
-        Boolean(value),
-    )
-  ) {
+  if (environmentApiKey(environment) !== null) {
     return false;
   }
   try {

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -581,6 +581,8 @@ export function environmentApiKey(
   environment: ProcessEnvironment,
 ): string | null {
   for (const requested of ["OPENAI_API_KEY", "CODEX_API_KEY"]) {
+    const canonical = environment[requested]?.trim();
+    if (canonical) return canonical;
     for (const [name, value] of Object.entries(environment)) {
       if (name.toUpperCase() === requested && value?.trim())
         return value.trim();

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -577,6 +577,18 @@ function withoutApiKeyCredentials(
   return sanitized;
 }
 
+export function environmentApiKey(
+  environment: ProcessEnvironment,
+): string | null {
+  for (const requested of ["OPENAI_API_KEY", "CODEX_API_KEY"]) {
+    for (const [name, value] of Object.entries(environment)) {
+      if (name.toUpperCase() === requested && value?.trim())
+        return value.trim();
+    }
+  }
+  return null;
+}
+
 export async function pluginMetadata(
   root: string,
 ): Promise<{ name: typeof PLUGIN_NAME; version: string }> {

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -1424,7 +1424,7 @@ async function sameFile(left: string, right: string): Promise<boolean> {
   }
 }
 
-function expandHome(value: string): string {
+export function expandHome(value: string): string {
   if (value === "~") return homedir();
   if (value.startsWith("~/") || value.startsWith("~\\")) {
     return join(homedir(), value.slice(2));

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -1254,7 +1254,9 @@ describe("CodexSecurity orchestration", () => {
 if (process.argv.slice(2).join(" ") !== "login --with-api-key") {
   process.exitCode = 2;
 } else {
-  for await (const _chunk of process.stdin) {}
+  let apiKey = "";
+  for await (const chunk of process.stdin) apiKey += chunk;
+  if (apiKey.trim() !== "ambient-key") process.exitCode = 3;
 }
 `,
     );
@@ -1268,7 +1270,8 @@ if (process.argv.slice(2).join(" ") !== "login --with-api-key") {
       {},
       {
         environment: {
-          openai_api_key: "ambient-key",
+          openai_api_key: "stale-key",
+          OPENAI_API_KEY: "ambient-key",
           Codex_Api_Key: "secondary-key",
         },
         prepareRuntime: async () => ({

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -5,6 +5,7 @@ import {
   mkdtemp,
   readFile,
   rm,
+  stat,
   symlink,
   writeFile,
 } from "node:fs/promises";
@@ -327,6 +328,56 @@ describe("CLI compatibility contract", () => {
       expect(stderr.text()).toBe("");
     }
   });
+
+  test("keeps delegated credentials in the configured Codex home", async () => {
+    const root = await mkdtemp(join(tmpdir(), "codex-security-login-home-"));
+    const repository = join(root, "repository");
+    const relativeHome = join(repository, ".codex-security-home");
+    const tildeHome = join(root, ".codex-security-home");
+    await mkdir(relativeHome, { recursive: true });
+    await mkdir(tildeHome, { recursive: true });
+    try {
+      for (const [configuredHome, expectedHome] of [
+        [".codex-security-home", relativeHome],
+        ["~/.codex-security-home", tildeHome],
+      ] as const) {
+        const environment = {
+          ...process.env,
+          HOME: root,
+          CODEX_HOME: configuredHome,
+          OPENAI_API_KEY: undefined,
+          CODEX_API_KEY: undefined,
+        };
+        const run = (args: string[], input?: string): number | null =>
+          spawnSync(
+            process.execPath,
+            [join(import.meta.dir, "../src/cli.ts"), ...args],
+            {
+              cwd: repository,
+              env: environment,
+              input,
+              encoding: "utf8",
+            },
+          ).status;
+        expect(
+          run(
+            [
+              "login",
+              "--with-api-key",
+              "-c",
+              'cli_auth_credentials_store="ephemeral"',
+            ],
+            "synthetic-key\n",
+          ),
+        ).toBe(0);
+        expect(await stat(join(expectedHome, "auth.json"))).toBeDefined();
+        expect(run(["login", "status"])).toBe(0);
+        expect(run(["logout"])).toBe(0);
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 30_000);
 
   test("recognizes a stored Codex sign-in only when no API key is set", async () => {
     const home = await mkdtemp(join(tmpdir(), "codex-security-home-"));

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -344,6 +344,7 @@ describe("CLI compatibility contract", () => {
         const environment = {
           ...process.env,
           HOME: root,
+          USERPROFILE: root,
           CODEX_HOME: configuredHome,
           OPENAI_API_KEY: undefined,
           CODEX_API_KEY: undefined,

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -177,7 +177,7 @@ function dependencies(
     writeSynchronously: (stream, value) => stream.write(value),
     forceExit: () => {},
     hasReusableCodexSignIn: () => options.storedSignIn ?? false,
-    runCodex: () => 0,
+    runCodex: async () => 0,
   };
 }
 
@@ -312,16 +312,16 @@ describe("CLI compatibility contract", () => {
       deps.createSecurity = () => {
         throw new Error("must not initialize Codex Security");
       };
-      deps.runCodex = (args) => {
+      deps.runCodex = async (args) => {
         forwarded = args;
         return 17;
       };
       expect(await main(argv, stdout.stream, stderr.stream, deps)).toBe(17);
       expect(forwarded).toEqual([
         argv[0],
+        ...argv.slice(1),
         "-c",
         'cli_auth_credentials_store="file"',
-        ...argv.slice(1),
       ]);
       expect(stdout.text()).toBe("");
       expect(stderr.text()).toBe("");
@@ -346,6 +346,12 @@ describe("CLI compatibility contract", () => {
           codex_api_key: "synthetic-key",
         }),
       ).toBe(false);
+      expect(
+        hasReusableCodexSignIn({
+          CODEX_HOME: home,
+          OPENAI_API_KEY: "   ",
+        }),
+      ).toBe(true);
     } finally {
       await rm(home, { recursive: true, force: true });
     }

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -393,6 +393,21 @@ describe("CLI compatibility contract", () => {
         expect(run(["login", "status"])).toBe(0);
         expect(run(["logout"])).toBe(0);
       }
+      expect(
+        spawnSync(
+          process.execPath,
+          [join(import.meta.dir, "../src/cli.ts"), "login", "--help"],
+          {
+            cwd: repository,
+            env: {
+              ...process.env,
+              CODEX_HOME: undefined,
+              Codex_Home: "   ",
+            },
+            encoding: "utf8",
+          },
+        ).status,
+      ).toBe(0);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -334,17 +334,20 @@ describe("CLI compatibility contract", () => {
     const repository = join(root, "repository");
     const relativeHome = join(repository, ".codex-security-home");
     const tildeHome = join(root, ".codex-security-home");
+    const mountedHome = join(root, "mounted-codex-home");
     await mkdir(relativeHome, { recursive: true });
     await mkdir(tildeHome, { recursive: true });
+    await mkdir(mountedHome, { recursive: true });
     try {
-      for (const [configuredHome, expectedHome] of [
-        [".codex-security-home", relativeHome],
-        ["~/.codex-security-home", tildeHome],
+      for (const [configuredHome, expectedHome, userHome] of [
+        [".codex-security-home", relativeHome, root],
+        ["~/.codex-security-home", tildeHome, root],
+        [mountedHome, mountedHome, join(root, "missing-home")],
       ] as const) {
         const environment = {
           ...process.env,
-          HOME: root,
-          USERPROFILE: root,
+          HOME: userHome,
+          USERPROFILE: userHome,
           CODEX_HOME: configuredHome,
           OPENAI_API_KEY: undefined,
           CODEX_API_KEY: undefined,

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -302,6 +302,8 @@ describe("CLI compatibility contract", () => {
       ["login", "--with-access-token"],
       ["login", "status"],
       ["login", "--help"],
+      ["login", "help"],
+      ["login", "help", "status"],
       ["logout"],
       ["logout", "--help"],
     ] as const;
@@ -318,12 +320,16 @@ describe("CLI compatibility contract", () => {
         return 17;
       };
       expect(await main(argv, stdout.stream, stderr.stream, deps)).toBe(17);
-      expect(forwarded).toEqual([
-        argv[0],
-        ...argv.slice(1),
-        "-c",
-        'cli_auth_credentials_store="file"',
-      ]);
+      expect(forwarded).toEqual(
+        argv[0] === "login" && argv[1] === "help"
+          ? argv
+          : [
+              argv[0],
+              ...argv.slice(1),
+              "-c",
+              'cli_auth_credentials_store="file"',
+            ],
+      );
       expect(stdout.text()).toBe("");
       expect(stderr.text()).toBe("");
     }
@@ -345,8 +351,12 @@ describe("CLI compatibility contract", () => {
         [".codex-security-home", relativeHome, root],
         ["~/.codex-security-home", tildeHome, root],
         [mountedHome, mountedHome, join(root, "missing-home")],
-        ["", defaultHome, root],
-        ["   ", defaultHome, root],
+        ...(process.platform === "win32"
+          ? []
+          : ([
+              ["", defaultHome, root],
+              ["   ", defaultHome, root],
+            ] as const)),
       ] as const) {
         const environment = {
           ...process.env,

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -6,6 +6,7 @@ import {
   readFile,
   rm,
   symlink,
+  writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -28,6 +29,7 @@ import type {
 } from "../src/index.js";
 import {
   main,
+  hasReusableCodexSignIn,
   parseCodexOverrides,
   parseScanArguments,
   resultJson,
@@ -141,6 +143,7 @@ function dependencies(
     signals?: FakeSignals;
     result?: ScanResult;
     platform?: NodeJS.Platform;
+    storedSignIn?: boolean;
   } = {},
 ): MainDependencies {
   const signals = options.signals ?? new FakeSignals();
@@ -173,6 +176,8 @@ function dependencies(
       signals.remove(signal, listener),
     writeSynchronously: (stream, value) => stream.write(value),
     forceExit: () => {},
+    hasReusableCodexSignIn: () => options.storedSignIn ?? false,
+    runCodex: () => 0,
   };
 }
 
@@ -286,6 +291,64 @@ describe("CLI compatibility contract", () => {
     ).toBe(0);
     expect(stdout.text()).toBe(`${versionText()}\n`);
     expect(stderr.text()).toBe("");
+  });
+
+  test("delegates login and logout to bundled Codex without starting a scan", async () => {
+    const cases = [
+      ["login"],
+      ["login", "--device-auth"],
+      ["login", "--with-api-key"],
+      ["login", "--with-access-token"],
+      ["login", "status"],
+      ["login", "--help"],
+      ["logout"],
+      ["logout", "--help"],
+    ] as const;
+    for (const argv of cases) {
+      const stdout = capture();
+      const stderr = capture();
+      const deps = dependencies();
+      let forwarded: readonly string[] | undefined;
+      deps.createSecurity = () => {
+        throw new Error("must not initialize Codex Security");
+      };
+      deps.runCodex = (args) => {
+        forwarded = args;
+        return 17;
+      };
+      expect(await main(argv, stdout.stream, stderr.stream, deps)).toBe(17);
+      expect(forwarded).toEqual([
+        argv[0],
+        "-c",
+        'cli_auth_credentials_store="file"',
+        ...argv.slice(1),
+      ]);
+      expect(stdout.text()).toBe("");
+      expect(stderr.text()).toBe("");
+    }
+  });
+
+  test("recognizes a stored Codex sign-in only when no API key is set", async () => {
+    const home = await mkdtemp(join(tmpdir(), "codex-security-home-"));
+    try {
+      expect(hasReusableCodexSignIn({ CODEX_HOME: home })).toBe(false);
+      await writeFile(join(home, "auth.json"), "{}\n");
+      expect(hasReusableCodexSignIn({ CODEX_HOME: home })).toBe(true);
+      expect(
+        hasReusableCodexSignIn({
+          CODEX_HOME: home,
+          OPENAI_API_KEY: "synthetic-key",
+        }),
+      ).toBe(false);
+      expect(
+        hasReusableCodexSignIn({
+          CODEX_HOME: home,
+          codex_api_key: "synthetic-key",
+        }),
+      ).toBe(false);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
   });
 
   test("accepts unambiguous root and scan help/version abbreviations", async () => {
@@ -937,7 +1000,7 @@ describe("CLI compatibility contract", () => {
     expect(repository).toBe("repo");
   });
 
-  test("uses Agents SDK by default for standard repository and path scans", async () => {
+  test("uses Agents SDK by default when no stored sign-in is available", async () => {
     for (const argv of [
       ["scan", "repo"],
       ["scan", "repo", "--path", "src", "--path", "tests"],
@@ -978,6 +1041,37 @@ describe("CLI compatibility contract", () => {
       expect(engine).toBe("agents");
       expect(config).not.toHaveProperty("codexOverrides");
     }
+  });
+
+  test("uses Codex by default when a stored sign-in is available", async () => {
+    let engine: "agents" | "codex" | undefined;
+    const stderr = capture();
+    expect(
+      await main(
+        ["scan", "repo"],
+        capture().stream,
+        stderr.stream,
+        dependencies({
+          storedSignIn: true,
+          onEngine: (value) => {
+            engine = value;
+          },
+        }),
+      ),
+    ).toBe(0);
+    expect(engine).toBe("codex");
+    expect(stderr.text()).toContain("Scan complete");
+
+    const incompatible = capture();
+    expect(
+      await main(
+        ["scan", "repo", "--model", "gpt-test"],
+        capture().stream,
+        incompatible.stream,
+        dependencies({ storedSignIn: true }),
+      ),
+    ).toBe(1);
+    expect(incompatible.text()).toContain("require the Agents SDK engine");
   });
 
   test("keeps diff, working-tree, and deep scans on Codex and rejects incompatible engine options", async () => {

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -335,14 +335,18 @@ describe("CLI compatibility contract", () => {
     const relativeHome = join(repository, ".codex-security-home");
     const tildeHome = join(root, ".codex-security-home");
     const mountedHome = join(root, "mounted-codex-home");
+    const defaultHome = join(root, ".codex");
     await mkdir(relativeHome, { recursive: true });
     await mkdir(tildeHome, { recursive: true });
     await mkdir(mountedHome, { recursive: true });
+    await mkdir(defaultHome, { recursive: true });
     try {
       for (const [configuredHome, expectedHome, userHome] of [
         [".codex-security-home", relativeHome, root],
         ["~/.codex-security-home", tildeHome, root],
         [mountedHome, mountedHome, join(root, "missing-home")],
+        ["", defaultHome, root],
+        ["   ", defaultHome, root],
       ] as const) {
         const environment = {
           ...process.env,
@@ -375,6 +379,7 @@ describe("CLI compatibility contract", () => {
           ),
         ).toBe(0);
         expect(await stat(join(expectedHome, "auth.json"))).toBeDefined();
+        await expect(stat(join(repository, "auth.json"))).rejects.toThrow();
         expect(run(["login", "status"])).toBe(0);
         expect(run(["logout"])).toBe(0);
       }

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -80,6 +80,18 @@ describe("plugin runtime preparation", () => {
     expect(environmentApiKey({ CoDeX_ApI_KeY: " codex-key " })).toBe(
       "codex-key",
     );
+    expect(
+      environmentApiKey({
+        openai_api_key: "stale-key",
+        OPENAI_API_KEY: " canonical-key ",
+      }),
+    ).toBe("canonical-key");
+    expect(
+      environmentApiKey({
+        codex_api_key: "stale-key",
+        CODEX_API_KEY: " canonical-key ",
+      }),
+    ).toBe("canonical-key");
     expect(environmentApiKey({ OPENAI_API_KEY: "   " })).toBeNull();
   });
 

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -36,6 +36,7 @@ import {
 import {
   bundledPluginCandidates,
   codexPlatformPackage,
+  environmentApiKey,
   isPythonPathCandidate,
 } from "../src/runtime.js";
 
@@ -69,6 +70,19 @@ async function plugin(root: string, version = "1.2.3"): Promise<string> {
 }
 
 describe("plugin runtime preparation", () => {
+  test("resolves API keys consistently across scan engines", () => {
+    expect(
+      environmentApiKey({
+        codex_api_key: " codex-key ",
+        openai_api_key: " openai-key ",
+      }),
+    ).toBe("openai-key");
+    expect(environmentApiKey({ CoDeX_ApI_KeY: " codex-key " })).toBe(
+      "codex-key",
+    );
+    expect(environmentApiKey({ OPENAI_API_KEY: "   " })).toBeNull();
+  });
+
   test("keeps installed-package plugin lookup inside the package", async () => {
     const root = await temporaryDirectory();
     const packageRoot = join(root, "node_modules", "@openai", "codex-security");


### PR DESCRIPTION
This follow-up to the Agents rewrite makes a standard scan work immediately after `codex-security login`. On macOS and Linux, API-key users use Agents and users with a stored Codex/ChatGPT sign-in use Codex. Diff, working-tree, deep, `--codex`, and native Windows scans continue to use Codex. Authentication stays delegated to the bundled executable.

### What changed

- Add ChatGPT, device, piped API-key/access-token login, `login status`, and `logout`, with inherited terminal streams, an isolated working directory, final file-store override, and interruption cleanup. The advertised `login help` and `login help status` forms also work.
- Select Codex for an implicit standard scan when a stored sign-in is available. Explicit engine choices and engine-specific options still fail clearly before a scan starts.
- Use one trimmed API-key resolver across Agents, Codex, and engine selection. Canonical variables take precedence over differently cased variants, while lowercase and blank values still behave consistently.
- Rewrite root help, scan help, and both READMEs in plain language. The docs now separate local, remote, and CI paths, label the Agents-only model example, state Windows and working-tree behavior accurately, and keep the read-only, network, and credential boundaries clear without the long exclusion wall.

### Test and QA

Automated validation passed:

- The full local run completed 214 passing tests and the expected real-Codex integration skip. Two resource-sensitive tests timed out in the combined run and both passed when rerun in isolation: large explicit path scopes (15.5 s) and canonical plugin example (115 ms). Focused runtime/API/CLI regressions also passed after the Codex review fixes.
- Typecheck, formatting, production build, npm pack, the 151-entry package check, static-secret check, and `git diff --check` passed.

Manual demo path:

```bash
export CODEX_HOME="$(mktemp -d)"

codex-security --help
codex-security login --help
codex-security login help
codex-security login help status
codex-security login status
printf '%s\n' 'SYNTHETIC_QA_API_KEY' | codex-security login --with-api-key
codex-security login status

# A stored sign-in selects Codex; Agents-only flags fail before runtime startup.
env -u OPENAI_API_KEY -u CODEX_API_KEY \
  codex-security scan /path/to/small-repo --model gpt-test

codex-security logout
codex-security login status
```

Verified relative, `~`-based, mounted, blank, and differently cased `CODEX_HOME` behavior; canonical, lowercase, and whitespace-only API-key variables; repository-local login-config isolation; and SIGINT/SIGTERM cleanup. The Windows login-home test now avoids writing to the runner's real profile when Windows ignores a temporary home override.

The stacked base PR (#6) is currently closed and already fails one Ubuntu host-PATH test and 20 native-Windows Agents tests. Those failures reproduce on the base; this PR fixes the one additional Windows login test introduced by this change.
