### PR TITLE
fix: harden Node CI and Windows package smoke

### DIFF
--- a/.github/workflows/container-ci.yml
+++ b/.github/workflows/container-ci.yml
@@ -25,6 +25,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   container:
     name: linux-amd64
@@ -96,7 +100,8 @@ jobs:
           mkdir -p results state
           chmod 700 results state
           printf 'id,repository,revision\n' > repositories.csv
-          export CODEX_SECURITY_USER="$(id -u):$(id -g)"
+          CODEX_SECURITY_USER="$(id -u):$(id -g)"
+          export CODEX_SECURITY_USER
           docker compose config --quiet
           docker compose run --rm codex-security --version
 

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -8,14 +8,25 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
-    name: ${{ matrix.os }} / node-22
+    name: ${{ matrix.os }} / node-${{ matrix.node }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        node: ["22"]
+        include:
+          - os: ubuntu-latest
+            node: "24"
+          - os: ubuntu-latest
+            node: "26"
 
     steps:
       - name: Checkout repository
@@ -23,19 +34,24 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          package_json_file: sdk/typescript/package.json
+          cache: true
+          cache_dependency_path: sdk/typescript/pnpm-lock.yaml
+
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: "22"
+          node-version: ${{ matrix.node }}
+          cache: npm
+          cache-dependency-path: sdk/typescript/pnpm-lock.yaml
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.14"
-
-      - name: Enable pnpm
-        shell: bash
-        run: corepack enable && corepack prepare "$(node -p 'require("./sdk/typescript/package.json").packageManager')" --activate
 
       - name: Install dependencies
         run: pnpm --dir sdk/typescript install --frozen-lockfile
@@ -65,3 +81,18 @@ jobs:
         working-directory: sdk/typescript
         shell: bash
         run: pnpm run check:package ../../dist/*.tgz
+
+      - name: Smoke-test Node.js runtime
+        working-directory: sdk/typescript
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --input-type=module --eval '
+            import { CodexSecurity } from "@openai/codex-security";
+
+            if (typeof CodexSecurity !== "function") {
+              throw new Error("The SDK does not export CodexSecurity.");
+            }
+          '
+          node bin/codex-security.mjs --version
+          node bin/codex-security.mjs --help

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -67,6 +67,7 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.14"
+          no-cache: true
 
       - name: Enable pnpm
         shell: bash

--- a/sdk/typescript/scripts/check-package.mjs
+++ b/sdk/typescript/scripts/check-package.mjs
@@ -4,6 +4,10 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { brotliDecompressSync, gunzipSync } from "node:zlib";
 import { assertExpectedGitHead } from "./package-provenance.mjs";
+import { packageSmokeTimeouts } from "./package-smoke-timeouts.mjs";
+
+const PACKAGE_SMOKE_PROCESS_TIMEOUT_MS =
+  packageSmokeTimeouts().processTimeoutMs;
 
 const args = process.argv.slice(2);
 if (args[0] === "--") args.shift();
@@ -279,15 +283,16 @@ if (args.length === 1) {
     [fileURLToPath(new URL("./smoke-package.mjs", import.meta.url)), archive],
     {
       stdio: "inherit",
-      timeout: 150_000,
+      timeout: PACKAGE_SMOKE_PROCESS_TIMEOUT_MS,
       killSignal: "SIGKILL",
       windowsHide: true,
     },
   );
   if (smoke.error?.code === "ETIMEDOUT") {
-    throw new Error("Installed npm package smoke timed out after 150000 ms.", {
-      cause: smoke.error,
-    });
+    throw new Error(
+      `Installed npm package smoke timed out after ${PACKAGE_SMOKE_PROCESS_TIMEOUT_MS} ms.`,
+      { cause: smoke.error },
+    );
   }
   if (smoke.error !== undefined) throw smoke.error;
   if (smoke.status !== 0) {

--- a/sdk/typescript/scripts/package-smoke-timeouts.mjs
+++ b/sdk/typescript/scripts/package-smoke-timeouts.mjs
@@ -1,0 +1,8 @@
+export function packageSmokeTimeouts(platform = process.platform) {
+  const commandTimeoutMs = platform === "win32" ? 180_000 : 120_000;
+
+  return {
+    commandTimeoutMs,
+    processTimeoutMs: commandTimeoutMs + 30_000,
+  };
+}

--- a/sdk/typescript/scripts/smoke-package.mjs
+++ b/sdk/typescript/scripts/smoke-package.mjs
@@ -11,8 +11,9 @@ import {
 import { tmpdir } from "node:os";
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
+import { packageSmokeTimeouts } from "./package-smoke-timeouts.mjs";
 
-const PACKAGE_SMOKE_TIMEOUT_MS = 120_000;
+const PACKAGE_SMOKE_TIMEOUT_MS = packageSmokeTimeouts().commandTimeoutMs;
 const packageRoot = fileURLToPath(new URL("../", import.meta.url));
 const packageManifest = JSON.parse(
   await readFile(new URL("../package.json", import.meta.url), "utf8"),
@@ -191,12 +192,11 @@ try {
     [
       ...npm.args,
       "install",
+      "--prefer-offline",
       "--include=optional",
       "--ignore-scripts",
       "--no-audit",
       "--no-fund",
-      "--cache",
-      join(consumer, ".npm-cache"),
       archive,
     ],
     { cwd: consumer },

--- a/sdk/typescript/tests-ts/package-smoke-timeouts.test.ts
+++ b/sdk/typescript/tests-ts/package-smoke-timeouts.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+
+type PackageSmokeTimeouts = {
+  packageSmokeTimeouts: (platform?: NodeJS.Platform) => {
+    commandTimeoutMs: number;
+    processTimeoutMs: number;
+  };
+};
+
+const { packageSmokeTimeouts } = (await import(
+  new URL("../scripts/package-smoke-timeouts.mjs", import.meta.url).href
+)) as PackageSmokeTimeouts;
+
+describe("npm package smoke timeouts", () => {
+  test("preserves the existing timeout on Linux and macOS", () => {
+    for (const platform of ["linux", "darwin"] as const) {
+      expect(packageSmokeTimeouts(platform)).toEqual({
+        commandTimeoutMs: 120_000,
+        processTimeoutMs: 150_000,
+      });
+    }
+  });
+
+  test("allows the Windows npm install to complete", () => {
+    expect(packageSmokeTimeouts("win32")).toEqual({
+      commandTimeoutMs: 180_000,
+      processTimeoutMs: 210_000,
+    });
+  });
+
+  test("keeps the parent smoke timeout above the command timeout", () => {
+    for (const platform of ["linux", "darwin", "win32"] as const) {
+      const { commandTimeoutMs, processTimeoutMs } =
+        packageSmokeTimeouts(platform);
+
+      expect(processTimeoutMs).toBe(commandTimeoutMs + 30_000);
+    }
+  });
+
+  test("uses the active runtime platform by default", () => {
+    expect(packageSmokeTimeouts()).toEqual(
+      packageSmokeTimeouts(process.platform),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Extend Node CI to Node 24 and Node 26 without introducing a full operating-system-by-Node-version cross-product: preserve Node 22 on Ubuntu, macOS, and Windows and add Node 24 and Node 26 on Ubuntu.
- Install the exact project-defined pnpm release through a full-SHA-pinned action and configure separate lockfile-keyed pnpm and npm caches, so Node 26 does not rely on the removed bundled Corepack executable and package smoke tests do not repeatedly cold-download dependencies.
- Cancel only superseded pull-request CI runs, retain read-only workflow permissions, and bound Node CI jobs without canceling main-branch or release runs.
- Retain a direct SDK and CLI smoke test for each selected Node runtime.
- Fix the Windows fresh-install package smoke without dropping Windows coverage: reuse the integrity-checked npm cache with `--prefer-offline`, and use a shared platform-aware timeout contract that preserves the existing 120-second command and 150-second supervisor limits on Linux and macOS while allowing 180 and 210 seconds, respectively, on Windows.
- Disable Bun executable caching in the protected npm release to remove the identified cache-poisoning finding while preserving release provenance, `gitHead` verification, protected environments, and OIDC publishing.
- Fix the pre-existing container-workflow shellcheck warning without changing its Compose behavior.

## Root cause

The current `main` Windows runner reaches package inspection successfully, but its clean npm consumer installation can exceed the smoke script's shared 120-second subprocess deadline. Each smoke test also created and immediately discarded its own private npm cache, forcing every matrix job to cold-download the same dependency graph. The parent inspector independently terminates the smoke at 150 seconds, so increasing the inner limit alone cannot fix the failure safely.

The smoke test now keeps the consumer installation isolated while reusing the lockfile-keyed npm download cache and preferring verified cached packages. A shared timeout helper coordinates both subprocess limits and gives additional time only to Windows. Regression tests assert the exact timeout budgets, the supervisor safety margin, and the default-platform behavior.

## Validation

- Focused Windows package-smoke regression tests.
- Complete TypeScript SDK test suites on Node 22, Node 24, and Node 26.
- Type-check, formatting, build, direct SDK import, CLI version/help smoke, package creation, and complete package inspection.
- Fresh npm consumer installation, SDK import, CLI execution, and bundled-plugin validation on Node 22, Node 24, and Node 26; the warmed shared cache reduced repeated 77-package installations from approximately two minutes to six seconds.
- GitHub Actions syntax and shell analysis with `actionlint`.
- GitHub Actions security analysis with `zizmor`; no reportable findings.
- Semantic assertions confirming exactly five matrix jobs, immutable action pins, safe PR-only concurrency, least-privilege permissions, and preserved npm OIDC release settings.
- `git diff --check`.
