### PR TITLE
fix: confine bulk scan receipt ledgers

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -403,7 +403,9 @@ service,https://github.com/acme/service.git,0123456789abcdef0123456789abcdef0123
 ```
 
 `--workers` limits concurrent scans and `--max-attempts` retries failures.
-Results remain under `--output-dir`; rerun the same command to resume.
+Results remain under `--output-dir`; rerun the same command to resume. A
+completed receipt is skipped only when its canonical artifacts and seal remain
+valid and its coverage is complete; otherwise the repository is scanned again.
 
 ### Scan history and reruns
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -412,6 +412,12 @@ GitHub discovery applies the same repository limit and stops before creating an
 inventory if the selected account exceeds it. Split larger campaigns into
 separate repository lists and output directories.
 
+Bulk-scan receipt ledgers are limited to 64 MiB total and 1 MiB per record.
+If a committed record is malformed, the original ledger is retained as
+`results.corrupt-<uuid>.jsonl` and valid records are republished to
+`results.jsonl` before the campaign resumes. An oversized ledger is quarantined
+whole and the campaign safely rescans its repositories.
+
 ### Scan history and reruns
 
 `npx @openai/codex-security scans list` lists scans for the current repository. Pass a

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -407,6 +407,11 @@ Results remain under `--output-dir`; rerun the same command to resume. A
 completed receipt is skipped only when its canonical artifacts and seal remain
 valid and its coverage is complete; otherwise the repository is scanned again.
 
+Bulk-scan inventories are limited to 8 MiB and 1,000 repositories. Interactive
+GitHub discovery applies the same repository limit and stops before creating an
+inventory if the selected account exceeds it. Split larger campaigns into
+separate repository lists and output directories.
+
 ### Scan history and reruns
 
 `npx @openai/codex-security scans list` lists scans for the current repository. Pass a

--- a/sdk/typescript/scripts/check-package.mjs
+++ b/sdk/typescript/scripts/check-package.mjs
@@ -143,6 +143,7 @@ const distFiles = new Set(
     "api",
     "auth",
     "bulk-scan-discovery",
+    "bulk-scan-limits",
     "cli",
     "config",
     "contract",

--- a/sdk/typescript/src/bulk-scan-discovery.ts
+++ b/sdk/typescript/src/bulk-scan-discovery.ts
@@ -198,11 +198,16 @@ async function selectGitHubOwner(
   signal?: AbortSignal,
 ): Promise<string> {
   const [orgs, user] = await Promise.all([
-    github.request("GET /user/orgs", { per_page: 100, request: { signal } }),
+    listGitHubOrganizations(github, signal),
     github.request("GET /user", { request: { signal } }),
   ]);
+  signal?.throwIfAborted();
   const personal = user.data.login;
-  const owners = [personal, ...orgs.data.map(({ login }) => login)].sort();
+  const owners = [
+    ...new Map(
+      [personal, ...orgs].map((owner) => [owner.toLowerCase(), owner]),
+    ).values(),
+  ].sort();
   if (owners.length > 1) {
     return await prompt.select(
       "Which account or organization should we scan?",
@@ -211,6 +216,28 @@ async function selectGitHubOwner(
   }
   prompt.write(`\nFinding repositories in ${personal}.\n`);
   return personal;
+}
+
+async function listGitHubOrganizations(
+  github: Octokit,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  const organizations: string[] = [];
+  let page = 1;
+  while (true) {
+    signal?.throwIfAborted();
+    const result = await github.request("GET /user/orgs", {
+      per_page: 100,
+      page,
+      request: { signal },
+    });
+    signal?.throwIfAborted();
+    organizations.push(...result.data.map(({ login }) => login));
+    if (!result.headers.link?.match(/;\s*rel="next"(?:\s*,|$)/u)) {
+      return organizations;
+    }
+    page += 1;
+  }
 }
 
 async function selectGitHubRepositories(

--- a/sdk/typescript/src/bulk-scan-discovery.ts
+++ b/sdk/typescript/src/bulk-scan-discovery.ts
@@ -8,6 +8,10 @@ import { promisify } from "node:util";
 import { confirm, input, search } from "@inquirer/prompts";
 import { Octokit } from "@octokit/core";
 import Papa from "papaparse";
+import {
+  bulkScanRepositoryLimitError,
+  MAX_BULK_SCAN_REPOSITORIES,
+} from "./bulk-scan-limits.js";
 import { resolveTrustedExecutable } from "./trusted-executable.js";
 
 const execFile = promisify(execFileCallback);
@@ -297,6 +301,9 @@ async function discoverGitHubRepositories(
         url: `https://${host}/${repository.nameWithOwner}.git`,
         revision: repository.defaultBranchRef.target.oid.toLowerCase(),
       });
+      if (repositories.length > MAX_BULK_SCAN_REPOSITORIES) {
+        throw bulkScanRepositoryLimitError();
+      }
     }
     cursor = connection.pageInfo.hasNextPage
       ? connection.pageInfo.endCursor

--- a/sdk/typescript/src/bulk-scan-discovery.ts
+++ b/sdk/typescript/src/bulk-scan-discovery.ts
@@ -12,6 +12,7 @@ import {
   bulkScanRepositoryLimitError,
   MAX_BULK_SCAN_REPOSITORIES,
 } from "./bulk-scan-limits.js";
+import { expandHome } from "./runtime.js";
 import { resolveTrustedExecutable } from "./trusted-executable.js";
 
 const execFile = promisify(execFileCallback);
