### PR TITLE
fix: validate bulk-scan resume artifacts

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -237,7 +237,9 @@ service,https://github.com/acme/service.git,0123456789abcdef0123456789abcdef0123
 ```
 
 `--workers` limits concurrent scans and `--max-attempts` retries failures.
-Results remain under `--output-dir`; rerun the same command to resume.
+Results remain under `--output-dir`; rerun the same command to resume. A
+completed receipt is skipped only when its canonical artifacts and seal remain
+valid and its coverage is complete; otherwise the repository is scanned again.
 
 ### Scan history and reruns
 

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -16,7 +16,9 @@ import { promisify } from "node:util";
 import Papa from "papaparse";
 import type { CodexSecurity } from "./api.js";
 import type { CodexSecurityConfig } from "./config.js";
+import { loadContract } from "./contract.js";
 import type { ScanCost } from "./cost.js";
+import { resolvePluginPath } from "./runtime.js";
 import type { ScanMode } from "./targets.js";
 import { resolveTrustedExecutable } from "./trusted-executable.js";
 
@@ -90,10 +92,28 @@ export async function runMultiscan(
   const output = resolve(options.outputDir);
   await ensureOutputDirectory(output);
   const unlock = await acquireLock(output);
+  let pluginWorkspace: string | null = null;
+  let pluginRoot: Promise<string> | null = null;
+  const resumePluginRoot = (): Promise<string> =>
+    (pluginRoot ??= (async () => {
+      if (options.config.pluginPath !== undefined) {
+        pluginWorkspace = await mkdirTemporaryPluginWorkspace(output);
+      }
+      return await resolvePluginPath(
+        options.config.pluginPath,
+        pluginWorkspace ?? output,
+        options.signal,
+      );
+    })());
   try {
-    return await runCampaign(options, tasks, output);
+    return await runCampaign(options, tasks, output, resumePluginRoot);
   } finally {
-    await unlock();
+    await Promise.all([
+      unlock(),
+      pluginWorkspace === null
+        ? undefined
+        : rm(pluginWorkspace, { recursive: true, force: true }),
+    ]);
   }
 }
 
@@ -101,6 +121,7 @@ async function runCampaign(
   options: MultiscanOptions,
   tasks: MultiscanTask[],
   output: string,
+  resumePluginRoot: () => Promise<string>,
 ): Promise<MultiscanResult> {
   const ledger = join(output, "results.jsonl");
   await ensureOutputDirectory(join(output, "checkouts"));
@@ -115,7 +136,11 @@ async function runCampaign(
       receipt?.status === "completed" &&
       receipt.outputDir ===
         join(output, "artifacts", task.id, `attempt-${receipt.attempt}`) &&
-      (await hasArtifacts(receipt.outputDir))
+      (await hasArtifacts(
+        receipt.outputDir,
+        await resumePluginRoot(),
+        options.signal,
+      ))
     ) {
       completed += 1;
     } else {
@@ -335,15 +360,34 @@ async function readReceipts(
   );
 }
 
-async function hasArtifacts(path: string): Promise<boolean> {
+async function hasArtifacts(
+  path: string,
+  pluginRoot: string,
+  signal?: AbortSignal,
+): Promise<boolean> {
   try {
+    signal?.throwIfAborted();
     if (!(await lstat(path)).isDirectory()) return false;
     for (const artifact of REQUIRED_ARTIFACTS) {
       if (!(await lstat(join(path, artifact))).isFile()) return false;
     }
-    return true;
-  } catch {
+    const contract = await loadContract(path, { pluginRoot, signal });
+    return contract.coverage.completeness === "complete";
+  } catch (error) {
+    if (signal?.aborted === true) signal.throwIfAborted();
     return false;
+  }
+}
+
+async function mkdirTemporaryPluginWorkspace(output: string): Promise<string> {
+  for (;;) {
+    const path = join(output, `.resume-plugin-${randomUUID()}`);
+    try {
+      await mkdir(path, { mode: 0o700 });
+      return path;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
   }
 }
 

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -1,7 +1,9 @@
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   access,
   appendFile,
+  cp,
   mkdir,
   mkdtemp,
   readFile,
@@ -13,13 +15,16 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
+import { loadContract } from "../src/contract.js";
 import type { ScanResult } from "../src/result.js";
 import { buildGitHubCredentialArgs, runMultiscan } from "../src/multiscan.js";
 import { resolveTrustedExecutable } from "../src/trusted-executable.js";
+import { PLUGIN_ROOT } from "./plugin-root.js";
 
 type MultiscanOptions = Parameters<typeof runMultiscan>[0];
 type SecurityClient = ReturnType<MultiscanOptions["createSecurity"]>;
 
+const COMPLETED_SCAN = join(PLUGIN_ROOT, "examples", "completed-scan");
 const temporaryDirectories: string[] = [];
 
 afterEach(async () => {
@@ -80,12 +85,8 @@ async function completedScan(
   outputDir: string,
   completeness: "complete" | "partial" = "complete",
 ): Promise<ScanResult> {
-  await mkdir(outputDir, { recursive: true });
-  await Promise.all(
-    ["scan-manifest.json", "findings.json", "coverage.json", "report.md"].map(
-      (name) => writeFile(join(outputDir, name), "{}\n"),
-    ),
-  );
+  await cp(COMPLETED_SCAN, outputDir, { recursive: true });
+  await writeFile(join(outputDir, "report.md"), "# Scan report\n");
   return { coverage: { completeness } } as ScanResult;
 }
 
@@ -118,6 +119,19 @@ async function results(path: string): Promise<Record<string, unknown>[]> {
     .trim()
     .split("\n")
     .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+async function reseal(scanDir: string): Promise<void> {
+  const manifestPath = join(scanDir, "scan-manifest.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as {
+    scan: { artifacts: Array<{ path: string; sha256: string }> };
+  };
+  for (const artifact of manifest.scan.artifacts) {
+    artifact.sha256 = createHash("sha256")
+      .update(await readFile(join(scanDir, artifact.path)))
+      .digest("hex");
+  }
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 }
 
 describe("multiscan", () => {
@@ -501,6 +515,57 @@ describe("multiscan", () => {
       "manifest does not match",
     );
     expect(calls).toBe(2);
+  });
+
+  test("rescans completed receipts with invalid, unsealed, or incomplete artifacts", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "resume-integrity");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\nresume-integrity,${source.path},${source.revision}\n`,
+    );
+    let calls = 0;
+    const security = client(async (_repository, scanOptions = {}) => {
+      calls += 1;
+      return await completedScan(scanOptions.outputDir!);
+    });
+    const run = async () => await runMultiscan(options(paths, security));
+    const latestOutput = async (): Promise<string> =>
+      (await results(join(paths.output, "results.jsonl"))).at(-1)?.[
+        "outputDir"
+      ] as string;
+
+    await run();
+    expect(calls).toBe(1);
+
+    await writeFile(join(await latestOutput(), "findings.json"), "");
+    expect(await run()).toMatchObject({ completed: 1, failed: 0, skipped: 0 });
+    expect(calls).toBe(2);
+
+    await appendFile(join(await latestOutput(), "coverage.json"), "\n");
+    expect(await run()).toMatchObject({ completed: 1, failed: 0, skipped: 0 });
+    expect(calls).toBe(3);
+
+    const incompleteOutput = await latestOutput();
+    const coveragePath = join(incompleteOutput, "coverage.json");
+    const coverage = JSON.parse(await readFile(coveragePath, "utf8")) as {
+      completeness: string;
+    };
+    coverage.completeness = "partial";
+    await writeFile(coveragePath, `${JSON.stringify(coverage, null, 2)}\n`);
+    await reseal(incompleteOutput);
+    expect(
+      (
+        await loadContract(incompleteOutput, {
+          pluginRoot: PLUGIN_ROOT,
+        })
+      ).coverage.completeness,
+    ).toBe("partial");
+    expect(await run()).toMatchObject({ completed: 1, failed: 0, skipped: 0 });
+    expect(calls).toBe(4);
+    expect(await latestOutput()).toBe(
+      join(paths.output, "artifacts", "resume-integrity", "attempt-4"),
+    );
   });
 
   test("ignores repository-local Git shims while preserving credential configuration", async () => {


### PR DESCRIPTION
## Maintainer tracking

Fixes #30.

  ## Summary

  Validate completed bulk-scan artifacts before treating a repository as successfully finished during resume.

  Previously, a completed ledger receipt was accepted when its expected output directory contained four filenames:

  - `scan-manifest.json`
  - `findings.json`
  - `coverage.json`
  - `report.md`

  Their contents were not inspected. Empty, malformed, modified, unsealed, or incomplete artifacts could therefore cause a repository to be
  silently skipped.

  ## Changes

  ### Canonical contract validation

  Resume now loads completed output through the existing canonical contract validator before skipping a task.

  This verifies:

  - contract JSON is present, bounded, valid UTF-8, and parseable;
  - manifest, findings, and coverage documents satisfy their schemas;
  - scan IDs and scope fields agree across documents;
  - canonical contract invariants are valid;
  - artifact paths are safe and unique;
  - sealed artifacts remain regular files;
  - sealed artifact SHA-256 hashes match the manifest;
  - the scan root remains unchanged throughout validation.

  The existing explicit `report.md` presence and regular-file requirement is preserved.

  ### Complete coverage requirement

  A contract-valid bundle is accepted only when:

  ```text
  coverage.completeness === "complete"

  A correctly resealed scan with partial or unknown coverage is therefore scanned again instead of being reported as skipped.

  ### Plugin schema handling

  Resume validation uses the configured plugin’s schemas:

  - the bundled plugin is resolved lazily for normal scans;
  - custom plugin directories and ZIPs are supported;
  - temporary custom-plugin extraction is created only when completed receipts require validation;
  - temporary validation workspaces are removed when the campaign finishes or fails.

  ### Cancellation

  The campaign’s abort signal is forwarded into plugin resolution and canonical contract validation. Cancellation is preserved rather than being
  interpreted as an invalid artifact requiring a rescan.

  ### Documentation

  The README now explains that completed receipts are skipped only when their canonical artifacts and seal remain valid and coverage is
  complete.

  ## Security impact

  This prevents bulk-scan resume from silently accepting corrupted or modified results as completed.

  Invalid saved output now becomes a pending task and receives a new scan attempt, covering:

  - empty or malformed contract documents;
  - schema-invalid artifacts;
  - modified artifacts with stale hashes;
  - invalid manifest seals;
  - missing required files;
  - incomplete coverage.

  ## Tests

  The multiscan fixtures now produce real, contract-valid completed bundles instead of placeholder {} documents.

  New regression coverage verifies that resume starts a new attempt when:

  - findings.json is empty;
  - coverage.json remains valid JSON but its bytes no longer match the sealed hash;
  - coverage is changed to partial and correctly resealed.

  The incomplete-coverage case is independently loaded through the canonical validator first, proving that the explicit completeness check—not
  another validation failure—causes the rescan.

  Verification performed:

  - pnpm run types
  - pnpm run format
  - pnpm run build
  - focused multiscan and canonical-contract tests
  - pnpm run test

  Full test result:

  - 408 passed
  - 5 expected platform/integration skips
  - 0 failed
