### PR TITLE
fix: preserve npm release gitHead

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -106,11 +106,17 @@ jobs:
 
       - name: Pack
         working-directory: sdk/typescript
-        run: pnpm pack --pack-destination ../../dist
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm pkg set "gitHead=$GITHUB_SHA"
+          pnpm pack --pack-destination ../../dist
 
       - name: Inspect package
         working-directory: sdk/typescript
         shell: bash
+        env:
+          CODEX_SECURITY_EXPECTED_GIT_HEAD: ${{ github.sha }}
         run: pnpm run check:package ../../dist/*.tgz
 
       - name: Smoke test package

--- a/sdk/typescript/scripts/check-package.mjs
+++ b/sdk/typescript/scripts/check-package.mjs
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { brotliDecompressSync, gunzipSync } from "node:zlib";
+import { assertExpectedGitHead } from "./package-provenance.mjs";
 
 const args = process.argv.slice(2);
 if (args[0] === "--") args.shift();
@@ -212,6 +213,10 @@ if (
 ) {
   throw new Error("npm package does not contain the expected public metadata.");
 }
+assertExpectedGitHead(
+  packageJson,
+  process.env.CODEX_SECURITY_EXPECTED_GIT_HEAD,
+);
 
 const internalMarker =
   /(?:internal\.api\.openai\.org|gateway\.[a-z0-9.-]*internal|\.openai\.org|openai\.firewall\.socket\.dev|socket\x2dfirewall\x2dregistry|openai\.(?:enterprise\.)?slack\.com|app\.slack\.com\/client|(?:app\.notion\.com\/p|notion\.so)\/openai|linear\.app\/openai|(?:github\.com[:/]|api\.github\.com\/repos\/|raw\.githubusercontent\.com\/)openai\/openai(?:\.git)?(?:[^a-z0-9_-]|$)|LicenseRef\x2dProprietary|\/Users\/|\/home\/dev-user|flow\.apps\.openai\.org|(?:^|[^a-z0-9_-])go\/[a-z0-9_-]+)/iu;

--- a/sdk/typescript/scripts/package-provenance.mjs
+++ b/sdk/typescript/scripts/package-provenance.mjs
@@ -1,0 +1,17 @@
+const fullGitCommit = /^[0-9a-f]{40}$/u;
+
+export function assertExpectedGitHead(packageJson, expectedGitHead) {
+  if (expectedGitHead === undefined) return;
+
+  if (!fullGitCommit.test(expectedGitHead)) {
+    throw new Error(
+      "Expected release gitHead must be a full 40-character lowercase Git commit SHA.",
+    );
+  }
+
+  if (packageJson.gitHead !== expectedGitHead) {
+    throw new Error(
+      `npm package gitHead must match release commit ${expectedGitHead}.`,
+    );
+  }
+}

--- a/sdk/typescript/tests-ts/package-provenance.test.ts
+++ b/sdk/typescript/tests-ts/package-provenance.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+
+type PackageProvenance = {
+  assertExpectedGitHead: (
+    packageJson: { gitHead?: unknown },
+    expectedGitHead: string | undefined,
+  ) => void;
+};
+
+const { assertExpectedGitHead } = (await import(
+  new URL("../scripts/package-provenance.mjs", import.meta.url).href
+)) as PackageProvenance;
+
+const releaseCommit = "e94d6bef9797a192febfde89a26ec7f831bc09b2";
+
+describe("npm package release provenance", () => {
+  test("accepts the exact release commit recorded in the package", () => {
+    expect(() =>
+      assertExpectedGitHead({ gitHead: releaseCommit }, releaseCommit),
+    ).not.toThrow();
+  });
+
+  test("keeps gitHead optional for local, CI, and container packages", () => {
+    expect(() => assertExpectedGitHead({}, undefined)).not.toThrow();
+  });
+
+  test("rejects a release package without gitHead", () => {
+    expect(() => assertExpectedGitHead({}, releaseCommit)).toThrow(
+      `npm package gitHead must match release commit ${releaseCommit}.`,
+    );
+  });
+
+  test("rejects a release package built from a different commit", () => {
+    expect(() =>
+      assertExpectedGitHead(
+        { gitHead: "f22d4a36f26d16287bcdfd707b369116e02a08c3" },
+        releaseCommit,
+      ),
+    ).toThrow(
+      `npm package gitHead must match release commit ${releaseCommit}.`,
+    );
+  });
+
+  test("rejects an invalid expected release commit", () => {
+    expect(() => assertExpectedGitHead({}, "main")).toThrow(
+      "Expected release gitHead must be a full 40-character lowercase Git commit SHA.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Record the exact GitHub Actions source commit as `gitHead` before packing the verified npm release artifact.
- Fail the protected release when the packed manifest has a missing, malformed, or mismatched source commit.
- Preserve existing local, ordinary CI, and container packaging behavior when release-source verification is not requested.
- Add focused regression coverage for matching, missing, mismatched, invalid, and non-release `gitHead` values.

## Why

The release is verified and packed in one job, then published from that immutable tarball in a separate job without a Git checkout. npm cannot infer `gitHead` at publish time, so currently published metadata omits the source commit even though the Sigstore provenance attestation is valid. Stamping the verified commit before packing preserves the existing artifact-integrity and trusted-publishing flow.

This improves published source metadata; it does not claim to fix npmjs.com's separate provenance-viewer JSON error.

## Validation

- `380 passed, 3 skipped` across the complete TypeScript test suite.
- All five new release-provenance regression tests pass.
- TypeScript and generated-model checks pass.
- Production TypeScript build and SDK/workflow formatting pass.
- A real packed tarball records the exact expected `gitHead` and passes release package validation.
- Real tarballs with a missing or mismatched `gitHead` are rejected.
- A fresh installation preserves the expected `gitHead`, imports the SDK, and passes CLI version/help smoke checks.