@@ -164,9 +165,11 @@ export async function runBulkScanWizard(
 
   const outputDir = resolve(
     dependencies.currentDirectory(),
-    await prompt.input(
-      "Where should scan results be saved?",
-      "./security-scans",
+    expandHome(
+      await prompt.input(
+        "Where should scan results be saved?",
+        "./security-scans",
+      ),
     ),
   );
   const inputPath = join(outputDir, "repositories.csv");

--- a/sdk/typescript/src/bulk-scan-limits.ts
+++ b/sdk/typescript/src/bulk-scan-limits.ts
@@ -1,0 +1,8 @@
+export const MAX_BULK_SCAN_INVENTORY_BYTES = 8 * 1_024 * 1_024;
+export const MAX_BULK_SCAN_REPOSITORIES = 1_000;
+
+export function bulkScanRepositoryLimitError(): Error {
+  return new Error(
+    "Bulk scans support at most 1,000 repositories per campaign. Split the repository list into smaller inventories.",
+  );
+}

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -180,6 +180,10 @@ function optionValue(flag: string) {
   return z.string().min(1, `${flag} must not be empty.`);
 }
 
+function resolveCliPath(directory: string, value: string): string {
+  return resolve(directory, expandHome(value));
+}
+
 function effortOption() {
   return z
     .enum(MODEL_REASONING_EFFORTS, {
@@ -734,14 +738,14 @@ export async function main(
         const repository =
           options.scanRoot !== undefined && args.repository === undefined
             ? undefined
-            : resolve(directory, args.repository ?? directory);
+            : resolveCliPath(directory, args.repository ?? directory);
         return presentHistory(
           await history([
             "list-scans",
             ...(repository === undefined ? [] : ["--repository", repository]),
             ...(options.scanRoot === undefined
               ? []
-              : ["--scan-root", resolve(directory, options.scanRoot)]),
+              : ["--scan-root", resolveCliPath(directory, options.scanRoot)]),
           ]),
           "list",
           format,
@@ -750,7 +754,7 @@ export async function main(
             scanRoot:
               options.scanRoot === undefined
                 ? undefined
-                : resolve(directory, options.scanRoot),
+                : resolveCliPath(directory, options.scanRoot),
           },
         );
       },
@@ -1111,7 +1115,10 @@ export async function main(
             "git",
             [
               "-C",
-              resolve(dependencies.currentDirectory(), args.repository ?? "."),
+              resolveCliPath(
+                dependencies.currentDirectory(),
+                args.repository ?? ".",
+              ),
               "rev-parse",
               "--path-format=absolute",
               "--git-path",
@@ -1284,8 +1291,8 @@ export async function main(
                 "--output-dir is required with a repository CSV.",
               );
             }
-            inputPath = resolve(currentDirectory, args.input);
-            outputDir = resolve(currentDirectory, options.outputDir);
+            inputPath = resolveCliPath(currentDirectory, args.input);
+            outputDir = resolveCliPath(currentDirectory, options.outputDir);
           }
           const result = await runMultiscan({
             inputPath,
@@ -1369,12 +1376,12 @@ export async function main(
         const currentDirectory = dependencies.currentDirectory();
         exitCode = await runExport(
           {
-            scanDir: resolve(currentDirectory, args.scanDir),
+            scanDir: resolveCliPath(currentDirectory, args.scanDir),
             format: options.exportFormat,
             output:
               options.output === "-"
                 ? "-"
-                : resolve(
+                : resolveCliPath(
                     currentDirectory,
                     options.output ??
                       EXPORT_DEFAULT_OUTPUTS[options.exportFormat],
@@ -1382,7 +1389,7 @@ export async function main(
             sourceRoot:
               options.sourceRoot === undefined
                 ? undefined
-                : resolve(currentDirectory, options.sourceRoot),
+                : resolveCliPath(currentDirectory, options.sourceRoot),
             pythonPath: options.python,
           },
           output,

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -9,6 +9,7 @@ import {
   mkdir,
   open,
   readFile,
+  readdir,
   realpath,
   rename,
   rm,
@@ -158,18 +159,27 @@ async function runCampaign(
       recorded !== undefined && sameMultiscanTask(recorded, task)
         ? recorded
         : undefined;
-    if (
-      receipt?.status === "completed" &&
-      receipt.outputDir ===
-        join(output, "artifacts", task.id, `attempt-${receipt.attempt}`) &&
-      (await hasArtifacts(
-        receipt.outputDir,
-        await resumePluginRoot(),
-        task,
-        options.signal,
-      ))
-    ) {
-      completed += 1;
+    if (receipt?.status === "completed") {
+      if (
+        receipt.outputDir ===
+          join(output, "artifacts", task.id, `attempt-${receipt.attempt}`) &&
+        (await hasArtifacts(
+          receipt.outputDir,
+          await resumePluginRoot(),
+          task,
+          options.signal,
+        ))
+      ) {
+        completed += 1;
+      } else {
+        pending.push({
+          task,
+          attempt:
+            receipt.attempt >= options.maxAttempts
+              ? Math.max(0, receipt.attempt - 1)
+              : receipt.attempt,
+        });
+      }
     } else if ((receipt?.attempt ?? 0) >= options.maxAttempts) {
       failed += 1;
     } else {
@@ -471,6 +481,9 @@ async function acquireLock(output: string): Promise<() => Promise<void>> {
         }
         continue;
       }
+      if (existing === null && (await hasCompetingPendingLock(output, token))) {
+        throw new Error("A multiscan supervisor is already running.");
+      }
 
       try {
         await publishLock(pending, recovery, owner);
@@ -547,6 +560,23 @@ async function acquireLock(output: string): Promise<() => Promise<void>> {
   } finally {
     await rm(pending, { force: true });
   }
+}
+
+async function hasCompetingPendingLock(
+  output: string,
+  ownToken: string,
+): Promise<boolean> {
+  for (const name of await readdir(output)) {
+    if (
+      !name.startsWith(".lock.pending-") ||
+      name === `.lock.pending-${ownToken}`
+    ) {
+      continue;
+    }
+    const owner = await readLockOwner(join(output, name));
+    if (owner !== null && processIsRunning(owner.pid)) return true;
+  }
+  return false;
 }
 
 async function publishLock(
@@ -673,6 +703,7 @@ async function readReceipts(
   signal?: AbortSignal,
 ): Promise<Map<string, MultiscanReceipt>> {
   signal?.throwIfAborted();
+  await recoverInterruptedReceiptRepair(path, signal);
   let file: FileHandle;
   try {
     file = await openReceiptLedger(path, constants.O_RDONLY);
@@ -704,6 +735,7 @@ async function readReceipts(
 
     const replacement = receiptRepairPath(path);
     let repaired: FileHandle | undefined;
+    let publishing = false;
     try {
       repaired = await open(replacement, "wx", 0o600);
       if (!initial.discardAll) {
@@ -719,16 +751,84 @@ async function readReceipts(
       repaired = undefined;
       await file.close();
       opened = undefined;
+      publishing = true;
       await publishReceiptRepair(path, replacement);
     } catch (error) {
       await repaired?.close();
-      await rm(replacement, { force: true });
+      if (!publishing) await rm(replacement, { force: true });
       throw error;
     }
     return receipts;
   } finally {
     await opened?.close();
   }
+}
+
+async function recoverInterruptedReceiptRepair(
+  path: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const candidates = (await readdir(dirname(path))).filter(
+    (name) => name.startsWith(".results.repair-") && name.endsWith(".jsonl"),
+  );
+  if (candidates.length === 0) return;
+  if (candidates.length !== 1) {
+    throw new Error(
+      "Multiple interrupted multiscan receipt repairs were found.",
+    );
+  }
+  const replacement = join(dirname(path), candidates[0]!);
+  const candidate = await openReceiptLedger(replacement, constants.O_RDONLY);
+  let replacementBytes: Buffer;
+  try {
+    if ((await candidate.stat()).size > MAX_RECEIPT_LEDGER_BYTES) {
+      throw new Error(
+        "Interrupted multiscan receipt repair exceeds its size limit.",
+      );
+    }
+    replacementBytes = await candidate.readFile();
+    const inspection = await readReceiptLines(
+      candidate,
+      signal,
+      async () => {},
+    );
+    if (inspection.corrupted) {
+      throw new Error("Interrupted multiscan receipt repair is invalid.");
+    }
+  } finally {
+    await candidate.close();
+  }
+
+  let existing: FileHandle;
+  try {
+    existing = await openReceiptLedger(path, constants.O_RDONLY);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    await rename(replacement, path);
+    return;
+  }
+  let complete = false;
+  try {
+    if ((await existing.stat()).size <= MAX_RECEIPT_LEDGER_BYTES) {
+      const bytes = await existing.readFile();
+      const inspection = await readReceiptLines(
+        existing,
+        signal,
+        async () => {},
+      );
+      complete =
+        !inspection.corrupted &&
+        bytes.length >= replacementBytes.length &&
+        bytes.subarray(0, replacementBytes.length).equals(replacementBytes);
+    }
+  } finally {
+    await existing.close();
+  }
+  if (complete) {
+    await rm(replacement, { force: true });
+    return;
+  }
+  await publishReceiptRepair(path, replacement);
 }
 
 async function readReceiptLines(
@@ -896,40 +996,35 @@ async function publishReceiptRepair(
   );
   await copyFile(path, quarantine, constants.COPYFILE_EXCL);
   try {
-    try {
-      await rename(replacement, path);
-    } catch (error) {
-      if (
-        process.platform !== "win32" ||
-        !["EPERM", "EACCES", "EEXIST"].includes(
-          (error as NodeJS.ErrnoException).code ?? "",
-        )
-      ) {
-        throw error;
-      }
-      const destination = await openReceiptLedger(path, constants.O_RDWR);
-      try {
-        const source = await open(replacement, constants.O_RDONLY);
-        try {
-          await destination.truncate(0);
-          for await (const chunk of source.createReadStream({
-            autoClose: false,
-            highWaterMark: 64 * 1024,
-          })) {
-            await destination.writeFile(chunk);
-          }
-          await destination.sync();
-        } finally {
-          await source.close();
-        }
-      } finally {
-        await destination.close();
-      }
-      await rm(replacement, { force: true });
-    }
+    await rename(replacement, path);
   } catch (error) {
+    if (
+      process.platform !== "win32" ||
+      !["EPERM", "EACCES", "EEXIST"].includes(
+        (error as NodeJS.ErrnoException).code ?? "",
+      )
+    ) {
+      throw error;
+    }
+    const destination = await openReceiptLedger(path, constants.O_RDWR);
+    try {
+      const source = await open(replacement, constants.O_RDONLY);
+      try {
+        await destination.truncate(0);
+        for await (const chunk of source.createReadStream({
+          autoClose: false,
+          highWaterMark: 64 * 1024,
+        })) {
+          await destination.writeFile(chunk);
+        }
+        await destination.sync();
+      } finally {
+        await source.close();
+      }
+    } finally {
+      await destination.close();
+    }
     await rm(replacement, { force: true });
-    throw error;
   }
 }
 
@@ -963,7 +1058,10 @@ async function hasArtifacts(
         pluginVersion: plugin.version,
       },
     });
-    return contract.coverage.completeness === "complete";
+    return (
+      contract.coverage.completeness === "complete" &&
+      contract.manifest.scan.target.kind !== "directory_snapshot"
+    );
   } catch (error) {
     if (signal?.aborted === true) signal.throwIfAborted();
     return false;
@@ -1143,12 +1241,16 @@ function parseInventoryRow(
   ) {
     throw new Error("Multiscan scope must stay inside its repository.");
   }
+  const normalizedScope = scope
+    .split("/")
+    .filter((segment) => segment !== "" && segment !== ".")
+    .join("/");
   return {
     id,
     repository: normalizeRepository(get("repository"), directory),
     revision,
     mode,
-    ...(scope ? { scope } : {}),
+    ...(normalizedScope ? { scope: normalizedScope } : {}),
   };
 }
 

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -735,10 +735,11 @@ async function readReceipts(
     if (!initial.corrupted) return receipts;
 
     const replacement = receiptRepairPath(path);
+    const pending = `${replacement}.pending`;
     let repaired: FileHandle | undefined;
     let publishing = false;
     try {
-      repaired = await open(replacement, "wx", 0o600);
+      repaired = await open(pending, "wx", 0o600);
       if (!initial.discardAll) {
         await readReceiptLines(file, signal, async (_receipt, bytes) => {
           await repaired!.write(bytes);
@@ -750,13 +751,17 @@ async function readReceipts(
       await repaired.sync();
       await repaired.close();
       repaired = undefined;
+      await rename(pending, replacement);
       await file.close();
       opened = undefined;
       publishing = true;
       await publishReceiptRepair(path, replacement);
     } catch (error) {
       await repaired?.close();
-      if (!publishing) await rm(replacement, { force: true });
+      if (!publishing) {
+        await rm(pending, { force: true });
+        await rm(replacement, { force: true });
+      }
       throw error;
     }
     return receipts;
@@ -769,7 +774,17 @@ async function recoverInterruptedReceiptRepair(
   path: string,
   signal?: AbortSignal,
 ): Promise<void> {
-  const candidates = (await readdir(dirname(path))).filter(
+  const entries = await readdir(dirname(path));
+  await Promise.all(
+    entries
+      .filter(
+        (name) =>
+          name.startsWith(".results.repair-") &&
+          name.endsWith(".jsonl.pending"),
+      )
+      .map((name) => rm(join(dirname(path), name), { force: true })),
+  );
+  const candidates = entries.filter(
     (name) => name.startsWith(".results.repair-") && name.endsWith(".jsonl"),
   );
   if (candidates.length === 0) return;
@@ -974,16 +989,18 @@ async function replaceCorruptReceiptLedger(
   writeReplacement: (file: Awaited<ReturnType<typeof open>>) => Promise<void>,
 ): Promise<void> {
   const replacement = receiptRepairPath(path);
-  const file = await open(replacement, "wx", 0o600);
+  const pending = `${replacement}.pending`;
+  const file = await open(pending, "wx", 0o600);
   try {
     await writeReplacement(file);
     await file.sync();
   } catch (error) {
     await file.close();
-    await rm(replacement, { force: true });
+    await rm(pending, { force: true });
     throw error;
   }
   await file.close();
+  await rename(pending, replacement);
   await publishReceiptRepair(path, replacement);
 }
 
@@ -1045,6 +1062,24 @@ async function hasArtifacts(
       await readFile(join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"),
     ) as { version?: unknown };
     if (typeof plugin.version !== "string") return false;
+    let canonicalScope = task.scope;
+    if (canonicalScope !== undefined) {
+      try {
+        const repository = await realpath(task.repository);
+        const selected = await realpath(join(repository, canonicalScope));
+        const relativeScope = relative(repository, selected);
+        if (
+          relativeScope === ".." ||
+          relativeScope.startsWith(`..${sep}`) ||
+          isAbsolute(relativeScope)
+        ) {
+          return false;
+        }
+        canonicalScope = relativeScope.split(sep).join("/");
+      } catch {
+        // Remote repositories cannot be inspected until a checkout exists.
+      }
+    }
     const contract = await loadContract(path, {
       pluginRoot,
       signal,
@@ -1052,9 +1087,9 @@ async function hasArtifacts(
         repository: task.repository,
         repositoryRevision: task.revision,
         target:
-          task.scope === undefined
+          canonicalScope === undefined
             ? { kind: "repository", paths: [] }
-            : { kind: "paths", paths: [task.scope] },
+            : { kind: "paths", paths: [canonicalScope] },
         mode: task.mode,
         pluginVersion: plugin.version,
       },

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -108,8 +108,9 @@ async function runCampaign(
   await ensureOutputDirectory(join(output, "artifacts"));
   await ensureManifest(join(output, "manifest.json"), tasks);
   const receipts = await readReceipts(ledger);
-  const pending: MultiscanTask[] = [];
+  const pending: Array<{ task: MultiscanTask; attempt: number }> = [];
   let completed = 0;
+  let failed = 0;
   for (const task of tasks) {
     const receipt = receipts.get(task.id.toLowerCase());
     if (
@@ -119,8 +120,10 @@ async function runCampaign(
       (await hasArtifacts(receipt.outputDir))
     ) {
       completed += 1;
+    } else if ((receipt?.attempt ?? 0) >= options.maxAttempts) {
+      failed += 1;
     } else {
-      pending.push(task);
+      pending.push({ task, attempt: receipt?.attempt ?? 0 });
     }
   }
   const skipped = completed;
@@ -128,23 +131,23 @@ async function runCampaign(
     return {
       total: tasks.length,
       completed,
-      failed: 0,
+      failed,
       skipped,
       resultsPath: ledger,
     };
   }
 
   let next = 0;
-  let failed = 0;
   const worker = async (
     security: Pick<CodexSecurity, "run" | "close">,
   ): Promise<void> => {
     for (;;) {
       options.signal?.throwIfAborted();
-      const task = pending[next++];
-      if (task === undefined) return;
-      let attempt = receipts.get(task.id.toLowerCase())?.attempt ?? 0;
-      for (let retry = 0; retry < options.maxAttempts; retry += 1) {
+      const pendingTask = pending[next++];
+      if (pendingTask === undefined) return;
+      const { task } = pendingTask;
+      let { attempt } = pendingTask;
+      while (attempt < options.maxAttempts) {
         options.signal?.throwIfAborted();
         attempt += 1;
         const checkout = join(output, "checkouts", task.id);
@@ -216,7 +219,7 @@ async function runCampaign(
           completed += 1;
           break;
         }
-        if (retry === options.maxAttempts - 1) failed += 1;
+        if (attempt === options.maxAttempts) failed += 1;
       }
     }
   };

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -222,7 +222,8 @@ async function runCampaign(
         let failure: string | undefined;
         let cost: Readonly<ScanCost> | null = null;
         try {
-          await mkdir(dirname(scanDir), { recursive: true, mode: 0o700 });
+          await ensureOutputDirectory(dirname(scanDir));
+          await rm(scanDir, { recursive: true, force: true });
           await rm(checkout, { recursive: true, force: true });
           await mkdir(checkout, { mode: 0o700 });
           await checkoutRevision(

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -245,7 +245,7 @@ async function runCampaign(
             ) {
               throw new Error("Multiscan scope escapes its repository.");
             }
-            canonicalScope = outside.split(sep).join("/");
+            canonicalScope = outside.split(sep).join("/") || ".";
           }
           const result = await security.run(checkout, {
             ...(task.scope === undefined ? {} : { target: [task.scope] }),
@@ -256,6 +256,13 @@ async function runCampaign(
           cost = result.cost;
           if (result.coverage.completeness !== "complete") {
             throw new Error("Multiscan repository coverage is incomplete.");
+          }
+          if (canonicalScope !== undefined && canonicalScope !== task.scope) {
+            await writeFile(
+              join(scanDir, ".multiscan-scope.json"),
+              `${JSON.stringify({ scope: task.scope, canonicalScope })}\n`,
+              { flag: "wx", mode: 0o600 },
+            );
           }
         } catch (error) {
           if (options.signal?.aborted === true) options.signal.throwIfAborted();
@@ -1089,9 +1096,26 @@ async function hasArtifacts(
         ) {
           return false;
         }
-        canonicalScope = relativeScope.split(sep).join("/");
+        canonicalScope = relativeScope.split(sep).join("/") || ".";
       } catch {
         if (recordedCanonicalScope !== undefined) {
+          if (recordedCanonicalScope !== canonicalScope) {
+            const bindingPath = join(path, ".multiscan-scope.json");
+            const bindingMetadata = await lstat(bindingPath);
+            if (!bindingMetadata.isFile() || bindingMetadata.nlink !== 1) {
+              return false;
+            }
+            const binding = JSON.parse(await readFile(bindingPath, "utf8")) as {
+              scope?: unknown;
+              canonicalScope?: unknown;
+            };
+            if (
+              binding.scope !== task.scope ||
+              binding.canonicalScope !== recordedCanonicalScope
+            ) {
+              return false;
+            }
+          }
           canonicalScope = recordedCanonicalScope;
         }
       }

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { constants } from "node:fs";
 import {
   type FileHandle,
+  link,
   lstat,
   mkdir,
   open,
@@ -30,6 +31,12 @@ const REQUIRED_ARTIFACTS = [
   "coverage.json",
   "report.md",
 ];
+const MAX_LOCK_OWNER_BYTES = 4 * 1024;
+
+interface MultiscanLockOwner {
+  pid: number;
+  token?: string;
+}
 
 interface MultiscanTask {
   id: string;
@@ -366,30 +373,132 @@ async function openReceiptLedger(
 
 async function acquireLock(output: string): Promise<() => Promise<void>> {
   const path = join(output, ".lock");
-  const ownerPath = join(path, "owner.json");
+  const token = randomUUID();
+  const pending = join(output, `.lock.pending-${token}`);
+  const owner = `${JSON.stringify({ pid: process.pid, token })}\n`;
+  const file = await open(pending, "wx", 0o600);
   try {
-    await mkdir(path, { mode: 0o700 });
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-    const { pid } = JSON.parse(await readFile(ownerPath, "utf8")) as {
-      pid: number;
-    };
-    try {
-      process.kill(pid, 0);
-      throw new Error("A multiscan supervisor is already running.");
-    } catch (failure) {
-      if ((failure as NodeJS.ErrnoException).code !== "ESRCH") throw failure;
-    }
-    const stale = join(output, `.lock.stale-${randomUUID()}`);
-    await rename(path, stale);
-    await rm(stale, { recursive: true });
-    return await acquireLock(output);
+    await file.writeFile(owner, "utf8");
+    await file.sync();
+  } finally {
+    await file.close();
   }
-  await writeFile(ownerPath, `${JSON.stringify({ pid: process.pid })}\n`, {
-    flag: "wx",
-    mode: 0o600,
-  });
-  return async () => rm(path, { recursive: true });
+
+  try {
+    for (;;) {
+      try {
+        await link(pending, path);
+        return async () => await releaseLock(path, token);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      }
+
+      const existing = await readLockOwner(path);
+      if (existing !== null && processIsRunning(existing.pid)) {
+        const current = await readLockOwner(path);
+        if (
+          current !== null &&
+          current.pid === existing.pid &&
+          current.token === existing.token
+        ) {
+          throw new Error("A multiscan supervisor is already running.");
+        }
+        continue;
+      }
+
+      const stale = join(output, `.lock.stale-${randomUUID()}`);
+      try {
+        await rename(path, stale);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+        throw error;
+      }
+      const moved = await readLockOwner(stale);
+      if (moved !== null && processIsRunning(moved.pid)) {
+        try {
+          await rename(stale, path);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+        }
+        throw new Error("A multiscan supervisor is already running.");
+      }
+      await rm(stale, { recursive: true, force: true });
+    }
+  } finally {
+    await rm(pending, { force: true });
+  }
+}
+
+async function readLockOwner(path: string): Promise<MultiscanLockOwner | null> {
+  let metadata;
+  try {
+    metadata = await lstat(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  let ownerPath = path;
+  if (metadata.isDirectory()) {
+    ownerPath = join(path, "owner.json");
+    try {
+      metadata = await lstat(ownerPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw error;
+    }
+  }
+  if (
+    !metadata.isFile() ||
+    metadata.isSymbolicLink() ||
+    metadata.size > MAX_LOCK_OWNER_BYTES
+  ) {
+    return null;
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(await readFile(ownerPath, "utf8"));
+  } catch (error) {
+    if (
+      error instanceof SyntaxError ||
+      (error as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return null;
+    }
+    throw error;
+  }
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("pid" in value) ||
+    !Number.isSafeInteger(value.pid) ||
+    (value.pid as number) <= 0 ||
+    ("token" in value && typeof value.token !== "string")
+  ) {
+    return null;
+  }
+  return {
+    pid: value.pid as number,
+    ...("token" in value ? { token: value.token as string } : {}),
+  };
+}
+
+function processIsRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ESRCH") return false;
+    if (code === "EPERM") return true;
+    throw error;
+  }
+}
+
+async function releaseLock(path: string, token: string): Promise<void> {
+  const owner = await readLockOwner(path);
+  if (owner?.token === token) {
+    await rm(path, { force: true });
+  }
 }
 
 async function ensureManifest(

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -1,5 +1,5 @@
 import { execFile as execFileCallback } from "node:child_process";
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { constants, createReadStream } from "node:fs";
 import {
   type FileHandle,
@@ -256,34 +256,6 @@ async function runCampaign(
           cost = result.cost;
           if (result.coverage.completeness !== "complete") {
             throw new Error("Multiscan repository coverage is incomplete.");
-          }
-          if (canonicalScope !== undefined && canonicalScope !== task.scope) {
-            const binding = `${JSON.stringify({ scope: task.scope, canonicalScope })}\n`;
-            const bindingName = ".multiscan-scope.json";
-            await writeFile(join(scanDir, bindingName), binding, {
-              flag: "wx",
-              mode: 0o600,
-            });
-            const manifestPath = join(scanDir, "scan-manifest.json");
-            const manifest = JSON.parse(
-              await readFile(manifestPath, "utf8"),
-            ) as {
-              scan?: { artifacts?: Array<Record<string, unknown>> };
-            };
-            if (!Array.isArray(manifest.scan?.artifacts)) {
-              throw new Error(
-                "Multiscan scope cannot be bound to an unsealed scan.",
-              );
-            }
-            manifest.scan.artifacts.push({
-              path: bindingName,
-              sha256: createHash("sha256").update(binding).digest("hex"),
-              mediaType: "application/json",
-            });
-            await writeFile(
-              manifestPath,
-              `${JSON.stringify(manifest, null, 2)}\n`,
-            );
           }
         } catch (error) {
           if (options.signal?.aborted === true) options.signal.throwIfAborted();
@@ -1120,23 +1092,7 @@ async function hasArtifacts(
         canonicalScope = relativeScope.split(sep).join("/") || ".";
       } catch {
         if (recordedCanonicalScope !== undefined) {
-          if (recordedCanonicalScope !== canonicalScope) {
-            const bindingPath = join(path, ".multiscan-scope.json");
-            const bindingMetadata = await lstat(bindingPath);
-            if (!bindingMetadata.isFile() || bindingMetadata.nlink !== 1) {
-              return false;
-            }
-            const binding = JSON.parse(await readFile(bindingPath, "utf8")) as {
-              scope?: unknown;
-              canonicalScope?: unknown;
-            };
-            if (
-              binding.scope !== task.scope ||
-              binding.canonicalScope !== recordedCanonicalScope
-            ) {
-              return false;
-            }
-          }
+          if (recordedCanonicalScope !== canonicalScope) return false;
           canonicalScope = recordedCanonicalScope;
         }
       }
@@ -1155,15 +1111,6 @@ async function hasArtifacts(
         pluginVersion: plugin.version,
       },
     });
-    if (
-      recordedCanonicalScope !== undefined &&
-      recordedCanonicalScope !== task.scope &&
-      !contract.manifest.scan.artifacts.some(
-        (artifact) => artifact.path === ".multiscan-scope.json",
-      )
-    ) {
-      return false;
-    }
     return (
       contract.coverage.completeness === "complete" &&
       contract.manifest.scan.target.kind !== "directory_snapshot"

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -12,7 +12,6 @@ import {
   rename,
   rm,
   stat,
-  truncate,
   writeFile,
 } from "node:fs/promises";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
@@ -40,6 +39,9 @@ const REQUIRED_ARTIFACTS = [
   "report.md",
 ];
 const MAX_LOCK_OWNER_BYTES = 4 * 1024;
+const MAX_RECEIPT_LEDGER_BYTES = 64 * 1024 * 1024;
+const MAX_RECEIPT_LINE_BYTES = 1024 * 1024;
+const MAX_RECEIPT_ERROR_BYTES = 64 * 1024;
 
 interface MultiscanLockOwner {
   pid: number;
@@ -144,7 +146,7 @@ async function runCampaign(
   await ensureOutputDirectory(join(output, "checkouts"));
   await ensureOutputDirectory(join(output, "artifacts"));
   await ensureManifest(join(output, "manifest.json"), tasks);
-  const receipts = await readReceipts(ledger);
+  const receipts = await readReceipts(ledger, options.signal);
   const pending: Array<{ task: MultiscanTask; attempt: number }> = [];
   let completed = 0;
   let failed = 0;
@@ -300,6 +302,9 @@ async function ensureOutputDirectory(path: string): Promise<void> {
 }
 
 async function appendReceipt(path: string, receipt: string): Promise<void> {
+  if (Buffer.byteLength(receipt) > MAX_RECEIPT_LINE_BYTES) {
+    throw new Error("Multiscan receipt exceeds the 1 MiB safety limit.");
+  }
   const file = await openReceiptLedger(
     path,
     constants.O_WRONLY | constants.O_APPEND | constants.O_CREAT,
@@ -563,7 +568,9 @@ async function ensureManifest(
 
 async function readReceipts(
   path: string,
+  signal?: AbortSignal,
 ): Promise<Map<string, MultiscanReceipt>> {
+  signal?.throwIfAborted();
   let file: FileHandle;
   try {
     file = await openReceiptLedger(path, constants.O_RDONLY);
@@ -571,34 +578,219 @@ async function readReceipts(
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return new Map();
     throw error;
   }
+  signal?.throwIfAborted();
+  const metadata = await file.stat();
+  if (!metadata.isFile() || metadata.isSymbolicLink()) {
+    await file.close();
+    throw new Error(
+      "Multiscan receipt ledger must be a regular file. Move results.jsonl aside before resuming.",
+    );
+  }
+  if (metadata.size > MAX_RECEIPT_LEDGER_BYTES) {
+    await file.close();
+    await replaceCorruptReceiptLedger(path, async () => {});
+    return new Map();
+  }
+
+  const receipts = new Map<string, MultiscanReceipt>();
+  const replacement = receiptRepairPath(path);
+  const repaired = await open(replacement, "wx", 0o600);
+  let corrupted = false;
+  let discardAll = false;
   try {
-    const contents = await file.readFile("utf8");
-    const lines = contents.split("\n");
-    if (!contents.endsWith("\n")) {
-      const partial = lines.pop()!;
-      const repair = await openReceiptLedger(path, constants.O_RDWR);
-      try {
-        if ((await repair.readFile("utf8")) !== contents) {
-          throw new Error(
-            "Multiscan results ledger changed during interrupted receipt repair.",
-          );
+    const pending = Buffer.alloc(MAX_RECEIPT_LINE_BYTES);
+    let pendingBytes = 0;
+    let discardingLine = false;
+    let totalBytes = 0;
+    const acceptLine = async (bytes: Buffer): Promise<void> => {
+      if (bytes.length === 0) return;
+      const receipt = parseMultiscanReceipt(bytes);
+      if (receipt === null) {
+        corrupted = true;
+        return;
+      }
+      await repaired.write(bytes);
+      await repaired.write("\n");
+      receipts.set(receipt.id.toLowerCase(), receipt);
+    };
+
+    const input = file.createReadStream({
+      autoClose: false,
+      highWaterMark: 64 * 1024,
+      ...(signal === undefined ? {} : { signal }),
+    });
+    for await (const rawChunk of input) {
+      signal?.throwIfAborted();
+      const chunk = Buffer.isBuffer(rawChunk)
+        ? rawChunk
+        : Buffer.from(rawChunk);
+      totalBytes += chunk.length;
+      if (totalBytes > MAX_RECEIPT_LEDGER_BYTES) {
+        corrupted = true;
+        discardAll = true;
+        receipts.clear();
+        break;
+      }
+
+      let start = 0;
+      while (start < chunk.length) {
+        signal?.throwIfAborted();
+        const newline = chunk.indexOf(0x0a, start);
+        const end = newline === -1 ? chunk.length : newline;
+        const segment = chunk.subarray(start, end);
+        if (!discardingLine) {
+          if (pendingBytes + segment.length > MAX_RECEIPT_LINE_BYTES) {
+            corrupted = true;
+            discardingLine = true;
+            pendingBytes = 0;
+          } else if (segment.length > 0) {
+            segment.copy(pending, pendingBytes);
+            pendingBytes += segment.length;
+          }
         }
-        await repair.truncate(
-          Buffer.byteLength(contents) - Buffer.byteLength(partial),
-        );
-        await repair.sync();
-      } finally {
-        await repair.close();
+        if (newline === -1) break;
+        if (!discardingLine) {
+          await acceptLine(pending.subarray(0, pendingBytes));
+        }
+        pendingBytes = 0;
+        discardingLine = false;
+        start = newline + 1;
       }
     }
-    return new Map(
-      lines.filter(Boolean).map((line): [string, MultiscanReceipt] => {
-        const receipt = JSON.parse(line) as MultiscanReceipt;
-        return [receipt.id.toLowerCase(), receipt];
-      }),
-    );
-  } finally {
+    signal?.throwIfAborted();
+    if (discardAll) {
+      await repaired.truncate(0);
+    } else if (discardingLine || pendingBytes > 0) {
+      corrupted = true;
+    }
+    await repaired.sync();
+  } catch (error) {
     await file.close();
+    await repaired.close();
+    await rm(replacement, { force: true });
+    throw error;
+  }
+  await file.close();
+  await repaired.close();
+
+  if (!corrupted) {
+    await rm(replacement, { force: true });
+    return receipts;
+  }
+  await publishReceiptRepair(path, replacement);
+  return receipts;
+}
+
+function parseMultiscanReceipt(bytes: Buffer): MultiscanReceipt | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+  } catch {
+    return null;
+  }
+  if (!isRecord(value)) return null;
+  const scope = value["scope"];
+  const cost = value["cost"];
+  const error = value["error"];
+  if (
+    typeof value["id"] !== "string" ||
+    !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u.test(value["id"]) ||
+    typeof value["repository"] !== "string" ||
+    value["repository"].length === 0 ||
+    value["repository"].length > 4096 ||
+    value["repository"].includes("\0") ||
+    typeof value["revision"] !== "string" ||
+    !/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u.test(value["revision"]) ||
+    (value["mode"] !== "standard" && value["mode"] !== "deep") ||
+    (scope !== undefined &&
+      (typeof scope !== "string" ||
+        scope.length > 4096 ||
+        isAbsolute(scope) ||
+        scope.includes("\\") ||
+        scope.split("/").includes("..") ||
+        scope.includes("\0"))) ||
+    (value["status"] !== "completed" && value["status"] !== "failed") ||
+    !Number.isSafeInteger(value["attempt"]) ||
+    (value["attempt"] as number) < 1 ||
+    typeof value["outputDir"] !== "string" ||
+    value["outputDir"].length === 0 ||
+    value["outputDir"].length > 4096 ||
+    !isAbsolute(value["outputDir"]) ||
+    value["outputDir"].includes("\0") ||
+    (cost !== undefined && !isScanCost(cost)) ||
+    (error !== undefined && typeof error !== "string")
+  ) {
+    return null;
+  }
+  return value as unknown as MultiscanReceipt;
+}
+
+function isScanCost(value: unknown): value is ScanCost {
+  if (
+    !isRecord(value) ||
+    typeof value["model"] !== "string" ||
+    value["model"].length === 0 ||
+    value["model"].length > 256
+  ) {
+    return false;
+  }
+  for (const name of [
+    "inputTokens",
+    "cachedInputTokens",
+    "cacheWriteInputTokens",
+    "outputTokens",
+  ]) {
+    const count = value[name];
+    if (!Number.isSafeInteger(count) || (count as number) < 0) return false;
+  }
+  return (
+    typeof value["estimatedUsd"] === "number" &&
+    Number.isFinite(value["estimatedUsd"]) &&
+    value["estimatedUsd"] >= 0
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function receiptRepairPath(path: string): string {
+  return join(dirname(path), `.results.repair-${randomUUID()}.jsonl`);
+}
+
+async function replaceCorruptReceiptLedger(
+  path: string,
+  writeReplacement: (file: Awaited<ReturnType<typeof open>>) => Promise<void>,
+): Promise<void> {
+  const replacement = receiptRepairPath(path);
+  const file = await open(replacement, "wx", 0o600);
+  try {
+    await writeReplacement(file);
+    await file.sync();
+  } catch (error) {
+    await file.close();
+    await rm(replacement, { force: true });
+    throw error;
+  }
+  await file.close();
+  await publishReceiptRepair(path, replacement);
+}
+
+async function publishReceiptRepair(
+  path: string,
+  replacement: string,
+): Promise<void> {
+  const quarantine = join(
+    dirname(path),
+    `results.corrupt-${randomUUID()}.jsonl`,
+  );
+  await rename(path, quarantine);
+  try {
+    await rename(replacement, path);
+  } catch (error) {
+    await rename(quarantine, path).catch(() => undefined);
+    await rm(replacement, { force: true });
+    throw error;
   }
 }
 
@@ -774,7 +966,8 @@ function parseInventoryRow(
   const scope = get("scope");
   if (
     scope &&
-    (isAbsolute(scope) ||
+    (scope.length > 4096 ||
+      isAbsolute(scope) ||
       scope.includes("\\") ||
       scope.split("/").includes("..") ||
       scope.includes("\0"))
@@ -902,7 +1095,7 @@ export function buildGitHubCredentialArgs(host: string | undefined): string[] {
 }
 
 function redactError(error: unknown): string {
-  return (error instanceof Error ? error.message : String(error))
+  const redacted = (error instanceof Error ? error.message : String(error))
     .replaceAll(
       /((?:api[_-]?key|token|secret|credential|password)[A-Za-z0-9_-]*\s*[:=]\s*)[^\s,;]+/giu,
       "$1[redacted]",
@@ -912,4 +1105,8 @@ function redactError(error: unknown): string {
       "[redacted]",
     )
     .replaceAll(/\b(Bearer|Basic|Token)\s+[^\s,;]+/giu, "$1 [redacted]");
+  const bytes = Buffer.from(redacted);
+  return bytes.length <= MAX_RECEIPT_ERROR_BYTES
+    ? redacted
+    : `${bytes.subarray(0, MAX_RECEIPT_ERROR_BYTES).toString("utf8")}[truncated]`;
 }

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -373,6 +373,7 @@ async function openReceiptLedger(
 
 async function acquireLock(output: string): Promise<() => Promise<void>> {
   const path = join(output, ".lock");
+  const recovery = join(output, ".lock.recovery");
   const token = randomUUID();
   const pending = join(output, `.lock.pending-${token}`);
   const owner = `${JSON.stringify({ pid: process.pid, token })}\n`;
@@ -388,6 +389,15 @@ async function acquireLock(output: string): Promise<() => Promise<void>> {
     for (;;) {
       try {
         await link(pending, path);
+        const recovering = await readLockOwner(recovery);
+        if (
+          recovering !== null &&
+          recovering.token !== token &&
+          processIsRunning(recovering.pid)
+        ) {
+          await releaseLock(path, token);
+          throw new Error("A multiscan supervisor is already running.");
+        }
         return async () => await releaseLock(path, token);
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
@@ -406,38 +416,47 @@ async function acquireLock(output: string): Promise<() => Promise<void>> {
         continue;
       }
 
-      const stale = join(output, `.lock.stale-${randomUUID()}`);
       try {
-        await rename(path, stale);
+        await link(pending, recovery);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+        const recovering = await readLockOwner(recovery);
+        if (recovering !== null && processIsRunning(recovering.pid)) {
+          throw new Error("A multiscan supervisor is already running.");
+        }
+        await rm(recovery, { force: true });
+        continue;
+      }
+      try {
+        const current = await readLockOwner(path);
+        if (current !== null && processIsRunning(current.pid)) {
+          throw new Error("A multiscan supervisor is already running.");
+        }
+        const metadata = await lstat(path).catch((error: unknown) => {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+          throw error;
+        });
+        if (metadata === null) continue;
+        if (metadata.isDirectory()) {
+          const stale = join(output, `.lock.stale-${randomUUID()}`);
+          await rename(path, stale);
+          try {
+            await rename(pending, path);
+          } finally {
+            await rm(stale, { recursive: true, force: true });
+          }
+        } else {
+          // Replace the stale regular lock atomically: the occupied lock name
+          // is never absent while another supervisor may be running.
+          await rename(pending, path);
+        }
+        return async () => await releaseLock(path, token);
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
         throw error;
+      } finally {
+        await releaseLock(recovery, token);
       }
-      const moved = await readLockOwner(stale);
-      if (moved !== null && processIsRunning(moved.pid)) {
-        try {
-          const metadata = await lstat(stale);
-          if (metadata.isDirectory()) {
-            await rename(stale, path);
-          } else {
-            await link(stale, path);
-          }
-        } catch (error) {
-          const code = (error as NodeJS.ErrnoException).code;
-          if (
-            code !== "EEXIST" &&
-            code !== "EISDIR" &&
-            code !== "ENOTDIR" &&
-            code !== "ENOTEMPTY"
-          ) {
-            throw error;
-          }
-        } finally {
-          await rm(stale, { recursive: true, force: true });
-        }
-        throw new Error("A multiscan supervisor is already running.");
-      }
-      await rm(stale, { recursive: true, force: true });
     }
   } finally {
     await rm(pending, { force: true });

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -168,9 +168,23 @@ async function runCampaign(
         ? recorded
         : undefined;
     if (receipt?.status === "completed") {
+      const expectedOutput = join(
+        output,
+        "artifacts",
+        task.id,
+        `attempt-${receipt.attempt}`,
+      );
+      const matchesOutput =
+        receipt.outputDir === expectedOutput ||
+        (await Promise.all([
+          realpath(receipt.outputDir).catch(() => undefined),
+          realpath(expectedOutput).catch(() => undefined),
+        ]).then(
+          ([recorded, expected]) =>
+            recorded !== undefined && recorded === expected,
+        ));
       if (
-        receipt.outputDir ===
-          join(output, "artifacts", task.id, `attempt-${receipt.attempt}`) &&
+        matchesOutput &&
         (await hasArtifacts(
           receipt.outputDir,
           await resumePluginRoot(),

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -65,6 +65,7 @@ interface MultiscanReceipt extends MultiscanTask {
   outputDir: string;
   cost?: ScanCost;
   error?: string;
+  canonicalScope?: string;
 }
 
 export interface MultiscanOptions {
@@ -167,6 +168,7 @@ async function runCampaign(
           receipt.outputDir,
           await resumePluginRoot(),
           task,
+          receipt.canonicalScope,
           options.signal,
         ))
       ) {
@@ -221,6 +223,7 @@ async function runCampaign(
         options.onProgress?.({ ...progress, status: "started" });
         let failure: string | undefined;
         let cost: Readonly<ScanCost> | null = null;
+        let canonicalScope: string | undefined;
         try {
           await ensureOutputDirectory(dirname(scanDir));
           await rm(scanDir, { recursive: true, force: true });
@@ -242,6 +245,7 @@ async function runCampaign(
             ) {
               throw new Error("Multiscan scope escapes its repository.");
             }
+            canonicalScope = outside.split(sep).join("/");
           }
           const result = await security.run(checkout, {
             ...(task.scope === undefined ? {} : { target: [task.scope] }),
@@ -267,6 +271,7 @@ async function runCampaign(
             status,
             attempt,
             outputDir: scanDir,
+            ...(canonicalScope === undefined ? {} : { canonicalScope }),
             ...(cost === null ? {} : { cost }),
             ...(failure === undefined ? {} : { error: failure }),
           })}\n`,
@@ -916,6 +921,7 @@ function parseMultiscanReceipt(bytes: Buffer): MultiscanReceipt | null {
   }
   if (!isRecord(value)) return null;
   const scope = value["scope"];
+  const canonicalScope = value["canonicalScope"];
   const cost = value["cost"];
   const error = value["error"];
   if (
@@ -935,6 +941,13 @@ function parseMultiscanReceipt(bytes: Buffer): MultiscanReceipt | null {
         scope.includes("\\") ||
         scope.split("/").includes("..") ||
         scope.includes("\0"))) ||
+    (canonicalScope !== undefined &&
+      (typeof canonicalScope !== "string" ||
+        canonicalScope.length > 4096 ||
+        isAbsolute(canonicalScope) ||
+        canonicalScope.includes("\\") ||
+        canonicalScope.split("/").includes("..") ||
+        canonicalScope.includes("\0"))) ||
     (value["status"] !== "completed" && value["status"] !== "failed") ||
     !Number.isSafeInteger(value["attempt"]) ||
     (value["attempt"] as number) < 1 ||
@@ -1050,6 +1063,7 @@ async function hasArtifacts(
   path: string,
   pluginRoot: string,
   task: MultiscanTask,
+  recordedCanonicalScope?: string,
   signal?: AbortSignal,
 ): Promise<boolean> {
   try {
@@ -1077,7 +1091,9 @@ async function hasArtifacts(
         }
         canonicalScope = relativeScope.split(sep).join("/");
       } catch {
-        // Remote repositories cannot be inspected until a checkout exists.
+        if (recordedCanonicalScope !== undefined) {
+          canonicalScope = recordedCanonicalScope;
+        }
       }
     }
     const contract = await loadContract(path, {

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -3,7 +3,6 @@ import { randomUUID } from "node:crypto";
 import { constants, createReadStream } from "node:fs";
 import {
   type FileHandle,
-  copyFile,
   link,
   lstat,
   mkdir,
@@ -765,10 +764,9 @@ async function readReceipts(
       await repaired.close();
       repaired = undefined;
       await rename(pending, replacement);
-      await file.close();
       opened = undefined;
       publishing = true;
-      await publishReceiptRepair(path, replacement);
+      await publishReceiptRepair(path, replacement, file);
     } catch (error) {
       await repaired?.close();
       if (!publishing) {
@@ -1028,12 +1026,34 @@ async function replaceCorruptReceiptLedger(
 async function publishReceiptRepair(
   path: string,
   replacement: string,
+  verifiedSource?: FileHandle,
 ): Promise<void> {
   const quarantine = join(
     dirname(path),
     `results.corrupt-${randomUUID()}.jsonl`,
   );
-  await copyFile(path, quarantine, constants.COPYFILE_EXCL);
+  const source =
+    verifiedSource ?? (await openReceiptLedger(path, constants.O_RDONLY));
+  let destination: FileHandle | undefined;
+  try {
+    destination = await open(quarantine, "wx", 0o600);
+    for await (const chunk of source.createReadStream({
+      autoClose: false,
+      start: 0,
+      highWaterMark: 64 * 1024,
+    })) {
+      await destination.writeFile(chunk);
+    }
+    await destination.sync();
+  } catch (error) {
+    await destination?.close();
+    destination = undefined;
+    await rm(quarantine, { force: true });
+    throw error;
+  } finally {
+    await destination?.close();
+    await source.close();
+  }
   try {
     await rename(replacement, path);
   } catch (error) {
@@ -1094,6 +1114,24 @@ async function hasArtifacts(
           canonicalScope,
           signal,
         );
+        if (
+          recordedCanonicalScope !== undefined &&
+          canonicalScope !== recordedCanonicalScope
+        ) {
+          for (const followsSymbolicLinks of [true, false]) {
+            const alternateScope = await pinnedMultiscanScope(
+              repository,
+              task.revision,
+              task.scope!,
+              signal,
+              followsSymbolicLinks,
+            );
+            if (alternateScope === recordedCanonicalScope) {
+              canonicalScope = alternateScope;
+              break;
+            }
+          }
+        }
       } catch {
         if (recordedCanonicalScope !== undefined) {
           if (recordedCanonicalScope !== canonicalScope) return false;
@@ -1130,6 +1168,7 @@ async function pinnedMultiscanScope(
   revision: string,
   scope: string,
   signal?: AbortSignal,
+  materializesSymbolicLinks?: boolean,
 ): Promise<string> {
   const environment: NodeJS.ProcessEnv = {
     ...process.env,
@@ -1166,7 +1205,8 @@ async function pinnedMultiscanScope(
     ],
     { env: command.environment, signal, maxBuffer: 64 * 1024 },
   );
-  const followsSymbolicLinks = symlinkConfiguration.stdout.trim() !== "false";
+  const followsSymbolicLinks =
+    materializesSymbolicLinks ?? symlinkConfiguration.stdout.trim() !== "false";
   let selected = posix.normalize(scope);
   for (let followed = 0; followed <= 40; followed += 1) {
     if (selected === ".") return selected;
@@ -1192,7 +1232,7 @@ async function pinnedMultiscanScope(
         { env: command.environment, signal, maxBuffer: 1024 * 1024 },
       );
       const matched =
-        /^(\d{6}) (blob|tree) ([a-f0-9]{40,64})\t([^\0]+)\0$/u.exec(
+        /^(\d{6}) (blob|tree|commit) ([a-f0-9]{40,64})\t([^\0]+)\0$/u.exec(
           listed.stdout,
         );
       let entry =
@@ -1221,7 +1261,7 @@ async function pinnedMultiscanScope(
         );
         const candidates = [
           ...listed.stdout.matchAll(
-            /(\d{6}) (blob|tree) ([a-f0-9]{40,64})\t([^\0]+)\0/gu,
+            /(\d{6}) (blob|tree|commit) ([a-f0-9]{40,64})\t([^\0]+)\0/gu,
           ),
         ].filter(
           (match) =>

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { constants, createReadStream } from "node:fs";
 import {
   type FileHandle,
+  copyFile,
   link,
   lstat,
   mkdir,
@@ -42,6 +43,7 @@ const MAX_LOCK_OWNER_BYTES = 4 * 1024;
 const MAX_RECEIPT_LEDGER_BYTES = 64 * 1024 * 1024;
 const MAX_RECEIPT_LINE_BYTES = 1024 * 1024;
 const MAX_RECEIPT_ERROR_BYTES = 64 * 1024;
+const pendingReceiptAppends = new Map<string, Promise<void>>();
 
 interface MultiscanLockOwner {
   pid: number;
@@ -151,7 +153,11 @@ async function runCampaign(
   let completed = 0;
   let failed = 0;
   for (const task of tasks) {
-    const receipt = receipts.get(task.id.toLowerCase());
+    const recorded = receipts.get(task.id.toLowerCase());
+    const receipt =
+      recorded !== undefined && sameMultiscanTask(recorded, task)
+        ? recorded
+        : undefined;
     if (
       receipt?.status === "completed" &&
       receipt.outputDir ===
@@ -159,6 +165,7 @@ async function runCampaign(
       (await hasArtifacts(
         receipt.outputDir,
         await resumePluginRoot(),
+        task,
         options.signal,
       ))
     ) {
@@ -302,19 +309,54 @@ async function ensureOutputDirectory(path: string): Promise<void> {
 }
 
 async function appendReceipt(path: string, receipt: string): Promise<void> {
-  if (Buffer.byteLength(receipt) > MAX_RECEIPT_LINE_BYTES) {
+  const receiptBytes = Buffer.byteLength(receipt);
+  if (receiptBytes > MAX_RECEIPT_LINE_BYTES) {
     throw new Error("Multiscan receipt exceeds the 1 MiB safety limit.");
   }
-  const file = await openReceiptLedger(
-    path,
-    constants.O_WRONLY | constants.O_APPEND | constants.O_CREAT,
-  );
+  const preceding = pendingReceiptAppends.get(path) ?? Promise.resolve();
+  const append = preceding
+    .catch(() => undefined)
+    .then(async () => {
+      const file = await openReceiptLedger(
+        path,
+        constants.O_WRONLY | constants.O_APPEND | constants.O_CREAT,
+      );
+      try {
+        if (
+          (await file.stat()).size + receiptBytes >
+          MAX_RECEIPT_LEDGER_BYTES
+        ) {
+          throw new Error(
+            "Multiscan receipt ledger exceeds the 64 MiB safety limit.",
+          );
+        }
+        await file.writeFile(receipt, "utf8");
+        await file.sync();
+      } finally {
+        await file.close();
+      }
+    });
+  pendingReceiptAppends.set(path, append);
   try {
-    await file.writeFile(receipt, "utf8");
-    await file.sync();
+    await append;
   } finally {
-    await file.close();
+    if (pendingReceiptAppends.get(path) === append) {
+      pendingReceiptAppends.delete(path);
+    }
   }
+}
+
+function sameMultiscanTask(
+  receipt: MultiscanReceipt,
+  task: MultiscanTask,
+): boolean {
+  return (
+    receipt.id.toLowerCase() === task.id.toLowerCase() &&
+    receipt.repository === task.repository &&
+    receipt.revision === task.revision &&
+    receipt.mode === task.mode &&
+    receipt.scope === task.scope
+  );
 }
 
 async function openReceiptLedger(
@@ -402,7 +444,7 @@ async function acquireLock(output: string): Promise<() => Promise<void>> {
   try {
     for (;;) {
       try {
-        await link(pending, path);
+        await publishLock(pending, path, owner);
         const recovering = await readLockOwner(recovery);
         if (
           recovering !== null &&
@@ -431,17 +473,43 @@ async function acquireLock(output: string): Promise<() => Promise<void>> {
       }
 
       try {
-        await link(pending, recovery);
+        await publishLock(pending, recovery, owner);
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
         const recovering = await readLockOwner(recovery);
         if (recovering !== null && processIsRunning(recovering.pid)) {
           throw new Error("A multiscan supervisor is already running.");
         }
-        await rm(recovery, { force: true });
+        const stale = join(output, `.lock.recovery.stale-${randomUUID()}`);
+        try {
+          await rename(recovery, stale);
+        } catch (renameError) {
+          if ((renameError as NodeJS.ErrnoException).code === "ENOENT") {
+            continue;
+          }
+          throw renameError;
+        }
+        try {
+          const moved = await readLockOwner(stale);
+          if (moved !== null && processIsRunning(moved.pid)) {
+            try {
+              await publishLock(stale, recovery, `${JSON.stringify(moved)}\n`);
+            } catch (restoreError) {
+              if ((restoreError as NodeJS.ErrnoException).code !== "EEXIST") {
+                throw restoreError;
+              }
+            }
+            throw new Error("A multiscan supervisor is already running.");
+          }
+        } finally {
+          await rm(stale, { force: true });
+        }
         continue;
       }
       try {
+        if ((await readLockOwner(recovery))?.token !== token) {
+          throw new Error("A multiscan supervisor is already running.");
+        }
         const current = await readLockOwner(path);
         if (current !== null && processIsRunning(current.pid)) {
           throw new Error("A multiscan supervisor is already running.");
@@ -464,6 +532,10 @@ async function acquireLock(output: string): Promise<() => Promise<void>> {
           // is never absent while another supervisor may be running.
           await rename(pending, path);
         }
+        if ((await readLockOwner(recovery))?.token !== token) {
+          await releaseLock(path, token);
+          throw new Error("A multiscan supervisor is already running.");
+        }
         return async () => await releaseLock(path, token);
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
@@ -475,6 +547,36 @@ async function acquireLock(output: string): Promise<() => Promise<void>> {
   } finally {
     await rm(pending, { force: true });
   }
+}
+
+async function publishLock(
+  pending: string,
+  destination: string,
+  owner: string,
+): Promise<void> {
+  try {
+    await link(pending, destination);
+    return;
+  } catch (error) {
+    if (
+      !["EPERM", "EOPNOTSUPP", "ENOTSUP", "EXDEV"].includes(
+        (error as NodeJS.ErrnoException).code ?? "",
+      )
+    ) {
+      throw error;
+    }
+  }
+
+  const file = await open(destination, "wx", 0o600);
+  try {
+    await file.writeFile(owner, "utf8");
+    await file.sync();
+  } catch (error) {
+    await file.close();
+    await rm(destination, { force: true });
+    throw error;
+  }
+  await file.close();
 }
 
 async function readLockOwner(path: string): Promise<MultiscanLockOwner | null> {
@@ -578,107 +680,115 @@ async function readReceipts(
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return new Map();
     throw error;
   }
-  signal?.throwIfAborted();
-  const metadata = await file.stat();
-  if (!metadata.isFile() || metadata.isSymbolicLink()) {
-    await file.close();
-    throw new Error(
-      "Multiscan receipt ledger must be a regular file. Move results.jsonl aside before resuming.",
-    );
-  }
-  if (metadata.size > MAX_RECEIPT_LEDGER_BYTES) {
-    await file.close();
-    await replaceCorruptReceiptLedger(path, async () => {});
-    return new Map();
-  }
+  let opened: FileHandle | undefined = file;
+  try {
+    signal?.throwIfAborted();
+    const metadata = await file.stat();
+    if (!metadata.isFile() || metadata.isSymbolicLink()) {
+      throw new Error(
+        "Multiscan receipt ledger must be a regular file. Move results.jsonl aside before resuming.",
+      );
+    }
+    if (metadata.size > MAX_RECEIPT_LEDGER_BYTES) {
+      await file.close();
+      opened = undefined;
+      await replaceCorruptReceiptLedger(path, async () => {});
+      return new Map();
+    }
 
-  const receipts = new Map<string, MultiscanReceipt>();
-  const replacement = receiptRepairPath(path);
-  const repaired = await open(replacement, "wx", 0o600);
+    const receipts = new Map<string, MultiscanReceipt>();
+    const initial = await readReceiptLines(file, signal, async (receipt) => {
+      receipts.set(receipt.id.toLowerCase(), receipt);
+    });
+    if (!initial.corrupted) return receipts;
+
+    const replacement = receiptRepairPath(path);
+    let repaired: FileHandle | undefined;
+    try {
+      repaired = await open(replacement, "wx", 0o600);
+      if (!initial.discardAll) {
+        await readReceiptLines(file, signal, async (_receipt, bytes) => {
+          await repaired!.write(bytes);
+          await repaired!.write("\n");
+        });
+      } else {
+        receipts.clear();
+      }
+      await repaired.sync();
+      await repaired.close();
+      repaired = undefined;
+      await file.close();
+      opened = undefined;
+      await publishReceiptRepair(path, replacement);
+    } catch (error) {
+      await repaired?.close();
+      await rm(replacement, { force: true });
+      throw error;
+    }
+    return receipts;
+  } finally {
+    await opened?.close();
+  }
+}
+
+async function readReceiptLines(
+  file: FileHandle,
+  signal: AbortSignal | undefined,
+  accept: (receipt: MultiscanReceipt, bytes: Buffer) => Promise<void>,
+): Promise<{ corrupted: boolean; discardAll: boolean }> {
+  const pending = Buffer.alloc(MAX_RECEIPT_LINE_BYTES);
+  let pendingBytes = 0;
+  let discardingLine = false;
+  let totalBytes = 0;
   let corrupted = false;
   let discardAll = false;
-  try {
-    const pending = Buffer.alloc(MAX_RECEIPT_LINE_BYTES);
-    let pendingBytes = 0;
-    let discardingLine = false;
-    let totalBytes = 0;
-    const acceptLine = async (bytes: Buffer): Promise<void> => {
-      if (bytes.length === 0) return;
-      const receipt = parseMultiscanReceipt(bytes);
-      if (receipt === null) {
-        corrupted = true;
-        return;
-      }
-      await repaired.write(bytes);
-      await repaired.write("\n");
-      receipts.set(receipt.id.toLowerCase(), receipt);
-    };
-
-    const input = file.createReadStream({
-      autoClose: false,
-      highWaterMark: 64 * 1024,
-      ...(signal === undefined ? {} : { signal }),
-    });
-    for await (const rawChunk of input) {
-      signal?.throwIfAborted();
-      const chunk = Buffer.isBuffer(rawChunk)
-        ? rawChunk
-        : Buffer.from(rawChunk);
-      totalBytes += chunk.length;
-      if (totalBytes > MAX_RECEIPT_LEDGER_BYTES) {
-        corrupted = true;
-        discardAll = true;
-        receipts.clear();
-        break;
-      }
-
-      let start = 0;
-      while (start < chunk.length) {
-        signal?.throwIfAborted();
-        const newline = chunk.indexOf(0x0a, start);
-        const end = newline === -1 ? chunk.length : newline;
-        const segment = chunk.subarray(start, end);
-        if (!discardingLine) {
-          if (pendingBytes + segment.length > MAX_RECEIPT_LINE_BYTES) {
-            corrupted = true;
-            discardingLine = true;
-            pendingBytes = 0;
-          } else if (segment.length > 0) {
-            segment.copy(pending, pendingBytes);
-            pendingBytes += segment.length;
-          }
-        }
-        if (newline === -1) break;
-        if (!discardingLine) {
-          await acceptLine(pending.subarray(0, pendingBytes));
-        }
-        pendingBytes = 0;
-        discardingLine = false;
-        start = newline + 1;
-      }
-    }
+  const input = file.createReadStream({
+    autoClose: false,
+    start: 0,
+    highWaterMark: 64 * 1024,
+    ...(signal === undefined ? {} : { signal }),
+  });
+  for await (const rawChunk of input) {
     signal?.throwIfAborted();
-    if (discardAll) {
-      await repaired.truncate(0);
-    } else if (discardingLine || pendingBytes > 0) {
+    const chunk = Buffer.isBuffer(rawChunk) ? rawChunk : Buffer.from(rawChunk);
+    totalBytes += chunk.length;
+    if (totalBytes > MAX_RECEIPT_LEDGER_BYTES) {
       corrupted = true;
+      discardAll = true;
+      break;
     }
-    await repaired.sync();
-  } catch (error) {
-    await file.close();
-    await repaired.close();
-    await rm(replacement, { force: true });
-    throw error;
-  }
-  await file.close();
-  await repaired.close();
 
-  if (!corrupted) {
-    await rm(replacement, { force: true });
-    return receipts;
+    let start = 0;
+    while (start < chunk.length) {
+      signal?.throwIfAborted();
+      const newline = chunk.indexOf(0x0a, start);
+      const end = newline === -1 ? chunk.length : newline;
+      const segment = chunk.subarray(start, end);
+      if (!discardingLine) {
+        if (pendingBytes + segment.length > MAX_RECEIPT_LINE_BYTES) {
+          corrupted = true;
+          discardingLine = true;
+          pendingBytes = 0;
+        } else if (segment.length > 0) {
+          segment.copy(pending, pendingBytes);
+          pendingBytes += segment.length;
+        }
+      }
+      if (newline === -1) break;
+      if (!discardingLine && pendingBytes > 0) {
+        const bytes = pending.subarray(0, pendingBytes);
+        const receipt = parseMultiscanReceipt(bytes);
+        if (receipt === null) corrupted = true;
+        else await accept(receipt, bytes);
+      }
+      pendingBytes = 0;
+      discardingLine = false;
+      start = newline + 1;
+    }
   }
-  await publishReceiptRepair(path, replacement);
-  return receipts;
+  signal?.throwIfAborted();
+  if (discardingLine || pendingBytes > 0) corrupted = true;
+  return { corrupted, discardAll };
 }
 
 function parseMultiscanReceipt(bytes: Buffer): MultiscanReceipt | null {
@@ -784,11 +894,10 @@ async function publishReceiptRepair(
     dirname(path),
     `results.corrupt-${randomUUID()}.jsonl`,
   );
-  await rename(path, quarantine);
+  await copyFile(path, quarantine, constants.COPYFILE_EXCL);
   try {
     await rename(replacement, path);
   } catch (error) {
-    await rename(quarantine, path).catch(() => undefined);
     await rm(replacement, { force: true });
     throw error;
   }
@@ -797,6 +906,7 @@ async function publishReceiptRepair(
 async function hasArtifacts(
   path: string,
   pluginRoot: string,
+  task: MultiscanTask,
   signal?: AbortSignal,
 ): Promise<boolean> {
   try {
@@ -805,7 +915,24 @@ async function hasArtifacts(
     for (const artifact of REQUIRED_ARTIFACTS) {
       if (!(await lstat(join(path, artifact))).isFile()) return false;
     }
-    const contract = await loadContract(path, { pluginRoot, signal });
+    const plugin = JSON.parse(
+      await readFile(join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"),
+    ) as { version?: unknown };
+    if (typeof plugin.version !== "string") return false;
+    const contract = await loadContract(path, {
+      pluginRoot,
+      signal,
+      expectation: {
+        repository: task.repository,
+        repositoryRevision: task.revision,
+        target:
+          task.scope === undefined
+            ? { kind: "repository", paths: [] }
+            : { kind: "paths", paths: [task.scope] },
+        mode: task.mode,
+        pluginVersion: plugin.version,
+      },
+    });
     return contract.coverage.completeness === "complete";
   } catch (error) {
     if (signal?.aborted === true) signal.throwIfAborted();
@@ -849,15 +976,27 @@ async function parseInventory(
     highWaterMark: 64 * 1_024,
     ...(signal === undefined ? {} : { signal }),
   });
+  const decoder = new TextDecoder("utf-8", { fatal: true });
   const bounded = new Transform({
+    readableObjectMode: true,
     transform(chunk: Buffer, _encoding, callback) {
       bytesRead += chunk.length;
-      callback(
-        bytesRead > MAX_BULK_SCAN_INVENTORY_BYTES
-          ? new Error("Multiscan CSV must not exceed 8 MiB.")
-          : null,
-        chunk,
-      );
+      if (bytesRead > MAX_BULK_SCAN_INVENTORY_BYTES) {
+        callback(new Error("Multiscan CSV must not exceed 8 MiB."));
+        return;
+      }
+      try {
+        callback(null, decoder.decode(chunk, { stream: true }));
+      } catch (error) {
+        callback(error instanceof Error ? error : new Error(String(error)));
+      }
+    },
+    flush(callback) {
+      try {
+        callback(null, decoder.decode());
+      } catch (error) {
+        callback(error instanceof Error ? error : new Error(String(error)));
+      }
     },
   });
   input.pipe(bounded);

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -1,6 +1,6 @@
 import { execFile as execFileCallback } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { constants } from "node:fs";
+import { constants, createReadStream } from "node:fs";
 import {
   type FileHandle,
   link,
@@ -11,12 +11,20 @@ import {
   realpath,
   rename,
   rm,
+  stat,
+  truncate,
   writeFile,
 } from "node:fs/promises";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { Transform } from "node:stream";
 import { promisify } from "node:util";
 import Papa from "papaparse";
 import type { CodexSecurity } from "./api.js";
+import {
+  bulkScanRepositoryLimitError,
+  MAX_BULK_SCAN_INVENTORY_BYTES,
+  MAX_BULK_SCAN_REPOSITORIES,
+} from "./bulk-scan-limits.js";
 import type { CodexSecurityConfig } from "./config.js";
 import { loadContract } from "./contract.js";
 import type { ScanCost } from "./cost.js";
@@ -92,10 +100,11 @@ export async function runMultiscan(
   if (!Number.isSafeInteger(options.maxAttempts) || options.maxAttempts < 1) {
     throw new Error("Multiscan max attempts must be a positive integer.");
   }
-  const tasks = parseInventory(
-    await readFile(options.inputPath, "utf8"),
+  const tasks = await parseInventory(
+    options.inputPath,
     dirname(resolve(options.inputPath)),
     options.mode,
+    options.signal,
   );
   const output = resolve(options.outputDir);
   await ensureOutputDirectory(output);
@@ -624,19 +633,106 @@ async function mkdirTemporaryPluginWorkspace(output: string): Promise<string> {
   }
 }
 
-function parseInventory(
-  source: string,
+async function parseInventory(
+  inputPath: string,
   directory: string,
   defaultMode: ScanMode,
-): MultiscanTask[] {
-  const { data: rows, errors } = Papa.parse<string[]>(source, {
-    delimiter: ",",
-    skipEmptyLines: "greedy",
-  });
-  if (errors.length > 0) {
-    throw new Error(`Multiscan CSV could not be parsed: ${errors[0]!.message}`);
+  signal?: AbortSignal,
+): Promise<MultiscanTask[]> {
+  signal?.throwIfAborted();
+  const metadata = await stat(inputPath);
+  signal?.throwIfAborted();
+  if (!metadata.isFile()) {
+    throw new Error("Multiscan inventory must be a regular CSV file.");
   }
-  const headers = rows.shift();
+  if (metadata.size > MAX_BULK_SCAN_INVENTORY_BYTES) {
+    throw new Error("Multiscan CSV must not exceed 8 MiB.");
+  }
+
+  const tasks: MultiscanTask[] = [];
+  const seen = new Set<string>();
+  let headers: string[] | undefined;
+  let bytesRead = 0;
+  const input = createReadStream(inputPath, {
+    highWaterMark: 64 * 1_024,
+    ...(signal === undefined ? {} : { signal }),
+  });
+  const bounded = new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      bytesRead += chunk.length;
+      callback(
+        bytesRead > MAX_BULK_SCAN_INVENTORY_BYTES
+          ? new Error("Multiscan CSV must not exceed 8 MiB.")
+          : null,
+        chunk,
+      );
+    },
+  });
+  input.pipe(bounded);
+
+  return await new Promise<MultiscanTask[]>((resolveTasks, rejectTasks) => {
+    let settled = false;
+    const fail = (error: unknown): void => {
+      if (settled) return;
+      settled = true;
+      const failure = error instanceof Error ? error : new Error(String(error));
+      input.destroy();
+      bounded.destroy();
+      rejectTasks(failure);
+    };
+    input.once("error", fail);
+    bounded.once("error", fail);
+
+    Papa.parse<string[]>(bounded as unknown as Papa.LocalFile, {
+      delimiter: ",",
+      skipEmptyLines: "greedy",
+      beforeFirstChunk: (chunk) =>
+        chunk.charCodeAt(0) === 0xfeff ? chunk.slice(1) : chunk,
+      step: ({ data: fields, errors }) => {
+        try {
+          signal?.throwIfAborted();
+          if (errors.length > 0) {
+            throw new Error(
+              `Multiscan CSV could not be parsed: ${errors[0]!.message}`,
+            );
+          }
+          if (headers === undefined) {
+            headers = fields;
+            validateInventoryHeaders(headers);
+            return;
+          }
+          if (tasks.length >= MAX_BULK_SCAN_REPOSITORIES) {
+            throw bulkScanRepositoryLimitError();
+          }
+          tasks.push(
+            parseInventoryRow(fields, headers, directory, defaultMode, seen),
+          );
+        } catch (error) {
+          fail(error);
+        }
+      },
+      complete: () => {
+        if (settled) return;
+        try {
+          signal?.throwIfAborted();
+          if (headers === undefined) validateInventoryHeaders(undefined);
+          if (tasks.length === 0) {
+            throw new Error(
+              "Multiscan CSV must contain at least one repository.",
+            );
+          }
+          settled = true;
+          resolveTasks(tasks);
+        } catch (error) {
+          fail(error);
+        }
+      },
+      error: fail,
+    });
+  });
+}
+
+function validateInventoryHeaders(headers: string[] | undefined): void {
   if (
     headers === undefined ||
     !["id", "repository", "revision"].every((name) => headers.includes(name)) ||
@@ -646,48 +742,52 @@ function parseInventory(
       "Multiscan CSV requires id, repository, and revision columns.",
     );
   }
-  if (rows.length === 0)
-    throw new Error("Multiscan CSV must contain at least one repository.");
-  const seen = new Set<string>();
-  return rows.map((fields) => {
-    if (fields.length !== headers.length) {
-      throw new Error("Multiscan CSV rows must match their header columns.");
-    }
-    const get = (name: string): string =>
-      fields[headers.indexOf(name)]?.trim() ?? "";
-    const id = get("id");
-    if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u.test(id)) {
-      throw new Error("Multiscan task IDs must be safe, unique path names.");
-    }
-    if (seen.has(id.toLowerCase()))
-      throw new Error("Multiscan task IDs must be unique.");
-    seen.add(id.toLowerCase());
-    const revision = get("revision").toLowerCase();
-    if (!/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u.test(revision)) {
-      throw new Error("Multiscan revisions must be full immutable Git SHAs.");
-    }
-    const mode = get("mode") || defaultMode;
-    if (mode !== "standard" && mode !== "deep") {
-      throw new Error("Multiscan mode must be standard or deep.");
-    }
-    const scope = get("scope");
-    if (
-      scope &&
-      (isAbsolute(scope) ||
-        scope.includes("\\") ||
-        scope.split("/").includes("..") ||
-        scope.includes("\0"))
-    ) {
-      throw new Error("Multiscan scope must stay inside its repository.");
-    }
-    return {
-      id,
-      repository: normalizeRepository(get("repository"), directory),
-      revision,
-      mode,
-      ...(scope ? { scope } : {}),
-    };
-  });
+}
+
+function parseInventoryRow(
+  fields: string[],
+  headers: string[],
+  directory: string,
+  defaultMode: ScanMode,
+  seen: Set<string>,
+): MultiscanTask {
+  if (fields.length !== headers.length) {
+    throw new Error("Multiscan CSV rows must match their header columns.");
+  }
+  const get = (name: string): string =>
+    fields[headers.indexOf(name)]?.trim() ?? "";
+  const id = get("id");
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u.test(id)) {
+    throw new Error("Multiscan task IDs must be safe, unique path names.");
+  }
+  if (seen.has(id.toLowerCase()))
+    throw new Error("Multiscan task IDs must be unique.");
+  seen.add(id.toLowerCase());
+  const revision = get("revision").toLowerCase();
+  if (!/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u.test(revision)) {
+    throw new Error("Multiscan revisions must be full immutable Git SHAs.");
+  }
+  const mode = get("mode") || defaultMode;
+  if (mode !== "standard" && mode !== "deep") {
+    throw new Error("Multiscan mode must be standard or deep.");
+  }
+  const scope = get("scope");
+  if (
+    scope &&
+    (isAbsolute(scope) ||
+      scope.includes("\\") ||
+      scope.split("/").includes("..") ||
+      scope.includes("\0"))
+  ) {
+    throw new Error("Multiscan scope must stay inside its repository.");
+  }
+  return {
+    id,
+    repository: normalizeRepository(get("repository"), directory),
+    revision,
+    mode,
+    ...(scope ? { scope } : {}),
+  };
 }
 
 function normalizeRepository(repository: string, directory: string): string {

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -896,7 +896,36 @@ async function publishReceiptRepair(
   );
   await copyFile(path, quarantine, constants.COPYFILE_EXCL);
   try {
-    await rename(replacement, path);
+    try {
+      await rename(replacement, path);
+    } catch (error) {
+      if (
+        process.platform !== "win32" ||
+        !["EPERM", "EACCES", "EEXIST"].includes(
+          (error as NodeJS.ErrnoException).code ?? "",
+        )
+      ) {
+        throw error;
+      }
+      const destination = await openReceiptLedger(
+        path,
+        constants.O_WRONLY | constants.O_TRUNC,
+      );
+      const source = await open(replacement, constants.O_RDONLY);
+      try {
+        for await (const chunk of source.createReadStream({
+          autoClose: false,
+          highWaterMark: 64 * 1024,
+        })) {
+          await destination.writeFile(chunk);
+        }
+        await destination.sync();
+      } finally {
+        await source.close();
+        await destination.close();
+      }
+      await rm(replacement, { force: true });
+    }
   } catch (error) {
     await rm(replacement, { force: true });
     throw error;

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -16,7 +16,15 @@ import {
   stat,
   writeFile,
 } from "node:fs/promises";
-import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import {
+  dirname,
+  isAbsolute,
+  join,
+  posix,
+  relative,
+  resolve,
+  sep,
+} from "node:path";
 import { Transform } from "node:stream";
 import { promisify } from "node:util";
 import Papa from "papaparse";
@@ -1080,16 +1088,12 @@ async function hasArtifacts(
     if (canonicalScope !== undefined) {
       try {
         const repository = await realpath(task.repository);
-        const selected = await realpath(join(repository, canonicalScope));
-        const relativeScope = relative(repository, selected);
-        if (
-          relativeScope === ".." ||
-          relativeScope.startsWith(`..${sep}`) ||
-          isAbsolute(relativeScope)
-        ) {
-          return false;
-        }
-        canonicalScope = relativeScope.split(sep).join("/") || ".";
+        canonicalScope = await pinnedMultiscanScope(
+          repository,
+          task.revision,
+          canonicalScope,
+          signal,
+        );
       } catch {
         if (recordedCanonicalScope !== undefined) {
           if (recordedCanonicalScope !== canonicalScope) return false;
@@ -1119,6 +1123,100 @@ async function hasArtifacts(
     if (signal?.aborted === true) signal.throwIfAborted();
     return false;
   }
+}
+
+async function pinnedMultiscanScope(
+  repository: string,
+  revision: string,
+  scope: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  const environment: NodeJS.ProcessEnv = {
+    ...process.env,
+    GIT_LITERAL_PATHSPECS: "1",
+  };
+  for (const name of [
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  ]) {
+    delete environment[name];
+  }
+  const command = await resolveTrustedExecutable(
+    "git",
+    environment,
+    repository,
+  );
+  if (command === null)
+    throw new Error("Git is not available on a trusted PATH.");
+  let selected = posix.normalize(scope);
+  for (let followed = 0; followed <= 40; followed += 1) {
+    if (selected === ".") return selected;
+    const segments = selected.split("/");
+    let redirected = false;
+    for (let index = 0; index < segments.length; index += 1) {
+      signal?.throwIfAborted();
+      const candidate = segments.slice(0, index + 1).join("/");
+      const listed = await execFile(
+        command.executable,
+        [
+          "--no-replace-objects",
+          "-c",
+          "core.hooksPath=/dev/null",
+          "-C",
+          repository,
+          "ls-tree",
+          "-z",
+          revision,
+          "--",
+          candidate,
+        ],
+        { env: command.environment, signal, maxBuffer: 1024 * 1024 },
+      );
+      const entry = /^(\d{6}) (blob|tree) ([a-f0-9]{40,64})\t([^\0]+)\0$/u.exec(
+        listed.stdout,
+      );
+      if (entry?.[4] !== candidate) {
+        throw new Error(
+          "Multiscan scope cannot be resolved at its pinned revision.",
+        );
+      }
+      if (entry[1] !== "120000") continue;
+      const target = await execFile(
+        command.executable,
+        [
+          "--no-replace-objects",
+          "-c",
+          "core.hooksPath=/dev/null",
+          "-C",
+          repository,
+          "cat-file",
+          "blob",
+          entry[3]!,
+        ],
+        { env: command.environment, signal, maxBuffer: 64 * 1024 },
+      );
+      if (posix.isAbsolute(target.stdout) || target.stdout.includes("\0")) {
+        throw new Error("Multiscan scope escapes its repository.");
+      }
+      selected = posix.normalize(
+        posix.join(
+          posix.dirname(candidate),
+          target.stdout,
+          ...segments.slice(index + 1),
+        ),
+      );
+      if (selected === ".." || selected.startsWith("../")) {
+        throw new Error("Multiscan scope escapes its repository.");
+      }
+      redirected = true;
+      break;
+    }
+    if (!redirected) return selected;
+  }
+  throw new Error("Multiscan scope contains too many symbolic links.");
 }
 
 async function mkdirTemporaryPluginWorkspace(output: string): Promise<string> {

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -907,21 +907,22 @@ async function publishReceiptRepair(
       ) {
         throw error;
       }
-      const destination = await openReceiptLedger(
-        path,
-        constants.O_WRONLY | constants.O_TRUNC,
-      );
-      const source = await open(replacement, constants.O_RDONLY);
+      const destination = await openReceiptLedger(path, constants.O_RDWR);
       try {
-        for await (const chunk of source.createReadStream({
-          autoClose: false,
-          highWaterMark: 64 * 1024,
-        })) {
-          await destination.writeFile(chunk);
+        const source = await open(replacement, constants.O_RDONLY);
+        try {
+          await destination.truncate(0);
+          for await (const chunk of source.createReadStream({
+            autoClose: false,
+            highWaterMark: 64 * 1024,
+          })) {
+            await destination.writeFile(chunk);
+          }
+          await destination.sync();
+        } finally {
+          await source.close();
         }
-        await destination.sync();
       } finally {
-        await source.close();
         await destination.close();
       }
       await rm(replacement, { force: true });

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -386,7 +386,7 @@ async function readReceipts(
 ): Promise<Map<string, MultiscanReceipt>> {
   let file: FileHandle;
   try {
-    file = await openReceiptLedger(path, constants.O_RDWR);
+    file = await openReceiptLedger(path, constants.O_RDONLY);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return new Map();
     throw error;
@@ -396,10 +396,20 @@ async function readReceipts(
     const lines = contents.split("\n");
     if (!contents.endsWith("\n")) {
       const partial = lines.pop()!;
-      await file.truncate(
-        Buffer.byteLength(contents) - Buffer.byteLength(partial),
-      );
-      await file.sync();
+      const repair = await openReceiptLedger(path, constants.O_RDWR);
+      try {
+        if ((await repair.readFile("utf8")) !== contents) {
+          throw new Error(
+            "Multiscan results ledger changed during interrupted receipt repair.",
+          );
+        }
+        await repair.truncate(
+          Buffer.byteLength(contents) - Buffer.byteLength(partial),
+        );
+        await repair.sync();
+      } finally {
+        await repair.close();
+      }
     }
     return new Map(
       lines.filter(Boolean).map((line): [string, MultiscanReceipt] => {

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -1,5 +1,5 @@
 import { execFile as execFileCallback } from "node:child_process";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { constants, createReadStream } from "node:fs";
 import {
   type FileHandle,
@@ -258,10 +258,31 @@ async function runCampaign(
             throw new Error("Multiscan repository coverage is incomplete.");
           }
           if (canonicalScope !== undefined && canonicalScope !== task.scope) {
+            const binding = `${JSON.stringify({ scope: task.scope, canonicalScope })}\n`;
+            const bindingName = ".multiscan-scope.json";
+            await writeFile(join(scanDir, bindingName), binding, {
+              flag: "wx",
+              mode: 0o600,
+            });
+            const manifestPath = join(scanDir, "scan-manifest.json");
+            const manifest = JSON.parse(
+              await readFile(manifestPath, "utf8"),
+            ) as {
+              scan?: { artifacts?: Array<Record<string, unknown>> };
+            };
+            if (!Array.isArray(manifest.scan?.artifacts)) {
+              throw new Error(
+                "Multiscan scope cannot be bound to an unsealed scan.",
+              );
+            }
+            manifest.scan.artifacts.push({
+              path: bindingName,
+              sha256: createHash("sha256").update(binding).digest("hex"),
+              mediaType: "application/json",
+            });
             await writeFile(
-              join(scanDir, ".multiscan-scope.json"),
-              `${JSON.stringify({ scope: task.scope, canonicalScope })}\n`,
-              { flag: "wx", mode: 0o600 },
+              manifestPath,
+              `${JSON.stringify(manifest, null, 2)}\n`,
             );
           }
         } catch (error) {
@@ -1134,6 +1155,15 @@ async function hasArtifacts(
         pluginVersion: plugin.version,
       },
     });
+    if (
+      recordedCanonicalScope !== undefined &&
+      recordedCanonicalScope !== task.scope &&
+      !contract.manifest.scan.artifacts.some(
+        (artifact) => artifact.path === ".multiscan-scope.json",
+      )
+    ) {
+      return false;
+    }
     return (
       contract.coverage.completeness === "complete" &&
       contract.manifest.scan.target.kind !== "directory_snapshot"

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -1,6 +1,8 @@
 import { execFile as execFileCallback } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { constants } from "node:fs";
 import {
+  type FileHandle,
   lstat,
   mkdir,
   open,
@@ -8,7 +10,6 @@ import {
   realpath,
   rename,
   rm,
-  truncate,
   writeFile,
 } from "node:fs/promises";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
@@ -255,12 +256,83 @@ async function ensureOutputDirectory(path: string): Promise<void> {
 }
 
 async function appendReceipt(path: string, receipt: string): Promise<void> {
-  const file = await open(path, "a", 0o600);
+  const file = await openReceiptLedger(
+    path,
+    constants.O_WRONLY | constants.O_APPEND | constants.O_CREAT,
+  );
   try {
     await file.writeFile(receipt, "utf8");
     await file.sync();
   } finally {
     await file.close();
+  }
+}
+
+async function openReceiptLedger(
+  path: string,
+  flags: number,
+): Promise<FileHandle> {
+  const parentPath = dirname(path);
+  const parent = await lstat(parentPath);
+  const expected = await lstat(path).catch((error: NodeJS.ErrnoException) => {
+    if (error.code !== "ENOENT") throw error;
+    return undefined;
+  });
+  if (
+    !parent.isDirectory() ||
+    parent.isSymbolicLink() ||
+    (expected !== undefined &&
+      (!expected.isFile() || expected.isSymbolicLink() || expected.nlink !== 1))
+  ) {
+    throw new Error(
+      "Multiscan results ledger must be a regular, single-link, non-symbolic-link file.",
+    );
+  }
+
+  let file: FileHandle | undefined;
+  try {
+    file = await open(
+      path,
+      flags |
+        (process.platform === "win32"
+          ? 0
+          : constants.O_NOFOLLOW | constants.O_NONBLOCK),
+      0o600,
+    );
+    const [opened, currentParent, current] = await Promise.all([
+      file.stat(),
+      lstat(parentPath),
+      lstat(path),
+    ]);
+    if (
+      !opened.isFile() ||
+      opened.nlink !== 1 ||
+      !currentParent.isDirectory() ||
+      currentParent.isSymbolicLink() ||
+      currentParent.dev !== parent.dev ||
+      currentParent.ino !== parent.ino ||
+      !current.isFile() ||
+      current.isSymbolicLink() ||
+      current.nlink !== 1 ||
+      current.dev !== opened.dev ||
+      current.ino !== opened.ino ||
+      (expected !== undefined &&
+        (opened.dev !== expected.dev || opened.ino !== expected.ino))
+    ) {
+      throw new Error(
+        "Multiscan results ledger must be a regular, single-link, non-symbolic-link file.",
+      );
+    }
+    return file;
+  } catch (error) {
+    await file?.close();
+    if ((error as NodeJS.ErrnoException).code === "ELOOP") {
+      throw new Error(
+        "Multiscan results ledger must be a regular, single-link, non-symbolic-link file.",
+        { cause: error },
+      );
+    }
+    throw error;
   }
 }
 
@@ -312,27 +384,32 @@ async function ensureManifest(
 async function readReceipts(
   path: string,
 ): Promise<Map<string, MultiscanReceipt>> {
-  let contents: string;
+  let file: FileHandle;
   try {
-    contents = await readFile(path, "utf8");
+    file = await openReceiptLedger(path, constants.O_RDWR);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return new Map();
     throw error;
   }
-  const lines = contents.split("\n");
-  if (!contents.endsWith("\n")) {
-    const partial = lines.pop()!;
-    await truncate(
-      path,
-      Buffer.byteLength(contents) - Buffer.byteLength(partial),
+  try {
+    const contents = await file.readFile("utf8");
+    const lines = contents.split("\n");
+    if (!contents.endsWith("\n")) {
+      const partial = lines.pop()!;
+      await file.truncate(
+        Buffer.byteLength(contents) - Buffer.byteLength(partial),
+      );
+      await file.sync();
+    }
+    return new Map(
+      lines.filter(Boolean).map((line): [string, MultiscanReceipt] => {
+        const receipt = JSON.parse(line) as MultiscanReceipt;
+        return [receipt.id.toLowerCase(), receipt];
+      }),
     );
+  } finally {
+    await file.close();
   }
-  return new Map(
-    lines.filter(Boolean).map((line): [string, MultiscanReceipt] => {
-      const receipt = JSON.parse(line) as MultiscanReceipt;
-      return [receipt.id.toLowerCase(), receipt];
-    }),
-  );
 }
 
 async function hasArtifacts(path: string): Promise<boolean> {

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -416,9 +416,24 @@ async function acquireLock(output: string): Promise<() => Promise<void>> {
       const moved = await readLockOwner(stale);
       if (moved !== null && processIsRunning(moved.pid)) {
         try {
-          await rename(stale, path);
+          const metadata = await lstat(stale);
+          if (metadata.isDirectory()) {
+            await rename(stale, path);
+          } else {
+            await link(stale, path);
+          }
         } catch (error) {
-          if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+          const code = (error as NodeJS.ErrnoException).code;
+          if (
+            code !== "EEXIST" &&
+            code !== "EISDIR" &&
+            code !== "ENOTDIR" &&
+            code !== "ENOTEMPTY"
+          ) {
+            throw error;
+          }
+        } finally {
+          await rm(stale, { recursive: true, force: true });
         }
         throw new Error("A multiscan supervisor is already running.");
       }

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -1151,6 +1151,22 @@ async function pinnedMultiscanScope(
   );
   if (command === null)
     throw new Error("Git is not available on a trusted PATH.");
+  const symlinkConfiguration = await execFile(
+    command.executable,
+    [
+      "--no-replace-objects",
+      "-c",
+      "core.hooksPath=/dev/null",
+      "-C",
+      repository,
+      "config",
+      "--type=bool",
+      "--default=true",
+      "core.symlinks",
+    ],
+    { env: command.environment, signal, maxBuffer: 64 * 1024 },
+  );
+  const followsSymbolicLinks = symlinkConfiguration.stdout.trim() !== "false";
   let selected = posix.normalize(scope);
   for (let followed = 0; followed <= 40; followed += 1) {
     if (selected === ".") return selected;
@@ -1158,8 +1174,8 @@ async function pinnedMultiscanScope(
     let redirected = false;
     for (let index = 0; index < segments.length; index += 1) {
       signal?.throwIfAborted();
-      const candidate = segments.slice(0, index + 1).join("/");
-      const listed = await execFile(
+      let candidate = segments.slice(0, index + 1).join("/");
+      let listed = await execFile(
         command.executable,
         [
           "--no-replace-objects",
@@ -1175,15 +1191,60 @@ async function pinnedMultiscanScope(
         ],
         { env: command.environment, signal, maxBuffer: 1024 * 1024 },
       );
-      const entry = /^(\d{6}) (blob|tree) ([a-f0-9]{40,64})\t([^\0]+)\0$/u.exec(
-        listed.stdout,
-      );
-      if (entry?.[4] !== candidate) {
+      const matched =
+        /^(\d{6}) (blob|tree) ([a-f0-9]{40,64})\t([^\0]+)\0$/u.exec(
+          listed.stdout,
+        );
+      let entry =
+        matched === null
+          ? undefined
+          : {
+              mode: matched[1]!,
+              objectId: matched[3]!,
+              path: matched[4]!,
+            };
+      if (entry?.path !== candidate) {
+        const parent = segments.slice(0, index).join("/");
+        listed = await execFile(
+          command.executable,
+          [
+            "--no-replace-objects",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-C",
+            repository,
+            "ls-tree",
+            "-z",
+            parent.length === 0 ? revision : `${revision}:${parent}`,
+          ],
+          { env: command.environment, signal, maxBuffer: 1024 * 1024 },
+        );
+        const candidates = [
+          ...listed.stdout.matchAll(
+            /(\d{6}) (blob|tree) ([a-f0-9]{40,64})\t([^\0]+)\0/gu,
+          ),
+        ].filter(
+          (match) =>
+            match[4]!.toLocaleLowerCase("en-US") ===
+            segments[index]!.toLocaleLowerCase("en-US"),
+        );
+        if (candidates.length === 1) {
+          segments[index] = candidates[0]![4]!;
+          selected = segments.join("/");
+          candidate = segments.slice(0, index + 1).join("/");
+          entry = {
+            mode: candidates[0]![1]!,
+            objectId: candidates[0]![3]!,
+            path: candidate,
+          };
+        }
+      }
+      if (entry?.path !== candidate) {
         throw new Error(
           "Multiscan scope cannot be resolved at its pinned revision.",
         );
       }
-      if (entry[1] !== "120000") continue;
+      if (entry.mode !== "120000" || !followsSymbolicLinks) continue;
       const target = await execFile(
         command.executable,
         [
@@ -1194,7 +1255,7 @@ async function pinnedMultiscanScope(
           repository,
           "cat-file",
           "blob",
-          entry[3]!,
+          entry.objectId,
         ],
         { env: command.environment, signal, maxBuffer: 64 * 1024 },
       );

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -17,7 +17,9 @@ import { promisify } from "node:util";
 import Papa from "papaparse";
 import type { CodexSecurity } from "./api.js";
 import type { CodexSecurityConfig } from "./config.js";
+import { loadContract } from "./contract.js";
 import type { ScanCost } from "./cost.js";
+import { resolvePluginPath } from "./runtime.js";
 import type { ScanMode } from "./targets.js";
 import { resolveTrustedExecutable } from "./trusted-executable.js";
 
@@ -91,10 +93,28 @@ export async function runMultiscan(
   const output = resolve(options.outputDir);
   await ensureOutputDirectory(output);
   const unlock = await acquireLock(output);
+  let pluginWorkspace: string | null = null;
+  let pluginRoot: Promise<string> | null = null;
+  const resumePluginRoot = (): Promise<string> =>
+    (pluginRoot ??= (async () => {
+      if (options.config.pluginPath !== undefined) {
+        pluginWorkspace = await mkdirTemporaryPluginWorkspace(output);
+      }
+      return await resolvePluginPath(
+        options.config.pluginPath,
+        pluginWorkspace ?? output,
+        options.signal,
+      );
+    })());
   try {
-    return await runCampaign(options, tasks, output);
+    return await runCampaign(options, tasks, output, resumePluginRoot);
   } finally {
-    await unlock();
+    await Promise.all([
+      unlock(),
+      pluginWorkspace === null
+        ? undefined
+        : rm(pluginWorkspace, { recursive: true, force: true }),
+    ]);
   }
 }
 
@@ -102,6 +122,7 @@ async function runCampaign(
   options: MultiscanOptions,
   tasks: MultiscanTask[],
   output: string,
+  resumePluginRoot: () => Promise<string>,
 ): Promise<MultiscanResult> {
   const ledger = join(output, "results.jsonl");
   await ensureOutputDirectory(join(output, "checkouts"));
@@ -117,7 +138,11 @@ async function runCampaign(
       receipt?.status === "completed" &&
       receipt.outputDir ===
         join(output, "artifacts", task.id, `attempt-${receipt.attempt}`) &&
-      (await hasArtifacts(receipt.outputDir))
+      (await hasArtifacts(
+        receipt.outputDir,
+        await resumePluginRoot(),
+        options.signal,
+      ))
     ) {
       completed += 1;
     } else if ((receipt?.attempt ?? 0) >= options.maxAttempts) {
@@ -425,15 +450,34 @@ async function readReceipts(
   }
 }
 
-async function hasArtifacts(path: string): Promise<boolean> {
+async function hasArtifacts(
+  path: string,
+  pluginRoot: string,
+  signal?: AbortSignal,
+): Promise<boolean> {
   try {
+    signal?.throwIfAborted();
     if (!(await lstat(path)).isDirectory()) return false;
     for (const artifact of REQUIRED_ARTIFACTS) {
       if (!(await lstat(join(path, artifact))).isFile()) return false;
     }
-    return true;
-  } catch {
+    const contract = await loadContract(path, { pluginRoot, signal });
+    return contract.coverage.completeness === "complete";
+  } catch (error) {
+    if (signal?.aborted === true) signal.throwIfAborted();
     return false;
+  }
+}
+
+async function mkdirTemporaryPluginWorkspace(output: string): Promise<string> {
+  for (;;) {
+    const path = join(output, `.resume-plugin-${randomUUID()}`);
+    try {
+      await mkdir(path, { mode: 0o700 });
+      return path;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
   }
 }
 

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -2006,9 +2006,11 @@ async function sameFile(left: string, right: string): Promise<boolean> {
 }
 
 export function expandHome(value: string): string {
-  if (value === "~") return homedir();
+  const home =
+    process.env["HOME"]?.trim() || process.env["USERPROFILE"]?.trim() || homedir();
+  if (value === "~") return home;
   if (value.startsWith("~/") || value.startsWith("~\\")) {
-    return join(homedir(), value.slice(2));
+    return join(home, value.slice(2));
   }
   return value;
 }

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -2006,9 +2006,11 @@ async function sameFile(left: string, right: string): Promise<boolean> {
 }
 
 export function expandHome(value: string): string {
+  const preferred = process.platform === "win32" ? "USERPROFILE" : "HOME";
+  const fallback = process.platform === "win32" ? "HOME" : "USERPROFILE";
   const home =
-    process.env["HOME"]?.trim() ||
-    process.env["USERPROFILE"]?.trim() ||
+    process.env[preferred]?.trim() ||
+    process.env[fallback]?.trim() ||
     homedir();
   if (value === "~") return home;
   if (value.startsWith("~/") || value.startsWith("~\\")) {

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -2007,7 +2007,9 @@ async function sameFile(left: string, right: string): Promise<boolean> {
 
 export function expandHome(value: string): string {
   const home =
-    process.env["HOME"]?.trim() || process.env["USERPROFILE"]?.trim() || homedir();
+    process.env["HOME"]?.trim() ||
+    process.env["USERPROFILE"]?.trim() ||
+    homedir();
   if (value === "~") return home;
   if (value.startsWith("~/") || value.startsWith("~\\")) {
     return join(home, value.slice(2));

--- a/sdk/typescript/src/targets.ts
+++ b/sdk/typescript/src/targets.ts
@@ -438,11 +438,13 @@ function abortReason(signal: AbortSignal): unknown {
 }
 
 function expandHome(value: string): string {
+  const home =
+    process.env["HOME"]?.trim() || process.env["USERPROFILE"]?.trim() || homedir();
   if (value === "~") {
-    return homedir();
+    return home;
   }
   if (value.startsWith("~/") || value.startsWith("~\\")) {
-    return resolve(homedir(), value.slice(2).replace(/^[/\\]+/, ""));
+    return resolve(home, value.slice(2).replace(/^[/\\]+/, ""));
   }
   return value;
 }

--- a/sdk/typescript/src/targets.ts
+++ b/sdk/typescript/src/targets.ts
@@ -439,7 +439,9 @@ function abortReason(signal: AbortSignal): unknown {
 
 function expandHome(value: string): string {
   const home =
-    process.env["HOME"]?.trim() || process.env["USERPROFILE"]?.trim() || homedir();
+    process.env["HOME"]?.trim() ||
+    process.env["USERPROFILE"]?.trim() ||
+    homedir();
   if (value === "~") {
     return home;
   }

--- a/sdk/typescript/src/targets.ts
+++ b/sdk/typescript/src/targets.ts
@@ -439,8 +439,9 @@ function abortReason(signal: AbortSignal): unknown {
 
 function expandHome(value: string): string {
   const home =
-    process.env["HOME"]?.trim() ||
-    process.env["USERPROFILE"]?.trim() ||
+    (process.platform === "win32"
+      ? process.env["USERPROFILE"]?.trim() || process.env["HOME"]?.trim()
+      : process.env["HOME"]?.trim() || process.env["USERPROFILE"]?.trim()) ||
     homedir();
   if (value === "~") {
     return home;

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -3901,7 +3901,7 @@ if (process.argv.slice(2).join(" ") !== "login status") {
     await writeFile(
       fakeCodex,
       `
-import { appendFileSync } from "node:fs";
+import { appendFileSync, writeSync } from "node:fs";
 
 const args = process.argv.slice(2).join(" ");
 if (args === "login --with-api-key") {
@@ -3913,7 +3913,7 @@ if (args === "login --with-api-key") {
     appendFileSync(${JSON.stringify(keyLog)}, apiKey);
   }
 } else if (args === "login") {
-  console.error("Open https://auth.example.test/login");
+  writeSync(2, "Open https://auth.example.test/login\\n");
 } else {
   process.exitCode = 2;
 }

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -3917,6 +3917,7 @@ if (args === "login --with-api-key") {
 } else {
   process.exitCode = 2;
 }
+process.exit(process.exitCode ?? 0);
 `,
     );
     let codexOptions: CodexOptions | null = null;

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -3901,12 +3901,11 @@ if (process.argv.slice(2).join(" ") !== "login status") {
     await writeFile(
       fakeCodex,
       `
-import { appendFileSync, writeSync } from "node:fs";
+import { appendFileSync, readFileSync, writeSync } from "node:fs";
 
 const args = process.argv.slice(2).join(" ");
 if (args === "login --with-api-key") {
-  let apiKey = "";
-  for await (const chunk of process.stdin) apiKey += chunk;
+  const apiKey = readFileSync(0, "utf8");
   if (!["secret-key", "ambient-key"].includes(apiKey.trim())) {
     process.exitCode = 3;
   } else {

--- a/sdk/typescript/tests-ts/bulk-scan-discovery.test.ts
+++ b/sdk/typescript/tests-ts/bulk-scan-discovery.test.ts
@@ -84,6 +84,7 @@ interface Repository {
 
 interface GitHubRequest {
   path: string;
+  page?: number;
   query?: string;
   variables?: { owner: string; cursor: string | null };
 }
@@ -93,6 +94,8 @@ function discoveryDependencies(
   options: {
     host?: string;
     organizations?: string[];
+    organizationPages?: string[][];
+    onOrganizationPage?(page: number): void;
     repositories?: Repository[];
     authenticated?: boolean;
   } = {},
@@ -153,16 +156,33 @@ function discoveryDependencies(
                     });
               requests.push({
                 path,
+                ...(path === "/user/orgs"
+                  ? { page: Number(url.searchParams.get("page") ?? 1) }
+                  : {}),
                 ...(body === undefined
                   ? {}
                   : { query: body.query, variables: body.variables }),
               });
 
               if (path === "/user/orgs") {
+                const page = Number(url.searchParams.get("page") ?? 1);
+                options.onOrganizationPage?.(page);
+                const organizationPages = options.organizationPages ?? [
+                  options.organizations ?? [],
+                ];
+                const nextPage =
+                  page < organizationPages.length ? page + 1 : null;
+                const headers =
+                  nextPage === null
+                    ? undefined
+                    : {
+                        Link: `<${url.origin}${url.pathname}?per_page=100&page=${nextPage}>; rel="next"`,
+                      };
                 return Response.json(
-                  (options.organizations ?? []).map((login) => ({
+                  (organizationPages[page - 1] ?? []).map((login) => ({
                     login,
                   })),
+                  { headers },
                 );
               }
               if (path === "/user") {
@@ -347,6 +367,60 @@ describe("bulk scan repository discovery", () => {
     expect(
       requests.find(({ path }) => path === "/graphql")?.variables?.owner,
     ).toBe("personal-account");
+  });
+
+  test("paginates and deduplicates organizations before account selection", async () => {
+    const root = await temporaryDirectory();
+    const firstPage = Array.from(
+      { length: 100 },
+      (_, index) => `organization-${String(index).padStart(3, "0")}`,
+    );
+    const { dependencies, prompt, requests } = discoveryDependencies(root, {
+      organizationPages: [firstPage, ["second-page", "ORGANIZATION-000"]],
+    });
+    prompt.confirms = [true];
+    prompt.choices = ["second-page"];
+
+    await runBulkScanWizard(dependencies);
+
+    expect(
+      requests
+        .filter(({ path }) => path === "/user/orgs")
+        .map(({ page }) => page),
+    ).toEqual([1, 2]);
+    expect(prompt.searchOptions[0]).toContain("personal-account");
+    expect(prompt.searchOptions[0]).toContain("second-page");
+    expect(
+      prompt.searchOptions[0]!.filter(
+        (owner) => owner.toLowerCase() === "organization-000",
+      ),
+    ).toHaveLength(1);
+    expect(
+      requests.find(({ path }) => path === "/graphql")?.variables?.owner,
+    ).toBe("second-page");
+  });
+
+  test("stops organization pagination when canceled", async () => {
+    const root = await temporaryDirectory();
+    const controller = new AbortController();
+    const { dependencies, prompt, requests } = discoveryDependencies(root, {
+      organizationPages: [["first-page"], ["second-page"]],
+      onOrganizationPage: (page) => {
+        if (page === 1) controller.abort(new Error("stop pagination"));
+      },
+    });
+
+    await expect(
+      runBulkScanWizard(dependencies, controller.signal),
+    ).rejects.toThrow("stop pagination");
+
+    expect(
+      requests
+        .filter(({ path }) => path === "/user/orgs")
+        .map(({ page }) => page),
+    ).toEqual([1]);
+    expect(requests.some(({ path }) => path === "/graphql")).toBe(false);
+    expect(prompt.questions).toEqual([]);
   });
 
   test("does not write an inventory when canceled or no repositories match", async () => {

--- a/sdk/typescript/tests-ts/bulk-scan-discovery.test.ts
+++ b/sdk/typescript/tests-ts/bulk-scan-discovery.test.ts
@@ -343,10 +343,10 @@ describe("bulk scan repository discovery", () => {
     const root = await temporaryDirectory();
     const home = join(root, "home");
     await mkdir(home);
-    const previousHome = process.env.HOME;
-    const previousProfile = process.env.USERPROFILE;
-    process.env.HOME = home;
-    process.env.USERPROFILE = home;
+    const previousHome = process.env["HOME"];
+    const previousProfile = process.env["USERPROFILE"];
+    process.env["HOME"] = home;
+    process.env["USERPROFILE"] = home;
     try {
       const { dependencies, prompt } = discoveryDependencies(root);
       prompt.confirms = [true];
@@ -357,10 +357,10 @@ describe("bulk scan repository discovery", () => {
       expect(result?.outputDir).toBe(join(home, "custom-results"));
       expect(await lstat(join(root, "~")).catch(() => null)).toBeNull();
     } finally {
-      if (previousHome === undefined) delete process.env.HOME;
-      else process.env.HOME = previousHome;
-      if (previousProfile === undefined) delete process.env.USERPROFILE;
-      else process.env.USERPROFILE = previousProfile;
+      if (previousHome === undefined) delete process.env["HOME"];
+      else process.env["HOME"] = previousHome;
+      if (previousProfile === undefined) delete process.env["USERPROFILE"];
+      else process.env["USERPROFILE"] = previousProfile;
     }
   });
 

--- a/sdk/typescript/tests-ts/bulk-scan-discovery.test.ts
+++ b/sdk/typescript/tests-ts/bulk-scan-discovery.test.ts
@@ -15,6 +15,7 @@ import {
   type BulkScanDiscoveryDependencies,
   type BulkScanPrompt,
 } from "../src/bulk-scan-discovery.js";
+import { MAX_BULK_SCAN_REPOSITORIES } from "../src/bulk-scan-limits.js";
 
 const temporaryDirectories: string[] = [];
 const NOW = Date.parse("2026-07-22T12:00:00.000Z");
@@ -273,6 +274,42 @@ describe("bulk scan repository discovery", () => {
     const csv = await readFile(result!.inputPath, "utf8");
     expect(csv).toContain("acme--service-100");
     expect(csv).not.toContain("acme--old");
+  });
+
+  test("enforces the discovery repository limit before creating an inventory", async () => {
+    const atLimit = Array.from(
+      { length: MAX_BULK_SCAN_REPOSITORIES },
+      (_value, index) => ({ fullName: `acme/service-${index}` }),
+    );
+    const acceptedRoot = await temporaryDirectory();
+    const accepted = discoveryDependencies(acceptedRoot, {
+      repositories: atLimit,
+    });
+    accepted.prompt.confirms = [false];
+    expect(await runBulkScanWizard(accepted.dependencies)).toBeNull();
+    expect(accepted.prompt.messages.join("")).toContain(
+      `Found ${MAX_BULK_SCAN_REPOSITORIES} repositories`,
+    );
+    expect(
+      accepted.requests.filter(({ path }) => path === "/graphql"),
+    ).toHaveLength(10);
+
+    const overflowRoot = await temporaryDirectory();
+    const overflow = discoveryDependencies(overflowRoot, {
+      repositories: [
+        ...atLimit,
+        { fullName: `acme/service-${MAX_BULK_SCAN_REPOSITORIES}` },
+      ],
+    });
+    await expect(runBulkScanWizard(overflow.dependencies)).rejects.toThrow(
+      "at most 1,000 repositories",
+    );
+    expect(
+      overflow.requests.filter(({ path }) => path === "/graphql"),
+    ).toHaveLength(11);
+    await expect(
+      lstat(join(overflowRoot, "security-scans")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   test("shows all repositories and scans only the selected ones", async () => {

--- a/sdk/typescript/tests-ts/bulk-scan-discovery.test.ts
+++ b/sdk/typescript/tests-ts/bulk-scan-discovery.test.ts
@@ -339,6 +339,31 @@ describe("bulk scan repository discovery", () => {
     expect(csv).not.toContain("unrelated");
   });
 
+  test("expands a home-relative output directory from the wizard prompt", async () => {
+    const root = await temporaryDirectory();
+    const home = join(root, "home");
+    await mkdir(home);
+    const previousHome = process.env.HOME;
+    const previousProfile = process.env.USERPROFILE;
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    try {
+      const { dependencies, prompt } = discoveryDependencies(root);
+      prompt.confirms = [true];
+      prompt.inputs = ["~/custom-results"];
+
+      const result = await runBulkScanWizard(dependencies);
+
+      expect(result?.outputDir).toBe(join(home, "custom-results"));
+      expect(await lstat(join(root, "~")).catch(() => null)).toBeNull();
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = previousProfile;
+    }
+  });
+
   test("includes public repositories and excludes archived, forked, and empty repositories", async () => {
     const root = await temporaryDirectory();
     const { dependencies, prompt } = discoveryDependencies(root, {

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -701,6 +701,49 @@ describe("CLI", () => {
     }
   });
 
+  test("expands ~ in bulk-scan path arguments", async () => {
+    const root = await mkdtemp(join(tmpdir(), "codex-security-cli-tilde-"));
+    const home = join(root, "home");
+    const work = join(root, "work");
+    const previousHome = process.env.HOME;
+    const previousProfile = process.env.USERPROFILE;
+    try {
+      await mkdir(home);
+      await mkdir(work);
+      await multiscanInventory(home);
+      process.env.HOME = home;
+      process.env.USERPROFILE = home;
+      const stdout = capture();
+      const stderr = capture();
+      expect(
+        await main(
+          [
+            "bulk-scan",
+            "~/repositories.csv",
+            "--output-dir",
+            "~/security-scans",
+            "--json",
+          ],
+          stdout.stream,
+          stderr.stream,
+          dependencies({
+            currentDirectory: work,
+          }),
+        ),
+      ).toBe(0);
+      expect(JSON.parse(stdout.text())).toMatchObject({
+        resultsPath: join(home, "security-scans", "results.jsonl"),
+      });
+      expect(await stat(join(work, "~")).catch(() => null)).toBeNull();
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = previousProfile;
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test("preserves the bulk-scan failure summary and redacts progress errors", async () => {
     const root = await mkdtemp(join(tmpdir(), "codex-security-cli-multiscan-"));
     try {

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -705,14 +705,14 @@ describe("CLI", () => {
     const root = await mkdtemp(join(tmpdir(), "codex-security-cli-tilde-"));
     const home = join(root, "home");
     const work = join(root, "work");
-    const previousHome = process.env.HOME;
-    const previousProfile = process.env.USERPROFILE;
+    const previousHome = process.env["HOME"];
+    const previousProfile = process.env["USERPROFILE"];
     try {
       await mkdir(home);
       await mkdir(work);
       await multiscanInventory(home);
-      process.env.HOME = home;
-      process.env.USERPROFILE = home;
+      process.env["HOME"] = home;
+      process.env["USERPROFILE"] = home;
       const stdout = capture();
       const stderr = capture();
       expect(
@@ -736,10 +736,10 @@ describe("CLI", () => {
       });
       expect(await stat(join(work, "~")).catch(() => null)).toBeNull();
     } finally {
-      if (previousHome === undefined) delete process.env.HOME;
-      else process.env.HOME = previousHome;
-      if (previousProfile === undefined) delete process.env.USERPROFILE;
-      else process.env.USERPROFILE = previousProfile;
+      if (previousHome === undefined) delete process.env["HOME"];
+      else process.env["HOME"] = previousHome;
+      if (previousProfile === undefined) delete process.env["USERPROFILE"];
+      else process.env["USERPROFILE"] = previousProfile;
       await rm(root, { recursive: true, force: true });
     }
   });

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -376,6 +376,32 @@ describe("multiscan", () => {
         skipped: 1,
       });
       expect(scans).toBe(1);
+
+      const remote = "https://example.invalid/symlinked-scope.git";
+      await writeFile(
+        paths.input,
+        `id,repository,revision,scope\nscoped,${remote},${revision},alias\n`,
+      );
+      const manifestPath = join(paths.output, "manifest.json");
+      const campaign = JSON.parse(await readFile(manifestPath, "utf8")) as {
+        tasks: Array<{ repository: string }>;
+      };
+      campaign.tasks[0]!.repository = remote;
+      await writeFile(manifestPath, `${JSON.stringify(campaign, null, 2)}\n`);
+      const ledgerPath = join(paths.output, "results.jsonl");
+      const receipts = await results(ledgerPath);
+      for (const receipt of receipts) receipt["repository"] = remote;
+      await writeFile(
+        ledgerPath,
+        `${receipts.map((receipt) => JSON.stringify(receipt)).join("\n")}\n`,
+      );
+
+      expect(await runMultiscan(options(paths, security))).toMatchObject({
+        completed: 1,
+        failed: 0,
+        skipped: 1,
+      });
+      expect(scans).toBe(1);
     },
   );
 

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -1,8 +1,10 @@
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   access,
   appendFile,
   chmod,
+  cp,
   link,
   mkdir,
   mkdtemp,
@@ -15,13 +17,16 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
+import { loadContract } from "../src/contract.js";
 import type { ScanResult } from "../src/result.js";
 import { buildGitHubCredentialArgs, runMultiscan } from "../src/multiscan.js";
 import { resolveTrustedExecutable } from "../src/trusted-executable.js";
+import { PLUGIN_ROOT } from "./plugin-root.js";
 
 type MultiscanOptions = Parameters<typeof runMultiscan>[0];
 type SecurityClient = ReturnType<MultiscanOptions["createSecurity"]>;
 
+const COMPLETED_SCAN = join(PLUGIN_ROOT, "examples", "completed-scan");
 const temporaryDirectories: string[] = [];
 
 afterEach(async () => {
@@ -82,12 +87,8 @@ async function completedScan(
   outputDir: string,
   completeness: "complete" | "partial" = "complete",
 ): Promise<ScanResult> {
-  await mkdir(outputDir, { recursive: true });
-  await Promise.all(
-    ["scan-manifest.json", "findings.json", "coverage.json", "report.md"].map(
-      (name) => writeFile(join(outputDir, name), "{}\n"),
-    ),
-  );
+  await cp(COMPLETED_SCAN, outputDir, { recursive: true });
+  await writeFile(join(outputDir, "report.md"), "# Scan report\n");
   return { coverage: { completeness } } as ScanResult;
 }
 
@@ -120,6 +121,19 @@ async function results(path: string): Promise<Record<string, unknown>[]> {
     .trim()
     .split("\n")
     .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+async function reseal(scanDir: string): Promise<void> {
+  const manifestPath = join(scanDir, "scan-manifest.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as {
+    scan: { artifacts: Array<{ path: string; sha256: string }> };
+  };
+  for (const artifact of manifest.scan.artifacts) {
+    artifact.sha256 = createHash("sha256")
+      .update(await readFile(join(scanDir, artifact.path)))
+      .digest("hex");
+  }
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 }
 
 describe("multiscan", () => {
@@ -834,6 +848,57 @@ describe("multiscan", () => {
     expect(recovered).toMatchObject({ completed: 1, failed: 0, skipped: 1 });
     expect(scans).toBe(1);
     expect(await readFile(initial.resultsPath, "utf8")).toBe(completed);
+  });
+
+  test("rescans completed receipts with invalid, unsealed, or incomplete artifacts", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "resume-integrity");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\nresume-integrity,${source.path},${source.revision}\n`,
+    );
+    let calls = 0;
+    const security = client(async (_repository, scanOptions = {}) => {
+      calls += 1;
+      return await completedScan(scanOptions.outputDir!);
+    });
+    const run = async () => await runMultiscan(options(paths, security));
+    const latestOutput = async (): Promise<string> =>
+      (await results(join(paths.output, "results.jsonl"))).at(-1)?.[
+        "outputDir"
+      ] as string;
+
+    await run();
+    expect(calls).toBe(1);
+
+    await writeFile(join(await latestOutput(), "findings.json"), "");
+    expect(await run()).toMatchObject({ completed: 1, failed: 0, skipped: 0 });
+    expect(calls).toBe(2);
+
+    await appendFile(join(await latestOutput(), "coverage.json"), "\n");
+    expect(await run()).toMatchObject({ completed: 1, failed: 0, skipped: 0 });
+    expect(calls).toBe(3);
+
+    const incompleteOutput = await latestOutput();
+    const coveragePath = join(incompleteOutput, "coverage.json");
+    const coverage = JSON.parse(await readFile(coveragePath, "utf8")) as {
+      completeness: string;
+    };
+    coverage.completeness = "partial";
+    await writeFile(coveragePath, `${JSON.stringify(coverage, null, 2)}\n`);
+    await reseal(incompleteOutput);
+    expect(
+      (
+        await loadContract(incompleteOutput, {
+          pluginRoot: PLUGIN_ROOT,
+        })
+      ).coverage.completeness,
+    ).toBe("partial");
+    expect(await run()).toMatchObject({ completed: 1, failed: 0, skipped: 0 });
+    expect(calls).toBe(4);
+    expect(await latestOutput()).toBe(
+      join(paths.output, "artifacts", "resume-integrity", "attempt-4"),
+    );
   });
 
   test("ignores repository-local Git shims while preserving credential configuration", async () => {

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -377,6 +377,16 @@ describe("multiscan", () => {
       });
       expect(scans).toBe(1);
 
+      await mkdir(join(source.path, "another"));
+      await rm(join(source.path, "alias"));
+      await symlink("another", join(source.path, "alias"));
+      expect(await runMultiscan(options(paths, security))).toMatchObject({
+        completed: 1,
+        failed: 0,
+        skipped: 1,
+      });
+      expect(scans).toBe(1);
+
       const ledgerPath = join(paths.output, "results.jsonl");
       const manipulated = await results(ledgerPath);
       manipulated[manipulated.length - 1]!["canonicalScope"] = "another";

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -915,6 +915,9 @@ describe("multiscan", () => {
     let calls = 0;
     const security = client(async (_repository, scanOptions = {}) => {
       calls += 1;
+      await expect(access(scanOptions.outputDir!)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
       return await completedScan(scanOptions.outputDir!);
     });
 
@@ -1444,6 +1447,9 @@ describe("multiscan", () => {
     let calls = 0;
     const security = client(async (_repository, scanOptions = {}) => {
       calls += 1;
+      await expect(access(scanOptions.outputDir!)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
       return await completedScan(scanOptions.outputDir!);
     });
     const initial = await runMultiscan(options(paths, security));

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -508,6 +508,95 @@ describe("multiscan", () => {
     },
   );
 
+  test.skipIf(process.platform === "win32")(
+    "resumes Git symlink entries materialized as ordinary checkout files",
+    async () => {
+      const paths = await fixture();
+      const source = await repository(paths.root, "materialized-symlink-scope");
+      await symlink("src", join(source.path, "alias"));
+      git(source.path, "add", "alias");
+      git(
+        source.path,
+        "-c",
+        "user.name=Multiscan Test",
+        "-c",
+        "user.email=multiscan@example.test",
+        "commit",
+        "-qm",
+        "add scope alias",
+      );
+      const revision = git(source.path, "rev-parse", "HEAD");
+      await writeFile(
+        paths.input,
+        `id,repository,revision,scope\nscoped,${source.path},${revision},alias\n`,
+      );
+      const original = new Map(
+        ["GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0"].map(
+          (key) => [key, process.env[key]],
+        ),
+      );
+      process.env["GIT_CONFIG_COUNT"] = "1";
+      process.env["GIT_CONFIG_KEY_0"] = "core.symlinks";
+      process.env["GIT_CONFIG_VALUE_0"] = "false";
+      try {
+        let scans = 0;
+        const security = client(async (_repository, scanOptions = {}) => {
+          scans += 1;
+          return await completedScan(scanOptions.outputDir!);
+        });
+
+        await runMultiscan(options(paths, security));
+        expect(await runMultiscan(options(paths, security))).toMatchObject({
+          completed: 1,
+          failed: 0,
+          skipped: 1,
+        });
+        expect(scans).toBe(1);
+      } finally {
+        for (const [key, value] of original) {
+          if (value === undefined) delete process.env[key];
+          else process.env[key] = value;
+        }
+      }
+    },
+  );
+
+  test("matches pinned scope paths using their recorded checkout casing", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "scope-casing");
+    const inventory = (scope: string): string =>
+      `id,repository,revision,scope\nscoped,${source.path},${source.revision},${scope}\n`;
+    await writeFile(paths.input, inventory("src"));
+    let scans = 0;
+    const security = client(async (_repository, scanOptions = {}) => {
+      scans += 1;
+      return await completedScan(scanOptions.outputDir!);
+    });
+    await runMultiscan(options(paths, security));
+
+    await writeFile(paths.input, inventory("SrC"));
+    const manifestPath = join(paths.output, "manifest.json");
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as {
+      tasks: Array<{ scope: string }>;
+    };
+    manifest.tasks[0]!.scope = "SrC";
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+    const ledgerPath = join(paths.output, "results.jsonl");
+    const receipts = await results(ledgerPath);
+    for (const receipt of receipts) receipt["scope"] = "SrC";
+    await writeFile(
+      ledgerPath,
+      `${receipts.map((receipt) => JSON.stringify(receipt)).join("\n")}\n`,
+    );
+
+    expect(await runMultiscan(options(paths, security))).toMatchObject({
+      completed: 1,
+      failed: 0,
+      skipped: 1,
+    });
+    expect(scans).toBe(1);
+  });
+
   test("records each completed scan's cost in the resumable ledger", async () => {
     const paths = await fixture();
     const source = await repository(paths.root, "priced");

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -377,7 +377,7 @@ describe("multiscan", () => {
       });
       expect(scans).toBe(1);
 
-      const remote = "https://example.invalid/symlinked-scope.git";
+      const remote = "ssh://127.0.0.1:1/symlinked-scope.git";
       await writeFile(
         paths.input,
         `id,repository,revision,scope\nscoped,${remote},${revision},alias\n`,
@@ -400,6 +400,97 @@ describe("multiscan", () => {
         completed: 1,
         failed: 0,
         skipped: 1,
+      });
+      expect(scans).toBe(1);
+
+      const manipulated = await results(ledgerPath);
+      manipulated[manipulated.length - 1]!["canonicalScope"] = "another";
+      await writeFile(
+        ledgerPath,
+        `${manipulated.map((receipt) => JSON.stringify(receipt)).join("\n")}\n`,
+      );
+      const scanManifestPath = join(
+        paths.output,
+        "artifacts",
+        "scoped",
+        "attempt-1",
+        "scan-manifest.json",
+      );
+      const scanManifest = JSON.parse(
+        await readFile(scanManifestPath, "utf8"),
+      ) as { scan: { scope: { includePaths: string[] } } };
+      scanManifest.scan.scope.includePaths = ["another"];
+      await writeFile(
+        scanManifestPath,
+        `${JSON.stringify(scanManifest, null, 2)}\n`,
+      );
+      const coveragePath = join(dirname(scanManifestPath), "coverage.json");
+      const coverage = JSON.parse(await readFile(coveragePath, "utf8")) as {
+        includePaths: string[];
+      };
+      coverage.includePaths = ["another"];
+      await writeFile(coveragePath, `${JSON.stringify(coverage, null, 2)}\n`);
+      await reseal(dirname(scanManifestPath));
+
+      const resumed = await runMultiscan(options(paths, security));
+      expect(resumed.skipped).toBe(0);
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "normalizes a symlinked repository-root scope for resumable scans",
+    async () => {
+      const paths = await fixture();
+      const source = await repository(paths.root, "repository-root-alias");
+      await symlink(".", join(source.path, "root-alias"));
+      git(source.path, "add", "root-alias");
+      git(
+        source.path,
+        "-c",
+        "user.name=Multiscan Test",
+        "-c",
+        "user.email=multiscan@example.test",
+        "commit",
+        "-qm",
+        "add repository-root alias",
+      );
+      const revision = git(source.path, "rev-parse", "HEAD");
+      await writeFile(
+        paths.input,
+        `id,repository,revision,scope\nroot,${source.path},${revision},root-alias\n`,
+      );
+      let scans = 0;
+      const security = client(async (_repository, scanOptions = {}) => {
+        scans += 1;
+        const result = await completedScan(scanOptions.outputDir!);
+        for (const artifact of ["scan-manifest.json", "coverage.json"]) {
+          const artifactPath = join(scanOptions.outputDir!, artifact);
+          const document = JSON.parse(await readFile(artifactPath, "utf8")) as {
+            scan?: { scope: { includePaths: string[] } };
+            includePaths?: string[];
+          };
+          if (document.scan === undefined) document.includePaths = ["."];
+          else document.scan.scope.includePaths = ["."];
+          await writeFile(
+            artifactPath,
+            `${JSON.stringify(document, null, 2)}\n`,
+          );
+        }
+        await reseal(scanOptions.outputDir!);
+        return result;
+      });
+
+      await runMultiscan(options(paths, security));
+      expect(await runMultiscan(options(paths, security))).toMatchObject({
+        completed: 1,
+        failed: 0,
+        skipped: 1,
+      });
+      expect(
+        (await results(join(paths.output, "results.jsonl")))[0],
+      ).toMatchObject({
+        scope: "root-alias",
+        canonicalScope: ".",
       });
       expect(scans).toBe(1);
     },

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -326,6 +326,59 @@ describe("multiscan", () => {
     expect(scans).toBe(1);
   });
 
+  test.skipIf(process.platform === "win32")(
+    "resumes symlinked scopes using their canonical repository paths",
+    async () => {
+      const paths = await fixture();
+      const source = await repository(paths.root, "symlinked-scope");
+      await symlink("src", join(source.path, "alias"));
+      git(source.path, "add", "alias");
+      git(
+        source.path,
+        "-c",
+        "user.name=Multiscan Test",
+        "-c",
+        "user.email=multiscan@example.test",
+        "commit",
+        "-qm",
+        "add scope alias",
+      );
+      const revision = git(source.path, "rev-parse", "HEAD");
+      await writeFile(
+        paths.input,
+        `id,repository,revision,scope\nscoped,${source.path},${revision},alias\n`,
+      );
+      let scans = 0;
+      const security = client(async (_repository, scanOptions = {}) => {
+        scans += 1;
+        const result = await completedScan(scanOptions.outputDir!);
+        for (const artifact of ["scan-manifest.json", "coverage.json"]) {
+          const path = join(scanOptions.outputDir!, artifact);
+          const document = JSON.parse(await readFile(path, "utf8")) as {
+            scan?: { scope: { includePaths: string[] } };
+            includePaths?: string[];
+          };
+          if (document.scan !== undefined) {
+            document.scan.scope.includePaths = ["src"];
+          } else {
+            document.includePaths = ["src"];
+          }
+          await writeFile(path, `${JSON.stringify(document, null, 2)}\n`);
+        }
+        await reseal(scanOptions.outputDir!);
+        return result;
+      });
+
+      await runMultiscan(options(paths, security));
+      expect(await runMultiscan(options(paths, security))).toMatchObject({
+        completed: 1,
+        failed: 0,
+        skipped: 1,
+      });
+      expect(scans).toBe(1);
+    },
+  );
+
   test("records each completed scan's cost in the resumable ledger", async () => {
     const paths = await fixture();
     const source = await repository(paths.root, "priced");
@@ -1338,6 +1391,46 @@ describe("multiscan", () => {
         code: "ENOENT",
       });
     }
+  });
+
+  test("never publishes an unfinished receipt-repair construction file", async () => {
+    const paths = await fixture();
+    const first = await repository(paths.root, "repair-first");
+    const second = await repository(paths.root, "repair-second");
+    await writeFile(
+      paths.input,
+      [
+        "id,repository,revision",
+        `first,${first.path},${first.revision}`,
+        `second,${second.path},${second.revision}`,
+        "",
+      ].join("\n"),
+    );
+    let scans = 0;
+    const security = client(async (_repository, scanOptions = {}) => {
+      scans += 1;
+      return await completedScan(scanOptions.outputDir!);
+    });
+    const initial = await runMultiscan(options(paths, security));
+    const saved = await readFile(initial.resultsPath, "utf8");
+    const unfinished = join(
+      paths.output,
+      ".results.repair-interrupted.jsonl.pending",
+    );
+    await writeFile(unfinished, `${saved.split("\n")[0]}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+    await appendFile(initial.resultsPath, '{"id":"interrupted"');
+
+    expect(await runMultiscan(options(paths, security))).toMatchObject({
+      completed: 2,
+      failed: 0,
+      skipped: 2,
+    });
+    expect(scans).toBe(2);
+    expect(await readFile(initial.resultsPath, "utf8")).toBe(saved);
+    await expect(access(unfinished)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   test("binds resumed scan bundles to their pinned task and plugin version", async () => {

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import {
   access,
   appendFile,
+  chmod,
   link,
   mkdir,
   mkdtemp,
@@ -503,6 +504,33 @@ describe("multiscan", () => {
     );
     expect(calls).toBe(2);
   });
+
+  test.skipIf(process.platform === "win32")(
+    "resumes a completed campaign when its receipt ledger is read-only",
+    async () => {
+      const paths = await fixture();
+      const source = await repository(paths.root, "readonly-ledger");
+      await writeFile(
+        paths.input,
+        `id,repository,revision\nreadonly,${source.path},${source.revision}\n`,
+      );
+      let scans = 0;
+      const security = client(async (_repository, scanOptions = {}) => {
+        scans += 1;
+        return await completedScan(scanOptions.outputDir!);
+      });
+      const initial = await runMultiscan(options(paths, security));
+      await chmod(initial.resultsPath, 0o400);
+      try {
+        const resumed = await runMultiscan(options(paths, security));
+
+        expect(resumed).toMatchObject({ completed: 1, failed: 0, skipped: 1 });
+        expect(scans).toBe(1);
+      } finally {
+        await chmod(initial.resultsPath, 0o600);
+      }
+    },
+  );
 
   test.skipIf(process.platform === "win32")(
     "rejects symlinked receipt ledgers without reading or changing external files",

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -1049,6 +1049,98 @@ describe("multiscan", () => {
     expect(calls).toBe(4);
   });
 
+  test("quarantines malformed committed receipts and preserves valid history", async () => {
+    const corruptions = (
+      receipt: Record<string, unknown>,
+    ): Array<[string, string]> => {
+      const { id: _id, ...withoutId } = receipt;
+      return [
+        ["malformed JSON", '{"broken":\n'],
+        ["non-object JSON", "null\n"],
+        ["missing ID", `${JSON.stringify(withoutId)}\n`],
+        ["invalid attempt", `${JSON.stringify({ ...receipt, attempt: 0 })}\n`],
+        [
+          "invalid status",
+          `${JSON.stringify({ ...receipt, status: "running" })}\n`,
+        ],
+        [
+          "invalid output path",
+          `${JSON.stringify({ ...receipt, outputDir: 42 })}\n`,
+        ],
+        [
+          "oversized line",
+          `${JSON.stringify({ padding: "x".repeat(1024 * 1024) })}\n`,
+        ],
+      ];
+    };
+
+    for (const [index] of Array.from({ length: 7 }).entries()) {
+      const paths = await fixture();
+      const source = await repository(paths.root, `corrupt-${index}`);
+      await writeFile(
+        paths.input,
+        `id,repository,revision\ncorrupt-${index},${source.path},${source.revision}\n`,
+      );
+      let calls = 0;
+      const security = client(async (_repository, scanOptions = {}) => {
+        calls += 1;
+        return await completedScan(scanOptions.outputDir!);
+      });
+      const initial = await runMultiscan(options(paths, security));
+      const [receipt] = await results(initial.resultsPath);
+      const [, corruption] = corruptions(receipt!)[index]!;
+      await appendFile(
+        initial.resultsPath,
+        `${corruption}${JSON.stringify(receipt)}\n`,
+      );
+
+      const resumed = await runMultiscan(options(paths, security));
+      expect(resumed).toMatchObject({
+        completed: 1,
+        failed: 0,
+        skipped: 1,
+      });
+      expect(calls).toBe(1);
+      expect(await results(resumed.resultsPath)).toHaveLength(2);
+      const quarantines = (await readdir(paths.output)).filter((entry) =>
+        entry.startsWith("results.corrupt-"),
+      );
+      expect(quarantines).toHaveLength(1);
+      expect(
+        await readFile(join(paths.output, quarantines[0]!), "utf8"),
+      ).toContain(corruption.trim());
+    }
+  });
+
+  test("quarantines an oversized receipt ledger before rescanning", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "oversized-ledger");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\noversized-ledger,${source.path},${source.revision}\n`,
+    );
+    let calls = 0;
+    const security = client(async (_repository, scanOptions = {}) => {
+      calls += 1;
+      return await completedScan(scanOptions.outputDir!);
+    });
+    const initial = await runMultiscan(options(paths, security));
+    await truncate(initial.resultsPath, 64 * 1024 * 1024 + 1);
+
+    const resumed = await runMultiscan(options(paths, security));
+
+    expect(resumed).toMatchObject({ completed: 1, failed: 0, skipped: 0 });
+    expect(calls).toBe(2);
+    expect(await results(resumed.resultsPath)).toHaveLength(1);
+    const quarantines = (await readdir(paths.output)).filter((entry) =>
+      entry.startsWith("results.corrupt-"),
+    );
+    expect(quarantines).toHaveLength(1);
+    expect(
+      (await lstat(join(paths.output, quarantines[0]!))).size,
+    ).toBeGreaterThan(64 * 1024 * 1024);
+  });
+
   test("ignores repository-local Git shims while preserving credential configuration", async () => {
     const paths = await fixture();
     const source = await repository(paths.root, "private");

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -431,6 +431,10 @@ describe("multiscan", () => {
       coverage.includePaths = ["another"];
       await writeFile(coveragePath, `${JSON.stringify(coverage, null, 2)}\n`);
       await reseal(dirname(scanManifestPath));
+      await writeFile(
+        join(dirname(scanManifestPath), ".multiscan-scope.json"),
+        `${JSON.stringify({ scope: "alias", canonicalScope: "another" })}\n`,
+      );
 
       const resumed = await runMultiscan(options(paths, security));
       expect(resumed.skipped).toBe(0);

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import {
   access,
   appendFile,
+  link,
   mkdir,
   mkdtemp,
   readFile,
@@ -501,6 +502,246 @@ describe("multiscan", () => {
       "manifest does not match",
     );
     expect(calls).toBe(2);
+  });
+
+  test.skipIf(process.platform === "win32")(
+    "rejects symlinked receipt ledgers without reading or changing external files",
+    async () => {
+      for (const contents of ["", '{"id":"interrupted"']) {
+        const paths = await fixture();
+        const source = await repository(paths.root, "ledger-source");
+        const external = join(paths.root, "external-results.jsonl");
+        await writeFile(
+          paths.input,
+          `id,repository,revision\nledger,${source.path},${source.revision}\n`,
+        );
+        await mkdir(paths.output);
+        await writeFile(external, contents);
+        await symlink(external, join(paths.output, "results.jsonl"));
+
+        let scans = 0;
+        await expect(
+          runMultiscan(
+            options(
+              paths,
+              client(async (_repository, scanOptions = {}) => {
+                scans += 1;
+                return await completedScan(scanOptions.outputDir!);
+              }),
+            ),
+          ),
+        ).rejects.toThrow(/ledger|symbolic link|ELOOP/iu);
+
+        expect(scans).toBe(0);
+        expect(await readFile(external, "utf8")).toBe(contents);
+      }
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "rejects dangling receipt-ledger symlinks without creating external files",
+    async () => {
+      const paths = await fixture();
+      const source = await repository(paths.root, "dangling-ledger");
+      const external = join(paths.root, "missing-external-results.jsonl");
+      await writeFile(
+        paths.input,
+        `id,repository,revision\ndangling,${source.path},${source.revision}\n`,
+      );
+      await mkdir(paths.output);
+      await symlink(external, join(paths.output, "results.jsonl"));
+
+      let scans = 0;
+      await expect(
+        runMultiscan(
+          options(
+            paths,
+            client(async (_repository, scanOptions = {}) => {
+              scans += 1;
+              return await completedScan(scanOptions.outputDir!);
+            }),
+          ),
+        ),
+      ).rejects.toThrow(/ledger|symbolic link|ELOOP/iu);
+
+      expect(scans).toBe(0);
+      await expect(access(external)).rejects.toThrow();
+    },
+  );
+
+  test("rejects hard-linked receipt ledgers without changing external files", async () => {
+    for (const contents of ["", '{"id":"interrupted"']) {
+      const paths = await fixture();
+      const source = await repository(paths.root, "hard-linked-ledger");
+      const external = join(paths.root, "external-results.jsonl");
+      await writeFile(
+        paths.input,
+        `id,repository,revision\nledger,${source.path},${source.revision}\n`,
+      );
+      await mkdir(paths.output);
+      await writeFile(external, contents);
+      await link(external, join(paths.output, "results.jsonl"));
+
+      let scans = 0;
+      await expect(
+        runMultiscan(
+          options(
+            paths,
+            client(async (_repository, scanOptions = {}) => {
+              scans += 1;
+              return await completedScan(scanOptions.outputDir!);
+            }),
+          ),
+        ),
+      ).rejects.toThrow(/ledger|regular|link/iu);
+
+      expect(scans).toBe(0);
+      expect(await readFile(external, "utf8")).toBe(contents);
+    }
+  });
+
+  test("rejects non-regular receipt ledgers before starting scans", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "directory-ledger");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\ndirectory,${source.path},${source.revision}\n`,
+    );
+    await mkdir(join(paths.output, "results.jsonl"), { recursive: true });
+
+    let scans = 0;
+    await expect(
+      runMultiscan(
+        options(
+          paths,
+          client(async (_repository, scanOptions = {}) => {
+            scans += 1;
+            return await completedScan(scanOptions.outputDir!);
+          }),
+        ),
+      ),
+    ).rejects.toThrow(/ledger|regular/iu);
+
+    expect(scans).toBe(0);
+  });
+
+  test.skipIf(process.platform === "win32")(
+    "rejects FIFO receipt ledgers without opening or blocking",
+    async () => {
+      const paths = await fixture();
+      const source = await repository(paths.root, "fifo-ledger");
+      await writeFile(
+        paths.input,
+        `id,repository,revision\nfifo,${source.path},${source.revision}\n`,
+      );
+      await mkdir(paths.output);
+      execFileSync("mkfifo", [join(paths.output, "results.jsonl")], {
+        stdio: "ignore",
+      });
+
+      let scans = 0;
+      await expect(
+        runMultiscan(
+          options(
+            paths,
+            client(async (_repository, scanOptions = {}) => {
+              scans += 1;
+              return await completedScan(scanOptions.outputDir!);
+            }),
+          ),
+        ),
+      ).rejects.toThrow(/ledger|regular/iu);
+
+      expect(scans).toBe(0);
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "rejects a receipt ledger replaced by a symlink before appending",
+    async () => {
+      const paths = await fixture();
+      const source = await repository(paths.root, "ledger-replacement");
+      const external = join(paths.root, "external-results.jsonl");
+      const preserved = "external file must not receive a scan receipt\n";
+      await writeFile(
+        paths.input,
+        `id,repository,revision\nledger,${source.path},${source.revision}\n`,
+      );
+      await writeFile(external, preserved);
+
+      let scans = 0;
+      await expect(
+        runMultiscan(
+          options(
+            paths,
+            client(async (_repository, scanOptions = {}) => {
+              scans += 1;
+              await symlink(external, join(paths.output, "results.jsonl"));
+              return await completedScan(scanOptions.outputDir!);
+            }),
+          ),
+        ),
+      ).rejects.toThrow(/ledger|symbolic link|ELOOP/iu);
+
+      expect(scans).toBe(1);
+      expect(await readFile(external, "utf8")).toBe(preserved);
+    },
+  );
+
+  test("rejects a receipt ledger replaced by a hard link before appending", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "hard-link-replacement");
+    const external = join(paths.root, "external-results.jsonl");
+    const preserved = "external file must not receive a scan receipt\n";
+    await writeFile(
+      paths.input,
+      `id,repository,revision\nledger,${source.path},${source.revision}\n`,
+    );
+    await writeFile(external, preserved);
+
+    let scans = 0;
+    await expect(
+      runMultiscan(
+        options(
+          paths,
+          client(async (_repository, scanOptions = {}) => {
+            scans += 1;
+            await link(external, join(paths.output, "results.jsonl"));
+            return await completedScan(scanOptions.outputDir!);
+          }),
+        ),
+      ),
+    ).rejects.toThrow(/ledger|regular|link/iu);
+
+    expect(scans).toBe(1);
+    expect(await readFile(external, "utf8")).toBe(preserved);
+  });
+
+  test("repairs an interrupted regular ledger without dropping completed receipts", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "ledger-recovery");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\nledger,${source.path},${source.revision}\n`,
+    );
+
+    let scans = 0;
+    const security = client(async (_repository, scanOptions = {}) => {
+      scans += 1;
+      return await completedScan(scanOptions.outputDir!);
+    });
+    const initial = await runMultiscan(options(paths, security));
+    const completed = await readFile(initial.resultsPath, "utf8");
+    await appendFile(
+      initial.resultsPath,
+      '{"id":"interrupted","error":"\u20ac',
+    );
+
+    const recovered = await runMultiscan(options(paths, security));
+
+    expect(recovered).toMatchObject({ completed: 1, failed: 0, skipped: 1 });
+    expect(scans).toBe(1);
+    expect(await readFile(initial.resultsPath, "utf8")).toBe(completed);
   });
 
   test("ignores repository-local Git shims while preserving credential configuration", async () => {

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -14,6 +14,7 @@ import {
   readdir,
   rm,
   symlink,
+  truncate,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -21,6 +22,10 @@ import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 import { loadContract } from "../src/contract.js";
 import type { ScanResult } from "../src/result.js";
+import {
+  MAX_BULK_SCAN_INVENTORY_BYTES,
+  MAX_BULK_SCAN_REPOSITORIES,
+} from "../src/bulk-scan-limits.js";
 import { buildGitHubCredentialArgs, runMultiscan } from "../src/multiscan.js";
 import { resolveTrustedExecutable } from "../src/trusted-executable.js";
 import { PLUGIN_ROOT } from "./plugin-root.js";
@@ -279,6 +284,47 @@ describe("multiscan", () => {
     }
 
     expect(scans).toBe(0);
+  });
+
+  test("rejects oversized and excessive inventories before creating campaign state", async () => {
+    for (const prepare of [
+      async (path: string) => {
+        await writeFile(path, "id,repository,revision\n");
+        await truncate(path, MAX_BULK_SCAN_INVENTORY_BYTES + 1);
+      },
+      async (path: string) => {
+        const rows = Array.from(
+          { length: MAX_BULK_SCAN_REPOSITORIES + 1 },
+          (_value, index) =>
+            `repository-${index},.,0123456789abcdef0123456789abcdef01234567`,
+        );
+        await writeFile(path, `id,repository,revision\n${rows.join("\n")}\n`);
+      },
+    ]) {
+      const paths = await fixture();
+      await prepare(paths.input);
+      let clients = 0;
+      await expect(
+        runMultiscan({
+          ...options(
+            paths,
+            client(async () => {
+              throw new Error("scan must not start");
+            }),
+          ),
+          createSecurity: () => {
+            clients += 1;
+            return client(async () => {
+              throw new Error("scan must not start");
+            });
+          },
+        }),
+      ).rejects.toThrow(/8 MiB|at most 1,000 repositories/u);
+      expect(clients).toBe(0);
+      await expect(lstat(paths.output)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    }
   });
 
   test("materializes the pinned commit, applies row options, and removes its checkout", async () => {

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -17,9 +17,10 @@ import {
   truncate,
   writeFile,
 } from "node:fs/promises";
+import * as fsPromises from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { loadContract } from "../src/contract.js";
 import type { ScanResult } from "../src/result.js";
 import {
@@ -344,6 +345,7 @@ describe("multiscan", () => {
         "add scope alias",
       );
       const revision = git(source.path, "rev-parse", "HEAD");
+      git(source.path, "config", "core.symlinks", "false");
       await writeFile(
         paths.input,
         `id,repository,revision,scope\nscoped,${source.path},${revision},alias\n`,
@@ -446,6 +448,69 @@ describe("multiscan", () => {
         skipped: 0,
       });
       expect(scans).toBe(2);
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "resumes scope aliases that resolve to a pinned Git submodule",
+    async () => {
+      const paths = await fixture();
+      const source = await repository(paths.root, "submodule-scope");
+      await mkdir(join(source.path, "vendor", "dependency"), {
+        recursive: true,
+      });
+      git(
+        source.path,
+        "update-index",
+        "--add",
+        "--cacheinfo",
+        `160000,${source.revision},vendor/dependency`,
+      );
+      await symlink("vendor/dependency", join(source.path, "alias"));
+      git(source.path, "add", "alias");
+      git(
+        source.path,
+        "-c",
+        "user.name=Multiscan Test",
+        "-c",
+        "user.email=multiscan@example.test",
+        "commit",
+        "-qm",
+        "add submodule scope alias",
+      );
+      const revision = git(source.path, "rev-parse", "HEAD");
+      await writeFile(
+        paths.input,
+        `id,repository,revision,scope\nscoped,${source.path},${revision},alias\n`,
+      );
+      let scans = 0;
+      const security = client(async (_repository, scanOptions = {}) => {
+        scans += 1;
+        const result = await completedScan(scanOptions.outputDir!);
+        for (const artifact of ["scan-manifest.json", "coverage.json"]) {
+          const path = join(scanOptions.outputDir!, artifact);
+          const document = JSON.parse(await readFile(path, "utf8")) as {
+            scan?: { scope: { includePaths: string[] } };
+            includePaths?: string[];
+          };
+          if (document.scan === undefined) {
+            document.includePaths = ["vendor/dependency"];
+          } else {
+            document.scan.scope.includePaths = ["vendor/dependency"];
+          }
+          await writeFile(path, `${JSON.stringify(document, null, 2)}\n`);
+        }
+        await reseal(scanOptions.outputDir!);
+        return result;
+      });
+
+      await runMultiscan(options(paths, security));
+      expect(await runMultiscan(options(paths, security))).toMatchObject({
+        completed: 1,
+        failed: 0,
+        skipped: 1,
+      });
+      expect(scans).toBe(1);
     },
   );
 
@@ -1747,6 +1812,68 @@ describe("multiscan", () => {
       ).toContain(corruption.trim());
     }
   });
+
+  test.skipIf(process.platform === "win32")(
+    "quarantines verified ledger bytes when the pathname becomes a symlink",
+    async () => {
+      const paths = await fixture();
+      const source = await repository(paths.root, "ledger-quarantine-race");
+      await writeFile(
+        paths.input,
+        `id,repository,revision\nrace,${source.path},${source.revision}\n`,
+      );
+      const security = client(async (_repository, scanOptions = {}) =>
+        completedScan(scanOptions.outputDir!),
+      );
+      const initial = await runMultiscan(options(paths, security));
+      await appendFile(initial.resultsPath, '{"malformed":\n');
+      const external = join(paths.root, "private.txt");
+      await writeFile(external, "private data must not enter quarantine\n");
+      const originalOpen = fsPromises.open;
+      let swapped = false;
+      mock.module("node:fs/promises", () => ({
+        ...fsPromises,
+        open: async (...args: Parameters<typeof originalOpen>) => {
+          if (
+            !swapped &&
+            basename(String(args[0])).startsWith("results.corrupt-")
+          ) {
+            swapped = true;
+            await rm(initial.resultsPath);
+            await symlink(external, initial.resultsPath);
+          }
+          return originalOpen(...args);
+        },
+      }));
+      try {
+        expect(await runMultiscan(options(paths, security))).toMatchObject({
+          completed: 1,
+          failed: 0,
+          skipped: 1,
+        });
+      } finally {
+        mock.module("node:fs/promises", () => ({
+          ...fsPromises,
+          open: originalOpen,
+        }));
+      }
+
+      expect(swapped).toBe(true);
+      const quarantine = (await readdir(paths.output)).find((entry) =>
+        entry.startsWith("results.corrupt-"),
+      );
+      expect(quarantine).toBeDefined();
+      expect(await readFile(join(paths.output, quarantine!), "utf8")).toContain(
+        '{"malformed":',
+      );
+      expect(
+        await readFile(join(paths.output, quarantine!), "utf8"),
+      ).not.toContain("private data");
+      expect(await readFile(external, "utf8")).toBe(
+        "private data must not enter quarantine\n",
+      );
+    },
+  );
 
   test("quarantines an oversized receipt ledger before rescanning", async () => {
     const paths = await fixture();

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -18,7 +18,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 import { loadContract } from "../src/contract.js";
 import type { ScanResult } from "../src/result.js";
@@ -95,6 +95,51 @@ async function completedScan(
   completeness: "complete" | "partial" = "complete",
 ): Promise<ScanResult> {
   await cp(COMPLETED_SCAN, outputDir, { recursive: true });
+  const campaign = dirname(dirname(dirname(outputDir)));
+  const taskId = basename(dirname(outputDir));
+  const campaignManifest = JSON.parse(
+    await readFile(join(campaign, "manifest.json"), "utf8"),
+  ) as {
+    tasks: Array<{
+      id: string;
+      revision: string;
+      mode: string;
+      scope?: string;
+    }>;
+  };
+  const task = campaignManifest.tasks.find(
+    (candidate) => candidate.id === taskId,
+  );
+  if (task === undefined) throw new Error("missing multiscan fixture task");
+  const plugin = JSON.parse(
+    await readFile(join(PLUGIN_ROOT, ".codex-plugin", "plugin.json"), "utf8"),
+  ) as { version: string };
+  const manifestPath = join(outputDir, "scan-manifest.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as {
+    scan: {
+      producer: { version: string };
+      target: { revision: string };
+      scope: { includePaths: string[] };
+    };
+  };
+  manifest.scan.producer.version = plugin.version;
+  manifest.scan.target.revision = task.revision;
+  if (task.scope !== undefined) manifest.scan.scope.includePaths = [task.scope];
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  const coveragePath = join(outputDir, "coverage.json");
+  const coverage = JSON.parse(await readFile(coveragePath, "utf8")) as {
+    mode: string;
+    includePaths: string[];
+  };
+  coverage.includePaths = manifest.scan.scope.includePaths;
+  coverage.mode =
+    task.scope !== undefined
+      ? "scoped_path"
+      : task.mode === "deep"
+        ? "deep_repository"
+        : "repository";
+  await writeFile(coveragePath, `${JSON.stringify(coverage, null, 2)}\n`);
+  await reseal(outputDir);
   await writeFile(join(outputDir, "report.md"), "# Scan report\n");
   return { coverage: { completeness } } as ScanResult;
 }
@@ -226,6 +271,36 @@ describe("multiscan", () => {
     expect(await results(summary.resultsPath)).toMatchObject([
       { id: "payments", repository: source.path },
     ]);
+  });
+
+  test("preserves UTF-8 repository paths split across inventory stream chunks", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "caf\u00e9");
+    const header = "id,notes,repository,revision\n";
+    const accentedOffset = source.path.indexOf("\u00e9");
+    const prefix = `${header}unicode,`;
+    const padding =
+      64 * 1024 -
+      1 -
+      Buffer.byteLength(`${prefix},${source.path.slice(0, accentedOffset)}`);
+    await writeFile(
+      paths.input,
+      `${prefix}${"x".repeat(padding)},${source.path},${source.revision}\n`,
+    );
+
+    let scans = 0;
+    const summary = await runMultiscan(
+      options(
+        paths,
+        client(async (_repository, scanOptions = {}) => {
+          scans += 1;
+          return await completedScan(scanOptions.outputDir!);
+        }),
+      ),
+    );
+
+    expect(summary).toMatchObject({ completed: 1, failed: 0 });
+    expect(scans).toBe(1);
   });
 
   test("records each completed scan's cost in the resumable ledger", async () => {
@@ -599,6 +674,61 @@ describe("multiscan", () => {
     }
   });
 
+  test("does not delete a recovery owner published by a concurrent supervisor", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "recovery-replacement");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\nrecovery,${source.path},${source.revision}\n`,
+    );
+    await mkdir(paths.output);
+    const lock = join(paths.output, ".lock");
+    const recovery = join(paths.output, ".lock.recovery");
+    await writeFile(lock, JSON.stringify({ pid: 999_999_997, token: "stale" }));
+    await writeFile(
+      recovery,
+      JSON.stringify({ pid: 999_999_998, token: "stale-recovery" }),
+    );
+    const originalKill = process.kill;
+    process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+      if (pid === 999_999_998) {
+        writeFileSync(
+          recovery,
+          JSON.stringify({ pid: process.pid, token: "replacement" }),
+        );
+        const error = new Error(
+          "simulated stale recovery",
+        ) as NodeJS.ErrnoException;
+        error.code = "ESRCH";
+        throw error;
+      }
+      return originalKill.call(process, pid, signal);
+    }) as typeof process.kill;
+
+    try {
+      await expect(
+        runMultiscan(
+          options(
+            paths,
+            client(async () => {
+              throw new Error("scan must not start");
+            }),
+          ),
+        ),
+      ).rejects.toThrow(/supervisor/iu);
+      expect(JSON.parse(await readFile(recovery, "utf8"))).toMatchObject({
+        pid: process.pid,
+        token: "replacement",
+      });
+      expect(JSON.parse(await readFile(lock, "utf8"))).toMatchObject({
+        pid: 999_999_997,
+        token: "stale",
+      });
+    } finally {
+      process.kill = originalKill;
+    }
+  });
+
   test("retries a failed attempt and records both durable receipts", async () => {
     const paths = await fixture();
     const source = await repository(paths.root, "retry");
@@ -691,6 +821,36 @@ describe("multiscan", () => {
     await run(3);
     expect(attempts).toBe(3);
     expect(clients).toBe(2);
+  });
+
+  test("does not exhaust attempts using a receipt from a different task", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "foreign-failed-receipt");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\nforeign,${source.path},${source.revision}\n`,
+    );
+    let scans = 0;
+    const security = client(async (_repository, scanOptions = {}) => {
+      scans += 1;
+      if (scans === 1) throw new Error("initial failure");
+      return await completedScan(scanOptions.outputDir!);
+    });
+    const initial = await runMultiscan(
+      options(paths, security, { maxAttempts: 1 }),
+    );
+    const [receipt] = await results(initial.resultsPath);
+    await writeFile(
+      initial.resultsPath,
+      `${JSON.stringify({ ...receipt, revision: "0".repeat(40) })}\n`,
+    );
+
+    const resumed = await runMultiscan(
+      options(paths, security, { maxAttempts: 1 }),
+    );
+
+    expect(resumed).toMatchObject({ completed: 1, failed: 0, skipped: 0 });
+    expect(scans).toBe(2);
   });
 
   test("resumes complete bundles, repairs missing output, and rejects manifest drift", async () => {
@@ -1049,6 +1209,40 @@ describe("multiscan", () => {
     expect(calls).toBe(4);
   });
 
+  test("binds resumed scan bundles to their pinned task and plugin version", async () => {
+    for (const mismatch of ["revision", "plugin"] as const) {
+      const paths = await fixture();
+      const source = await repository(paths.root, `foreign-bundle-${mismatch}`);
+      await writeFile(
+        paths.input,
+        `id,repository,revision\nforeign,${source.path},${source.revision}\n`,
+      );
+      let scans = 0;
+      const security = client(async (_repository, scanOptions = {}) => {
+        scans += 1;
+        return await completedScan(scanOptions.outputDir!);
+      });
+      const initial = await runMultiscan(options(paths, security));
+      const [receipt] = await results(initial.resultsPath);
+      const outputDir = receipt!["outputDir"] as string;
+      const manifestPath = join(outputDir, "scan-manifest.json");
+      const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as {
+        scan: { producer: { version: string }; target: { revision: string } };
+      };
+      if (mismatch === "revision") {
+        manifest.scan.target.revision = "0".repeat(40);
+      } else {
+        manifest.scan.producer.version = "0.0.0";
+      }
+      await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+      const resumed = await runMultiscan(options(paths, security));
+
+      expect(resumed).toMatchObject({ completed: 1, failed: 0, skipped: 0 });
+      expect(scans).toBe(2);
+    }
+  });
+
   test("quarantines malformed committed receipts and preserves valid history", async () => {
     const corruptions = (
       receipt: Record<string, unknown>,
@@ -1139,6 +1333,45 @@ describe("multiscan", () => {
     expect(
       (await lstat(join(paths.output, quarantines[0]!))).size,
     ).toBeGreaterThan(64 * 1024 * 1024);
+  });
+
+  test("never appends a receipt beyond the durable total-ledger limit", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "bounded-ledger");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\nbounded,${source.path},${source.revision}\n`,
+    );
+    let scans = 0;
+    const security = client(async (_repository, scanOptions = {}) => {
+      scans += 1;
+      return await completedScan(scanOptions.outputDir!);
+    });
+    const initial = await runMultiscan(options(paths, security));
+    const [receipt] = await results(initial.resultsPath);
+    const base = { ...receipt, error: "" };
+    const empty = `${JSON.stringify(base)}\n`;
+    const padded = `${JSON.stringify({ ...base, error: "x".repeat(64_000) })}\n`;
+    const maximum = 64 * 1024 * 1024;
+    let count = Math.floor(maximum / Buffer.byteLength(padded));
+    let remaining = maximum - count * Buffer.byteLength(padded);
+    if (remaining < Buffer.byteLength(empty)) {
+      count -= 1;
+      remaining += Buffer.byteLength(padded);
+    }
+    const tail = `${JSON.stringify({
+      ...base,
+      error: "x".repeat(remaining - Buffer.byteLength(empty)),
+    })}\n`;
+    await writeFile(initial.resultsPath, padded.repeat(count) + tail);
+    await rm(join(receipt!["outputDir"] as string, "report.md"));
+
+    await expect(runMultiscan(options(paths, security))).rejects.toThrow(
+      /64 MiB safety limit/u,
+    );
+
+    expect(scans).toBe(2);
+    expect((await lstat(initial.resultsPath)).size).toBe(maximum);
   });
 
   test("ignores repository-local Git shims while preserving credential configuration", async () => {

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -377,32 +377,7 @@ describe("multiscan", () => {
       });
       expect(scans).toBe(1);
 
-      const remote = "ssh://127.0.0.1:1/symlinked-scope.git";
-      await writeFile(
-        paths.input,
-        `id,repository,revision,scope\nscoped,${remote},${revision},alias\n`,
-      );
-      const manifestPath = join(paths.output, "manifest.json");
-      const campaign = JSON.parse(await readFile(manifestPath, "utf8")) as {
-        tasks: Array<{ repository: string }>;
-      };
-      campaign.tasks[0]!.repository = remote;
-      await writeFile(manifestPath, `${JSON.stringify(campaign, null, 2)}\n`);
       const ledgerPath = join(paths.output, "results.jsonl");
-      const receipts = await results(ledgerPath);
-      for (const receipt of receipts) receipt["repository"] = remote;
-      await writeFile(
-        ledgerPath,
-        `${receipts.map((receipt) => JSON.stringify(receipt)).join("\n")}\n`,
-      );
-
-      expect(await runMultiscan(options(paths, security))).toMatchObject({
-        completed: 1,
-        failed: 0,
-        skipped: 1,
-      });
-      expect(scans).toBe(1);
-
       const manipulated = await results(ledgerPath);
       manipulated[manipulated.length - 1]!["canonicalScope"] = "another";
       await writeFile(
@@ -431,13 +406,36 @@ describe("multiscan", () => {
       coverage.includePaths = ["another"];
       await writeFile(coveragePath, `${JSON.stringify(coverage, null, 2)}\n`);
       await reseal(dirname(scanManifestPath));
-      await writeFile(
-        join(dirname(scanManifestPath), ".multiscan-scope.json"),
-        `${JSON.stringify({ scope: "alias", canonicalScope: "another" })}\n`,
-      );
 
       const resumed = await runMultiscan(options(paths, security));
       expect(resumed.skipped).toBe(0);
+      expect(resumed.completed).toBe(1);
+      expect(scans).toBe(2);
+
+      const remote = "ssh://127.0.0.1:1/symlinked-scope.git";
+      await writeFile(
+        paths.input,
+        `id,repository,revision,scope\nscoped,${remote},${revision},alias\n`,
+      );
+      const manifestPath = join(paths.output, "manifest.json");
+      const campaign = JSON.parse(await readFile(manifestPath, "utf8")) as {
+        tasks: Array<{ repository: string }>;
+      };
+      campaign.tasks[0]!.repository = remote;
+      await writeFile(manifestPath, `${JSON.stringify(campaign, null, 2)}\n`);
+      const receipts = await results(ledgerPath);
+      for (const receipt of receipts) receipt["repository"] = remote;
+      await writeFile(
+        ledgerPath,
+        `${receipts.map((receipt) => JSON.stringify(receipt)).join("\n")}\n`,
+      );
+
+      expect(await runMultiscan(options(paths, security))).toMatchObject({
+        completed: 0,
+        failed: 1,
+        skipped: 0,
+      });
+      expect(scans).toBe(2);
     },
   );
 

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -6,6 +6,7 @@ import {
   chmod,
   cp,
   link,
+  lstat,
   mkdir,
   mkdtemp,
   readFile,
@@ -428,9 +429,20 @@ describe("multiscan", () => {
       await finish;
       return await completedScan(scanOptions.outputDir!);
     });
+    const lock = join(paths.output, ".lock");
     const first = runMultiscan(options(paths, security));
     await running;
     try {
+      expect((await lstat(lock)).isFile()).toBe(true);
+      expect(JSON.parse(await readFile(lock, "utf8"))).toMatchObject({
+        pid: process.pid,
+        token: expect.any(String),
+      });
+      expect(
+        (await readdir(paths.output)).some((name) =>
+          name.startsWith(".lock.pending-"),
+        ),
+      ).toBe(false);
       await expect(runMultiscan(options(paths, security))).rejects.toThrow(
         /running|locked|supervisor/iu,
       );
@@ -441,7 +453,6 @@ describe("multiscan", () => {
 
     const [receipt] = await results(join(paths.output, "results.jsonl"));
     await rm(join(receipt!["outputDir"] as string, "report.md"));
-    const lock = join(paths.output, ".lock");
     await mkdir(lock);
     await writeFile(
       join(lock, "owner.json"),
@@ -454,6 +465,42 @@ describe("multiscan", () => {
     expect(recovered).toMatchObject({ completed: 1, failed: 0, skipped: 0 });
     expect(await readdir(join(paths.output, "checkouts"))).toEqual([]);
     await expect(access(lock)).rejects.toThrow();
+  });
+
+  test("recovers missing and malformed legacy lock ownership", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "lock-recovery");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\nlock-recovery,${source.path},${source.revision}\n`,
+    );
+    await mkdir(paths.output);
+    const lock = join(paths.output, ".lock");
+    let scans = 0;
+    const security = client(async (_repository, scanOptions = {}) => {
+      scans += 1;
+      return await completedScan(scanOptions.outputDir!);
+    });
+
+    for (const owner of [undefined, '{"pid":', '{"pid":"invalid"}']) {
+      await mkdir(lock);
+      if (owner !== undefined) {
+        await writeFile(join(lock, "owner.json"), owner);
+      }
+      expect(await runMultiscan(options(paths, security))).toMatchObject({
+        completed: 1,
+        failed: 0,
+      });
+      await expect(access(lock)).rejects.toThrow();
+    }
+
+    expect(scans).toBe(1);
+    expect(
+      (await readdir(paths.output)).some(
+        (name) =>
+          name.startsWith(".lock.pending-") || name.startsWith(".lock.stale-"),
+      ),
+    ).toBe(false);
   });
 
   test("retries a failed attempt and records both durable receipts", async () => {

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -472,6 +472,70 @@ describe("multiscan", () => {
     expect(await readFile(summary.resultsPath, "utf8")).not.toContain(secret);
   });
 
+  test("does not exceed the durable maximum attempt count across resumes", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "attempt-budget");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\nattempt-budget,${source.path},${source.revision}\n`,
+    );
+    let attempts = 0;
+    let clients = 0;
+    const security = client(async () => {
+      attempts += 1;
+      throw new Error("persistent failure");
+    });
+    const run = async (maxAttempts: number) =>
+      await runMultiscan(
+        options(paths, security, {
+          maxAttempts,
+          createSecurity: () => {
+            clients += 1;
+            return security;
+          },
+        }),
+      );
+
+    expect(await run(2)).toMatchObject({
+      total: 1,
+      completed: 0,
+      failed: 1,
+      skipped: 0,
+    });
+    expect(attempts).toBe(2);
+    expect(clients).toBe(1);
+    expect(await results(join(paths.output, "results.jsonl"))).toMatchObject([
+      { status: "failed", attempt: 1 },
+      { status: "failed", attempt: 2 },
+    ]);
+
+    expect(await run(2)).toMatchObject({
+      total: 1,
+      completed: 0,
+      failed: 1,
+      skipped: 0,
+    });
+    expect(attempts).toBe(2);
+    expect(clients).toBe(1);
+    expect(await results(join(paths.output, "results.jsonl"))).toHaveLength(2);
+
+    expect(await run(3)).toMatchObject({
+      total: 1,
+      completed: 0,
+      failed: 1,
+      skipped: 0,
+    });
+    expect(attempts).toBe(3);
+    expect(clients).toBe(2);
+    expect(
+      (await results(join(paths.output, "results.jsonl"))).at(-1),
+    ).toMatchObject({ status: "failed", attempt: 3 });
+
+    await run(3);
+    expect(attempts).toBe(3);
+    expect(clients).toBe(2);
+  });
+
   test("resumes complete bundles, repairs missing output, and rejects manifest drift", async () => {
     const paths = await fixture();
     const source = await repository(paths.root, "resume");

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
+import { writeFileSync } from "node:fs";
 import {
   access,
   appendFile,
@@ -503,6 +504,55 @@ describe("multiscan", () => {
     ).toBe(false);
   });
 
+  test("never overwrites a supervisor lock published during stale-lock recovery", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "lock-replacement");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\nlock-replacement,${source.path},${source.revision}\n`,
+    );
+    await mkdir(paths.output);
+    const lock = join(paths.output, ".lock");
+    await writeFile(lock, JSON.stringify({ pid: process.pid, token: "moved" }));
+    const originalKill = process.kill;
+    let checks = 0;
+    process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+      if (pid !== process.pid) return originalKill.call(process, pid, signal);
+      checks += 1;
+      if (checks === 1) {
+        const error = new Error(
+          "simulated stale owner",
+        ) as NodeJS.ErrnoException;
+        error.code = "ESRCH";
+        throw error;
+      }
+      if (checks === 2) {
+        writeFileSync(lock, JSON.stringify({ pid, token: "replacement" }));
+      }
+      return true;
+    }) as typeof process.kill;
+
+    try {
+      await expect(
+        runMultiscan(
+          options(
+            paths,
+            client(async (_repository, scanOptions = {}) =>
+              completedScan(scanOptions.outputDir!),
+            ),
+          ),
+        ),
+      ).rejects.toThrow("A multiscan supervisor is already running.");
+      expect(JSON.parse(await readFile(lock, "utf8"))).toMatchObject({
+        pid: process.pid,
+        token: "replacement",
+      });
+    } finally {
+      process.kill = originalKill;
+      await rm(lock, { force: true });
+    }
+  });
+
   test("retries a failed attempt and records both durable receipts", async () => {
     const paths = await fixture();
     const source = await repository(paths.root, "retry");
@@ -909,7 +959,8 @@ describe("multiscan", () => {
       calls += 1;
       return await completedScan(scanOptions.outputDir!);
     });
-    const run = async () => await runMultiscan(options(paths, security));
+    const run = async () =>
+      await runMultiscan(options(paths, security, { maxAttempts: 4 }));
     const latestOutput = async (): Promise<string> =>
       (await results(join(paths.output, "results.jsonl"))).at(-1)?.[
         "outputDir"
@@ -946,6 +997,10 @@ describe("multiscan", () => {
     expect(await latestOutput()).toBe(
       join(paths.output, "artifacts", "resume-integrity", "attempt-4"),
     );
+
+    await writeFile(join(await latestOutput(), "findings.json"), "");
+    expect(await run()).toMatchObject({ completed: 0, failed: 1, skipped: 0 });
+    expect(calls).toBe(4);
   });
 
   test("ignores repository-local Git shims while preserving credential configuration", async () => {

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -273,6 +273,29 @@ describe("multiscan", () => {
     ]);
   });
 
+  test("resumes equivalent canonical repository scopes", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "canonical-scope");
+    const inventory = (scope: string): string =>
+      `id,repository,revision,scope\nscoped,${source.path},${source.revision},${scope}\n`;
+    await writeFile(paths.input, inventory("./src//"));
+    let scans = 0;
+    const security = client(async (_repository, scanOptions = {}) => {
+      scans += 1;
+      expect(scanOptions.target).toEqual(["src"]);
+      return await completedScan(scanOptions.outputDir!);
+    });
+    await runMultiscan(options(paths, security));
+    await writeFile(paths.input, inventory("src/."));
+
+    expect(await runMultiscan(options(paths, security))).toMatchObject({
+      completed: 1,
+      failed: 0,
+      skipped: 1,
+    });
+    expect(scans).toBe(1);
+  });
+
   test("preserves UTF-8 repository paths split across inventory stream chunks", async () => {
     const paths = await fixture();
     const source = await repository(paths.root, "caf\u00e9");
@@ -623,6 +646,37 @@ describe("multiscan", () => {
           name.startsWith(".lock.pending-") || name.startsWith(".lock.stale-"),
       ),
     ).toBe(false);
+  });
+
+  test("never recovers a lock while another live owner is publishing it", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "lock-publication");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\npublishing,${source.path},${source.revision}\n`,
+    );
+    await mkdir(paths.output);
+    const lock = join(paths.output, ".lock");
+    await writeFile(lock, "");
+    await writeFile(
+      join(paths.output, ".lock.pending-other-owner"),
+      `${JSON.stringify({ pid: process.pid, token: "other-owner" })}\n`,
+    );
+    let scans = 0;
+
+    await expect(
+      runMultiscan(
+        options(
+          paths,
+          client(async (_repository, scanOptions = {}) => {
+            scans += 1;
+            return await completedScan(scanOptions.outputDir!);
+          }),
+        ),
+      ),
+    ).rejects.toThrow(/running|supervisor/iu);
+    expect(scans).toBe(0);
+    expect(await readFile(lock, "utf8")).toBe("");
   });
 
   test("never overwrites a supervisor lock published during stale-lock recovery", async () => {
@@ -1205,8 +1259,82 @@ describe("multiscan", () => {
     );
 
     await writeFile(join(await latestOutput(), "findings.json"), "");
-    expect(await run()).toMatchObject({ completed: 0, failed: 1, skipped: 0 });
-    expect(calls).toBe(4);
+    expect(await run()).toMatchObject({ completed: 1, failed: 0, skipped: 0 });
+    expect(calls).toBe(5);
+    expect(await latestOutput()).toBe(
+      join(paths.output, "artifacts", "resume-integrity", "attempt-4"),
+    );
+  });
+
+  test("does not reuse a directory snapshot for a pinned Git campaign", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "snapshot-mismatch");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\nsnapshot,${source.path},${source.revision}\n`,
+    );
+    let scans = 0;
+    const security = client(async (_repository, scanOptions = {}) => {
+      scans += 1;
+      return await completedScan(scanOptions.outputDir!);
+    });
+    const initial = await runMultiscan(options(paths, security));
+    const [receipt] = await results(initial.resultsPath);
+    const manifestPath = join(
+      receipt!["outputDir"] as string,
+      "scan-manifest.json",
+    );
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as {
+      scan: { target: { kind: string } };
+    };
+    manifest.scan.target.kind = "directory_snapshot";
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+    expect(await runMultiscan(options(paths, security))).toMatchObject({
+      completed: 1,
+      failed: 0,
+      skipped: 0,
+    });
+    expect(scans).toBe(2);
+  });
+
+  test("recovers interrupted receipt replacement without dropping valid history", async () => {
+    for (const interruption of ["truncated", "missing", "published"]) {
+      const paths = await fixture();
+      const source = await repository(paths.root, `repair-${interruption}`);
+      await writeFile(
+        paths.input,
+        `id,repository,revision\nrepair,${source.path},${source.revision}\n`,
+      );
+      let scans = 0;
+      const security = client(async (_repository, scanOptions = {}) => {
+        scans += 1;
+        return await completedScan(scanOptions.outputDir!);
+      });
+      const initial = await runMultiscan(options(paths, security));
+      const saved = await readFile(initial.resultsPath, "utf8");
+      const replacement = join(
+        paths.output,
+        ".results.repair-interrupted.jsonl",
+      );
+      await writeFile(replacement, saved, { flag: "wx", mode: 0o600 });
+      if (interruption === "truncated") {
+        await writeFile(initial.resultsPath, saved.slice(0, 10));
+      } else if (interruption === "missing") {
+        await rm(initial.resultsPath);
+      }
+
+      expect(await runMultiscan(options(paths, security))).toMatchObject({
+        completed: 1,
+        failed: 0,
+        skipped: 1,
+      });
+      expect(scans).toBe(1);
+      expect(await readFile(initial.resultsPath, "utf8")).toBe(saved);
+      await expect(access(replacement)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    }
   });
 
   test("binds resumed scan bundles to their pinned task and plugin version", async () => {

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -12,6 +12,7 @@ import {
   mkdtemp,
   readFile,
   readdir,
+  realpath,
   rm,
   symlink,
   truncate,
@@ -653,6 +654,45 @@ describe("multiscan", () => {
       ledgerPath,
       `${receipts.map((receipt) => JSON.stringify(receipt)).join("\n")}\n`,
     );
+
+    expect(await runMultiscan(options(paths, security))).toMatchObject({
+      completed: 1,
+      failed: 0,
+      skipped: 1,
+    });
+    expect(scans).toBe(1);
+  });
+
+  test("resumes completed artifacts through equivalent filesystem path casing", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "artifact-directory-casing");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\nscoped,${source.path},${source.revision}\n`,
+    );
+    let scans = 0;
+    const security = client(async (_repository, scanOptions = {}) => {
+      scans += 1;
+      return await completedScan(scanOptions.outputDir!);
+    });
+    const initial = await runMultiscan(options(paths, security));
+    const [receipt] = await results(initial.resultsPath);
+    const changedCase = (receipt!["outputDir"] as string).replace(
+      `${paths.output}/`,
+      `${join(dirname(paths.output), basename(paths.output).toUpperCase())}/`,
+    );
+    try {
+      if (
+        (await realpath(changedCase)) !==
+        (await realpath(receipt!["outputDir"] as string))
+      ) {
+        return;
+      }
+    } catch {
+      return;
+    }
+    receipt!["outputDir"] = changedCase;
+    await writeFile(initial.resultsPath, `${JSON.stringify(receipt)}\n`);
 
     expect(await runMultiscan(options(paths, security))).toMatchObject({
       completed: 1,

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -50,6 +50,7 @@ import {
   codexSecurityCredentialAllowsAmbientImport,
   codexSecurityCredentialHome,
   codexSecurityStateDirectory,
+  expandHome,
   codexPlatformPackage,
   isPythonPathCandidate,
   planOutputArchive,
@@ -64,6 +65,26 @@ import { PLUGIN_ROOT } from "./plugin-root.js";
 
 const temporaryDirectories: string[] = [];
 const testPosix = process.platform === "win32" ? test.skip : test;
+
+test.skipIf(process.platform !== "win32")(
+  "expands home using USERPROFILE before a conflicting HOME on Windows",
+  () => {
+    const savedHome = process.env["HOME"];
+    const savedUserProfile = process.env["USERPROFILE"];
+    try {
+      process.env["HOME"] = "C:\\legacy-posix-home";
+      process.env["USERPROFILE"] = "C:\\Users\\scan-owner";
+      expect(expandHome("~/.codex")).toBe(
+        join("C:\\Users\\scan-owner", ".codex"),
+      );
+    } finally {
+      if (savedHome === undefined) delete process.env["HOME"];
+      else process.env["HOME"] = savedHome;
+      if (savedUserProfile === undefined) delete process.env["USERPROFILE"];
+      else process.env["USERPROFILE"] = savedUserProfile;
+    }
+  },
+);
 
 afterEach(async () => {
   await Promise.all(

--- a/sdk/typescript/tests-ts/targets.test.ts
+++ b/sdk/typescript/tests-ts/targets.test.ts
@@ -406,4 +406,33 @@ describe("scan target normalization", () => {
       canonicalProject,
     ]);
   });
+
+  test.skipIf(process.platform !== "win32")(
+    "prefers USERPROFILE to a conflicting HOME for scan target expansion",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "codex-security-userprofile-"));
+      temporaryDirectories.push(root);
+      const project = join(root, "project");
+      await mkdir(project);
+      const result = spawnSync(
+        process.execPath,
+        [
+          "-e",
+          'const { normalizeRepository } = await import(process.argv[1]); console.log(await normalizeRepository("~/project"));',
+          fileURLToPath(new URL("../src/targets.ts", import.meta.url)),
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            HOME: "C:\\missing-posix-home",
+            USERPROFILE: root,
+          },
+        },
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout.trim()).toBe(await realpath(project));
+    },
+  );
 });


### PR DESCRIPTION
## Summary

- Require the bulk-scan results ledger to be a regular, single-link file inside its intended output directory.
- Reject preexisting and newly substituted symlinks, hard links, directories, and FIFOs.
- Bind receipt reads, writes, and interrupted-line recovery to a verified file descriptor.
- Preserve private ledger permissions, durable recovery, parallel workers, retries, existing receipts, and Windows compatibility.
- Leave all bundled skills and `SECURITY.md` unchanged.

## Why

Recovering or appending bulk-scan results must never follow a link and modify a file outside the authorized output directory.

## Verification

- Full SDK regression suite with the CI-pinned Bun 1.3.14: **403 passed, 3 expected skips, 0 failed**.
- Real bulk-scan regressions for existing and swapped symlinks, hard links, dangling links, FIFOs, and multibyte interrupted-line recovery.
- TypeScript type check, production build, complete package formatting, and generated-model checks.
- `git diff --check`.
