### PR TITLE
fix: surface actual security scan failures

### DIFF
--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -2496,9 +2496,7 @@ function scanFailureMessage(
     case "rate_limited":
       return "The configured account reached its rate limit. Wait and retry.";
     case "network_error":
-      return "The model service could not be reached. Check your network connection and try again.";
     case "timeout":
-      return "The connection timed out. Check your network connection and try again.";
     case "unknown":
       return cliErrorMessage(error);
   }

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -1677,13 +1677,11 @@ describe("CLI", () => {
     expect(JSON.parse(stdout.text())).toEqual(fakeResult().toJSON());
   });
 
-  test("turns provider-specific scan failures into actionable safe messages", async () => {
+  test("turns authentication and rate-limit failures into actionable safe messages", async () => {
     for (const [message, expected] of [
       ["401 invalid API key for org-private", "provide a valid API key"],
       ["403 model access denied for org-private", "model access"],
       ["429 rate limit reached for org-private", "rate limit"],
-      ["network failure ECONNRESET for org-private", "network connection"],
-      ["request timed out for org-private", "connection timed out"],
     ] as const) {
       const stdout = capture();
       const stderr = capture();
@@ -1700,6 +1698,58 @@ describe("CLI", () => {
       expect(stderr.text()).toContain(expected);
       expect(stderr.text()).not.toContain("org-private");
     }
+  });
+
+  test("surfaces underlying scanner errors instead of inventing a model outage", async () => {
+    for (const message of [
+      "Could not save the Codex Security scan: UNIQUE constraint failed: scans.scan_dir",
+      "sandbox-exec: sandbox_apply: Operation not permitted during network setup.",
+      "network failure ECONNRESET while connecting to the model.",
+      "request timed out while reading the scanner response.",
+    ]) {
+      const stdout = capture();
+      const stderr = capture();
+      const deps = dependencies();
+      deps.createSecurity = () => ({
+        run: async () => {
+          throw new CodexSecurityError(message);
+        },
+        preflight: async () => fakePreflight(),
+        close: async () => {},
+      });
+
+      expect(
+        await main(["scan", ".", "--json"], stdout.stream, stderr.stream, deps),
+      ).toBe(2);
+      expect(stdout.text()).toBe("");
+      expect(stderr.text()).toContain(`codex-security: ${message}\n`);
+      expect(stderr.text()).not.toContain("model service could not be reached");
+    }
+  });
+
+  test("redacts credentials in underlying network errors", async () => {
+    const stdout = capture();
+    const stderr = capture();
+    const deps = dependencies();
+    deps.createSecurity = () => ({
+      run: async () => {
+        throw new CodexSecurityError(
+          `network failure ECONNRESET ${SYNTHETIC_CREDENTIALS}`,
+        );
+      },
+      preflight: async () => fakePreflight(),
+      close: async () => {},
+    });
+
+    expect(
+      await main(["scan", ".", "--json"], stdout.stream, stderr.stream, deps),
+    ).toBe(2);
+    expect(stdout.text()).toBe("");
+    expect(stderr.text()).toContain(
+      `network failure ECONNRESET ${REDACTED_CREDENTIALS}`,
+    );
+    expect(stderr.text()).not.toContain("SYNTHETIC_KEY_123");
+    expect(stderr.text()).not.toContain("model service could not be reached");
   });
 
   test("reports database connection failures without claiming the model network failed", async () => {


### PR DESCRIPTION
## Summary
- Show the actual sanitized scan failure instead of replacing network, timeout, SQLite, and sandbox errors with an invented model outage.
- Keep actionable authentication, authorization, and rate-limit guidance.
- Add regression coverage for scanner failures and credential redaction.

## Validation
- Full public SDK suite: 377 passed, 3 expected skips.
- TypeScript and generated-model checks.
- Prettier and `git diff --check`.