### PR TITLE
fix: Could not save the Codex Security scan

### DIFF
--- a/sdk/typescript/src/config.ts
+++ b/sdk/typescript/src/config.ts
@@ -33,6 +33,10 @@ export const DEFAULT_CODEX_CONFIG: Readonly<JsonObject> = {
       max_concurrent_threads_per_session: 9,
     },
   },
+  // Named filesystem profiles need an active Windows sandbox backend.
+  windows: {
+    sandbox: "unelevated",
+  },
 };
 
 deepFreezeJson(DEFAULT_CODEX_CONFIG);

--- a/sdk/typescript/tests-ts/config.test.ts
+++ b/sdk/typescript/tests-ts/config.test.ts
@@ -32,6 +32,7 @@ describe("Codex configuration", () => {
       codexOverrides: {
         features: { multi_agent_v2: { max_concurrent_threads_per_session: 4 } },
         model_reasoning_effort: "high",
+        windows: { sandbox: "elevated" },
       },
     });
     expect(merged["features"]).toEqual({
@@ -45,6 +46,7 @@ describe("Codex configuration", () => {
     expect(merged["agents"]).toBeUndefined();
     expect(merged["model"]).toBe("gpt-5.6-sol");
     expect(merged["model_reasoning_effort"]).toBe("high");
+    expect(merged["windows"]).toEqual({ sandbox: "elevated" });
   });
 
   test("rejects prototype-bearing override keys", async () => {
@@ -92,6 +94,9 @@ describe("Codex configuration", () => {
     expect(await mergedCodexConfig({})).toMatchObject({
       model: "gpt-5.6-sol",
       model_reasoning_effort: "xhigh",
+      windows: {
+        sandbox: "unelevated",
+      },
     });
   });
 


### PR DESCRIPTION
## Summary

Fix Windows scans failing with `Could not save the Codex Security scan` because the isolated runtime has no active Windows sandbox backend.

- Enable the `unelevated` Windows sandbox backend by default in `DEFAULT_CODEX_CONFIG`, allowing the existing named filesystem permission profile to be enforced while scans read the target repository and write scan artifacts.
- Preserve explicit sandbox overrides, so a caller passing `windows: { sandbox: "elevated" }` continues to take precedence over the default.
- Add regression coverage for both the default configuration and the overridden case.

## Verification

- Focused configuration tests: default `windows.sandbox` resolves to `unelevated`, and explicit overrides are preserved through `mergedCodexConfig`.
- Windows sandbox probe with the pinned Codex `0.144.6`: successfully read the plugin and target repository and wrote workspace output.
- TypeScript typecheck and production build.
- Prettier formatting check.
- Git diff whitespace check.

Fixes #51
Fixes #60
Fixes #66