### PR TITLE
fix: invoke trusted git absolute path in multiscan checkout

### DIFF
--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -470,8 +470,10 @@ async function checkoutRevision(
     throw new Error("Git is not available on a trusted PATH.");
   }
   const git = async (...args: string[]): Promise<string> => {
+    // Use the resolved absolute path so Windows PATHEXT cannot prefer a
+    // .bat/.cmd shim over the trusted executable selected above.
     const result = await execFile(
-      "git",
+      command.executable,
       [
         "-c",
         "core.hooksPath=/dev/null",


### PR DESCRIPTION
## Summary

- Fixes #58: multiscan checkout now runs `command.executable` from `resolveTrustedExecutable` instead of re-launching bare `"git"` via PATH.
- Matches the existing contract in `targets.ts` so Windows PATHEXT cannot prefer a `.bat`/`.cmd` shim over the trusted executable.

## Test plan

- [x] `bun test --timeout 30000 ./tests-ts/multiscan.test.ts` (14 pass)
- [ ] Confirm CI `node-ci` passes on this branch


Made with [Cursor](https://cursor.com)