### PR TITLE
Add Socket Firewall to GitHub Actions workflows

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -32,6 +32,13 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
+      # Socket Firewall installed by security
+      # https://app.notion.com/p/openai/Socket-Firewall-33c8e50b62b0802a82cee42fd51e2c01?source=copy_link#3768e50b62b0806097edebce817e14a5
+      # Slack: #socket-firewall
+      - name: Activate Socket Firewall
+        uses: openai/socket-firewall@40af4b6b4b00fb88c59af22858dc9f15e077617d # v0.1.0
+        with:
+          disabled-until: ${{ vars.SOCKET_FIREWALL_DISABLED_UNTIL }}
       - name: Set up npm trusted publishing
         run: npm install --global npm@11.15.0
 


### PR DESCRIPTION
## Summary
- Activate Socket Firewall before vulnerable dependency installation steps.
- Pin the released action to commit `40af4b6b4b00fb88c59af22858dc9f15e077617d` (`v0.1.0`).
- Respect the organization-wide `SOCKET_FIREWALL_DISABLED_UNTIL` kill switch.

## Validation
- Ran the repository-wide Socket Firewall workflow checker successfully.