### PR TITLE
fix: include personal account in bulk-scan discovery

### DIFF
--- a/sdk/typescript/src/bulk-scan-discovery.ts
+++ b/sdk/typescript/src/bulk-scan-discovery.ts
@@ -197,22 +197,20 @@ async function selectGitHubOwner(
   prompt: BulkScanPrompt,
   signal?: AbortSignal,
 ): Promise<string> {
-  const { data } = await github.request("GET /user/orgs", {
-    per_page: 100,
-    request: { signal },
-  });
-  const organizations = data.map(({ login }) => login).sort();
-  if (organizations.length > 1) {
+  const [orgs, user] = await Promise.all([
+    github.request("GET /user/orgs", { per_page: 100, request: { signal } }),
+    github.request("GET /user", { request: { signal } }),
+  ]);
+  const personal = user.data.login;
+  const owners = [personal, ...orgs.data.map(({ login }) => login)].sort();
+  if (owners.length > 1) {
     return await prompt.select(
       "Which account or organization should we scan?",
-      organizations.map((owner) => ({ label: owner, value: owner })),
+      owners.map((owner) => ({ label: owner, value: owner })),
     );
   }
-  const owner =
-    organizations[0] ??
-    (await github.request("GET /user", { request: { signal } })).data.login;
-  prompt.write(`\nFinding repositories in ${owner}.\n`);
-  return owner;
+  prompt.write(`\nFinding repositories in ${personal}.\n`);
+  return personal;
 }
 
 async function selectGitHubRepositories(

--- a/sdk/typescript/tests-ts/bulk-scan-discovery.test.ts
+++ b/sdk/typescript/tests-ts/bulk-scan-discovery.test.ts
@@ -160,7 +160,7 @@ function discoveryDependencies(
 
               if (path === "/user/orgs") {
                 return Response.json(
-                  (options.organizations ?? ["acme"]).map((login) => ({
+                  (options.organizations ?? []).map((login) => ({
                     login,
                   })),
                 );
@@ -333,19 +333,20 @@ describe("bulk scan repository discovery", () => {
     expect(requests).toEqual([]);
   });
 
-  test("asks for the owner only when several organizations are available", async () => {
+  test("includes the personal account alongside organizations", async () => {
     const root = await temporaryDirectory();
-    const { dependencies, prompt } = discoveryDependencies(root, {
-      organizations: ["acme", "acme-labs"],
+    const { dependencies, prompt, requests } = discoveryDependencies(root, {
+      organizations: ["acme"],
     });
     prompt.confirms = [true];
-    prompt.choices = ["acme"];
+    prompt.choices = ["personal-account"];
 
     await runBulkScanWizard(dependencies);
 
-    expect(prompt.questions).toContain(
-      "Which account or organization should we scan?",
-    );
+    expect(prompt.searchOptions[0]).toEqual(["acme", "personal-account"]);
+    expect(
+      requests.find(({ path }) => path === "/graphql")?.variables?.owner,
+    ).toBe("personal-account");
   });
 
   test("does not write an inventory when canceled or no repositories match", async () => {


### PR DESCRIPTION
## Summary

- Include the authenticated personal GitHub account alongside organization owners.
- Prompt for an owner when both personal and organization accounts are available.
- Add regression coverage for selecting the personal account.

Fixes #28.