### PR TITLE
release: publish Codex Security 0.1.1

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-security",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TypeScript SDK and CLI for Codex Security",
   "license": "Apache-2.0",
   "author": "OpenAI",


### PR DESCRIPTION
## Summary
- Release the current Codex Security main as @openai/codex-security 0.1.1.
- Change only the package version from 0.1.0 to 0.1.1; the SDK and CLI derive their versions directly from package.json.
- Preserve the exact current main fixes, based on b1e2af91f5cb3e59c3f8c4ad2987709389ebe017.

## Completed verification
- [x] Confirm npm latest is 0.1.0 and 0.1.1 is not already published.
- [x] Confirm npm-v0.1.1 does not exist and the protected release workflow accepts only a matching version on main.
- [x] Install the exact frozen pnpm lockfile.
- [x] Verify generated models, TypeScript, formatting, and the production build.
- [x] Run the complete test suite: 361 passed, 3 expected platform/integration skips, 0 failed.
- [x] Build and validate the release tarball: 178 expected entries.
- [x] Independently install the tarball and verify the CLI, public SDK import, and all 94 bundled plugin files.

## Protected publication
- [ ] Obtain the required independent review and merge this exact release PR.
- [ ] Create npm-v0.1.1 on the resulting main commit.
- [ ] Verify the protected node-release workflow, npm latest, provenance, and a fresh installation of the registry-published package.
