### PR TITLE
release: bump Codex Security to 0.1.3

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-security",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "TypeScript SDK and CLI for Codex Security",
   "license": "Apache-2.0",
   "author": "OpenAI",


### PR DESCRIPTION
## Summary

- Bump `@openai/codex-security` from `0.1.2` to `0.1.3` with a one-line change on the latest `main`; the frozen dependency lockfile and protected release workflow remain unchanged.
- Release the fixes already merged since `npm-v0.1.2`: actionable ChatGPT/API-key authentication and access-token override guidance, platform-safe Windows scan paths, personal-account bulk-scan discovery, malformed-finding recovery, and the documented trusted-local security model.
- Preserve the existing protected, provenance-enabled `npm-v0.1.3` publishing process.

## Validation

- Confirmed against the live package registry that `latest` is `0.1.2`, the only published versions are `0.1.0`, `0.1.1`, and `0.1.2`, and no `npm-v0.1.3` tag or competing release PR exists.
- `pnpm install --frozen-lockfile`: passed, including the lockfile supply-chain policy.
- `pnpm run types`: generated-model and TypeScript checks passed.
- `pnpm run format`: passed.
- `pnpm run test`: **407 passed, 5 expected platform/integration skips, 0 failed**.
- `pnpm run build`: production SDK and CLI build passed.
- Packed `openai-codex-security-0.1.3.tgz` from PR head `87ab7134a068a8ecf133a43aca7182fda6e0a8b1` with the exact expected `gitHead`.
- `CODEX_SECURITY_EXPECTED_GIT_HEAD=87ab7134a068a8ecf133a43aca7182fda6e0a8b1 pnpm run check:package ../../dist/openai-codex-security-0.1.3.tgz`: passed; **179 validated archive entries**, exact commit provenance, no internal-reference leakage, and all **95 bundled plugin files**.
- The package checker and an independent `pnpm run test:package -- ../../dist/openai-codex-security-0.1.3.tgz` both performed fresh npm installations and verified the public SDK import, installed CLI, `--version`, `--help`, and complete plugin contract.
- Validated artifact SHA-256: `9aaacc8c601b710d28d2c0a6c100e10aed12d944db0a471a0f7577bcf1c4f6f2`.

## Release

After approval and merge, create `npm-v0.1.3` on the resulting `main` commit. The existing `node-release` workflow then verifies and packs that exact commit, stamps its actual `gitHead`, and publishes through the protected `npm` environment with trusted provenance.

Opening or merging this PR does not itself publish the package or create the release tag.