### PR TITLE
fix(windows): preserve sandbox override compatibility

### DIFF
--- a/sdk/typescript/src/config.ts
+++ b/sdk/typescript/src/config.ts
@@ -72,6 +72,19 @@ export async function mergedCodexConfig(
   const overrides = cloneJson(config.codexOverrides ?? {});
   validateOverrides(overrides);
   validateNativeMultiAgentV2Overrides(overrides);
+  const features = overrides["features"];
+  const windows = overrides["windows"];
+  if (
+    isObject(features) &&
+    features["elevated_windows_sandbox"] === true &&
+    (windows === undefined ||
+      (isObject(windows) && !Object.hasOwn(windows, "sandbox")))
+  ) {
+    overrides["windows"] = {
+      ...(isObject(windows) ? windows : {}),
+      sandbox: "elevated",
+    };
+  }
   return deepMerge(cloneJson(DEFAULT_CODEX_CONFIG), overrides);
 }
 

--- a/sdk/typescript/src/config.ts
+++ b/sdk/typescript/src/config.ts
@@ -72,20 +72,38 @@ export async function mergedCodexConfig(
   const overrides = cloneJson(config.codexOverrides ?? {});
   validateOverrides(overrides);
   validateNativeMultiAgentV2Overrides(overrides);
-  const features = overrides["features"];
-  const windows = overrides["windows"];
-  if (
-    isObject(features) &&
-    features["elevated_windows_sandbox"] === true &&
-    (windows === undefined ||
-      (isObject(windows) && !Object.hasOwn(windows, "sandbox")))
-  ) {
-    overrides["windows"] = {
-      ...(isObject(windows) ? windows : {}),
-      sandbox: "elevated",
-    };
+  normalizeLegacyWindowsSandboxOverride(overrides);
+  const profiles = overrides["profiles"];
+  if (isObject(profiles)) {
+    for (const profile of Object.values(profiles)) {
+      if (isObject(profile)) {
+        normalizeLegacyWindowsSandboxOverride(profile);
+      }
+    }
   }
   return deepMerge(cloneJson(DEFAULT_CODEX_CONFIG), overrides);
+}
+
+function normalizeLegacyWindowsSandboxOverride(overrides: JsonObject): void {
+  const features = overrides["features"];
+  if (!isObject(features)) {
+    return;
+  }
+  const elevated = features["elevated_windows_sandbox"];
+  if (typeof elevated !== "boolean") {
+    return;
+  }
+  const windows = overrides["windows"];
+  if (
+    windows !== undefined &&
+    (!isObject(windows) || Object.hasOwn(windows, "sandbox"))
+  ) {
+    return;
+  }
+  overrides["windows"] = {
+    ...(isObject(windows) ? windows : {}),
+    sandbox: elevated ? "elevated" : "unelevated",
+  };
 }
 
 export async function writeCodexConfig(

--- a/sdk/typescript/tests-ts/config.test.ts
+++ b/sdk/typescript/tests-ts/config.test.ts
@@ -7,6 +7,7 @@ import { scanRuntimeCodexConfig } from "../src/api.js";
 import {
   ConfigurationError,
   DEFAULT_CODEX_CONFIG,
+  type JsonObject,
   mergedCodexConfig,
   writeCodexConfig,
 } from "../src/index.js";
@@ -25,6 +26,39 @@ async function temporaryDirectory(): Promise<string> {
   const path = await mkdtemp(join(tmpdir(), "codex-security-config-"));
   temporaryDirectories.push(path);
   return path;
+}
+
+function runPinnedCodex(codexHome: string, arguments_: readonly string[]) {
+  const node = Bun.which("node");
+  if (node === null) {
+    throw new Error("The pinned Codex CLI requires Node.js.");
+  }
+  const environment: NodeJS.ProcessEnv = {
+    ...process.env,
+    CODEX_HOME: codexHome,
+  };
+  delete environment["OPENAI_API_KEY"];
+  delete environment["CODEX_API_KEY"];
+  return Bun.spawnSync(
+    [
+      node,
+      join(
+        import.meta.dir,
+        "..",
+        "node_modules",
+        "@openai",
+        "codex",
+        "bin",
+        "codex.js",
+      ),
+      ...arguments_,
+    ],
+    {
+      env: environment,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
 }
 
 describe("Codex configuration", () => {
@@ -60,6 +94,76 @@ describe("Codex configuration", () => {
     expect(merged).toMatchObject({
       features: { elevated_windows_sandbox: true },
       windows: { sandbox: "elevated" },
+    });
+  });
+
+  test("projects legacy elevated Windows overrides into selected profiles", async () => {
+    const merged = await mergedCodexConfig({
+      codexOverrides: {
+        profile: "elevated",
+        profiles: {
+          elevated: {
+            features: { elevated_windows_sandbox: true },
+          },
+        },
+      },
+    });
+
+    expect(merged).toMatchObject({
+      windows: { sandbox: "unelevated" },
+      profiles: {
+        elevated: {
+          features: { elevated_windows_sandbox: true },
+          windows: { sandbox: "elevated" },
+        },
+      },
+    });
+  });
+
+  test("allows selected profiles to override root elevated sandbox defaults", async () => {
+    const merged = await mergedCodexConfig({
+      codexOverrides: {
+        features: { elevated_windows_sandbox: true },
+        profile: "restricted",
+        profiles: {
+          restricted: {
+            features: { elevated_windows_sandbox: false },
+          },
+        },
+      },
+    });
+
+    expect(merged).toMatchObject({
+      windows: { sandbox: "elevated" },
+      profiles: {
+        restricted: {
+          features: { elevated_windows_sandbox: false },
+          windows: { sandbox: "unelevated" },
+        },
+      },
+    });
+  });
+
+  test("gives profile-local Windows sandbox overrides precedence", async () => {
+    const merged = await mergedCodexConfig({
+      codexOverrides: {
+        profile: "restricted",
+        profiles: {
+          restricted: {
+            features: { elevated_windows_sandbox: true },
+            windows: { sandbox: "unelevated" },
+          },
+        },
+      },
+    });
+
+    expect(merged).toMatchObject({
+      profiles: {
+        restricted: {
+          features: { elevated_windows_sandbox: true },
+          windows: { sandbox: "unelevated" },
+        },
+      },
     });
   });
 
@@ -105,33 +209,54 @@ describe("Codex configuration", () => {
       windows: { sandbox: "unelevated" },
     });
 
-    const node = Bun.which("node");
-    expect(node).not.toBeNull();
-    const environment: NodeJS.ProcessEnv = { ...process.env, CODEX_HOME: root };
-    delete environment["OPENAI_API_KEY"];
-    delete environment["CODEX_API_KEY"];
-    const result = Bun.spawnSync(
-      [
-        node!,
-        join(
-          import.meta.dir,
-          "..",
-          "node_modules",
-          "@openai",
-          "codex",
-          "bin",
-          "codex.js",
-        ),
-        "features",
-        "list",
-      ],
-      {
-        env: environment,
-        stdout: "pipe",
-        stderr: "pipe",
-      },
-    );
+    const result = runPinnedCodex(root, ["features", "list"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.length).toBeGreaterThan(0);
+  });
 
+  test("writes selected profile sandbox settings accepted by the pinned Codex CLI", async () => {
+    const root = await temporaryDirectory();
+    const path = join(root, "config.toml");
+    const config = await mergedCodexConfig({
+      codexOverrides: {
+        profile: "elevated",
+        profiles: {
+          elevated: {
+            features: { elevated_windows_sandbox: true },
+          },
+        },
+      },
+    });
+    const nativeConfig = structuredClone(config);
+    delete nativeConfig["profile"];
+    delete nativeConfig["profiles"];
+    const profileConfig = (config["profiles"] as JsonObject)[
+      "elevated"
+    ] as JsonObject;
+    const profilePath = join(root, "elevated.config.toml");
+    await writeCodexConfig(path, nativeConfig);
+    await writeCodexConfig(profilePath, profileConfig);
+
+    expect(parse(await readFile(path, "utf8"))).toMatchObject({
+      windows: { sandbox: "unelevated" },
+    });
+    expect(parse(await readFile(profilePath, "utf8"))).toMatchObject({
+      features: { elevated_windows_sandbox: true },
+      windows: { sandbox: "elevated" },
+    });
+
+    const result = runPinnedCodex(root, [
+      "--profile",
+      "elevated",
+      "mcp",
+      "list",
+      "--json",
+    ]);
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `The pinned Codex CLI rejected the selected Windows sandbox profile: ${new TextDecoder().decode(result.stderr)}`,
+      );
+    }
     expect(result.exitCode).toBe(0);
     expect(result.stdout.length).toBeGreaterThan(0);
   });

--- a/sdk/typescript/tests-ts/config.test.ts
+++ b/sdk/typescript/tests-ts/config.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 import { parse } from "smol-toml";
+import { scanRuntimeCodexConfig } from "../src/api.js";
 import {
   ConfigurationError,
   DEFAULT_CODEX_CONFIG,
@@ -49,6 +50,92 @@ describe("Codex configuration", () => {
     expect(merged["windows"]).toEqual({ sandbox: "elevated" });
   });
 
+  test("preserves legacy elevated Windows sandbox overrides", async () => {
+    const merged = await mergedCodexConfig({
+      codexOverrides: {
+        features: { elevated_windows_sandbox: true },
+      },
+    });
+
+    expect(merged).toMatchObject({
+      features: { elevated_windows_sandbox: true },
+      windows: { sandbox: "elevated" },
+    });
+  });
+
+  test("gives explicit Windows sandbox overrides precedence", async () => {
+    const merged = await mergedCodexConfig({
+      codexOverrides: {
+        features: { elevated_windows_sandbox: true },
+        windows: { sandbox: "unelevated" },
+      },
+    });
+
+    expect(merged).toMatchObject({
+      features: { elevated_windows_sandbox: true },
+      windows: { sandbox: "unelevated" },
+    });
+  });
+
+  test("retains the Windows sandbox in the hardened scan profile", async () => {
+    const stateDirectory = join(tmpdir(), "codex-security-windows-state");
+    const merged = await mergedCodexConfig({});
+
+    expect(scanRuntimeCodexConfig(merged, stateDirectory)).toMatchObject({
+      windows: { sandbox: "unelevated" },
+      default_permissions: "codex_security_scan",
+      permissions: {
+        codex_security_scan: {
+          filesystem: {
+            ":root": "read",
+            ":workspace_roots": "write",
+            [stateDirectory]: "write",
+          },
+        },
+      },
+    });
+  });
+
+  test("writes Windows sandbox settings accepted by the pinned Codex CLI", async () => {
+    const root = await temporaryDirectory();
+    const path = join(root, "config.toml");
+    await writeCodexConfig(path, await mergedCodexConfig({}));
+
+    expect(parse(await readFile(path, "utf8"))).toMatchObject({
+      windows: { sandbox: "unelevated" },
+    });
+
+    const node = Bun.which("node");
+    expect(node).not.toBeNull();
+    const environment: NodeJS.ProcessEnv = { ...process.env, CODEX_HOME: root };
+    delete environment["OPENAI_API_KEY"];
+    delete environment["CODEX_API_KEY"];
+    const result = Bun.spawnSync(
+      [
+        node!,
+        join(
+          import.meta.dir,
+          "..",
+          "node_modules",
+          "@openai",
+          "codex",
+          "bin",
+          "codex.js",
+        ),
+        "features",
+        "list",
+      ],
+      {
+        env: environment,
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.length).toBeGreaterThan(0);
+  });
+
   test("rejects prototype-bearing override keys", async () => {
     for (const key of ["__proto__", "constructor", "prototype"]) {
       await expect(
@@ -73,6 +160,7 @@ describe("Codex configuration", () => {
   test("keeps exported default configuration deeply immutable", async () => {
     expect(Object.isFrozen(DEFAULT_CODEX_CONFIG)).toBe(true);
     expect(Object.isFrozen(DEFAULT_CODEX_CONFIG["features"])).toBe(true);
+    expect(Object.isFrozen(DEFAULT_CODEX_CONFIG["windows"])).toBe(true);
     expect(
       Object.isFrozen(
         (DEFAULT_CODEX_CONFIG["features"] as Record<string, unknown>)[


### PR DESCRIPTION
## Summary

Follow up on @Alessio2405's Windows sandbox fix in #67 without changing its
secure restricted-token default.

- Preserve the legacy `features.elevated_windows_sandbox` override by projecting
  it into the modern Windows sandbox configuration.
- Apply the same compatibility and explicit-override precedence to every
  configured Codex profile, including a selected profile that disables a
  root-level elevated setting.
- Keep an explicit modern `windows.sandbox` setting authoritative when both
  configuration styles are present.
- Verify the selected backend survives the hardened scan filesystem-permission
  profile.
- Write and validate the actual configuration with the pinned Codex CLI on each
  platform, including the modern `--profile` and profile-file runtime.
- Verify that the nested exported Windows defaults remain deeply immutable.

The original contribution fixes the underlying Windows scan failure. This
follow-up only preserves backward-compatible configuration and adds focused
security and native-runtime coverage.

## Verification

- Confirmed that the legacy-elevated regression fails on the exact original #67
  head and passes with this change.
- Confirmed the missing restricted-token default fails on the pre-#67 `main`
  control.
- 17 focused configuration tests pass, including root and profile-level
  precedence and actual pinned-Codex runtime loading.
- Four independent sandbox, override, filesystem-permission, and pinned-native
  CLI regressions pass.
- Current-main integration: 415 tests pass; five platform/model-dependent tests
  are explicitly skipped.
- Revalidated against the current `0.1.3` release after `main` advanced,
  including the exact `0.1.3` npm tarball and clean installation.
- Frozen install, typecheck, formatting, build, complete package inspection, and
  clean npm-consumer installation pass.
- The packaged Node 22 `0.1.3` CLI runs successfully in a network-isolated Linux
  customer container.
- Official GitHub checks pass on Windows, macOS, Ubuntu, and the `linux-amd64`
  customer container.
- The automated selected-profile review finding is fixed, regression-tested,
  and resolved.

Contributor credit: @Alessio2405, whose original fix is retained in #67.
