### PR TITLE
fix: harden Git hook installation without changing trust boundaries

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,11 @@ operations can use repository configuration, hooks, filters, attributes,
 credential helpers, worktrees, and executables on your `PATH`. These are not
 separate security boundaries.
 
+Some commands defensively resolve executables outside Git checkout roots to
+avoid accidentally running repository-local or package-manager-provided shims.
+This does not make untrusted repositories safe, turn `PATH` into an isolation
+boundary, or override the operator's Git configuration.
+
 The product also does not isolate users, tasks, repositories, or scan jobs
 that share the same operating-system account, credentials, or local state.
 Do not treat shared local state as a multi-user or multi-tenant system.

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -136,6 +136,7 @@ npx @openai/codex-security scan /path/to/repository --dry-run
 npx @openai/codex-security scan /path/to/repository --fail-on-severity high
 npx @openai/codex-security scan /path/to/repository --max-cost 5
 npx @openai/codex-security install-hook
+npx @openai/codex-security install-hook /path/to/repository
 npx @openai/codex-security bulk-scan
 npx @openai/codex-security bulk-scan --model gpt-5.6-terra --effort high
 npx @openai/codex-security bulk-scan repositories.csv --output-dir /path/outside/repositories/security-scans --workers 4
@@ -162,9 +163,11 @@ default model, reasoning effort, and first-scan command. A scan with `--dry-run`
 also reports its effective model and reasoning effort, including `--codex`
 overrides, without starting Codex or contacting the network.
 
-`install-hook` scans staged and unstaged changes before each commit. It respects
-`core.hooksPath`, does not replace an existing hook, and blocks high-severity
-findings or failed scans. Set `--fail-on-severity` to change the threshold.
+`install-hook` scans staged and unstaged changes before each commit. It resolves
+Git outside the invoking and selected Git checkouts while preserving the
+operator's effective Git configuration, including `core.hooksPath`. It does not
+replace an existing hook and blocks high-severity findings or failed scans. Set
+`--fail-on-severity` to change the threshold.
 
 `--path` scopes a scan to one or more paths, `--diff` scans committed changes,
 and `--working-tree` scans staged and unstaged changes. Deep scans support

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -3150,9 +3150,15 @@ async function protectedHookExecutableRoots(
   }
   if (!selectedWorktree) {
     for (const [gitDirectory, configured] of configuredWorktrees) {
-      const worktree = configuredEnvironmentWorktree ?? configured;
-      for (const base of [repository, gitDirectory]) {
-        roots.add(await canonicalProtectedHookRoot(resolve(base, worktree)));
+      for (const worktree of new Set([
+        configured,
+        ...(configuredEnvironmentWorktree === undefined
+          ? []
+          : [configuredEnvironmentWorktree]),
+      ])) {
+        for (const base of [repository, gitDirectory]) {
+          roots.add(await canonicalProtectedHookRoot(resolve(base, worktree)));
+        }
       }
     }
     if (
@@ -3376,14 +3382,50 @@ async function gitIncludeConditionMatches(
         closing += 1;
       }
       if (pattern[closing] === "]") closing += 1;
-      closing = pattern.indexOf("]", closing);
-      if (closing < 0) {
+      while (closing < pattern.length && pattern[closing] !== "]") {
+        if (pattern[closing] === "[" && pattern[closing + 1] === ":") {
+          const end = pattern.indexOf(":]", closing + 2);
+          if (end >= 0) {
+            closing = end + 2;
+            continue;
+          }
+        }
+        closing += 1;
+      }
+      if (closing >= pattern.length) {
         expression += "\\[";
         continue;
       }
-      let members = pattern.slice(index + 1, closing);
+      let members = pattern.slice(index + 1, closing).replaceAll("\\", "\\\\");
       if (members.startsWith("!")) members = `^${members.slice(1)}`;
-      expression += `(?=[^/])[${members.replaceAll("\\", "\\\\")}]`;
+      let unsupportedClass = false;
+      members = members.replace(
+        /\[:([A-Za-z]+):\]/gu,
+        (_match, name: string) => {
+          const classes: Readonly<Record<string, string>> = {
+            alnum: "A-Za-z0-9",
+            alpha: "A-Za-z",
+            blank: "\\t ",
+            cntrl: "\\x00-\\x1F\\x7F",
+            digit: "0-9",
+            graph: "\\x21-\\x7E",
+            lower: "a-z",
+            print: "\\x20-\\x7E",
+            punct: "!-/:-@\\[-\\x60\\{-~",
+            space: "\\t\\n\\v\\f\\r ",
+            upper: "A-Z",
+            xdigit: "A-Fa-f0-9",
+          };
+          const characters = classes[name.toLowerCase()];
+          if (characters === undefined) {
+            unsupportedClass = true;
+            return "";
+          }
+          return characters;
+        },
+      );
+      if (unsupportedClass) return false;
+      expression += `(?=[^/])[${members}]`;
       index = closing;
     } else {
       expression += character.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -17,7 +17,7 @@ import {
   stat,
   writeFile,
 } from "node:fs/promises";
-import { homedir, userInfo } from "node:os";
+import { userInfo } from "node:os";
 import {
   basename,
   delimiter,
@@ -2931,6 +2931,7 @@ async function protectedHookExecutableRoots(
   const gitDirectories = new Set<string>();
   const objectDirectories = new Set<string>();
   const configuredWorktrees = new Map<string, string>();
+  const configuredHookPaths = new Map<string, string>();
   if (selectedGitDirectory) {
     const selected = await canonicalProtectedHookRoot(
       resolve(repository, selectedGitDirectory),
@@ -3040,6 +3041,7 @@ async function protectedHookExecutableRoots(
     let configurationFiles = 0;
     let worktreeConfigEnabled = false;
     let configuredWorktree: string | undefined;
+    let configuredHookPath: string | undefined;
     const readConfiguration = async (path: string): Promise<void> => {
       try {
         const canonicalPath = await canonicalProtectedHookRoot(path);
@@ -3062,6 +3064,8 @@ async function protectedHookExecutableRoots(
           for (const entry of gitConfigEntries(await readFile(path, "utf8"))) {
             if (entry.kind === "worktree") {
               configuredWorktree = entry.value;
+            } else if (entry.kind === "hooksPath") {
+              configuredHookPath = entry.value;
             } else if (entry.kind === "worktreeConfig") {
               worktreeConfigEnabled = entry.value;
             } else if (
@@ -3093,6 +3097,9 @@ async function protectedHookExecutableRoots(
     }
     if (configuredWorktree !== undefined) {
       configuredWorktrees.set(gitDirectory, configuredWorktree);
+    }
+    if (configuredHookPath !== undefined) {
+      configuredHookPaths.set(gitDirectory, configuredHookPath);
     }
     objectDirectories.add(join(gitDirectory, "objects"));
   }
@@ -3133,6 +3140,37 @@ async function protectedHookExecutableRoots(
       "Git environment configuration exceeds the protected-worktree safety limit.",
     );
   }
+  let environmentHookPath: string | undefined;
+  for (let index = 0; index < Number(configuredCount ?? "0"); index += 1) {
+    const key = hookGitEnvironmentValue(environment, `GIT_CONFIG_KEY_${index}`);
+    const value = hookGitEnvironmentValue(
+      environment,
+      `GIT_CONFIG_VALUE_${index}`,
+    );
+    if (key === undefined || value === undefined) {
+      throw new Error(
+        "Git environment hook configuration cannot be parsed safely.",
+      );
+    }
+    if (key.toLowerCase() === "core.hookspath") environmentHookPath = value;
+  }
+  if (hookGitEnvironmentValue(environment, "GIT_CONFIG_PARAMETERS")) {
+    throw new Error(
+      "Git environment hook configuration cannot be parsed safely.",
+    );
+  }
+  for (const [gitDirectory, configured] of configuredHookPaths) {
+    const hooksPath = await expandGitConfigIncludePath(
+      environmentHookPath ?? configured,
+    );
+    for (const base of [repository, gitDirectory]) {
+      roots.add(await canonicalProtectedHookRoot(resolve(base, hooksPath)));
+    }
+  }
+  if (environmentHookPath !== undefined && configuredHookPaths.size === 0) {
+    const hooksPath = await expandGitConfigIncludePath(environmentHookPath);
+    roots.add(await canonicalProtectedHookRoot(resolve(repository, hooksPath)));
+  }
   if (!selectedWorktree) {
     for (const [gitDirectory, configured] of configuredWorktrees) {
       for (const base of [repository, gitDirectory]) {
@@ -3157,6 +3195,7 @@ function hookGitEnvironmentValue(
 
 type GitHookConfigurationEntry =
   | { kind: "worktree"; value: string }
+  | { kind: "hooksPath"; value: string }
   | { kind: "worktreeConfig"; value: boolean }
   | { kind: "include"; path: string; condition?: string };
 
@@ -3184,7 +3223,7 @@ function gitConfigEntries(contents: string): GitHookConfigurationEntry[] {
     }
     const key =
       sectionName === "core" && subsection === undefined
-        ? "worktree"
+        ? "(?:worktree|hookspath)"
         : sectionName === "extensions" && subsection === undefined
           ? "worktreeconfig"
           : (sectionName === "include" && subsection === undefined) ||
@@ -3228,7 +3267,10 @@ function gitConfigEntries(contents: string): GitHookConfigurationEntry[] {
     } else if (value.length === 0) {
       continue;
     } else if (sectionName === "core") {
-      entries.push({ kind: "worktree", value });
+      entries.push({
+        kind: /^\s*hookspath\b/iu.test(line) ? "hooksPath" : "worktree",
+        value,
+      });
     } else {
       entries.push({
         kind: "include",
@@ -3248,7 +3290,7 @@ export async function expandGitConfigIncludePath(
   const account = named[1]!;
   let home: string;
   if (account === userInfo().username) {
-    home = homedir();
+    home = userInfo().homedir;
   } else {
     const records = await readFile("/etc/passwd", "utf8");
     const entry = records

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -2926,11 +2926,10 @@ async function protectedHookExecutableRoots(
   environment: Readonly<Record<string, string | undefined>>,
 ): Promise<readonly string[]> {
   const roots = new Set([repository]);
-  let effectiveWorktree = repository;
-  let discoveredWorktree = false;
   const selectedGitDirectory = hookGitEnvironmentValue(environment, "GIT_DIR");
   const gitDirectories = new Set<string>();
   const objectDirectories = new Set<string>();
+  const configuredWorktrees = new Map<string, string>();
   if (selectedGitDirectory) {
     const selected = await canonicalProtectedHookRoot(
       resolve(repository, selectedGitDirectory),
@@ -2942,22 +2941,23 @@ async function protectedHookExecutableRoots(
     environment,
     "GIT_COMMON_DIR",
   );
-  if (selectedCommonDirectory) {
-    const common = await canonicalProtectedHookRoot(
-      resolve(repository, selectedCommonDirectory),
-    );
-    roots.add(common);
-    objectDirectories.add(join(common, "objects"));
+  const selectedCommonRoot = selectedCommonDirectory
+    ? await canonicalProtectedHookRoot(
+        resolve(repository, selectedCommonDirectory),
+      )
+    : undefined;
+  if (selectedCommonRoot !== undefined) {
+    roots.add(selectedCommonRoot);
+    objectDirectories.add(join(selectedCommonRoot, "objects"));
   }
   const selectedWorktree = hookGitEnvironmentValue(
     environment,
     "GIT_WORK_TREE",
   );
   if (selectedWorktree) {
-    effectiveWorktree = await canonicalProtectedHookRoot(
-      resolve(repository, selectedWorktree),
+    roots.add(
+      await canonicalProtectedHookRoot(resolve(repository, selectedWorktree)),
     );
-    roots.add(effectiveWorktree);
   }
 
   for (const directory of new Set([invocationDirectory, repository])) {
@@ -2970,10 +2970,6 @@ async function protectedHookExecutableRoots(
           ? await stat(marker)
           : markerMetadata;
         roots.add(current);
-        if (!selectedWorktree && !discoveredWorktree) {
-          effectiveWorktree = current;
-          discoveredWorktree = true;
-        }
         if (metadata.isFile()) {
           const contents = await readFile(marker, "utf8");
           const matched =
@@ -3008,7 +3004,7 @@ async function protectedHookExecutableRoots(
     "GIT_OBJECT_DIRECTORY",
   );
   if (selectedObjectDirectory) {
-    objectDirectories.add(resolve(effectiveWorktree, selectedObjectDirectory));
+    objectDirectories.add(resolve(repository, selectedObjectDirectory));
   }
   const selectedAlternates = hookGitEnvironmentValue(
     environment,
@@ -3018,12 +3014,12 @@ async function protectedHookExecutableRoots(
     for (const objectDirectory of gitAlternateObjectDirectories(
       selectedAlternates,
     )) {
-      objectDirectories.add(resolve(effectiveWorktree, objectDirectory));
+      objectDirectories.add(resolve(repository, objectDirectory));
     }
   }
 
   for (const gitDirectory of gitDirectories) {
-    let commonGitDirectory = gitDirectory;
+    let commonGitDirectory = selectedCommonRoot ?? gitDirectory;
     try {
       const commonDirectory = (
         await readFile(join(gitDirectory, "commondir"), "utf8")
@@ -3032,68 +3028,67 @@ async function protectedHookExecutableRoots(
         const canonical = await canonicalProtectedHookRoot(
           resolve(gitDirectory, commonDirectory),
         );
-        commonGitDirectory = canonical;
+        commonGitDirectory = selectedCommonRoot ?? canonical;
         roots.add(canonical);
         objectDirectories.add(join(canonical, "objects"));
       }
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     }
-    const configuration = [join(commonGitDirectory, "config")];
-    const visitedConfiguration = new Set<string>();
+    const activeConfiguration = new Set<string>();
+    let configurationFiles = 0;
     let worktreeConfigEnabled = false;
-    let addedWorktreeConfiguration = false;
-    for (let index = 0; index < configuration.length; index += 1) {
-      const path = configuration[index]!;
+    let configuredWorktree: string | undefined;
+    const readConfiguration = async (path: string): Promise<void> => {
       try {
         const canonicalPath = await canonicalProtectedHookRoot(path);
-        if (visitedConfiguration.has(canonicalPath)) continue;
-        if (visitedConfiguration.size >= 256) {
+        if (
+          activeConfiguration.has(canonicalPath) ||
+          configurationFiles >= 256
+        ) {
           throw new Error("Too many Git configuration includes.");
         }
-        visitedConfiguration.add(canonicalPath);
         const metadata = await stat(path);
-        if (!metadata.isFile()) continue;
+        if (!metadata.isFile()) return;
         if (metadata.size > 1_024 * 1_024) {
           throw new Error(
             "Git configuration is too large to safely discover protected worktrees.",
           );
         }
-        const entries = gitConfigEntries(await readFile(path, "utf8"));
-        if (entries.worktreeConfig !== undefined) {
-          worktreeConfigEnabled = entries.worktreeConfig;
-        }
-        for (const worktree of entries.worktrees) {
-          for (const base of [repository, gitDirectory]) {
-            roots.add(
-              await canonicalProtectedHookRoot(resolve(base, worktree)),
-            );
+        configurationFiles += 1;
+        activeConfiguration.add(canonicalPath);
+        try {
+          for (const entry of gitConfigEntries(await readFile(path, "utf8"))) {
+            if (entry.kind === "worktree") {
+              configuredWorktree = entry.value;
+            } else if (entry.kind === "worktreeConfig") {
+              worktreeConfigEnabled = entry.value;
+            } else if (
+              entry.condition === undefined ||
+              (await gitIncludeConditionMatches(
+                entry.condition,
+                gitDirectory,
+                path,
+              ))
+            ) {
+              await readConfiguration(
+                resolve(dirname(path), expandHome(entry.path)),
+              );
+            }
           }
-        }
-        for (const included of entries.includes) {
-          if (
-            included.condition !== undefined &&
-            !(await gitIncludeConditionMatches(
-              included.condition,
-              gitDirectory,
-              path,
-            ))
-          ) {
-            continue;
-          }
-          configuration.push(resolve(dirname(path), expandHome(included.path)));
+        } finally {
+          activeConfiguration.delete(canonicalPath);
         }
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
       }
-      if (
-        worktreeConfigEnabled &&
-        !addedWorktreeConfiguration &&
-        index === configuration.length - 1
-      ) {
-        addedWorktreeConfiguration = true;
-        configuration.push(join(gitDirectory, "config.worktree"));
-      }
+    };
+    await readConfiguration(join(commonGitDirectory, "config"));
+    if (worktreeConfigEnabled) {
+      await readConfiguration(join(gitDirectory, "config.worktree"));
+    }
+    if (configuredWorktree !== undefined) {
+      configuredWorktrees.set(gitDirectory, configuredWorktree);
     }
     objectDirectories.add(join(gitDirectory, "objects"));
   }
@@ -3135,6 +3130,7 @@ async function protectedHookExecutableRoots(
     );
   }
   const count = Number(configuredCount);
+  let configuredEnvironmentWorktree: string | undefined;
   if (Number.isSafeInteger(count) && count > 0) {
     for (let index = 0; index < count; index += 1) {
       if (
@@ -3149,13 +3145,30 @@ async function protectedHookExecutableRoots(
         environment,
         `GIT_CONFIG_VALUE_${index}`,
       );
-      if (!worktree) continue;
+      if (worktree) configuredEnvironmentWorktree = worktree;
+    }
+  }
+  if (!selectedWorktree) {
+    for (const [gitDirectory, configured] of configuredWorktrees) {
+      const worktree = configuredEnvironmentWorktree ?? configured;
+      for (const base of [repository, gitDirectory]) {
+        roots.add(await canonicalProtectedHookRoot(resolve(base, worktree)));
+      }
+    }
+    if (
+      configuredEnvironmentWorktree !== undefined &&
+      configuredWorktrees.size === 0
+    ) {
       roots.add(
-        await canonicalProtectedHookRoot(resolve(repository, worktree)),
+        await canonicalProtectedHookRoot(
+          resolve(repository, configuredEnvironmentWorktree),
+        ),
       );
       for (const gitDirectory of gitDirectories) {
         roots.add(
-          await canonicalProtectedHookRoot(resolve(gitDirectory, worktree)),
+          await canonicalProtectedHookRoot(
+            resolve(gitDirectory, configuredEnvironmentWorktree),
+          ),
         );
       }
     }
@@ -3175,16 +3188,15 @@ function hookGitEnvironmentValue(
     : environment[name];
 }
 
-function gitConfigEntries(contents: string): {
-  worktrees: string[];
-  includes: Array<{ path: string; condition?: string }>;
-  worktreeConfig?: boolean;
-} {
-  const worktrees: string[] = [];
-  const includes: Array<{ path: string; condition?: string }> = [];
+type GitHookConfigurationEntry =
+  | { kind: "worktree"; value: string }
+  | { kind: "worktreeConfig"; value: boolean }
+  | { kind: "include"; path: string; condition?: string };
+
+function gitConfigEntries(contents: string): GitHookConfigurationEntry[] {
+  const entries: GitHookConfigurationEntry[] = [];
   let sectionName = "";
   let subsection: string | undefined;
-  let worktreeConfig: boolean | undefined;
   let continuation = "";
   for (const segment of contents.split(/\r?\n/u)) {
     let line = continuation + segment;
@@ -3213,38 +3225,43 @@ function gitConfigEntries(contents: string): {
             ? "path"
             : null;
     if (key === null) continue;
-    const matched = new RegExp(`^\\s*${key}\\s*=\\s*(.+?)\\s*$`, "iu").exec(
-      line,
-    );
-    const configured = matched?.[1];
-    if (configured === undefined) continue;
+    const matched = new RegExp(
+      `^\\s*${key}(?:\\s*=\\s*(.*?))?\\s*$`,
+      "iu",
+    ).exec(line);
+    if (matched === null) continue;
+    const configured = matched[1];
+    if (configured === undefined) {
+      if (sectionName === "extensions") {
+        entries.push({ kind: "worktreeConfig", value: true });
+      }
+      continue;
+    }
     const value = gitConfigValue(configured);
-    if (value.length === 0) continue;
     if (sectionName === "extensions") {
       const normalized = value.toLowerCase();
       if (["true", "yes", "on", "1"].includes(normalized)) {
-        worktreeConfig = true;
-      } else if (["false", "no", "off", "0"].includes(normalized)) {
-        worktreeConfig = false;
+        entries.push({ kind: "worktreeConfig", value: true });
+      } else if (["", "false", "no", "off", "0"].includes(normalized)) {
+        entries.push({ kind: "worktreeConfig", value: false });
       } else {
         throw new Error(
           "Git worktree configuration extension cannot be parsed safely.",
         );
       }
+    } else if (value.length === 0) {
+      continue;
     } else if (sectionName === "core") {
-      worktrees.push(value);
+      entries.push({ kind: "worktree", value });
     } else {
-      includes.push({
+      entries.push({
+        kind: "include",
         path: value,
         ...(sectionName === "includeif" ? { condition: subsection! } : {}),
       });
     }
   }
-  return {
-    worktrees,
-    includes,
-    ...(worktreeConfig === undefined ? {} : { worktreeConfig }),
-  };
+  return entries;
 }
 
 function gitConfigValue(value: string): string {
@@ -3353,6 +3370,21 @@ async function gitIncludeConditionMatches(
       }
     } else if (character === "?") {
       expression += "[^/]";
+    } else if (character === "[") {
+      let closing = index + 1;
+      if (pattern[closing] === "!" || pattern[closing] === "^") {
+        closing += 1;
+      }
+      if (pattern[closing] === "]") closing += 1;
+      closing = pattern.indexOf("]", closing);
+      if (closing < 0) {
+        expression += "\\[";
+        continue;
+      }
+      let members = pattern.slice(index + 1, closing);
+      if (members.startsWith("!")) members = `^${members.slice(1)}`;
+      expression += `(?=[^/])[${members.replaceAll("\\", "\\\\")}]`;
+      index = closing;
     } else {
       expression += character.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
     }

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -19,6 +19,7 @@ import {
 } from "node:fs/promises";
 import {
   basename,
+  delimiter,
   dirname,
   isAbsolute,
   join,
@@ -2925,12 +2926,7 @@ async function protectedHookExecutableRoots(
   environment: Readonly<Record<string, string | undefined>>,
 ): Promise<readonly string[]> {
   const roots = new Set([repository]);
-  const selectedGitDirectory =
-    process.platform === "win32"
-      ? Object.entries(environment).find(
-          ([name]) => name.toUpperCase() === "GIT_DIR",
-        )?.[1]
-      : environment["GIT_DIR"];
+  const selectedGitDirectory = hookGitEnvironmentValue(environment, "GIT_DIR");
   const gitDirectories = new Set<string>();
   if (selectedGitDirectory) {
     const selected = await canonicalProtectedHookRoot(
@@ -2939,12 +2935,10 @@ async function protectedHookExecutableRoots(
     roots.add(selected);
     gitDirectories.add(selected);
   }
-  const selectedCommonDirectory =
-    process.platform === "win32"
-      ? Object.entries(environment).find(
-          ([name]) => name.toUpperCase() === "GIT_COMMON_DIR",
-        )?.[1]
-      : environment["GIT_COMMON_DIR"];
+  const selectedCommonDirectory = hookGitEnvironmentValue(
+    environment,
+    "GIT_COMMON_DIR",
+  );
   if (selectedCommonDirectory) {
     roots.add(
       await canonicalProtectedHookRoot(
@@ -2952,16 +2946,26 @@ async function protectedHookExecutableRoots(
       ),
     );
   }
-  const selectedWorktree =
-    process.platform === "win32"
-      ? Object.entries(environment).find(
-          ([name]) => name.toUpperCase() === "GIT_WORK_TREE",
-        )?.[1]
-      : environment["GIT_WORK_TREE"];
+  const selectedWorktree = hookGitEnvironmentValue(
+    environment,
+    "GIT_WORK_TREE",
+  );
   if (selectedWorktree) {
     roots.add(
       await canonicalProtectedHookRoot(resolve(repository, selectedWorktree)),
     );
+  }
+  for (const name of [
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  ] as const) {
+    const selected = hookGitEnvironmentValue(environment, name);
+    for (const objectDirectory of selected?.split(delimiter) ?? []) {
+      if (objectDirectory.length === 0) continue;
+      roots.add(
+        await canonicalProtectedHookRoot(resolve(repository, objectDirectory)),
+      );
+    }
   }
 
   for (const directory of new Set([invocationDirectory, repository])) {
@@ -2969,7 +2973,10 @@ async function protectedHookExecutableRoots(
     while (true) {
       try {
         const marker = join(current, ".git");
-        const metadata = await lstat(marker);
+        const markerMetadata = await lstat(marker);
+        const metadata = markerMetadata.isSymbolicLink()
+          ? await stat(marker)
+          : markerMetadata;
         roots.add(current);
         if (metadata.isFile()) {
           const contents = await readFile(marker, "utf8");
@@ -2982,7 +2989,9 @@ async function protectedHookExecutableRoots(
             gitDirectories.add(selected);
           }
         } else if (metadata.isDirectory()) {
-          gitDirectories.add(await canonicalProtectedHookRoot(marker));
+          const selected = await canonicalProtectedHookRoot(marker);
+          roots.add(selected);
+          gitDirectories.add(selected);
         }
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
@@ -3009,9 +3018,93 @@ async function protectedHookExecutableRoots(
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     }
+    for (const name of ["config", "config.worktree"]) {
+      const path = join(gitDirectory, name);
+      try {
+        const metadata = await stat(path);
+        if (!metadata.isFile() || metadata.size > 1_024 * 1_024) continue;
+        for (const worktree of gitConfigWorktrees(
+          await readFile(path, "utf8"),
+        )) {
+          for (const base of [repository, gitDirectory]) {
+            roots.add(
+              await canonicalProtectedHookRoot(resolve(base, worktree)),
+            );
+          }
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      }
+    }
+  }
+
+  const count = Number(
+    hookGitEnvironmentValue(environment, "GIT_CONFIG_COUNT"),
+  );
+  if (Number.isSafeInteger(count) && count > 0) {
+    for (let index = 0; index < count && index < 1_024; index += 1) {
+      if (
+        hookGitEnvironmentValue(
+          environment,
+          `GIT_CONFIG_KEY_${index}`,
+        )?.toLowerCase() !== "core.worktree"
+      ) {
+        continue;
+      }
+      const worktree = hookGitEnvironmentValue(
+        environment,
+        `GIT_CONFIG_VALUE_${index}`,
+      );
+      if (!worktree) continue;
+      roots.add(
+        await canonicalProtectedHookRoot(resolve(repository, worktree)),
+      );
+      for (const gitDirectory of gitDirectories) {
+        roots.add(
+          await canonicalProtectedHookRoot(resolve(gitDirectory, worktree)),
+        );
+      }
+    }
   }
 
   return [...roots];
+}
+
+function hookGitEnvironmentValue(
+  environment: Readonly<Record<string, string | undefined>>,
+  name: string,
+): string | undefined {
+  return process.platform === "win32"
+    ? Object.entries(environment).find(
+        ([candidate]) => candidate.toUpperCase() === name,
+      )?.[1]
+    : environment[name];
+}
+
+function gitConfigWorktrees(contents: string): readonly string[] {
+  const worktrees: string[] = [];
+  let core = false;
+  for (const line of contents.split(/\r?\n/u)) {
+    const section = /^\s*\[([^\]]+)\]/u.exec(line);
+    if (section?.[1] !== undefined) {
+      core = section[1].trim().toLowerCase() === "core";
+      continue;
+    }
+    if (!core) continue;
+    const matched = /^\s*worktree\s*=\s*(.+?)\s*$/iu.exec(line);
+    let worktree = matched?.[1];
+    if (worktree === undefined) continue;
+    if (worktree.startsWith('"') && worktree.endsWith('"')) {
+      try {
+        const decoded: unknown = JSON.parse(worktree);
+        if (typeof decoded === "string") worktree = decoded;
+      } catch {
+        worktree = worktree.slice(1, -1);
+      }
+    }
+    if (worktree.length > 0) worktrees.push(worktree);
+  }
+  return worktrees;
 }
 
 async function canonicalProtectedHookRoot(path: string): Promise<string> {

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -2935,8 +2935,26 @@ async function protectedHookExecutableRoots(
           ([name]) => name.toUpperCase() === "GIT_DIR",
         )?.[1]
       : environment["GIT_DIR"];
+  const gitDirectories = new Set<string>();
   if (selectedGitDirectory) {
-    roots.add(await realpath(resolve(repository, selectedGitDirectory)));
+    const selected = await canonicalProtectedHookRoot(
+      resolve(repository, selectedGitDirectory),
+    );
+    roots.add(selected);
+    gitDirectories.add(selected);
+  }
+  const selectedCommonDirectory =
+    process.platform === "win32"
+      ? Object.entries(environment).find(
+          ([name]) => name.toUpperCase() === "GIT_COMMON_DIR",
+        )?.[1]
+      : environment["GIT_COMMON_DIR"];
+  if (selectedCommonDirectory) {
+    roots.add(
+      await canonicalProtectedHookRoot(
+        resolve(repository, selectedCommonDirectory),
+      ),
+    );
   }
   const selectedWorktree =
     process.platform === "win32"
@@ -2945,15 +2963,31 @@ async function protectedHookExecutableRoots(
         )?.[1]
       : environment["GIT_WORK_TREE"];
   if (selectedWorktree) {
-    roots.add(await realpath(resolve(repository, selectedWorktree)));
+    roots.add(
+      await canonicalProtectedHookRoot(resolve(repository, selectedWorktree)),
+    );
   }
 
   for (const directory of new Set([invocationDirectory, repository])) {
     let current = directory;
     while (true) {
       try {
-        await lstat(join(current, ".git"));
+        const marker = join(current, ".git");
+        const metadata = await lstat(marker);
         roots.add(current);
+        if (metadata.isFile()) {
+          const contents = await readFile(marker, "utf8");
+          const matched = /^gitdir: ([^\r\n]+)\r?\n?$/u.exec(contents);
+          if (matched?.[1] !== undefined) {
+            const selected = await canonicalProtectedHookRoot(
+              resolve(current, matched[1]),
+            );
+            roots.add(selected);
+            gitDirectories.add(selected);
+          }
+        } else if (metadata.isDirectory()) {
+          gitDirectories.add(await canonicalProtectedHookRoot(marker));
+        }
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
       }
@@ -2964,7 +2998,33 @@ async function protectedHookExecutableRoots(
     }
   }
 
+  for (const gitDirectory of gitDirectories) {
+    try {
+      const commonDirectory = (
+        await readFile(join(gitDirectory, "commondir"), "utf8")
+      ).trim();
+      if (commonDirectory.length > 0) {
+        roots.add(
+          await canonicalProtectedHookRoot(
+            resolve(gitDirectory, commonDirectory),
+          ),
+        );
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+
   return [...roots];
+}
+
+async function canonicalProtectedHookRoot(path: string): Promise<string> {
+  try {
+    return await realpath(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    return resolve(path);
+  }
 }
 
 function targetFromArguments(arguments_: ScanArguments): ScanTarget {

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -2929,9 +2929,21 @@ async function protectedHookExecutableRoots(
   environment: Readonly<Record<string, string | undefined>>,
 ): Promise<readonly string[]> {
   const roots = new Set([repository]);
-  const selectedWorktree = Object.entries(environment).find(
-    ([name]) => name.toUpperCase() === "GIT_WORK_TREE",
-  )?.[1];
+  const selectedGitDirectory =
+    process.platform === "win32"
+      ? Object.entries(environment).find(
+          ([name]) => name.toUpperCase() === "GIT_DIR",
+        )?.[1]
+      : environment["GIT_DIR"];
+  if (selectedGitDirectory) {
+    roots.add(await realpath(resolve(repository, selectedGitDirectory)));
+  }
+  const selectedWorktree =
+    process.platform === "win32"
+      ? Object.entries(environment).find(
+          ([name]) => name.toUpperCase() === "GIT_WORK_TREE",
+        )?.[1]
+      : environment["GIT_WORK_TREE"];
   if (selectedWorktree) {
     roots.add(await realpath(resolve(repository, selectedWorktree)));
   }

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -1078,7 +1078,11 @@ export async function main(
           const git = await resolveTrustedExecutable(
             "git",
             dependencies.environment,
-            await protectedHookExecutableRoots(invocationDirectory, repository),
+            await protectedHookExecutableRoots(
+              invocationDirectory,
+              repository,
+              dependencies.environment,
+            ),
           );
           if (git === null) {
             throw new Error("Git is not available on a trusted PATH.");
@@ -2789,8 +2793,15 @@ function quoteCliPath(path: string): string {
 async function protectedHookExecutableRoots(
   invocationDirectory: string,
   repository: string,
+  environment: Readonly<Record<string, string | undefined>>,
 ): Promise<readonly string[]> {
   const roots = new Set([repository]);
+  const selectedWorktree = Object.entries(environment).find(
+    ([name]) => name.toUpperCase() === "GIT_WORK_TREE",
+  )?.[1];
+  if (selectedWorktree) {
+    roots.add(await realpath(resolve(repository, selectedWorktree)));
+  }
 
   for (const directory of new Set([invocationDirectory, repository])) {
     let current = directory;

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -17,6 +17,7 @@ import {
   stat,
   writeFile,
 } from "node:fs/promises";
+import { homedir, userInfo } from "node:os";
 import {
   basename,
   delimiter,
@@ -3072,7 +3073,10 @@ async function protectedHookExecutableRoots(
               ))
             ) {
               await readConfiguration(
-                resolve(dirname(path), expandHome(entry.path)),
+                resolve(
+                  dirname(path),
+                  await expandGitConfigIncludePath(entry.path),
+                ),
               );
             }
           }
@@ -3129,53 +3133,10 @@ async function protectedHookExecutableRoots(
       "Git environment configuration exceeds the protected-worktree safety limit.",
     );
   }
-  const count = Number(configuredCount);
-  let configuredEnvironmentWorktree: string | undefined;
-  if (Number.isSafeInteger(count) && count > 0) {
-    for (let index = 0; index < count; index += 1) {
-      if (
-        hookGitEnvironmentValue(
-          environment,
-          `GIT_CONFIG_KEY_${index}`,
-        )?.toLowerCase() !== "core.worktree"
-      ) {
-        continue;
-      }
-      const worktree = hookGitEnvironmentValue(
-        environment,
-        `GIT_CONFIG_VALUE_${index}`,
-      );
-      if (worktree) configuredEnvironmentWorktree = worktree;
-    }
-  }
   if (!selectedWorktree) {
     for (const [gitDirectory, configured] of configuredWorktrees) {
-      for (const worktree of new Set([
-        configured,
-        ...(configuredEnvironmentWorktree === undefined
-          ? []
-          : [configuredEnvironmentWorktree]),
-      ])) {
-        for (const base of [repository, gitDirectory]) {
-          roots.add(await canonicalProtectedHookRoot(resolve(base, worktree)));
-        }
-      }
-    }
-    if (
-      configuredEnvironmentWorktree !== undefined &&
-      configuredWorktrees.size === 0
-    ) {
-      roots.add(
-        await canonicalProtectedHookRoot(
-          resolve(repository, configuredEnvironmentWorktree),
-        ),
-      );
-      for (const gitDirectory of gitDirectories) {
-        roots.add(
-          await canonicalProtectedHookRoot(
-            resolve(gitDirectory, configuredEnvironmentWorktree),
-          ),
-        );
+      for (const base of [repository, gitDirectory]) {
+        roots.add(await canonicalProtectedHookRoot(resolve(base, configured)));
       }
     }
   }
@@ -3250,6 +3211,15 @@ function gitConfigEntries(contents: string): GitHookConfigurationEntry[] {
         entries.push({ kind: "worktreeConfig", value: true });
       } else if (["", "false", "no", "off", "0"].includes(normalized)) {
         entries.push({ kind: "worktreeConfig", value: false });
+      } else if (/^[+-]?(?:0x[0-9a-f]+|\d+)[kmg]?$/iu.test(normalized)) {
+        const digits = normalized
+          .replace(/^[+-]/u, "")
+          .replace(/^0x/iu, "")
+          .replace(/[kmg]$/iu, "");
+        entries.push({
+          kind: "worktreeConfig",
+          value: /[1-9a-f]/iu.test(digits),
+        });
       } else {
         throw new Error(
           "Git worktree configuration extension cannot be parsed safely.",
@@ -3268,6 +3238,31 @@ function gitConfigEntries(contents: string): GitHookConfigurationEntry[] {
     }
   }
   return entries;
+}
+
+export async function expandGitConfigIncludePath(
+  path: string,
+): Promise<string> {
+  const named = /^~([^/\\]+)(?:[/\\](.*))?$/u.exec(path);
+  if (named === null) return expandHome(path);
+  const account = named[1]!;
+  let home: string;
+  if (account === userInfo().username) {
+    home = homedir();
+  } else {
+    const records = await readFile("/etc/passwd", "utf8");
+    const entry = records
+      .split(/\r?\n/u)
+      .map((line) => line.split(":"))
+      .find((fields) => fields[0] === account);
+    if (entry?.[5] === undefined || !isAbsolute(entry[5])) {
+      throw new Error(
+        "Named-user Git configuration include cannot be resolved safely.",
+      );
+    }
+    home = entry[5];
+  }
+  return named[2] === undefined ? home : resolve(home, named[2]);
 }
 
 function gitConfigValue(value: string): string {
@@ -3336,8 +3331,11 @@ async function gitIncludeConditionMatches(
         "\\",
         "/",
       );
-    } else if (pattern.startsWith("~/")) {
-      pattern = expandHome(pattern).replaceAll("\\", "/");
+    } else if (pattern.startsWith("~")) {
+      pattern = (await expandGitConfigIncludePath(pattern)).replaceAll(
+        "\\",
+        "/",
+      );
     } else if (!isAbsolute(pattern) && !pattern.startsWith("**/")) {
       pattern = `**/${pattern}`;
     }
@@ -3364,8 +3362,12 @@ async function gitIncludeConditionMatches(
     const character = pattern[index]!;
     if (character === "*") {
       if (pattern[index + 1] === "*") {
+        const precededBySlash = index === 0 || pattern[index - 1] === "/";
+        const followedBySlash = pattern[index + 2] === "/";
+        const atEnd = index + 2 === pattern.length;
+        if (!precededBySlash || (!followedBySlash && !atEnd)) return false;
         index += 1;
-        if (pattern[index + 1] === "/") {
+        if (followedBySlash) {
           index += 1;
           expression += "(?:.*/)?";
         } else {
@@ -3416,7 +3418,7 @@ async function gitIncludeConditionMatches(
             upper: "A-Z",
             xdigit: "A-Fa-f0-9",
           };
-          const characters = classes[name.toLowerCase()];
+          const characters = classes[name];
           if (characters === undefined) {
             unsupportedClass = true;
             return "";

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -2973,7 +2973,7 @@ async function protectedHookExecutableRoots(
     const [head, configuration, objects] = await Promise.all([
       lstat(join(repository, "HEAD")),
       lstat(join(repository, "config")),
-      lstat(join(repository, "objects")),
+      stat(join(repository, "objects")),
     ]);
     if (head.isFile() && configuration.isFile() && objects.isDirectory()) {
       gitDirectories.add(repository);
@@ -3046,9 +3046,18 @@ async function protectedHookExecutableRoots(
   for (const gitDirectory of gitDirectories) {
     let commonGitDirectory = selectedCommonRoot ?? gitDirectory;
     try {
-      const commonDirectory = (
-        await readFile(join(gitDirectory, "commondir"), "utf8")
-      ).replace(/\r?\n$/u, "");
+      const commonDirectoryContents = await readFile(
+        join(gitDirectory, "commondir"),
+        "utf8",
+      );
+      const commonDirectory = /^([^\r\n]+?)(?=\r?\n|$)(?:\r?\n[\t ]*)*$/u.exec(
+        commonDirectoryContents,
+      )?.[1];
+      if (commonDirectory === undefined) {
+        throw new Error(
+          "Git common-directory pointer cannot be parsed safely.",
+        );
+      }
       if (commonDirectory.length > 0) {
         const canonical = await canonicalProtectedHookRoot(
           resolve(gitDirectory, commonDirectory),
@@ -3065,6 +3074,25 @@ async function protectedHookExecutableRoots(
     let worktreeConfigEnabled = false;
     let configuredWorktree: string | undefined;
     let configuredHookPath: string | undefined;
+    const globalConfigurationPaths = gitGlobalConfigurationPaths(environment);
+    const remoteUrls = new Set<string>();
+    for (const configurationPath of new Set([
+      ...globalConfigurationPaths,
+      join(commonGitDirectory, "config"),
+      join(gitDirectory, "config.worktree"),
+    ])) {
+      try {
+        const metadata = await stat(configurationPath);
+        if (!metadata.isFile() || metadata.size > 1_024 * 1_024) continue;
+        for (const entry of gitConfigEntries(
+          await readFile(configurationPath, "utf8"),
+        )) {
+          if (entry.kind === "remoteUrl") remoteUrls.add(entry.value);
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      }
+    }
     const readConfiguration = async (path: string): Promise<void> => {
       try {
         const canonicalPath = await canonicalProtectedHookRoot(path);
@@ -3091,12 +3119,15 @@ async function protectedHookExecutableRoots(
               configuredHookPath = entry.value;
             } else if (entry.kind === "worktreeConfig") {
               worktreeConfigEnabled = entry.value;
+            } else if (entry.kind === "remoteUrl") {
+              remoteUrls.add(entry.value);
             } else if (
               entry.condition === undefined ||
               (await gitIncludeConditionMatches(
                 entry.condition,
                 gitDirectory,
                 path,
+                remoteUrls,
               ))
             ) {
               await readConfiguration(
@@ -3114,7 +3145,7 @@ async function protectedHookExecutableRoots(
         if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
       }
     };
-    for (const globalPath of gitGlobalConfigurationPaths(environment)) {
+    for (const globalPath of globalConfigurationPaths) {
       await readConfiguration(globalPath);
     }
     await readConfiguration(join(commonGitDirectory, "config"));
@@ -3208,7 +3239,12 @@ async function protectedHookExecutableRoots(
       );
     }
     const hooksPath = await expandGitConfigIncludePath(environmentHookPath);
-    roots.add(await canonicalProtectedHookRoot(resolve(repository, hooksPath)));
+    for (const base of new Set([
+      repository,
+      ...discoveredWorktreeRoots.values(),
+    ])) {
+      roots.add(await canonicalProtectedHookRoot(resolve(base, hooksPath)));
+    }
   }
   if (!selectedWorktree) {
     for (const [gitDirectory, configured] of configuredWorktrees) {
@@ -3230,22 +3266,40 @@ function gitGlobalConfigurationPaths(
     "GIT_CONFIG_NOSYSTEM",
   );
   const home =
-    hookGitEnvironmentValue(
-      environment,
-      process.platform === "win32" ? "USERPROFILE" : "HOME",
-    ) ?? userInfo().homedir;
+    hookGitEnvironmentValue(environment, "HOME") ??
+    (process.platform === "win32"
+      ? hookGitEnvironmentValue(environment, "USERPROFILE")
+      : undefined) ??
+    userInfo().homedir;
   const xdg =
-    hookGitEnvironmentValue(environment, "XDG_CONFIG_HOME") ??
+    hookGitEnvironmentValue(environment, "XDG_CONFIG_HOME") ||
     join(home, ".config");
   const global = hookGitEnvironmentValue(environment, "GIT_CONFIG_GLOBAL");
+  const pathEntries = (
+    hookGitEnvironmentValue(environment, "PATH") ?? ""
+  ).split(delimiter);
+  if (pathEntries.length > 128) {
+    throw new Error("Too many Git executable search directories.");
+  }
+  const installationConfigurations = pathEntries.flatMap((entry) => {
+    if (!isAbsolute(entry)) return [];
+    const prefix = dirname(entry);
+    return [
+      join(prefix, "etc", "gitconfig"),
+      join(prefix, "mingw64", "etc", "gitconfig"),
+      join(prefix, "mingw32", "etc", "gitconfig"),
+    ];
+  });
   return [
-    ...(disableSystem === undefined ||
-    ["0", "false", "no"].includes(disableSystem)
+    ...(disableSystem === undefined || !gitConfigurationBoolean(disableSystem)
       ? system === undefined
         ? [
-            "/etc/gitconfig",
-            "/usr/local/etc/gitconfig",
-            "/opt/homebrew/etc/gitconfig",
+            ...new Set([
+              "/etc/gitconfig",
+              "/usr/local/etc/gitconfig",
+              "/opt/homebrew/etc/gitconfig",
+              ...installationConfigurations,
+            ]),
           ]
         : [system]
       : []),
@@ -3253,6 +3307,20 @@ function gitGlobalConfigurationPaths(
       ? [join(xdg, "git", "config"), join(home, ".gitconfig")]
       : [global]),
   ];
+}
+
+function gitConfigurationBoolean(value: string): boolean {
+  const normalized = value.toLowerCase();
+  if (["true", "yes", "on"].includes(normalized)) return true;
+  if (["false", "no", "off"].includes(normalized)) return false;
+  if (/^[+-]?(?:0x[0-9a-f]+|\d+)[kmg]?$/iu.test(normalized)) {
+    const digits = normalized
+      .replace(/^[+-]/u, "")
+      .replace(/^0x/iu, "")
+      .replace(/[kmg]$/iu, "");
+    return /[1-9a-f]/iu.test(digits);
+  }
+  throw new Error("Invalid Git system-configuration boolean.");
 }
 
 function hookGitEnvironmentValue(
@@ -3270,6 +3338,7 @@ type GitHookConfigurationEntry =
   | { kind: "worktree"; value: string }
   | { kind: "hooksPath"; value: string }
   | { kind: "worktreeConfig"; value: boolean }
+  | { kind: "remoteUrl"; value: string }
   | { kind: "include"; path: string; condition?: string };
 
 function gitConfigEntries(contents: string): GitHookConfigurationEntry[] {
@@ -3299,10 +3368,12 @@ function gitConfigEntries(contents: string): GitHookConfigurationEntry[] {
         ? "(?:worktree|hookspath)"
         : sectionName === "extensions" && subsection === undefined
           ? "worktreeconfig"
-          : (sectionName === "include" && subsection === undefined) ||
-              (sectionName === "includeif" && subsection !== undefined)
-            ? "path"
-            : null;
+          : sectionName === "remote" && subsection !== undefined
+            ? "url"
+            : (sectionName === "include" && subsection === undefined) ||
+                (sectionName === "includeif" && subsection !== undefined)
+              ? "path"
+              : null;
     if (key === null) continue;
     const matched = new RegExp(
       `^\\s*${key}(?:\\s*=\\s*(.*?))?\\s*$`,
@@ -3317,6 +3388,10 @@ function gitConfigEntries(contents: string): GitHookConfigurationEntry[] {
       continue;
     }
     const value = gitConfigValue(configured);
+    if (sectionName === "remote") {
+      entries.push({ kind: "remoteUrl", value });
+      continue;
+    }
     if (sectionName === "extensions") {
       const normalized = value.toLowerCase();
       if (["true", "yes", "on", "1"].includes(normalized)) {
@@ -3432,6 +3507,7 @@ async function gitIncludeConditionMatches(
   condition: string,
   gitDirectory: string,
   configurationPath: string,
+  remoteUrls: ReadonlySet<string>,
 ): Promise<boolean> {
   const separator = condition.indexOf(":");
   if (separator < 0) {
@@ -3439,7 +3515,7 @@ async function gitIncludeConditionMatches(
   }
   const kind = condition.slice(0, separator).toLowerCase();
   let pattern = condition.slice(separator + 1).replaceAll("\\", "/");
-  let candidate: string;
+  let candidates: readonly string[];
   if (kind === "gitdir" || kind === "gitdir/i") {
     if (pattern.startsWith("./")) {
       pattern = resolve(dirname(configurationPath), pattern).replaceAll(
@@ -3455,7 +3531,7 @@ async function gitIncludeConditionMatches(
       pattern = `**/${pattern}`;
     }
     if (pattern.endsWith("/")) pattern += "**";
-    candidate = gitDirectory.replaceAll("\\", "/");
+    candidates = [gitDirectory.replaceAll("\\", "/")];
   } else if (kind === "onbranch") {
     let head: string;
     try {
@@ -3467,7 +3543,14 @@ async function gitIncludeConditionMatches(
     const branch = /^ref:[\t ]*refs\/heads\/(.+?)(?:\r?\n)?$/u.exec(head)?.[1];
     if (branch === undefined) return false;
     if (pattern.endsWith("/")) pattern += "**";
-    candidate = branch;
+    candidates = [branch];
+  } else if (kind === "hasconfig") {
+    const remotePrefix = "remote.*.url:";
+    if (!pattern.toLowerCase().startsWith(remotePrefix)) {
+      throw new Error("Unsupported conditional Git configuration include.");
+    }
+    pattern = pattern.slice(remotePrefix.length);
+    candidates = [...remoteUrls];
   } else {
     throw new Error("Unsupported conditional Git configuration include.");
   }
@@ -3550,7 +3633,9 @@ async function gitIncludeConditionMatches(
   }
   expression += "$";
   const matcher = new RegExp(expression, kind === "gitdir/i" ? "iu" : "u");
-  return matcher.test(candidate) || matcher.test(`${candidate}/`);
+  return candidates.some(
+    (candidate) => matcher.test(candidate) || matcher.test(`${candidate}/`),
+  );
 }
 
 function gitAlternateObjectDirectoryLine(value: string): string {

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -8,7 +8,14 @@ import {
   realpathSync,
   writeSync,
 } from "node:fs";
-import { mkdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  readFile,
+  realpath,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import {
   basename,
   dirname,
@@ -1070,8 +1077,8 @@ export async function main(
           );
           const git = await resolveTrustedExecutable(
             "git",
-            isolatedGitEnvironment(dependencies.environment),
-            [invocationDirectory, repository],
+            dependencies.environment,
+            await protectedHookExecutableRoots(invocationDirectory, repository),
           );
           if (git === null) {
             throw new Error("Git is not available on a trusted PATH.");
@@ -2779,14 +2786,29 @@ function quoteCliPath(path: string): string {
     : `'${path.replaceAll("'", `'"'"'`)}'`;
 }
 
-function isolatedGitEnvironment(
-  environment: Readonly<NodeJS.ProcessEnv>,
-): NodeJS.ProcessEnv {
-  return Object.fromEntries(
-    Object.entries(environment).filter(
-      ([name]) => !name.toUpperCase().startsWith("GIT_"),
-    ),
-  );
+async function protectedHookExecutableRoots(
+  invocationDirectory: string,
+  repository: string,
+): Promise<readonly string[]> {
+  const roots = new Set([repository]);
+
+  for (const directory of new Set([invocationDirectory, repository])) {
+    let current = directory;
+    while (true) {
+      try {
+        await lstat(join(current, ".git"));
+        roots.add(current);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      }
+
+      const parent = dirname(current);
+      if (parent === current) break;
+      current = parent;
+    }
+  }
+
+  return [...roots];
 }
 
 function targetFromArguments(arguments_: ScanArguments): ScanTarget {

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -2928,6 +2928,7 @@ async function protectedHookExecutableRoots(
   const roots = new Set([repository]);
   const selectedGitDirectory = hookGitEnvironmentValue(environment, "GIT_DIR");
   const gitDirectories = new Set<string>();
+  const objectDirectories = new Set<string>();
   if (selectedGitDirectory) {
     const selected = await canonicalProtectedHookRoot(
       resolve(repository, selectedGitDirectory),
@@ -2940,11 +2941,11 @@ async function protectedHookExecutableRoots(
     "GIT_COMMON_DIR",
   );
   if (selectedCommonDirectory) {
-    roots.add(
-      await canonicalProtectedHookRoot(
-        resolve(repository, selectedCommonDirectory),
-      ),
+    const common = await canonicalProtectedHookRoot(
+      resolve(repository, selectedCommonDirectory),
     );
+    roots.add(common);
+    objectDirectories.add(join(common, "objects"));
   }
   const selectedWorktree = hookGitEnvironmentValue(
     environment,
@@ -2955,7 +2956,6 @@ async function protectedHookExecutableRoots(
       await canonicalProtectedHookRoot(resolve(repository, selectedWorktree)),
     );
   }
-  const objectDirectories = new Set<string>();
   const selectedObjectDirectory = hookGitEnvironmentValue(
     environment,
     "GIT_OBJECT_DIRECTORY",
@@ -3029,7 +3029,12 @@ async function protectedHookExecutableRoots(
       const path = join(gitDirectory, name);
       try {
         const metadata = await stat(path);
-        if (!metadata.isFile() || metadata.size > 1_024 * 1_024) continue;
+        if (!metadata.isFile()) continue;
+        if (metadata.size > 1_024 * 1_024) {
+          throw new Error(
+            "Git configuration is too large to safely discover protected worktrees.",
+          );
+        }
         for (const worktree of gitConfigWorktrees(
           await readFile(path, "utf8"),
         )) {
@@ -3064,7 +3069,9 @@ async function protectedHookExecutableRoots(
       if (objectDirectories.size >= 1_024) {
         throw new Error("Too many Git alternate object directories.");
       }
-      objectDirectories.add(resolve(canonical, alternate));
+      for (const decoded of gitAlternateObjectDirectories(alternate)) {
+        objectDirectories.add(resolve(canonical, decoded));
+      }
     }
   }
 
@@ -3114,7 +3121,14 @@ function hookGitEnvironmentValue(
 function gitConfigWorktrees(contents: string): readonly string[] {
   const worktrees: string[] = [];
   let core = false;
-  for (const line of contents.split(/\r?\n/u)) {
+  let continuation = "";
+  for (const segment of contents.split(/\r?\n/u)) {
+    let line = continuation + segment;
+    if (/(^|[^\\])(?:\\\\)*\\$/u.test(line)) {
+      continuation = line.slice(0, -1);
+      continue;
+    }
+    continuation = "";
     const section = /^\s*\[([^\]]+)\]/u.exec(line);
     if (section?.[1] !== undefined) {
       core = section[1].trim().toLowerCase() === "core";

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -2932,12 +2932,14 @@ async function protectedHookExecutableRoots(
   const objectDirectories = new Set<string>();
   const configuredWorktrees = new Map<string, string>();
   const configuredHookPaths = new Map<string, string>();
+  const discoveredWorktreeRoots = new Map<string, string>();
   if (selectedGitDirectory) {
     const selected = await canonicalProtectedHookRoot(
       resolve(repository, selectedGitDirectory),
     );
     roots.add(selected);
     gitDirectories.add(selected);
+    discoveredWorktreeRoots.set(selected, repository);
   }
   const selectedCommonDirectory = hookGitEnvironmentValue(
     environment,
@@ -2960,6 +2962,25 @@ async function protectedHookExecutableRoots(
     roots.add(
       await canonicalProtectedHookRoot(resolve(repository, selectedWorktree)),
     );
+    for (const gitDirectory of gitDirectories) {
+      discoveredWorktreeRoots.set(
+        gitDirectory,
+        resolve(repository, selectedWorktree),
+      );
+    }
+  }
+  try {
+    const [head, configuration, objects] = await Promise.all([
+      lstat(join(repository, "HEAD")),
+      lstat(join(repository, "config")),
+      lstat(join(repository, "objects")),
+    ]);
+    if (head.isFile() && configuration.isFile() && objects.isDirectory()) {
+      gitDirectories.add(repository);
+      roots.add(repository);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }
 
   for (const directory of new Set([invocationDirectory, repository])) {
@@ -2986,10 +3007,12 @@ async function protectedHookExecutableRoots(
           );
           roots.add(selected);
           gitDirectories.add(selected);
+          discoveredWorktreeRoots.set(selected, current);
         } else if (metadata.isDirectory()) {
           const selected = await canonicalProtectedHookRoot(marker);
           roots.add(selected);
           gitDirectories.add(selected);
+          discoveredWorktreeRoots.set(selected, current);
         }
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
@@ -3091,6 +3114,9 @@ async function protectedHookExecutableRoots(
         if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
       }
     };
+    for (const globalPath of gitGlobalConfigurationPaths(environment)) {
+      await readConfiguration(globalPath);
+    }
     await readConfiguration(join(commonGitDirectory, "config"));
     if (worktreeConfigEnabled) {
       await readConfiguration(join(gitDirectory, "config.worktree"));
@@ -3160,14 +3186,27 @@ async function protectedHookExecutableRoots(
     );
   }
   for (const [gitDirectory, configured] of configuredHookPaths) {
-    const hooksPath = await expandGitConfigIncludePath(
-      environmentHookPath ?? configured,
-    );
-    for (const base of [repository, gitDirectory]) {
+    const selectedHooksPath = environmentHookPath ?? configured;
+    if (selectedHooksPath.startsWith("%(prefix)/")) {
+      throw new Error(
+        "Git prefix-relative hook paths cannot be resolved safely.",
+      );
+    }
+    const hooksPath = await expandGitConfigIncludePath(selectedHooksPath);
+    for (const base of new Set([
+      repository,
+      gitDirectory,
+      discoveredWorktreeRoots.get(gitDirectory) ?? repository,
+    ])) {
       roots.add(await canonicalProtectedHookRoot(resolve(base, hooksPath)));
     }
   }
   if (environmentHookPath !== undefined && configuredHookPaths.size === 0) {
+    if (environmentHookPath.startsWith("%(prefix)/")) {
+      throw new Error(
+        "Git prefix-relative hook paths cannot be resolved safely.",
+      );
+    }
     const hooksPath = await expandGitConfigIncludePath(environmentHookPath);
     roots.add(await canonicalProtectedHookRoot(resolve(repository, hooksPath)));
   }
@@ -3180,6 +3219,40 @@ async function protectedHookExecutableRoots(
   }
 
   return [...roots];
+}
+
+function gitGlobalConfigurationPaths(
+  environment: Readonly<Record<string, string | undefined>>,
+): readonly string[] {
+  const system = hookGitEnvironmentValue(environment, "GIT_CONFIG_SYSTEM");
+  const disableSystem = hookGitEnvironmentValue(
+    environment,
+    "GIT_CONFIG_NOSYSTEM",
+  );
+  const home =
+    hookGitEnvironmentValue(
+      environment,
+      process.platform === "win32" ? "USERPROFILE" : "HOME",
+    ) ?? userInfo().homedir;
+  const xdg =
+    hookGitEnvironmentValue(environment, "XDG_CONFIG_HOME") ??
+    join(home, ".config");
+  const global = hookGitEnvironmentValue(environment, "GIT_CONFIG_GLOBAL");
+  return [
+    ...(disableSystem === undefined ||
+    ["0", "false", "no"].includes(disableSystem)
+      ? system === undefined
+        ? [
+            "/etc/gitconfig",
+            "/usr/local/etc/gitconfig",
+            "/opt/homebrew/etc/gitconfig",
+          ]
+        : [system]
+      : []),
+    ...(global === undefined
+      ? [join(xdg, "git", "config"), join(home, ".gitconfig")]
+      : [global]),
+  ];
 }
 
 function hookGitEnvironmentValue(

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -3076,22 +3076,52 @@ async function protectedHookExecutableRoots(
     let configuredHookPath: string | undefined;
     const globalConfigurationPaths = gitGlobalConfigurationPaths(environment);
     const remoteUrls = new Set<string>();
+    const remoteConfigurationPaths = new Set<string>();
+    const collectRemoteUrls = async (
+      configurationPath: string,
+    ): Promise<void> => {
+      if (remoteConfigurationPaths.has(configurationPath)) return;
+      if (remoteConfigurationPaths.size >= 256) {
+        throw new Error("Too many Git configuration includes.");
+      }
+      remoteConfigurationPaths.add(configurationPath);
+      try {
+        const metadata = await stat(configurationPath);
+        if (!metadata.isFile() || metadata.size > 1_024 * 1_024) return;
+        for (const entry of gitConfigEntries(
+          await readFile(configurationPath, "utf8"),
+        )) {
+          if (entry.kind === "remoteUrl") {
+            remoteUrls.add(entry.value);
+          } else if (
+            entry.kind === "include" &&
+            (entry.condition === undefined ||
+              (!entry.condition.toLowerCase().startsWith("hasconfig:") &&
+                (await gitIncludeConditionMatches(
+                  entry.condition,
+                  gitDirectory,
+                  configurationPath,
+                  remoteUrls,
+                ))))
+          ) {
+            await collectRemoteUrls(
+              resolve(
+                dirname(configurationPath),
+                await expandGitConfigIncludePath(entry.path),
+              ),
+            );
+          }
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      }
+    };
     for (const configurationPath of new Set([
       ...globalConfigurationPaths,
       join(commonGitDirectory, "config"),
       join(gitDirectory, "config.worktree"),
     ])) {
-      try {
-        const metadata = await stat(configurationPath);
-        if (!metadata.isFile() || metadata.size > 1_024 * 1_024) continue;
-        for (const entry of gitConfigEntries(
-          await readFile(configurationPath, "utf8"),
-        )) {
-          if (entry.kind === "remoteUrl") remoteUrls.add(entry.value);
-        }
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-      }
+      await collectRemoteUrls(configurationPath);
     }
     const readConfiguration = async (path: string): Promise<void> => {
       try {
@@ -3283,6 +3313,23 @@ function gitGlobalConfigurationPaths(
   }
   const installationConfigurations = pathEntries.flatMap((entry) => {
     if (!isAbsolute(entry)) return [];
+    const names =
+      process.platform === "win32" ? ["git.exe", "git.com"] : ["git"];
+    const containsGit = names.some((name) => {
+      const candidate = join(entry, name);
+      try {
+        const metadata = lstatSync(candidate);
+        if (!metadata.isFile() && !metadata.isSymbolicLink()) return false;
+        accessSync(
+          candidate,
+          process.platform === "win32" ? constants.F_OK : constants.X_OK,
+        );
+        return true;
+      } catch {
+        return false;
+      }
+    });
+    if (!containsGit) return [];
     const prefix = dirname(entry);
     return [
       join(prefix, "etc", "gitconfig"),
@@ -3634,7 +3681,9 @@ async function gitIncludeConditionMatches(
   expression += "$";
   const matcher = new RegExp(expression, kind === "gitdir/i" ? "iu" : "u");
   return candidates.some(
-    (candidate) => matcher.test(candidate) || matcher.test(`${candidate}/`),
+    (candidate) =>
+      matcher.test(candidate) ||
+      (kind !== "hasconfig" && matcher.test(`${candidate}/`)),
   );
 }
 

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -78,6 +78,7 @@ import {
   renderScanHistory,
   type HistoryCommand,
 } from "./scan-history-renderer.js";
+import { resolveTrustedExecutable } from "./trusted-executable.js";
 import type { ScanWorkerPhase, ScanWorkerStatus } from "./worker-progress.js";
 import { DiffTarget, type ScanMode, type ScanTarget } from "./targets.js";
 import {
@@ -1061,18 +1062,39 @@ export async function main(
         .optional(),
       async run({ args, options }) {
         try {
-          const hook = execFileSync(
+          const invocationDirectory = await realpath(
+            dependencies.currentDirectory(),
+          );
+          const repository = await realpath(
+            resolve(invocationDirectory, args.repository ?? "."),
+          );
+          const git = await resolveTrustedExecutable(
             "git",
+            isolatedGitEnvironment(dependencies.environment),
+            [invocationDirectory, repository],
+          );
+          if (git === null) {
+            throw new Error("Git is not available on a trusted PATH.");
+          }
+          const hook = execFileSync(
+            git.executable,
             [
               "-C",
-              resolve(dependencies.currentDirectory(), args.repository ?? "."),
+              repository,
               "rev-parse",
               "--path-format=absolute",
               "--git-path",
               "hooks/pre-commit",
             ],
-            { encoding: "utf8" },
+            { encoding: "utf8", env: git.environment },
           ).trim();
+          if (
+            hook.length === 0 ||
+            !isAbsolute(hook) ||
+            /[\u0000-\u001f\u007f-\u009f\u2028\u2029]/u.test(hook)
+          ) {
+            throw new Error("Git returned an invalid pre-commit hook path.");
+          }
           const command = [
             realpathSync(process.execPath),
             realpathSync(fileURLToPath(import.meta.url)),
@@ -2755,6 +2777,16 @@ function quoteCliPath(path: string): string {
   return process.platform === "win32"
     ? `"${path}"`
     : `'${path.replaceAll("'", `'"'"'`)}'`;
+}
+
+function isolatedGitEnvironment(
+  environment: Readonly<NodeJS.ProcessEnv>,
+): NodeJS.ProcessEnv {
+  return Object.fromEntries(
+    Object.entries(environment).filter(
+      ([name]) => !name.toUpperCase().startsWith("GIT_"),
+    ),
+  );
 }
 
 function targetFromArguments(arguments_: ScanArguments): ScanTarget {

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -2926,6 +2926,8 @@ async function protectedHookExecutableRoots(
   environment: Readonly<Record<string, string | undefined>>,
 ): Promise<readonly string[]> {
   const roots = new Set([repository]);
+  let effectiveWorktree = repository;
+  let discoveredWorktree = false;
   const selectedGitDirectory = hookGitEnvironmentValue(environment, "GIT_DIR");
   const gitDirectories = new Set<string>();
   const objectDirectories = new Set<string>();
@@ -2952,27 +2954,10 @@ async function protectedHookExecutableRoots(
     "GIT_WORK_TREE",
   );
   if (selectedWorktree) {
-    roots.add(
-      await canonicalProtectedHookRoot(resolve(repository, selectedWorktree)),
+    effectiveWorktree = await canonicalProtectedHookRoot(
+      resolve(repository, selectedWorktree),
     );
-  }
-  const selectedObjectDirectory = hookGitEnvironmentValue(
-    environment,
-    "GIT_OBJECT_DIRECTORY",
-  );
-  if (selectedObjectDirectory) {
-    objectDirectories.add(resolve(repository, selectedObjectDirectory));
-  }
-  const selectedAlternates = hookGitEnvironmentValue(
-    environment,
-    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
-  );
-  if (selectedAlternates) {
-    for (const objectDirectory of gitAlternateObjectDirectories(
-      selectedAlternates,
-    )) {
-      objectDirectories.add(resolve(repository, objectDirectory));
-    }
+    roots.add(effectiveWorktree);
   }
 
   for (const directory of new Set([invocationDirectory, repository])) {
@@ -2985,16 +2970,21 @@ async function protectedHookExecutableRoots(
           ? await stat(marker)
           : markerMetadata;
         roots.add(current);
+        if (!selectedWorktree && !discoveredWorktree) {
+          effectiveWorktree = current;
+          discoveredWorktree = true;
+        }
         if (metadata.isFile()) {
           const contents = await readFile(marker, "utf8");
-          const matched = /^gitdir:[\t ]*([^\r\n]+?)(?:\r?\n[\t ]*)*$/u.exec(
-            contents,
-          );
+          const matched =
+            /^gitdir:[\t ]*([^\r\n]+?)(?=\r?\n|$)(?:\r?\n[\t ]*)*$/u.exec(
+              contents,
+            );
           if (matched?.[1] === undefined) {
             throw new Error("Git worktree pointer cannot be parsed safely.");
           }
           const selected = await canonicalProtectedHookRoot(
-            resolve(current, matched[1].trimEnd()),
+            resolve(current, matched[1]),
           );
           roots.add(selected);
           gitDirectories.add(selected);
@@ -3013,7 +3003,27 @@ async function protectedHookExecutableRoots(
     }
   }
 
+  const selectedObjectDirectory = hookGitEnvironmentValue(
+    environment,
+    "GIT_OBJECT_DIRECTORY",
+  );
+  if (selectedObjectDirectory) {
+    objectDirectories.add(resolve(effectiveWorktree, selectedObjectDirectory));
+  }
+  const selectedAlternates = hookGitEnvironmentValue(
+    environment,
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  );
+  if (selectedAlternates) {
+    for (const objectDirectory of gitAlternateObjectDirectories(
+      selectedAlternates,
+    )) {
+      objectDirectories.add(resolve(effectiveWorktree, objectDirectory));
+    }
+  }
+
   for (const gitDirectory of gitDirectories) {
+    let commonGitDirectory = gitDirectory;
     try {
       const commonDirectory = (
         await readFile(join(gitDirectory, "commondir"), "utf8")
@@ -3022,18 +3032,19 @@ async function protectedHookExecutableRoots(
         const canonical = await canonicalProtectedHookRoot(
           resolve(gitDirectory, commonDirectory),
         );
+        commonGitDirectory = canonical;
         roots.add(canonical);
         objectDirectories.add(join(canonical, "objects"));
       }
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     }
-    const configuration = [
-      join(gitDirectory, "config"),
-      join(gitDirectory, "config.worktree"),
-    ];
+    const configuration = [join(commonGitDirectory, "config")];
     const visitedConfiguration = new Set<string>();
-    for (const path of configuration) {
+    let worktreeConfigEnabled = false;
+    let addedWorktreeConfiguration = false;
+    for (let index = 0; index < configuration.length; index += 1) {
+      const path = configuration[index]!;
       try {
         const canonicalPath = await canonicalProtectedHookRoot(path);
         if (visitedConfiguration.has(canonicalPath)) continue;
@@ -3049,6 +3060,9 @@ async function protectedHookExecutableRoots(
           );
         }
         const entries = gitConfigEntries(await readFile(path, "utf8"));
+        if (entries.worktreeConfig !== undefined) {
+          worktreeConfigEnabled = entries.worktreeConfig;
+        }
         for (const worktree of entries.worktrees) {
           for (const base of [repository, gitDirectory]) {
             roots.add(
@@ -3057,10 +3071,28 @@ async function protectedHookExecutableRoots(
           }
         }
         for (const included of entries.includes) {
-          configuration.push(resolve(dirname(path), expandHome(included)));
+          if (
+            included.condition !== undefined &&
+            !(await gitIncludeConditionMatches(
+              included.condition,
+              gitDirectory,
+              path,
+            ))
+          ) {
+            continue;
+          }
+          configuration.push(resolve(dirname(path), expandHome(included.path)));
         }
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      }
+      if (
+        worktreeConfigEnabled &&
+        !addedWorktreeConfiguration &&
+        index === configuration.length - 1
+      ) {
+        addedWorktreeConfiguration = true;
+        configuration.push(join(gitDirectory, "config.worktree"));
       }
     }
     objectDirectories.add(join(gitDirectory, "objects"));
@@ -3145,11 +3177,14 @@ function hookGitEnvironmentValue(
 
 function gitConfigEntries(contents: string): {
   worktrees: string[];
-  includes: string[];
+  includes: Array<{ path: string; condition?: string }>;
+  worktreeConfig?: boolean;
 } {
   const worktrees: string[] = [];
-  const includes: string[] = [];
+  const includes: Array<{ path: string; condition?: string }> = [];
   let sectionName = "";
+  let subsection: string | undefined;
+  let worktreeConfig: boolean | undefined;
   let continuation = "";
   for (const segment of contents.split(/\r?\n/u)) {
     let line = continuation + segment;
@@ -3158,61 +3193,179 @@ function gitConfigEntries(contents: string): {
       continue;
     }
     continuation = "";
-    const section = /^\s*\[([^\]]+)\]/u.exec(line);
+    const section =
+      /^\s*\[([A-Za-z0-9.-]+)(?:\s+"((?:\\.|[^"\\])*)")?\s*\]/u.exec(line);
     if (section?.[1] !== undefined) {
-      sectionName = section[1].trim().split(/[\s"]/u, 1)[0]!.toLowerCase();
+      sectionName = section[1].toLowerCase();
+      subsection =
+        section[2] === undefined
+          ? undefined
+          : gitConfigValue(`"${section[2]}"`);
       continue;
     }
     const key =
-      sectionName === "core"
+      sectionName === "core" && subsection === undefined
         ? "worktree"
-        : sectionName === "include" || sectionName === "includeif"
-          ? "path"
-          : null;
+        : sectionName === "extensions" && subsection === undefined
+          ? "worktreeconfig"
+          : (sectionName === "include" && subsection === undefined) ||
+              (sectionName === "includeif" && subsection !== undefined)
+            ? "path"
+            : null;
     if (key === null) continue;
     const matched = new RegExp(`^\\s*${key}\\s*=\\s*(.+?)\\s*$`, "iu").exec(
       line,
     );
-    let configured = matched?.[1];
+    const configured = matched?.[1];
     if (configured === undefined) continue;
-    let quoted = false;
-    let escaped = false;
-    let value = "";
-    for (const character of configured) {
-      if (!escaped && character === '"') quoted = !quoted;
-      if (!quoted && !escaped && (character === "#" || character === ";")) {
-        break;
+    const value = gitConfigValue(configured);
+    if (value.length === 0) continue;
+    if (sectionName === "extensions") {
+      const normalized = value.toLowerCase();
+      if (["true", "yes", "on", "1"].includes(normalized)) {
+        worktreeConfig = true;
+      } else if (["false", "no", "off", "0"].includes(normalized)) {
+        worktreeConfig = false;
+      } else {
+        throw new Error(
+          "Git worktree configuration extension cannot be parsed safely.",
+        );
       }
-      value += character;
-      escaped = !escaped && character === "\\";
-    }
-    configured = value.trimEnd();
-    if (configured.startsWith('"') && configured.endsWith('"')) {
-      try {
-        const decoded: unknown = JSON.parse(configured);
-        if (typeof decoded === "string") configured = decoded;
-      } catch {
-        configured = configured.slice(1, -1);
-      }
-    }
-    if (configured.length > 0) {
-      (sectionName === "core" ? worktrees : includes).push(configured);
+    } else if (sectionName === "core") {
+      worktrees.push(value);
+    } else {
+      includes.push({
+        path: value,
+        ...(sectionName === "includeif" ? { condition: subsection! } : {}),
+      });
     }
   }
-  return { worktrees, includes };
+  return {
+    worktrees,
+    includes,
+    ...(worktreeConfig === undefined ? {} : { worktreeConfig }),
+  };
+}
+
+function gitConfigValue(value: string): string {
+  let decoded = "";
+  let quoted = false;
+  let significantLength = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index]!;
+    if (character === '"') {
+      quoted = !quoted;
+      continue;
+    }
+    if (!quoted && (character === "#" || character === ";")) break;
+    if (character === "\\") {
+      const escaped = value[++index];
+      if (escaped === undefined) {
+        throw new Error("Invalid escaped Git configuration value.");
+      }
+      const special: Record<string, string> = {
+        b: "\b",
+        n: "\n",
+        t: "\t",
+        '"': '"',
+        "\\": "\\",
+      };
+      if (escaped in special) {
+        decoded += special[escaped];
+      } else if (/[0-7]/u.test(escaped)) {
+        let octal = escaped;
+        while (octal.length < 3 && /[0-7]/u.test(value[index + 1] ?? "")) {
+          octal += value[++index];
+        }
+        decoded += String.fromCharCode(Number.parseInt(octal, 8));
+      } else {
+        throw new Error("Invalid escaped Git configuration value.");
+      }
+      significantLength = decoded.length;
+      continue;
+    }
+    decoded += character;
+    if (quoted || !/[\t ]/u.test(character)) {
+      significantLength = decoded.length;
+    }
+  }
+  if (quoted) {
+    throw new Error("Invalid quoted Git configuration value.");
+  }
+  return decoded.slice(0, significantLength);
+}
+
+async function gitIncludeConditionMatches(
+  condition: string,
+  gitDirectory: string,
+  configurationPath: string,
+): Promise<boolean> {
+  const separator = condition.indexOf(":");
+  if (separator < 0) {
+    throw new Error("Unsupported conditional Git configuration include.");
+  }
+  const kind = condition.slice(0, separator).toLowerCase();
+  let pattern = condition.slice(separator + 1).replaceAll("\\", "/");
+  let candidate: string;
+  if (kind === "gitdir" || kind === "gitdir/i") {
+    if (pattern.startsWith("./")) {
+      pattern = resolve(dirname(configurationPath), pattern).replaceAll(
+        "\\",
+        "/",
+      );
+    } else if (pattern.startsWith("~/")) {
+      pattern = expandHome(pattern).replaceAll("\\", "/");
+    } else if (!isAbsolute(pattern) && !pattern.startsWith("**/")) {
+      pattern = `**/${pattern}`;
+    }
+    if (pattern.endsWith("/")) pattern += "**";
+    candidate = gitDirectory.replaceAll("\\", "/");
+  } else if (kind === "onbranch") {
+    let head: string;
+    try {
+      head = await readFile(join(gitDirectory, "HEAD"), "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+      throw error;
+    }
+    const branch = /^ref:[\t ]*refs\/heads\/(.+?)(?:\r?\n)?$/u.exec(head)?.[1];
+    if (branch === undefined) return false;
+    if (pattern.endsWith("/")) pattern += "**";
+    candidate = branch;
+  } else {
+    throw new Error("Unsupported conditional Git configuration include.");
+  }
+
+  let expression = "^";
+  for (let index = 0; index < pattern.length; index += 1) {
+    const character = pattern[index]!;
+    if (character === "*") {
+      if (pattern[index + 1] === "*") {
+        index += 1;
+        if (pattern[index + 1] === "/") {
+          index += 1;
+          expression += "(?:.*/)?";
+        } else {
+          expression += ".*";
+        }
+      } else {
+        expression += "[^/]*";
+      }
+    } else if (character === "?") {
+      expression += "[^/]";
+    } else {
+      expression += character.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+    }
+  }
+  expression += "$";
+  const matcher = new RegExp(expression, kind === "gitdir/i" ? "iu" : "u");
+  return matcher.test(candidate) || matcher.test(`${candidate}/`);
 }
 
 function gitAlternateObjectDirectoryLine(value: string): string {
   if (!value.startsWith('"')) return value;
-  let decoded: unknown;
-  try {
-    decoded = JSON.parse(value);
-  } catch (error) {
-    throw new Error("Invalid quoted Git alternate object directory.", {
-      cause: error,
-    });
-  }
-  if (typeof decoded !== "string") {
+  const decoded = gitConfigValue(value);
+  if (!value.endsWith('"')) {
     throw new Error("Invalid quoted Git alternate object directory.");
   }
   return decoded;
@@ -3237,18 +3390,9 @@ function gitAlternateObjectDirectories(value: string): readonly string[] {
       if (end === value.length) {
         throw new Error("Invalid quoted Git alternate object directory.");
       }
-      let decoded: unknown;
-      try {
-        decoded = JSON.parse(value.slice(offset, end + 1));
-      } catch (error) {
-        throw new Error("Invalid quoted Git alternate object directory.", {
-          cause: error,
-        });
-      }
-      if (typeof decoded !== "string") {
-        throw new Error("Invalid quoted Git alternate object directory.");
-      }
-      entries.push(decoded);
+      entries.push(
+        gitAlternateObjectDirectoryLine(value.slice(offset, end + 1)),
+      );
       offset = end + 1;
       if (offset < value.length && value[offset] !== delimiter) {
         throw new Error("Invalid Git alternate object directory separator.");

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -2955,16 +2955,23 @@ async function protectedHookExecutableRoots(
       await canonicalProtectedHookRoot(resolve(repository, selectedWorktree)),
     );
   }
-  for (const name of [
+  const objectDirectories = new Set<string>();
+  const selectedObjectDirectory = hookGitEnvironmentValue(
+    environment,
     "GIT_OBJECT_DIRECTORY",
+  );
+  if (selectedObjectDirectory) {
+    objectDirectories.add(resolve(repository, selectedObjectDirectory));
+  }
+  const selectedAlternates = hookGitEnvironmentValue(
+    environment,
     "GIT_ALTERNATE_OBJECT_DIRECTORIES",
-  ] as const) {
-    const selected = hookGitEnvironmentValue(environment, name);
-    for (const objectDirectory of selected?.split(delimiter) ?? []) {
-      if (objectDirectory.length === 0) continue;
-      roots.add(
-        await canonicalProtectedHookRoot(resolve(repository, objectDirectory)),
-      );
+  );
+  if (selectedAlternates) {
+    for (const objectDirectory of gitAlternateObjectDirectories(
+      selectedAlternates,
+    )) {
+      objectDirectories.add(resolve(repository, objectDirectory));
     }
   }
 
@@ -3007,13 +3014,13 @@ async function protectedHookExecutableRoots(
     try {
       const commonDirectory = (
         await readFile(join(gitDirectory, "commondir"), "utf8")
-      ).trim();
+      ).replace(/\r?\n$/u, "");
       if (commonDirectory.length > 0) {
-        roots.add(
-          await canonicalProtectedHookRoot(
-            resolve(gitDirectory, commonDirectory),
-          ),
+        const canonical = await canonicalProtectedHookRoot(
+          resolve(gitDirectory, commonDirectory),
         );
+        roots.add(canonical);
+        objectDirectories.add(join(canonical, "objects"));
       }
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
@@ -3035,6 +3042,29 @@ async function protectedHookExecutableRoots(
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
       }
+    }
+    objectDirectories.add(join(gitDirectory, "objects"));
+  }
+
+  for (const objectDirectory of objectDirectories) {
+    const canonical = await canonicalProtectedHookRoot(objectDirectory);
+    roots.add(canonical);
+    let alternates: string;
+    try {
+      alternates = await readFile(
+        join(canonical, "info", "alternates"),
+        "utf8",
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw error;
+    }
+    for (const alternate of alternates.split(/\r?\n/u)) {
+      if (alternate.length === 0 || alternate.startsWith("#")) continue;
+      if (objectDirectories.size >= 1_024) {
+        throw new Error("Too many Git alternate object directories.");
+      }
+      objectDirectories.add(resolve(canonical, alternate));
     }
   }
 
@@ -3094,6 +3124,18 @@ function gitConfigWorktrees(contents: string): readonly string[] {
     const matched = /^\s*worktree\s*=\s*(.+?)\s*$/iu.exec(line);
     let worktree = matched?.[1];
     if (worktree === undefined) continue;
+    let quoted = false;
+    let escaped = false;
+    let value = "";
+    for (const character of worktree) {
+      if (!escaped && character === '"') quoted = !quoted;
+      if (!quoted && !escaped && (character === "#" || character === ";")) {
+        break;
+      }
+      value += character;
+      escaped = !escaped && character === "\\";
+    }
+    worktree = value.trimEnd();
     if (worktree.startsWith('"') && worktree.endsWith('"')) {
       try {
         const decoded: unknown = JSON.parse(worktree);
@@ -3105,6 +3147,50 @@ function gitConfigWorktrees(contents: string): readonly string[] {
     if (worktree.length > 0) worktrees.push(worktree);
   }
   return worktrees;
+}
+
+function gitAlternateObjectDirectories(value: string): readonly string[] {
+  const entries: string[] = [];
+  let offset = 0;
+  while (offset < value.length) {
+    if (value[offset] === delimiter) {
+      offset += 1;
+      continue;
+    }
+    if (value[offset] === '"') {
+      let end = offset + 1;
+      let escaped = false;
+      for (; end < value.length; end += 1) {
+        const character = value[end]!;
+        if (!escaped && character === '"') break;
+        escaped = !escaped && character === "\\";
+      }
+      if (end === value.length) {
+        throw new Error("Invalid quoted Git alternate object directory.");
+      }
+      let decoded: unknown;
+      try {
+        decoded = JSON.parse(value.slice(offset, end + 1));
+      } catch (error) {
+        throw new Error("Invalid quoted Git alternate object directory.", {
+          cause: error,
+        });
+      }
+      if (typeof decoded !== "string") {
+        throw new Error("Invalid quoted Git alternate object directory.");
+      }
+      entries.push(decoded);
+      offset = end + 1;
+      if (offset < value.length && value[offset] !== delimiter) {
+        throw new Error("Invalid Git alternate object directory separator.");
+      }
+      continue;
+    }
+    const end = value.indexOf(delimiter, offset);
+    entries.push(value.slice(offset, end === -1 ? undefined : end));
+    offset = end === -1 ? value.length : end + 1;
+  }
+  return entries.filter((entry) => entry.length > 0);
 }
 
 async function canonicalProtectedHookRoot(path: string): Promise<string> {

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -2987,14 +2987,17 @@ async function protectedHookExecutableRoots(
         roots.add(current);
         if (metadata.isFile()) {
           const contents = await readFile(marker, "utf8");
-          const matched = /^gitdir: ([^\r\n]+)\r?\n?$/u.exec(contents);
-          if (matched?.[1] !== undefined) {
-            const selected = await canonicalProtectedHookRoot(
-              resolve(current, matched[1]),
-            );
-            roots.add(selected);
-            gitDirectories.add(selected);
+          const matched = /^gitdir:[\t ]*([^\r\n]+?)(?:\r?\n[\t ]*)*$/u.exec(
+            contents,
+          );
+          if (matched?.[1] === undefined) {
+            throw new Error("Git worktree pointer cannot be parsed safely.");
           }
+          const selected = await canonicalProtectedHookRoot(
+            resolve(current, matched[1].trimEnd()),
+          );
+          roots.add(selected);
+          gitDirectories.add(selected);
         } else if (metadata.isDirectory()) {
           const selected = await canonicalProtectedHookRoot(marker);
           roots.add(selected);
@@ -3025,9 +3028,19 @@ async function protectedHookExecutableRoots(
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     }
-    for (const name of ["config", "config.worktree"]) {
-      const path = join(gitDirectory, name);
+    const configuration = [
+      join(gitDirectory, "config"),
+      join(gitDirectory, "config.worktree"),
+    ];
+    const visitedConfiguration = new Set<string>();
+    for (const path of configuration) {
       try {
+        const canonicalPath = await canonicalProtectedHookRoot(path);
+        if (visitedConfiguration.has(canonicalPath)) continue;
+        if (visitedConfiguration.size >= 256) {
+          throw new Error("Too many Git configuration includes.");
+        }
+        visitedConfiguration.add(canonicalPath);
         const metadata = await stat(path);
         if (!metadata.isFile()) continue;
         if (metadata.size > 1_024 * 1_024) {
@@ -3035,14 +3048,16 @@ async function protectedHookExecutableRoots(
             "Git configuration is too large to safely discover protected worktrees.",
           );
         }
-        for (const worktree of gitConfigWorktrees(
-          await readFile(path, "utf8"),
-        )) {
+        const entries = gitConfigEntries(await readFile(path, "utf8"));
+        for (const worktree of entries.worktrees) {
           for (const base of [repository, gitDirectory]) {
             roots.add(
               await canonicalProtectedHookRoot(resolve(base, worktree)),
             );
           }
+        }
+        for (const included of entries.includes) {
+          configuration.push(resolve(dirname(path), expandHome(included)));
         }
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
@@ -3069,17 +3084,27 @@ async function protectedHookExecutableRoots(
       if (objectDirectories.size >= 1_024) {
         throw new Error("Too many Git alternate object directories.");
       }
-      for (const decoded of gitAlternateObjectDirectories(alternate)) {
-        objectDirectories.add(resolve(canonical, decoded));
-      }
+      objectDirectories.add(
+        resolve(canonical, gitAlternateObjectDirectoryLine(alternate)),
+      );
     }
   }
 
-  const count = Number(
-    hookGitEnvironmentValue(environment, "GIT_CONFIG_COUNT"),
+  const configuredCount = hookGitEnvironmentValue(
+    environment,
+    "GIT_CONFIG_COUNT",
   );
+  if (
+    configuredCount !== undefined &&
+    (!/^\d+$/u.test(configuredCount) || Number(configuredCount) > 1_024)
+  ) {
+    throw new Error(
+      "Git environment configuration exceeds the protected-worktree safety limit.",
+    );
+  }
+  const count = Number(configuredCount);
   if (Number.isSafeInteger(count) && count > 0) {
-    for (let index = 0; index < count && index < 1_024; index += 1) {
+    for (let index = 0; index < count; index += 1) {
       if (
         hookGitEnvironmentValue(
           environment,
@@ -3118,9 +3143,13 @@ function hookGitEnvironmentValue(
     : environment[name];
 }
 
-function gitConfigWorktrees(contents: string): readonly string[] {
+function gitConfigEntries(contents: string): {
+  worktrees: string[];
+  includes: string[];
+} {
   const worktrees: string[] = [];
-  let core = false;
+  const includes: string[] = [];
+  let sectionName = "";
   let continuation = "";
   for (const segment of contents.split(/\r?\n/u)) {
     let line = continuation + segment;
@@ -3131,17 +3160,25 @@ function gitConfigWorktrees(contents: string): readonly string[] {
     continuation = "";
     const section = /^\s*\[([^\]]+)\]/u.exec(line);
     if (section?.[1] !== undefined) {
-      core = section[1].trim().toLowerCase() === "core";
+      sectionName = section[1].trim().split(/[\s"]/u, 1)[0]!.toLowerCase();
       continue;
     }
-    if (!core) continue;
-    const matched = /^\s*worktree\s*=\s*(.+?)\s*$/iu.exec(line);
-    let worktree = matched?.[1];
-    if (worktree === undefined) continue;
+    const key =
+      sectionName === "core"
+        ? "worktree"
+        : sectionName === "include" || sectionName === "includeif"
+          ? "path"
+          : null;
+    if (key === null) continue;
+    const matched = new RegExp(`^\\s*${key}\\s*=\\s*(.+?)\\s*$`, "iu").exec(
+      line,
+    );
+    let configured = matched?.[1];
+    if (configured === undefined) continue;
     let quoted = false;
     let escaped = false;
     let value = "";
-    for (const character of worktree) {
+    for (const character of configured) {
       if (!escaped && character === '"') quoted = !quoted;
       if (!quoted && !escaped && (character === "#" || character === ";")) {
         break;
@@ -3149,18 +3186,36 @@ function gitConfigWorktrees(contents: string): readonly string[] {
       value += character;
       escaped = !escaped && character === "\\";
     }
-    worktree = value.trimEnd();
-    if (worktree.startsWith('"') && worktree.endsWith('"')) {
+    configured = value.trimEnd();
+    if (configured.startsWith('"') && configured.endsWith('"')) {
       try {
-        const decoded: unknown = JSON.parse(worktree);
-        if (typeof decoded === "string") worktree = decoded;
+        const decoded: unknown = JSON.parse(configured);
+        if (typeof decoded === "string") configured = decoded;
       } catch {
-        worktree = worktree.slice(1, -1);
+        configured = configured.slice(1, -1);
       }
     }
-    if (worktree.length > 0) worktrees.push(worktree);
+    if (configured.length > 0) {
+      (sectionName === "core" ? worktrees : includes).push(configured);
+    }
   }
-  return worktrees;
+  return { worktrees, includes };
+}
+
+function gitAlternateObjectDirectoryLine(value: string): string {
+  if (!value.startsWith('"')) return value;
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(value);
+  } catch (error) {
+    throw new Error("Invalid quoted Git alternate object directory.", {
+      cause: error,
+    });
+  }
+  if (typeof decoded !== "string") {
+    throw new Error("Invalid quoted Git alternate object directory.");
+  }
+  return decoded;
 }
 
 function gitAlternateObjectDirectories(value: string): readonly string[] {

--- a/sdk/typescript/src/trusted-executable.ts
+++ b/sdk/typescript/src/trusted-executable.ts
@@ -10,10 +10,12 @@ export interface TrustedExecutable {
 export async function resolveTrustedExecutable(
   candidate: string,
   environment: Readonly<Record<string, string | undefined>>,
-  protectedRoot: string,
+  protectedRoot: string | readonly string[],
 ): Promise<TrustedExecutable | null> {
-  const root = await realpath(protectedRoot).catch(() =>
-    resolve(protectedRoot),
+  const protectedRoots = await Promise.all(
+    (typeof protectedRoot === "string" ? [protectedRoot] : protectedRoot).map(
+      async (root) => await realpath(root).catch(() => resolve(root)),
+    ),
   );
   const path = Object.entries(environment).find(
     ([name]) => name.toUpperCase() === "PATH",
@@ -22,7 +24,12 @@ export async function resolveTrustedExecutable(
   for (const entry of path?.split(delimiter) ?? []) {
     if (entry.length === 0 || !isAbsolute(entry)) continue;
     const canonical = await realpath(entry).catch(() => null);
-    if (canonical === null || isWithin(root, canonical)) continue;
+    if (
+      canonical === null ||
+      protectedRoots.some((root) => isWithin(root, canonical))
+    ) {
+      continue;
+    }
     if (!entries.includes(canonical)) entries.push(canonical);
   }
 
@@ -54,7 +61,7 @@ export async function resolveTrustedExecutable(
   for (const current of candidates) {
     const canonical = await realpath(current.path).catch(() => null);
     if (canonical === null) continue;
-    if (isWithin(root, canonical)) {
+    if (protectedRoots.some((root) => isWithin(root, canonical))) {
       if (current.entry !== null) unsafeEntries.add(current.entry);
       continue;
     }

--- a/sdk/typescript/src/trusted-executable.ts
+++ b/sdk/typescript/src/trusted-executable.ts
@@ -17,9 +17,12 @@ export async function resolveTrustedExecutable(
       async (root) => await realpath(root).catch(() => resolve(root)),
     ),
   );
-  const path = Object.entries(environment).find(
-    ([name]) => name.toUpperCase() === "PATH",
-  )?.[1];
+  const path =
+    process.platform === "win32"
+      ? Object.entries(environment).find(
+          ([name]) => name.toUpperCase() === "PATH",
+        )?.[1]
+      : environment["PATH"];
   const entries: string[] = [];
   for (const entry of path?.split(delimiter) ?? []) {
     if (entry.length === 0 || !isAbsolute(entry)) continue;
@@ -81,7 +84,13 @@ export async function resolveTrustedExecutable(
 
   const sanitizedEnvironment = { ...environment };
   for (const name of Object.keys(sanitizedEnvironment)) {
-    if (name.toUpperCase() === "PATH") delete sanitizedEnvironment[name];
+    if (
+      process.platform === "win32"
+        ? name.toUpperCase() === "PATH"
+        : name === "PATH"
+    ) {
+      delete sanitizedEnvironment[name];
+    }
   }
   sanitizedEnvironment["PATH"] = entries
     .filter((entry) => !unsafeEntries.has(entry))

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -3901,7 +3901,7 @@ if (process.argv.slice(2).join(" ") !== "login status") {
     await writeFile(
       fakeCodex,
       `
-import { appendFileSync } from "node:fs";
+import { appendFileSync, writeSync } from "node:fs";
 
 const args = process.argv.slice(2).join(" ");
 if (args === "login --with-api-key") {
@@ -3913,7 +3913,7 @@ if (args === "login --with-api-key") {
     appendFileSync(${JSON.stringify(keyLog)}, apiKey);
   }
 } else if (args === "login") {
-  console.error("Open https://auth.example.test/login");
+  writeSync(2, "Open https://auth.example.test/login\\n");
 } else {
   process.exitCode = 2;
 }

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -1382,17 +1382,24 @@ describe("CLI", () => {
   test("protects active conditional and enabled Git worktree configuration", async () => {
     for (const mode of [
       "active-include",
+      "hasconfig-include",
       "character-class-include",
       "posix-character-class-include",
       "environment-config-override",
       "external-hooks-path",
       "environment-hooks-path",
+      "environment-relative-subdirectory-hooks-path",
       "included-hooks-path",
       "relative-subdirectory-hooks-path",
       "global-hooks-path",
       "xdg-hooks-path",
+      "xdg-empty-hooks-path",
       "system-hooks-path",
+      "system-hooks-path-off",
+      "system-hooks-path-uppercase",
+      "system-hooks-path-signed-zero",
       "bare-hooks-path",
+      "bare-symlink-hooks-path",
       "prefix-hooks-path",
       "enabled-worktree-config",
       "integer-worktree-config",
@@ -1400,6 +1407,9 @@ describe("CLI", () => {
       "ordered-worktree-config",
       "common-directory",
     ] as const) {
+      if (mode === "bare-symlink-hooks-path" && process.platform === "win32") {
+        continue;
+      }
       const root = await realpath(
         await mkdtemp(join(tmpdir(), `codex-security-cli-${mode}-`)),
       );
@@ -1410,7 +1420,7 @@ describe("CLI", () => {
         const marker = join(root, "git-shim-executed");
         execFileSync(
           "git",
-          mode === "bare-hooks-path"
+          mode === "bare-hooks-path" || mode === "bare-symlink-hooks-path"
             ? ["init", "--bare", "-q", repository]
             : ["init", "-q", repository],
           { timeout: 10_000 },
@@ -1419,10 +1429,13 @@ describe("CLI", () => {
         const configuredWorktree = worktree.replaceAll("\\", "/");
         const config = join(
           repository,
-          ...(mode === "bare-hooks-path" ? ["config"] : [".git", "config"]),
+          ...(mode === "bare-hooks-path" || mode === "bare-symlink-hooks-path"
+            ? ["config"]
+            : [".git", "config"]),
         );
         const invocation =
-          mode === "relative-subdirectory-hooks-path"
+          mode === "relative-subdirectory-hooks-path" ||
+          mode === "environment-relative-subdirectory-hooks-path"
             ? join(repository, "nested")
             : repository;
         if (invocation !== repository) await mkdir(invocation);
@@ -1430,6 +1443,7 @@ describe("CLI", () => {
         let globalConfiguration: Record<string, string> = {};
         if (
           mode === "active-include" ||
+          mode === "hasconfig-include" ||
           mode === "character-class-include" ||
           mode === "posix-character-class-include" ||
           mode === "included-hooks-path"
@@ -1437,24 +1451,40 @@ describe("CLI", () => {
           const included = join(root, "active.gitconfig");
           await writeFile(
             included,
-            `[core]\n\t${mode === "included-hooks-path" ? "hooksPath" : "worktree"} = ${configuredWorktree}\n`,
+            `[core]\n\t${mode === "included-hooks-path" || mode === "hasconfig-include" ? "hooksPath" : "worktree"} = ${configuredWorktree}\n`,
           );
           const gitDirectory = join(repository, ".git").replaceAll("\\", "/");
           const condition =
-            mode === "character-class-include"
-              ? gitDirectory.replace("repository", "repositor[y]")
-              : mode === "posix-character-class-include"
-                ? gitDirectory.replace("repository", "repositor[[:alpha:]]")
-                : gitDirectory;
+            mode === "hasconfig-include"
+              ? "hasconfig:remote.*.url:https://github.com/**"
+              : mode === "character-class-include"
+                ? gitDirectory.replace("repository", "repositor[y]")
+                : mode === "posix-character-class-include"
+                  ? gitDirectory.replace("repository", "repositor[[:alpha:]]")
+                  : gitDirectory;
+          if (mode === "hasconfig-include") {
+            execFileSync(
+              "git",
+              [
+                "-C",
+                repository,
+                "config",
+                "remote.origin.url",
+                "https://github.com/openai/codex-security",
+              ],
+              { timeout: 10_000 },
+            );
+          }
           await writeFile(
             config,
-            `${await readFile(config, "utf8")}[includeIf "gitdir:${condition}/"]\n\tpath = ${included.replaceAll("\\", "/")}\n`,
+            `${await readFile(config, "utf8")}[includeIf "${mode === "hasconfig-include" ? condition : `gitdir:${condition}/`}"]\n\tpath = ${included.replaceAll("\\", "/")}\n`,
           );
         } else if (
           mode === "environment-config-override" ||
           mode === "external-hooks-path" ||
           mode === "relative-subdirectory-hooks-path" ||
           mode === "bare-hooks-path" ||
+          mode === "bare-symlink-hooks-path" ||
           mode === "prefix-hooks-path"
         ) {
           execFileSync(
@@ -1466,6 +1496,7 @@ describe("CLI", () => {
               mode === "external-hooks-path" ||
               mode === "relative-subdirectory-hooks-path" ||
               mode === "bare-hooks-path" ||
+              mode === "bare-symlink-hooks-path" ||
               mode === "prefix-hooks-path"
                 ? "core.hooksPath"
                 : "core.worktree",
@@ -1477,18 +1508,32 @@ describe("CLI", () => {
             ],
             { timeout: 10_000 },
           );
-        } else if (mode === "environment-hooks-path") {
+          if (mode === "bare-symlink-hooks-path") {
+            const objectStore = join(root, "symlinked-objects");
+            await rename(join(repository, "objects"), objectStore);
+            await symlink(objectStore, join(repository, "objects"), "dir");
+          }
+        } else if (
+          mode === "environment-hooks-path" ||
+          mode === "environment-relative-subdirectory-hooks-path"
+        ) {
           // This late configuration changes Git's hook path without affecting
           // repository setup, so it must be protected before resolving Git.
         } else if (
           mode === "global-hooks-path" ||
           mode === "xdg-hooks-path" ||
-          mode === "system-hooks-path"
+          mode === "xdg-empty-hooks-path" ||
+          mode === "system-hooks-path" ||
+          mode === "system-hooks-path-off" ||
+          mode === "system-hooks-path-uppercase" ||
+          mode === "system-hooks-path-signed-zero"
         ) {
           const path =
             mode === "xdg-hooks-path"
               ? join(root, "xdg", "git", "config")
-              : join(root, `${mode}.gitconfig`);
+              : mode === "xdg-empty-hooks-path"
+                ? join(root, "home", ".config", "git", "config")
+                : join(root, `${mode}.gitconfig`);
           await mkdir(dirname(path), { recursive: true });
           await writeFile(
             path,
@@ -1497,15 +1542,26 @@ describe("CLI", () => {
           globalConfiguration =
             mode === "global-hooks-path"
               ? { GIT_CONFIG_GLOBAL: path }
-              : mode === "system-hooks-path"
+              : mode === "system-hooks-path" ||
+                  mode === "system-hooks-path-off" ||
+                  mode === "system-hooks-path-uppercase" ||
+                  mode === "system-hooks-path-signed-zero"
                 ? {
                     GIT_CONFIG_SYSTEM: path,
-                    GIT_CONFIG_NOSYSTEM: "0",
+                    GIT_CONFIG_NOSYSTEM:
+                      mode === "system-hooks-path-off"
+                        ? "off"
+                        : mode === "system-hooks-path-uppercase"
+                          ? "FALSE"
+                          : mode === "system-hooks-path-signed-zero"
+                            ? "+0"
+                            : "0",
                     GIT_CONFIG_GLOBAL: "/dev/null",
                   }
                 : {
                     HOME: join(root, "home"),
-                    XDG_CONFIG_HOME: join(root, "xdg"),
+                    XDG_CONFIG_HOME:
+                      mode === "xdg-empty-hooks-path" ? "" : join(root, "xdg"),
                   };
         } else if (mode === "common-directory") {
           selectedCommonDirectory = join(root, "selected-common");
@@ -1592,11 +1648,15 @@ describe("CLI", () => {
                     GIT_CONFIG_KEY_0: "core.worktree",
                     GIT_CONFIG_VALUE_0: join(root, "other-worktree"),
                   }
-                : mode === "environment-hooks-path"
+                : mode === "environment-hooks-path" ||
+                    mode === "environment-relative-subdirectory-hooks-path"
                   ? {
                       GIT_CONFIG_COUNT: "1",
                       GIT_CONFIG_KEY_0: "core.hooksPath",
-                      GIT_CONFIG_VALUE_0: configuredWorktree,
+                      GIT_CONFIG_VALUE_0:
+                        mode === "environment-relative-subdirectory-hooks-path"
+                          ? "../configured-worktree"
+                          : configuredWorktree,
                     }
                   : {}),
               PATH: [binaries, process.env["PATH"] ?? ""].join(delimiter),
@@ -2038,7 +2098,7 @@ describe("CLI", () => {
         ).trimEnd();
         await writeFile(
           join(linkedGitDirectory, "commondir"),
-          `${commonDirectory}\n`,
+          `${commonDirectory}\n\n`,
         );
         const binaries = join(commonDirectory, "node_modules", ".bin");
         const marker = join(root, "git-shim-executed");

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -1037,6 +1037,55 @@ describe("CLI", () => {
     }
   });
 
+  test("parses blank-line Git worktree pointers before trusting Git", async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), "codex-security-cli-blank-gitfile-")),
+    );
+    try {
+      const repository = join(root, "repository");
+      const gitDirectory = join(root, "external-git");
+      execFileSync(
+        "git",
+        ["init", "-q", "--separate-git-dir", gitDirectory, repository],
+        { timeout: 10_000 },
+      );
+      const pointer = join(repository, ".git");
+      await writeFile(pointer, `${await readFile(pointer, "utf8")}\n`);
+      const binaries = join(gitDirectory, "node_modules", ".bin");
+      await mkdir(binaries, { recursive: true });
+      const marker = join(root, "git-shim-executed");
+      const gitName = process.platform === "win32" ? "git.cmd" : "git";
+      await writeFile(
+        join(binaries, gitName),
+        process.platform === "win32"
+          ? `@echo off\r\n> "${marker}" echo hijacked\r\nexit /b 1\r\n`
+          : `#!/bin/sh\nprintf '%s' hijacked > '${marker}'\nexit 1\n`,
+        { mode: 0o755 },
+      );
+      const stderr = capture();
+      const exitCode = await main(
+        ["install-hook", repository, "--json"],
+        capture().stream,
+        stderr.stream,
+        dependencies({
+          currentDirectory: repository,
+          environment: {
+            ...process.env,
+            PATH: [binaries, process.env["PATH"] ?? ""].join(delimiter),
+          },
+        }),
+      );
+
+      expect([0, 2]).toContain(exitCode);
+      if (exitCode === 2) {
+        expect(stderr.text()).toContain("A pre-commit hook already exists");
+      }
+      await expect(stat(marker)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test("ignores Git shims in a config-selected worktree", async () => {
     const root = await realpath(
       await mkdtemp(join(tmpdir(), "codex-security-cli-config-worktree-")),
@@ -1097,6 +1146,72 @@ describe("CLI", () => {
           },
         }),
       );
+      expect([0, 2]).toContain(exitCode);
+      if (exitCode === 2) {
+        expect(stderr.text()).toContain("A pre-commit hook already exists");
+      }
+      await expect(stat(marker)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("follows Git configuration includes before trusting a worktree Git shim", async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), "codex-security-cli-included-worktree-")),
+    );
+    try {
+      const repository = join(root, "repository");
+      const gitDirectory = join(root, "git-directory");
+      const worktree = join(root, "included-worktree");
+      const binaries = join(worktree, "node_modules", ".bin");
+      await Promise.all([
+        mkdir(repository, { recursive: true }),
+        mkdir(binaries, { recursive: true }),
+      ]);
+      execFileSync("git", ["init", "--bare", "-q", gitDirectory], {
+        timeout: 10_000,
+      });
+      execFileSync(
+        "git",
+        ["-C", gitDirectory, "config", "core.bare", "false"],
+        {
+          timeout: 10_000,
+        },
+      );
+      const included = join(root, "included.gitconfig");
+      await writeFile(included, `[core]\n\tworktree = ${worktree}\n`);
+      execFileSync(
+        "git",
+        ["-C", gitDirectory, "config", "include.path", included],
+        {
+          timeout: 10_000,
+        },
+      );
+      const marker = join(root, "git-shim-executed");
+      const gitName = process.platform === "win32" ? "git.cmd" : "git";
+      await writeFile(
+        join(binaries, gitName),
+        process.platform === "win32"
+          ? `@echo off\r\n> "${marker}" echo hijacked\r\nexit /b 1\r\n`
+          : `#!/bin/sh\nprintf '%s' hijacked > '${marker}'\nexit 1\n`,
+        { mode: 0o755 },
+      );
+      const stderr = capture();
+      const exitCode = await main(
+        ["install-hook", repository, "--json"],
+        capture().stream,
+        stderr.stream,
+        dependencies({
+          currentDirectory: repository,
+          environment: {
+            ...process.env,
+            GIT_DIR: gitDirectory,
+            PATH: [binaries, process.env["PATH"] ?? ""].join(delimiter),
+          },
+        }),
+      );
+
       expect([0, 2]).toContain(exitCode);
       if (exitCode === 2) {
         expect(stderr.text()).toContain("A pre-commit hook already exists");
@@ -1215,6 +1330,59 @@ describe("CLI", () => {
     }
   });
 
+  test.skipIf(process.platform === "win32")(
+    "treats a colon-containing alternate-file line as one pathname",
+    async () => {
+      const root = await realpath(
+        await mkdtemp(join(tmpdir(), "codex-security-cli-colon-alternate-")),
+      );
+      try {
+        const repository = join(root, "repository");
+        const alternate = join(root, "objects:with-colon");
+        const binaries = join(alternate, "node_modules", ".bin");
+        const pathEntry = join(root, "safe-path-entry");
+        const marker = join(root, "git-shim-executed");
+        execFileSync("git", ["init", "-q", repository], { timeout: 10_000 });
+        await Promise.all([
+          mkdir(binaries, { recursive: true }),
+          mkdir(join(alternate, "info"), { recursive: true }),
+          mkdir(join(alternate, "pack"), { recursive: true }),
+        ]);
+        await writeFile(
+          join(repository, ".git", "objects", "info", "alternates"),
+          `${alternate}\n`,
+        );
+        await writeFile(
+          join(binaries, "git"),
+          `#!/bin/sh\nprintf '%s' hijacked > '${marker}'\nexit 1\n`,
+          { mode: 0o755 },
+        );
+        await symlink(binaries, pathEntry, "dir");
+        const stderr = capture();
+        const exitCode = await main(
+          ["install-hook", repository, "--json"],
+          capture().stream,
+          stderr.stream,
+          dependencies({
+            currentDirectory: repository,
+            environment: {
+              ...process.env,
+              PATH: [pathEntry, process.env["PATH"] ?? ""].join(delimiter),
+            },
+          }),
+        );
+
+        expect([0, 2]).toContain(exitCode);
+        if (exitCode === 2) {
+          expect(stderr.text()).toContain("A pre-commit hook already exists");
+        }
+        await expect(stat(marker)).rejects.toMatchObject({ code: "ENOENT" });
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
   test("ignores alternate object stores selected through GIT_COMMON_DIR", async () => {
     const root = await realpath(
       await mkdtemp(join(tmpdir(), "codex-security-cli-common-alternates-")),
@@ -1273,6 +1441,35 @@ describe("CLI", () => {
         expect(stderr.text()).toContain("A pre-commit hook already exists");
       }
       await expect(stat(marker)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects truncated environment Git configuration before trusting Git", async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), "codex-security-cli-config-count-")),
+    );
+    try {
+      execFileSync("git", ["init", "-q", root], { timeout: 10_000 });
+      const stderr = capture();
+      expect(
+        await main(
+          ["install-hook", root, "--json"],
+          capture().stream,
+          stderr.stream,
+          dependencies({
+            currentDirectory: root,
+            environment: { ...process.env, GIT_CONFIG_COUNT: "1025" },
+          }),
+        ),
+      ).toBe(2);
+      expect(stderr.text()).toContain("protected-worktree safety limit");
+      await expect(
+        stat(join(root, ".git", "hooks", "pre-commit")),
+      ).rejects.toMatchObject({
+        code: "ENOENT",
+      });
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -11,7 +11,7 @@ import {
   symlink,
   writeFile,
 } from "node:fs/promises";
-import { homedir, tmpdir, userInfo } from "node:os";
+import { tmpdir, userInfo } from "node:os";
 import {
   delimiter,
   dirname,
@@ -1385,6 +1385,9 @@ describe("CLI", () => {
       "character-class-include",
       "posix-character-class-include",
       "environment-config-override",
+      "external-hooks-path",
+      "environment-hooks-path",
+      "included-hooks-path",
       "enabled-worktree-config",
       "integer-worktree-config",
       "implicit-worktree-config",
@@ -1407,12 +1410,13 @@ describe("CLI", () => {
         if (
           mode === "active-include" ||
           mode === "character-class-include" ||
-          mode === "posix-character-class-include"
+          mode === "posix-character-class-include" ||
+          mode === "included-hooks-path"
         ) {
           const included = join(root, "active.gitconfig");
           await writeFile(
             included,
-            `[core]\n\tworktree = ${configuredWorktree}\n`,
+            `[core]\n\t${mode === "included-hooks-path" ? "hooksPath" : "worktree"} = ${configuredWorktree}\n`,
           );
           const gitDirectory = join(repository, ".git").replaceAll("\\", "/");
           const condition =
@@ -1425,12 +1429,26 @@ describe("CLI", () => {
             config,
             `${await readFile(config, "utf8")}[includeIf "gitdir:${condition}/"]\n\tpath = ${included.replaceAll("\\", "/")}\n`,
           );
-        } else if (mode === "environment-config-override") {
+        } else if (
+          mode === "environment-config-override" ||
+          mode === "external-hooks-path"
+        ) {
           execFileSync(
             "git",
-            ["-C", repository, "config", "core.worktree", configuredWorktree],
+            [
+              "-C",
+              repository,
+              "config",
+              mode === "external-hooks-path"
+                ? "core.hooksPath"
+                : "core.worktree",
+              configuredWorktree,
+            ],
             { timeout: 10_000 },
           );
+        } else if (mode === "environment-hooks-path") {
+          // This late configuration changes Git's hook path without affecting
+          // repository setup, so it must be protected before resolving Git.
         } else if (mode === "common-directory") {
           selectedCommonDirectory = join(root, "selected-common");
           execFileSync(
@@ -1515,7 +1533,13 @@ describe("CLI", () => {
                     GIT_CONFIG_KEY_0: "core.worktree",
                     GIT_CONFIG_VALUE_0: join(root, "other-worktree"),
                   }
-                : {}),
+                : mode === "environment-hooks-path"
+                  ? {
+                      GIT_CONFIG_COUNT: "1",
+                      GIT_CONFIG_KEY_0: "core.hooksPath",
+                      GIT_CONFIG_VALUE_0: configuredWorktree,
+                    }
+                  : {}),
               PATH: [binaries, process.env["PATH"] ?? ""].join(delimiter),
             },
           }),
@@ -1537,8 +1561,18 @@ describe("CLI", () => {
     async () => {
       const current = userInfo().username;
       expect(await expandGitConfigIncludePath(`~${current}/.gitconfig`)).toBe(
-        join(homedir(), ".gitconfig"),
+        join(userInfo().homedir, ".gitconfig"),
       );
+      const configuredHome = process.env["HOME"];
+      process.env["HOME"] = join(tmpdir(), "codex-security-different-home");
+      try {
+        expect(await expandGitConfigIncludePath(`~${current}/.gitconfig`)).toBe(
+          join(userInfo().homedir, ".gitconfig"),
+        );
+      } finally {
+        if (configuredHome === undefined) delete process.env["HOME"];
+        else process.env["HOME"] = configuredHome;
+      }
       const root = (await readFile("/etc/passwd", "utf8"))
         .split(/\r?\n/u)
         .map((entry) => entry.split(":"))

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -674,6 +674,66 @@ describe("CLI", () => {
     }
   });
 
+  test("ignores Git shims in an environment-selected worktree", async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), "codex-security-cli-environment-worktree-")),
+    );
+    try {
+      const worktree = join(root, "worktree");
+      const repository = join(worktree, "packages", "service");
+      const binaries = join(worktree, "node_modules", ".bin");
+      const gitDirectory = join(root, "git-directory");
+      await Promise.all([
+        mkdir(repository, { recursive: true }),
+        mkdir(binaries, { recursive: true }),
+      ]);
+      execFileSync("git", ["init", "--bare", "-q", gitDirectory], {
+        timeout: 10_000,
+      });
+
+      const marker = join(root, "git-shim-executed");
+      const gitName = process.platform === "win32" ? "git.cmd" : "git";
+      const maliciousGit =
+        process.platform === "win32"
+          ? `@echo off\r\n> "${marker}" echo hijacked\r\nexit /b 1\r\n`
+          : `#!/bin/sh\nprintf '%s' hijacked > '${marker.replaceAll("'", `'"'"'`)}'\nexit 1\n`;
+      await writeFile(join(binaries, gitName), maliciousGit, { mode: 0o755 });
+      const path = Object.entries(process.env).find(
+        ([name]) => name.toUpperCase() === "PATH",
+      )?.[1];
+      const environment = Object.fromEntries(
+        Object.entries(process.env).filter(
+          ([name]) => name.toUpperCase() !== "PATH",
+        ),
+      );
+      environment["GIT_DIR"] = gitDirectory;
+      environment["GIT_WORK_TREE"] = worktree;
+      environment["GIT_CONFIG_COUNT"] = "1";
+      environment["GIT_CONFIG_KEY_0"] = "core.hooksPath";
+      environment["GIT_CONFIG_VALUE_0"] = join(gitDirectory, "hooks");
+      environment["PATH"] = [binaries, path ?? ""].join(delimiter);
+      const stdout = capture();
+      const stderr = capture();
+
+      const exitCode = await main(
+        ["install-hook", repository, "--json"],
+        stdout.stream,
+        stderr.stream,
+        dependencies({ currentDirectory: repository, environment }),
+      );
+      expect({ exitCode, stderr: stderr.text() }).toEqual({
+        exitCode: 0,
+        stderr: "",
+      });
+      expect(
+        normalize((JSON.parse(stdout.text()) as { hook: string }).hook),
+      ).toBe(join(gitDirectory, "hooks", "pre-commit"));
+      await expect(stat(marker)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test("runs a bulk scan and keeps structured output on stdout", async () => {
     const root = await mkdtemp(join(tmpdir(), "codex-security-cli-multiscan-"));
     try {

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -1388,6 +1388,12 @@ describe("CLI", () => {
       "external-hooks-path",
       "environment-hooks-path",
       "included-hooks-path",
+      "relative-subdirectory-hooks-path",
+      "global-hooks-path",
+      "xdg-hooks-path",
+      "system-hooks-path",
+      "bare-hooks-path",
+      "prefix-hooks-path",
       "enabled-worktree-config",
       "integer-worktree-config",
       "implicit-worktree-config",
@@ -1402,11 +1408,26 @@ describe("CLI", () => {
         const worktree = join(root, "configured-worktree");
         const binaries = join(worktree, "node_modules", ".bin");
         const marker = join(root, "git-shim-executed");
-        execFileSync("git", ["init", "-q", repository], { timeout: 10_000 });
+        execFileSync(
+          "git",
+          mode === "bare-hooks-path"
+            ? ["init", "--bare", "-q", repository]
+            : ["init", "-q", repository],
+          { timeout: 10_000 },
+        );
         await mkdir(binaries, { recursive: true });
         const configuredWorktree = worktree.replaceAll("\\", "/");
-        const config = join(repository, ".git", "config");
+        const config = join(
+          repository,
+          ...(mode === "bare-hooks-path" ? ["config"] : [".git", "config"]),
+        );
+        const invocation =
+          mode === "relative-subdirectory-hooks-path"
+            ? join(repository, "nested")
+            : repository;
+        if (invocation !== repository) await mkdir(invocation);
         let selectedCommonDirectory: string | undefined;
+        let globalConfiguration: Record<string, string> = {};
         if (
           mode === "active-include" ||
           mode === "character-class-include" ||
@@ -1431,7 +1452,10 @@ describe("CLI", () => {
           );
         } else if (
           mode === "environment-config-override" ||
-          mode === "external-hooks-path"
+          mode === "external-hooks-path" ||
+          mode === "relative-subdirectory-hooks-path" ||
+          mode === "bare-hooks-path" ||
+          mode === "prefix-hooks-path"
         ) {
           execFileSync(
             "git",
@@ -1439,16 +1463,50 @@ describe("CLI", () => {
               "-C",
               repository,
               "config",
-              mode === "external-hooks-path"
+              mode === "external-hooks-path" ||
+              mode === "relative-subdirectory-hooks-path" ||
+              mode === "bare-hooks-path" ||
+              mode === "prefix-hooks-path"
                 ? "core.hooksPath"
                 : "core.worktree",
-              configuredWorktree,
+              mode === "relative-subdirectory-hooks-path"
+                ? "../configured-worktree"
+                : mode === "prefix-hooks-path"
+                  ? "%(prefix)/../tmp/unsafe-hooks"
+                  : configuredWorktree,
             ],
             { timeout: 10_000 },
           );
         } else if (mode === "environment-hooks-path") {
           // This late configuration changes Git's hook path without affecting
           // repository setup, so it must be protected before resolving Git.
+        } else if (
+          mode === "global-hooks-path" ||
+          mode === "xdg-hooks-path" ||
+          mode === "system-hooks-path"
+        ) {
+          const path =
+            mode === "xdg-hooks-path"
+              ? join(root, "xdg", "git", "config")
+              : join(root, `${mode}.gitconfig`);
+          await mkdir(dirname(path), { recursive: true });
+          await writeFile(
+            path,
+            `[core]\n\thooksPath = ${configuredWorktree}\n`,
+          );
+          globalConfiguration =
+            mode === "global-hooks-path"
+              ? { GIT_CONFIG_GLOBAL: path }
+              : mode === "system-hooks-path"
+                ? {
+                    GIT_CONFIG_SYSTEM: path,
+                    GIT_CONFIG_NOSYSTEM: "0",
+                    GIT_CONFIG_GLOBAL: "/dev/null",
+                  }
+                : {
+                    HOME: join(root, "home"),
+                    XDG_CONFIG_HOME: join(root, "xdg"),
+                  };
         } else if (mode === "common-directory") {
           selectedCommonDirectory = join(root, "selected-common");
           execFileSync(
@@ -1517,13 +1575,14 @@ describe("CLI", () => {
         );
         const stderr = capture();
         const exitCode = await main(
-          ["install-hook", repository, "--json"],
+          ["install-hook", invocation, "--json"],
           capture().stream,
           stderr.stream,
           dependencies({
-            currentDirectory: repository,
+            currentDirectory: invocation,
             environment: {
               ...process.env,
+              ...globalConfiguration,
               ...(selectedCommonDirectory === undefined
                 ? {}
                 : { GIT_COMMON_DIR: selectedCommonDirectory }),
@@ -1547,7 +1606,11 @@ describe("CLI", () => {
 
         expect([0, 2], `${mode}: ${stderr.text()}`).toContain(exitCode);
         if (exitCode === 2) {
-          expect(stderr.text()).toContain("A pre-commit hook already exists");
+          expect(stderr.text()).toContain(
+            mode === "prefix-hooks-path"
+              ? "prefix-relative hook paths cannot be resolved safely"
+              : "A pre-commit hook already exists",
+          );
         }
         await expect(stat(marker)).rejects.toMatchObject({ code: "ENOENT" });
       } finally {

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -1299,6 +1299,8 @@ describe("CLI", () => {
       "inactive-include",
       "uppercase-posix-class-include",
       "invalid-double-star-include",
+      "hasconfig-trailing-slash",
+      "unrelated-installation-config",
       "core-subsection",
       "disabled-worktree-config",
       "overridden-worktree",
@@ -1311,10 +1313,12 @@ describe("CLI", () => {
         const repository = join(root, "repository");
         execFileSync("git", ["init", "-q", repository], { timeout: 10_000 });
         const config = join(repository, ".git", "config");
+        let executablePath = dirname(trustedGit!);
         if (
           mode === "inactive-include" ||
           mode === "uppercase-posix-class-include" ||
-          mode === "invalid-double-star-include"
+          mode === "invalid-double-star-include" ||
+          mode === "hasconfig-trailing-slash"
         ) {
           const included = join(root, "inactive.gitconfig");
           await writeFile(
@@ -1323,15 +1327,41 @@ describe("CLI", () => {
           );
           const gitDirectory = join(repository, ".git").replaceAll("\\", "/");
           const condition =
-            mode === "uppercase-posix-class-include"
-              ? gitDirectory.replace("repository", "repositor[[:ALPHA:]]")
-              : mode === "invalid-double-star-include"
-                ? gitDirectory.replace("repository", "repo**sitory")
-                : "/never/selected";
+            mode === "hasconfig-trailing-slash"
+              ? "hasconfig:remote.*.url:https://github.com/openai/codex-security/"
+              : mode === "uppercase-posix-class-include"
+                ? gitDirectory.replace("repository", "repositor[[:ALPHA:]]")
+                : mode === "invalid-double-star-include"
+                  ? gitDirectory.replace("repository", "repo**sitory")
+                  : "/never/selected";
+          if (mode === "hasconfig-trailing-slash") {
+            execFileSync(
+              "git",
+              [
+                "-C",
+                repository,
+                "config",
+                "remote.origin.url",
+                "https://github.com/openai/codex-security",
+              ],
+              { timeout: 10_000 },
+            );
+          }
           await writeFile(
             config,
-            `${await readFile(config, "utf8")}[includeIf "gitdir:${condition}/"]\n\tpath = ${included.replaceAll("\\", "/")}\n`,
+            `${await readFile(config, "utf8")}[includeIf "${mode === "hasconfig-trailing-slash" ? condition : `gitdir:${condition}/`}"]\n\tpath = ${included.replaceAll("\\", "/")}\n`,
           );
+        } else if (mode === "unrelated-installation-config") {
+          const tools = join(root, "unrelated-tools");
+          const binaries = join(tools, "bin");
+          const configuration = join(tools, "etc", "gitconfig");
+          await mkdir(binaries, { recursive: true });
+          await mkdir(dirname(configuration), { recursive: true });
+          await writeFile(
+            configuration,
+            `[core]\n\thooksPath = ${trustedDirectory}\n`,
+          );
+          executablePath = [binaries, dirname(trustedGit!)].join(delimiter);
         } else if (mode === "core-subsection") {
           await writeFile(
             config,
@@ -1364,7 +1394,7 @@ describe("CLI", () => {
                     GIT_CONFIG_VALUE_0: trustedDirectory,
                   }
                 : {}),
-              PATH: dirname(trustedGit!),
+              PATH: executablePath,
             },
           }),
         );
@@ -1383,6 +1413,7 @@ describe("CLI", () => {
     for (const mode of [
       "active-include",
       "hasconfig-include",
+      "hasconfig-transitive-include",
       "character-class-include",
       "posix-character-class-include",
       "environment-config-override",
@@ -1444,6 +1475,7 @@ describe("CLI", () => {
         if (
           mode === "active-include" ||
           mode === "hasconfig-include" ||
+          mode === "hasconfig-transitive-include" ||
           mode === "character-class-include" ||
           mode === "posix-character-class-include" ||
           mode === "included-hooks-path"
@@ -1451,11 +1483,12 @@ describe("CLI", () => {
           const included = join(root, "active.gitconfig");
           await writeFile(
             included,
-            `[core]\n\t${mode === "included-hooks-path" || mode === "hasconfig-include" ? "hooksPath" : "worktree"} = ${configuredWorktree}\n`,
+            `[core]\n\t${mode === "included-hooks-path" || mode === "hasconfig-include" || mode === "hasconfig-transitive-include" ? "hooksPath" : "worktree"} = ${configuredWorktree}\n`,
           );
           const gitDirectory = join(repository, ".git").replaceAll("\\", "/");
           const condition =
-            mode === "hasconfig-include"
+            mode === "hasconfig-include" ||
+            mode === "hasconfig-transitive-include"
               ? "hasconfig:remote.*.url:https://github.com/**"
               : mode === "character-class-include"
                 ? gitDirectory.replace("repository", "repositor[y]")
@@ -1475,9 +1508,16 @@ describe("CLI", () => {
               { timeout: 10_000 },
             );
           }
+          const remoteInclude = join(root, "remote.gitconfig");
+          if (mode === "hasconfig-transitive-include") {
+            await writeFile(
+              remoteInclude,
+              '[remote "origin"]\n\turl = https://github.com/openai/codex-security\n',
+            );
+          }
           await writeFile(
             config,
-            `${await readFile(config, "utf8")}[includeIf "${mode === "hasconfig-include" ? condition : `gitdir:${condition}/`}"]\n\tpath = ${included.replaceAll("\\", "/")}\n`,
+            `${await readFile(config, "utf8")}[includeIf "${mode === "hasconfig-include" || mode === "hasconfig-transitive-include" ? condition : `gitdir:${condition}/`}"]\n\tpath = ${included.replaceAll("\\", "/")}\n${mode === "hasconfig-transitive-include" ? `[include]\n\tpath = ${remoteInclude.replaceAll("\\", "/")}\n` : ""}`,
           );
         } else if (
           mode === "environment-config-override" ||

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -915,6 +915,116 @@ describe("CLI", () => {
     }
   });
 
+  test("ignores Git shims inside a linked worktree's common Git directory", async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), "codex-security-cli-common-git-")),
+    );
+    try {
+      const primary = join(root, "primary");
+      const linked = join(root, "linked");
+      execFileSync("git", ["init", "-q", primary], { timeout: 10_000 });
+      execFileSync(
+        "git",
+        [
+          "-C",
+          primary,
+          "-c",
+          "user.email=test@example.com",
+          "-c",
+          "user.name=Test",
+          "commit",
+          "--allow-empty",
+          "-qm",
+          "initial",
+        ],
+        { timeout: 10_000 },
+      );
+      execFileSync(
+        "git",
+        ["-C", primary, "worktree", "add", "-q", "--detach", linked],
+        {
+          timeout: 10_000,
+        },
+      );
+      const commonDirectory = execFileSync(
+        "git",
+        [
+          "-C",
+          linked,
+          "rev-parse",
+          "--path-format=absolute",
+          "--git-common-dir",
+        ],
+        { encoding: "utf8", timeout: 10_000 },
+      ).trim();
+      const binaries = join(commonDirectory, "node_modules", ".bin");
+      await mkdir(binaries, { recursive: true });
+      const marker = join(root, "git-shim-executed");
+      const gitName = process.platform === "win32" ? "git.cmd" : "git";
+      const maliciousGit =
+        process.platform === "win32"
+          ? `@echo off\r\n> "${marker}" echo hijacked\r\nexit /b 1\r\n`
+          : `#!/bin/sh\nprintf '%s' hijacked > '${marker.replaceAll("'", `'"'"'`)}'\nexit 1\n`;
+      await writeFile(join(binaries, gitName), maliciousGit, { mode: 0o755 });
+      const environment = {
+        ...process.env,
+        PATH: [binaries, process.env["PATH"] ?? ""].join(delimiter),
+      };
+      const stdout = capture();
+      const stderr = capture();
+
+      const exitCode = await main(
+        ["install-hook", linked, "--json"],
+        stdout.stream,
+        stderr.stream,
+        dependencies({ currentDirectory: linked, environment }),
+      );
+      expect([0, 2]).toContain(exitCode);
+      if (exitCode === 2) {
+        expect(stderr.text()).toContain("A pre-commit hook already exists");
+      }
+      await expect(stat(marker)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("accepts a selected Git worktree that has not been created yet", async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), "codex-security-cli-future-worktree-")),
+    );
+    try {
+      const repository = join(root, "repository");
+      const gitDirectory = join(root, "git-directory");
+      await mkdir(repository);
+      execFileSync("git", ["init", "--bare", "-q", gitDirectory], {
+        timeout: 10_000,
+      });
+      const stdout = capture();
+      const stderr = capture();
+
+      const exitCode = await main(
+        ["install-hook", repository, "--json"],
+        stdout.stream,
+        stderr.stream,
+        dependencies({
+          currentDirectory: repository,
+          environment: {
+            ...process.env,
+            GIT_DIR: gitDirectory,
+            GIT_WORK_TREE: join(root, "not-created-yet"),
+          },
+        }),
+      );
+      expect([0, 2]).toContain(exitCode);
+      if (exitCode === 2) {
+        expect(stderr.text()).toContain("A pre-commit hook already exists");
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test("runs a bulk scan and keeps structured output on stdout", async () => {
     const root = await mkdtemp(join(tmpdir(), "codex-security-cli-multiscan-"));
     try {

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -321,6 +321,12 @@ describe("CLI", () => {
       const hook = join(root, ".custom hooks", "pre-commit");
       const deps = dependencies({
         currentDirectory: root,
+        environment: {
+          ...process.env,
+          GIT_CONFIG_COUNT: "1",
+          GIT_CONFIG_KEY_0: "core.hooksPath",
+          GIT_CONFIG_VALUE_0: join(root, "injected-hooks"),
+        },
         onRun: () => (started = true),
       });
       for (let attempt = 0; attempt < 2; attempt += 1) {
@@ -343,6 +349,9 @@ describe("CLI", () => {
       expect(await readFile(hook, "utf8")).toContain(
         "--working-tree --fail-on-severity medium",
       );
+      await expect(stat(join(root, "injected-hooks"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
       expect(started).toBe(false);
 
       const trustedHook = await readFile(hook, "utf8");

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -1068,11 +1068,12 @@ describe("CLI", () => {
       );
       const configPath = join(gitDirectory, "config");
       const config = await readFile(configPath, "utf8");
+      const split = Math.floor(worktree.length / 2);
       await writeFile(
         configPath,
         config.replace(
-          /^(\s*worktree\s*=\s*.+)$/mu,
-          "$1 ; repository owner configuration",
+          /^(\s*worktree\s*=\s*).+$/mu,
+          `$1${worktree.slice(0, split)}\\\n${worktree.slice(split)} ; repository owner configuration`,
         ),
       );
       const gitName = process.platform === "win32" ? "git.cmd" : "git";
@@ -1163,7 +1164,7 @@ describe("CLI", () => {
     try {
       const repository = join(root, "repository");
       const firstAlternate = join(root, "first-alternate");
-      const secondAlternate = join(root, "second-alternate");
+      const secondAlternate = join(root, "second-alternate quoted");
       const binaries = join(secondAlternate, "node_modules", ".bin");
       const marker = join(root, "git-shim-executed");
       execFileSync("git", ["init", "-q", repository], { timeout: 10_000 });
@@ -1181,7 +1182,7 @@ describe("CLI", () => {
         ),
         writeFile(
           join(firstAlternate, "info", "alternates"),
-          `${secondAlternate}\n`,
+          `${JSON.stringify(secondAlternate)}\n`,
         ),
       ]);
       const gitName = process.platform === "win32" ? "git.cmd" : "git";
@@ -1209,6 +1210,103 @@ describe("CLI", () => {
         expect(stderr.text()).toContain("A pre-commit hook already exists");
       }
       await expect(stat(marker)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("ignores alternate object stores selected through GIT_COMMON_DIR", async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), "codex-security-cli-common-alternates-")),
+    );
+    try {
+      const repository = join(root, "repository");
+      const common = join(root, "common");
+      const alternate = join(root, "alternate");
+      const binaries = join(alternate, "node_modules", ".bin");
+      const marker = join(root, "git-shim-executed");
+      execFileSync("git", ["init", "-q", repository], { timeout: 10_000 });
+      execFileSync("git", ["init", "--bare", "-q", common], {
+        timeout: 10_000,
+      });
+      execFileSync("git", ["-C", common, "config", "core.bare", "false"], {
+        timeout: 10_000,
+      });
+      execFileSync(
+        "git",
+        ["-C", common, "config", "core.worktree", repository],
+        { timeout: 10_000 },
+      );
+      await Promise.all([
+        mkdir(join(alternate, "info"), { recursive: true }),
+        mkdir(join(alternate, "pack"), { recursive: true }),
+        mkdir(binaries, { recursive: true }),
+      ]);
+      await writeFile(
+        join(common, "objects", "info", "alternates"),
+        `${alternate}\n`,
+      );
+      const gitName = process.platform === "win32" ? "git.cmd" : "git";
+      const maliciousGit =
+        process.platform === "win32"
+          ? `@echo off\r\n> "${marker}" echo hijacked\r\nexit /b 1\r\n`
+          : `#!/bin/sh\nprintf '%s' hijacked > '${marker.replaceAll("'", `'"'"'`)}'\nexit 1\n`;
+      await writeFile(join(binaries, gitName), maliciousGit, { mode: 0o755 });
+      const stdout = capture();
+      const stderr = capture();
+
+      const exitCode = await main(
+        ["install-hook", repository, "--json"],
+        stdout.stream,
+        stderr.stream,
+        dependencies({
+          currentDirectory: repository,
+          environment: {
+            ...process.env,
+            GIT_COMMON_DIR: common,
+            PATH: [binaries, process.env["PATH"] ?? ""].join(delimiter),
+          },
+        }),
+      );
+      expect([0, 2]).toContain(exitCode);
+      if (exitCode === 2) {
+        expect(stderr.text()).toContain("A pre-commit hook already exists");
+      }
+      await expect(stat(marker)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects oversized Git configuration before trusting an install-hook executable", async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), "codex-security-cli-oversized-git-config-")),
+    );
+    try {
+      const repository = join(root, "repository");
+      execFileSync("git", ["init", "-q", repository], { timeout: 10_000 });
+      const configPath = join(repository, ".git", "config");
+      await writeFile(
+        configPath,
+        `${await readFile(configPath, "utf8")}# ${"x".repeat(1_024 * 1_024)}\n`,
+      );
+      const stdout = capture();
+      const stderr = capture();
+
+      expect(
+        await main(
+          ["install-hook", repository, "--json"],
+          stdout.stream,
+          stderr.stream,
+          dependencies({ currentDirectory: repository }),
+        ),
+      ).toBe(2);
+      expect(stderr.text()).toContain("Git configuration is too large");
+      await expect(
+        stat(join(repository, ".git", "hooks", "pre-commit")),
+      ).rejects.toMatchObject({
+        code: "ENOENT",
+      });
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -12,7 +12,14 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { delimiter, join, normalize, parse, relative } from "node:path";
+import {
+  delimiter,
+  dirname,
+  join,
+  normalize,
+  parse,
+  relative,
+} from "node:path";
 import { Writable } from "node:stream";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { stripVTControlCharacters } from "node:util";
@@ -1086,6 +1093,53 @@ describe("CLI", () => {
     }
   });
 
+  test.skipIf(process.platform === "win32")(
+    "preserves significant trailing spaces in Git worktree pointers",
+    async () => {
+      const root = await realpath(
+        await mkdtemp(join(tmpdir(), "codex-security-cli-spaced-gitfile-")),
+      );
+      try {
+        const repository = join(root, "repository");
+        const gitDirectory = join(root, "external-git ");
+        execFileSync(
+          "git",
+          ["init", "-q", "--separate-git-dir", gitDirectory, repository],
+          { timeout: 10_000 },
+        );
+        const binaries = join(gitDirectory, "node_modules", ".bin");
+        await mkdir(binaries, { recursive: true });
+        const marker = join(root, "git-shim-executed");
+        await writeFile(
+          join(binaries, "git"),
+          `#!/bin/sh\nprintf '%s' hijacked > '${marker}'\nexit 1\n`,
+          { mode: 0o755 },
+        );
+        const stderr = capture();
+        const exitCode = await main(
+          ["install-hook", repository, "--json"],
+          capture().stream,
+          stderr.stream,
+          dependencies({
+            currentDirectory: repository,
+            environment: {
+              ...process.env,
+              PATH: [binaries, process.env["PATH"] ?? ""].join(delimiter),
+            },
+          }),
+        );
+
+        expect([0, 2]).toContain(exitCode);
+        if (exitCode === 2) {
+          expect(stderr.text()).toContain("A pre-commit hook already exists");
+        }
+        await expect(stat(marker)).rejects.toMatchObject({ code: "ENOENT" });
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
   test("ignores Git shims in a config-selected worktree", async () => {
     const root = await realpath(
       await mkdtemp(join(tmpdir(), "codex-security-cli-config-worktree-")),
@@ -1117,12 +1171,13 @@ describe("CLI", () => {
       );
       const configPath = join(gitDirectory, "config");
       const config = await readFile(configPath, "utf8");
-      const split = Math.floor(worktree.length / 2);
+      const gitConfigWorktree = worktree.replaceAll("\\", "/");
+      const split = Math.floor(gitConfigWorktree.length / 2);
       await writeFile(
         configPath,
         config.replace(
           /^(\s*worktree\s*=\s*).+$/mu,
-          `$1${worktree.slice(0, split)}\\\n${worktree.slice(split)} ; repository owner configuration`,
+          `$1${gitConfigWorktree.slice(0, split)}\\\n${gitConfigWorktree.slice(split)} ; repository owner configuration`,
         ),
       );
       const gitName = process.platform === "win32" ? "git.cmd" : "git";
@@ -1180,7 +1235,12 @@ describe("CLI", () => {
         },
       );
       const included = join(root, "included.gitconfig");
-      await writeFile(included, `[core]\n\tworktree = ${worktree}\n`);
+      const configuredWorktree = worktree.replaceAll("\\", "/");
+      const quotedPrefix = Math.floor(configuredWorktree.length / 2);
+      await writeFile(
+        included,
+        `[core]\n\tworktree = "${configuredWorktree.slice(0, quotedPrefix)}"${configuredWorktree.slice(quotedPrefix)}\n`,
+      );
       execFileSync(
         "git",
         ["-C", gitDirectory, "config", "include.path", included],
@@ -1222,6 +1282,140 @@ describe("CLI", () => {
     }
   });
 
+  test("ignores inactive and ineffective Git worktree configuration", async () => {
+    const trustedGit = Bun.which("git");
+    expect(trustedGit).not.toBeNull();
+    const trustedDirectory = dirname(await realpath(trustedGit!)).replaceAll(
+      "\\",
+      "/",
+    );
+
+    for (const mode of [
+      "inactive-include",
+      "core-subsection",
+      "disabled-worktree-config",
+    ] as const) {
+      const root = await realpath(
+        await mkdtemp(join(tmpdir(), `codex-security-cli-${mode}-`)),
+      );
+      try {
+        const repository = join(root, "repository");
+        execFileSync("git", ["init", "-q", repository], { timeout: 10_000 });
+        const config = join(repository, ".git", "config");
+        if (mode === "inactive-include") {
+          const included = join(root, "inactive.gitconfig");
+          await writeFile(
+            included,
+            `[core]\n\tworktree = ${trustedDirectory}\n`,
+          );
+          await writeFile(
+            config,
+            `${await readFile(config, "utf8")}[includeIf "gitdir:/never/selected/"]\n\tpath = ${included.replaceAll("\\", "/")}\n`,
+          );
+        } else if (mode === "core-subsection") {
+          await writeFile(
+            config,
+            `${await readFile(config, "utf8")}[core "example"]\n\tworktree = ${trustedDirectory}\n`,
+          );
+        } else {
+          await writeFile(
+            join(repository, ".git", "config.worktree"),
+            `[core]\n\tworktree = ${trustedDirectory}\n`,
+          );
+        }
+        const stderr = capture();
+        const exitCode = await main(
+          ["install-hook", repository, "--json"],
+          capture().stream,
+          stderr.stream,
+          dependencies({
+            currentDirectory: repository,
+            environment: {
+              ...process.env,
+              PATH: dirname(trustedGit!),
+            },
+          }),
+        );
+
+        expect([0, 2], `${mode}: ${stderr.text()}`).toContain(exitCode);
+        if (exitCode === 2) {
+          expect(stderr.text()).toContain("A pre-commit hook already exists");
+        }
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    }
+  });
+
+  test("protects active conditional and enabled Git worktree configuration", async () => {
+    for (const mode of ["active-include", "enabled-worktree-config"] as const) {
+      const root = await realpath(
+        await mkdtemp(join(tmpdir(), `codex-security-cli-${mode}-`)),
+      );
+      try {
+        const repository = join(root, "repository");
+        const worktree = join(root, "configured-worktree");
+        const binaries = join(worktree, "node_modules", ".bin");
+        const marker = join(root, "git-shim-executed");
+        execFileSync("git", ["init", "-q", repository], { timeout: 10_000 });
+        await mkdir(binaries, { recursive: true });
+        const configuredWorktree = worktree.replaceAll("\\", "/");
+        const config = join(repository, ".git", "config");
+        if (mode === "active-include") {
+          const included = join(root, "active.gitconfig");
+          await writeFile(
+            included,
+            `[core]\n\tworktree = ${configuredWorktree}\n`,
+          );
+          const gitDirectory = join(repository, ".git").replaceAll("\\", "/");
+          await writeFile(
+            config,
+            `${await readFile(config, "utf8")}[includeIf "gitdir:${gitDirectory}/"]\n\tpath = ${included.replaceAll("\\", "/")}\n`,
+          );
+        } else {
+          execFileSync(
+            "git",
+            ["-C", repository, "config", "extensions.worktreeConfig", "true"],
+            { timeout: 10_000 },
+          );
+          await writeFile(
+            join(repository, ".git", "config.worktree"),
+            `[core]\n\tworktree = ${configuredWorktree}\n`,
+          );
+        }
+        const gitName = process.platform === "win32" ? "git.cmd" : "git";
+        await writeFile(
+          join(binaries, gitName),
+          process.platform === "win32"
+            ? `@echo off\r\n> "${marker}" echo hijacked\r\nexit /b 1\r\n`
+            : `#!/bin/sh\nprintf '%s' hijacked > '${marker}'\nexit 1\n`,
+          { mode: 0o755 },
+        );
+        const stderr = capture();
+        const exitCode = await main(
+          ["install-hook", repository, "--json"],
+          capture().stream,
+          stderr.stream,
+          dependencies({
+            currentDirectory: repository,
+            environment: {
+              ...process.env,
+              PATH: [binaries, process.env["PATH"] ?? ""].join(delimiter),
+            },
+          }),
+        );
+
+        expect([0, 2], `${mode}: ${stderr.text()}`).toContain(exitCode);
+        if (exitCode === 2) {
+          expect(stderr.text()).toContain("A pre-commit hook already exists");
+        }
+        await expect(stat(marker)).rejects.toMatchObject({ code: "ENOENT" });
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    }
+  });
+
   test("ignores Git shims in externally selected Git object stores", async () => {
     const root = await realpath(
       await mkdtemp(join(tmpdir(), "codex-security-cli-git-object-stores-")),
@@ -1255,7 +1449,10 @@ describe("CLI", () => {
               ...process.env,
               [name]:
                 name === "GIT_ALTERNATE_OBJECT_DIRECTORIES"
-                  ? JSON.stringify(objectDirectory)
+                  ? JSON.stringify(objectDirectory).replace(
+                      "alternate",
+                      "alt\\145rnate",
+                    )
                   : objectDirectory,
               PATH: [binaries, process.env["PATH"] ?? ""].join(delimiter),
             },
@@ -1269,6 +1466,62 @@ describe("CLI", () => {
       }
     } finally {
       await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("resolves relative Git object stores from the effective worktree", async () => {
+    for (const name of [
+      "GIT_OBJECT_DIRECTORY",
+      "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    ] as const) {
+      const root = await realpath(
+        await mkdtemp(join(tmpdir(), "codex-security-cli-relative-objects-")),
+      );
+      try {
+        const repository = join(root, "repository");
+        const invocation = join(repository, "nested", "source");
+        const objectDirectory = join(root, "external-objects");
+        const binaries = join(objectDirectory, "node_modules", ".bin");
+        const marker = join(root, "git-shim-executed");
+        execFileSync("git", ["init", "-q", repository], { timeout: 10_000 });
+        await Promise.all([
+          mkdir(invocation, { recursive: true }),
+          mkdir(binaries, { recursive: true }),
+          mkdir(join(objectDirectory, "info"), { recursive: true }),
+          mkdir(join(objectDirectory, "pack"), { recursive: true }),
+        ]);
+        const gitName = process.platform === "win32" ? "git.cmd" : "git";
+        await writeFile(
+          join(binaries, gitName),
+          process.platform === "win32"
+            ? `@echo off\r\n> "${marker}" echo hijacked\r\nexit /b 1\r\n`
+            : `#!/bin/sh\nprintf '%s' hijacked > '${marker}'\nexit 1\n`,
+          { mode: 0o755 },
+        );
+        const stderr = capture();
+        const exitCode = await main(
+          ["install-hook", repository, "--json"],
+          capture().stream,
+          stderr.stream,
+          dependencies({
+            currentDirectory: invocation,
+            environment: {
+              ...process.env,
+              GIT_WORK_TREE: repository,
+              [name]: join("..", "external-objects"),
+              PATH: [binaries, process.env["PATH"] ?? ""].join(delimiter),
+            },
+          }),
+        );
+
+        expect([0, 2], `${name}: ${stderr.text()}`).toContain(exitCode);
+        if (exitCode === 2) {
+          expect(stderr.text()).toContain("A pre-commit hook already exists");
+        }
+        await expect(stat(marker)).rejects.toMatchObject({ code: "ENOENT" });
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
     }
   });
 
@@ -1297,7 +1550,7 @@ describe("CLI", () => {
         ),
         writeFile(
           join(firstAlternate, "info", "alternates"),
-          `${JSON.stringify(secondAlternate)}\n`,
+          `${JSON.stringify(secondAlternate).replace("quoted", "quot\\145d")}\n`,
         ),
       ]);
       const gitName = process.platform === "win32" ? "git.cmd" : "git";

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -5,6 +5,7 @@ import {
   mkdtemp,
   readFile,
   realpath,
+  rename,
   rm,
   stat,
   symlink,
@@ -984,6 +985,160 @@ describe("CLI", () => {
         expect(stderr.text()).toContain("A pre-commit hook already exists");
       }
       await expect(stat(marker)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("ignores Git shims inside symlinked repository metadata", async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), "codex-security-cli-symlinked-git-")),
+    );
+    try {
+      const repository = join(root, "repository");
+      const gitDirectory = join(root, "git-directory");
+      const binaries = join(gitDirectory, "node_modules", ".bin");
+      const marker = join(root, "git-shim-executed");
+      execFileSync("git", ["init", "-q", repository], { timeout: 10_000 });
+      await rename(join(repository, ".git"), gitDirectory);
+      await symlink(
+        gitDirectory,
+        join(repository, ".git"),
+        process.platform === "win32" ? "junction" : "dir",
+      );
+      await mkdir(binaries, { recursive: true });
+      const gitName = process.platform === "win32" ? "git.cmd" : "git";
+      const maliciousGit =
+        process.platform === "win32"
+          ? `@echo off\r\n> "${marker}" echo hijacked\r\nexit /b 1\r\n`
+          : `#!/bin/sh\nprintf '%s' hijacked > '${marker.replaceAll("'", `'"'"'`)}'\nexit 1\n`;
+      await writeFile(join(binaries, gitName), maliciousGit, { mode: 0o755 });
+      const stdout = capture();
+      const stderr = capture();
+      const exitCode = await main(
+        ["install-hook", repository, "--json"],
+        stdout.stream,
+        stderr.stream,
+        dependencies({
+          currentDirectory: repository,
+          environment: {
+            ...process.env,
+            PATH: [binaries, process.env["PATH"] ?? ""].join(delimiter),
+          },
+        }),
+      );
+      expect([0, 2]).toContain(exitCode);
+      if (exitCode === 2) {
+        expect(stderr.text()).toContain("A pre-commit hook already exists");
+      }
+      await expect(stat(marker)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("ignores Git shims in a config-selected worktree", async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), "codex-security-cli-config-worktree-")),
+    );
+    try {
+      const repository = join(root, "repository");
+      const gitDirectory = join(root, "git-directory");
+      const worktree = join(root, "configured-worktree");
+      const binaries = join(worktree, "node_modules", ".bin");
+      const marker = join(root, "git-shim-executed");
+      await Promise.all([
+        mkdir(repository, { recursive: true }),
+        mkdir(binaries, { recursive: true }),
+      ]);
+      execFileSync("git", ["init", "--bare", "-q", gitDirectory], {
+        timeout: 10_000,
+      });
+      execFileSync(
+        "git",
+        ["-C", gitDirectory, "config", "core.bare", "false"],
+        {
+          timeout: 10_000,
+        },
+      );
+      execFileSync(
+        "git",
+        ["-C", gitDirectory, "config", "core.worktree", worktree],
+        { timeout: 10_000 },
+      );
+      const gitName = process.platform === "win32" ? "git.cmd" : "git";
+      const maliciousGit =
+        process.platform === "win32"
+          ? `@echo off\r\n> "${marker}" echo hijacked\r\nexit /b 1\r\n`
+          : `#!/bin/sh\nprintf '%s' hijacked > '${marker.replaceAll("'", `'"'"'`)}'\nexit 1\n`;
+      await writeFile(join(binaries, gitName), maliciousGit, { mode: 0o755 });
+      const stdout = capture();
+      const stderr = capture();
+      const exitCode = await main(
+        ["install-hook", repository, "--json"],
+        stdout.stream,
+        stderr.stream,
+        dependencies({
+          currentDirectory: repository,
+          environment: {
+            ...process.env,
+            GIT_DIR: gitDirectory,
+            PATH: [binaries, process.env["PATH"] ?? ""].join(delimiter),
+          },
+        }),
+      );
+      expect([0, 2]).toContain(exitCode);
+      if (exitCode === 2) {
+        expect(stderr.text()).toContain("A pre-commit hook already exists");
+      }
+      await expect(stat(marker)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("ignores Git shims in externally selected Git object stores", async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), "codex-security-cli-git-object-stores-")),
+    );
+    try {
+      const repository = join(root, "repository");
+      execFileSync("git", ["init", "-q", repository], { timeout: 10_000 });
+      for (const name of [
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+      ] as const) {
+        const objectDirectory = join(root, name.toLowerCase());
+        const binaries = join(objectDirectory, "node_modules", ".bin");
+        const marker = join(root, `${name.toLowerCase()}-executed`);
+        await mkdir(binaries, { recursive: true });
+        const gitName = process.platform === "win32" ? "git.cmd" : "git";
+        const maliciousGit =
+          process.platform === "win32"
+            ? `@echo off\r\n> "${marker}" echo hijacked\r\nexit /b 1\r\n`
+            : `#!/bin/sh\nprintf '%s' hijacked > '${marker.replaceAll("'", `'"'"'`)}'\nexit 1\n`;
+        await writeFile(join(binaries, gitName), maliciousGit, { mode: 0o755 });
+        const stdout = capture();
+        const stderr = capture();
+        const exitCode = await main(
+          ["install-hook", repository, "--json"],
+          stdout.stream,
+          stderr.stream,
+          dependencies({
+            currentDirectory: repository,
+            environment: {
+              ...process.env,
+              [name]: objectDirectory,
+              PATH: [binaries, process.env["PATH"] ?? ""].join(delimiter),
+            },
+          }),
+        );
+        expect([0, 2]).toContain(exitCode);
+        if (exitCode === 2) {
+          expect(stderr.text()).toContain("A pre-commit hook already exists");
+        }
+        await expect(stat(marker)).rejects.toMatchObject({ code: "ENOENT" });
+      }
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -11,7 +11,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { delimiter, join, normalize, parse } from "node:path";
+import { delimiter, join, normalize, parse, relative } from "node:path";
 import { Writable } from "node:stream";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { stripVTControlCharacters } from "node:util";
@@ -859,6 +859,7 @@ describe("CLI", () => {
       const repository = join(worktree, "packages", "service");
       const binaries = join(worktree, "node_modules", ".bin");
       const gitDirectory = join(root, "git-directory");
+      const gitBinaries = join(gitDirectory, "node_modules", ".bin");
       await Promise.all([
         mkdir(repository, { recursive: true }),
         mkdir(binaries, { recursive: true }),
@@ -866,6 +867,7 @@ describe("CLI", () => {
       execFileSync("git", ["init", "--bare", "-q", gitDirectory], {
         timeout: 10_000,
       });
+      await mkdir(gitBinaries, { recursive: true });
 
       const marker = join(root, "git-shim-executed");
       const gitName = process.platform === "win32" ? "git.cmd" : "git";
@@ -873,7 +875,10 @@ describe("CLI", () => {
         process.platform === "win32"
           ? `@echo off\r\n> "${marker}" echo hijacked\r\nexit /b 1\r\n`
           : `#!/bin/sh\nprintf '%s' hijacked > '${marker.replaceAll("'", `'"'"'`)}'\nexit 1\n`;
-      await writeFile(join(binaries, gitName), maliciousGit, { mode: 0o755 });
+      await Promise.all([
+        writeFile(join(binaries, gitName), maliciousGit, { mode: 0o755 }),
+        writeFile(join(gitBinaries, gitName), maliciousGit, { mode: 0o755 }),
+      ]);
       const path = Object.entries(process.env).find(
         ([name]) => name.toUpperCase() === "PATH",
       )?.[1];
@@ -882,12 +887,12 @@ describe("CLI", () => {
           ([name]) => name.toUpperCase() !== "PATH",
         ),
       );
-      environment["GIT_DIR"] = gitDirectory;
+      environment["GIT_DIR"] = relative(repository, gitDirectory);
       environment["GIT_WORK_TREE"] = worktree;
       environment["GIT_CONFIG_COUNT"] = "1";
       environment["GIT_CONFIG_KEY_0"] = "core.hooksPath";
       environment["GIT_CONFIG_VALUE_0"] = join(gitDirectory, "hooks");
-      environment["PATH"] = [binaries, path ?? ""].join(delimiter);
+      environment["PATH"] = [gitBinaries, binaries, path ?? ""].join(delimiter);
       const stdout = capture();
       const stderr = capture();
 

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -1294,6 +1294,7 @@ describe("CLI", () => {
       "inactive-include",
       "core-subsection",
       "disabled-worktree-config",
+      "overridden-worktree",
     ] as const) {
       const root = await realpath(
         await mkdtemp(join(tmpdir(), `codex-security-cli-${mode}-`)),
@@ -1317,10 +1318,15 @@ describe("CLI", () => {
             config,
             `${await readFile(config, "utf8")}[core "example"]\n\tworktree = ${trustedDirectory}\n`,
           );
-        } else {
+        } else if (mode === "disabled-worktree-config") {
           await writeFile(
             join(repository, ".git", "config.worktree"),
             `[core]\n\tworktree = ${trustedDirectory}\n`,
+          );
+        } else {
+          await writeFile(
+            config,
+            `${await readFile(config, "utf8")}[core]\n\tworktree = ${trustedDirectory}\n\tworktree = ${repository.replaceAll("\\", "/")}\n`,
           );
         }
         const stderr = capture();
@@ -1348,7 +1354,14 @@ describe("CLI", () => {
   });
 
   test("protects active conditional and enabled Git worktree configuration", async () => {
-    for (const mode of ["active-include", "enabled-worktree-config"] as const) {
+    for (const mode of [
+      "active-include",
+      "character-class-include",
+      "enabled-worktree-config",
+      "implicit-worktree-config",
+      "ordered-worktree-config",
+      "common-directory",
+    ] as const) {
       const root = await realpath(
         await mkdtemp(join(tmpdir(), `codex-security-cli-${mode}-`)),
       );
@@ -1361,23 +1374,70 @@ describe("CLI", () => {
         await mkdir(binaries, { recursive: true });
         const configuredWorktree = worktree.replaceAll("\\", "/");
         const config = join(repository, ".git", "config");
-        if (mode === "active-include") {
+        let selectedCommonDirectory: string | undefined;
+        if (mode === "active-include" || mode === "character-class-include") {
           const included = join(root, "active.gitconfig");
           await writeFile(
             included,
             `[core]\n\tworktree = ${configuredWorktree}\n`,
           );
           const gitDirectory = join(repository, ".git").replaceAll("\\", "/");
+          const condition =
+            mode === "character-class-include"
+              ? gitDirectory.replace("repository", "repositor[y]")
+              : gitDirectory;
           await writeFile(
             config,
-            `${await readFile(config, "utf8")}[includeIf "gitdir:${gitDirectory}/"]\n\tpath = ${included.replaceAll("\\", "/")}\n`,
+            `${await readFile(config, "utf8")}[includeIf "gitdir:${condition}/"]\n\tpath = ${included.replaceAll("\\", "/")}\n`,
           );
-        } else {
+        } else if (mode === "common-directory") {
+          selectedCommonDirectory = join(root, "selected-common");
           execFileSync(
             "git",
-            ["-C", repository, "config", "extensions.worktreeConfig", "true"],
+            ["init", "--bare", "-q", selectedCommonDirectory],
+            {
+              timeout: 10_000,
+            },
+          );
+          execFileSync(
+            "git",
+            ["-C", selectedCommonDirectory, "config", "core.bare", "false"],
             { timeout: 10_000 },
           );
+          execFileSync(
+            "git",
+            [
+              "-C",
+              selectedCommonDirectory,
+              "config",
+              "core.worktree",
+              configuredWorktree,
+            ],
+            { timeout: 10_000 },
+          );
+        } else {
+          if (mode === "ordered-worktree-config") {
+            const included = join(root, "disabled-worktree.gitconfig");
+            await writeFile(
+              included,
+              "[extensions]\n\tworktreeConfig = false\n",
+            );
+            await writeFile(
+              config,
+              `${await readFile(config, "utf8")}[include]\n\tpath = ${included.replaceAll("\\", "/")}\n[extensions]\n\tworktreeConfig\n`,
+            );
+          } else if (mode === "implicit-worktree-config") {
+            await writeFile(
+              config,
+              `${await readFile(config, "utf8")}[extensions]\n\tworktreeConfig\n`,
+            );
+          } else {
+            execFileSync(
+              "git",
+              ["-C", repository, "config", "extensions.worktreeConfig", "true"],
+              { timeout: 10_000 },
+            );
+          }
           await writeFile(
             join(repository, ".git", "config.worktree"),
             `[core]\n\tworktree = ${configuredWorktree}\n`,
@@ -1400,6 +1460,9 @@ describe("CLI", () => {
             currentDirectory: repository,
             environment: {
               ...process.env,
+              ...(selectedCommonDirectory === undefined
+                ? {}
+                : { GIT_COMMON_DIR: selectedCommonDirectory }),
               PATH: [binaries, process.env["PATH"] ?? ""].join(delimiter),
             },
           }),
@@ -1469,7 +1532,7 @@ describe("CLI", () => {
     }
   });
 
-  test("resolves relative Git object stores from the effective worktree", async () => {
+  test("resolves relative Git object stores from Git's invocation directory", async () => {
     for (const name of [
       "GIT_OBJECT_DIRECTORY",
       "GIT_ALTERNATE_OBJECT_DIRECTORIES",
@@ -1480,12 +1543,14 @@ describe("CLI", () => {
       try {
         const repository = join(root, "repository");
         const invocation = join(repository, "nested", "source");
+        const selectedWorktree = join(root, "elsewhere", "selected-worktree");
         const objectDirectory = join(root, "external-objects");
         const binaries = join(objectDirectory, "node_modules", ".bin");
         const marker = join(root, "git-shim-executed");
         execFileSync("git", ["init", "-q", repository], { timeout: 10_000 });
         await Promise.all([
           mkdir(invocation, { recursive: true }),
+          mkdir(selectedWorktree, { recursive: true }),
           mkdir(binaries, { recursive: true }),
           mkdir(join(objectDirectory, "info"), { recursive: true }),
           mkdir(join(objectDirectory, "pack"), { recursive: true }),
@@ -1507,7 +1572,7 @@ describe("CLI", () => {
             currentDirectory: invocation,
             environment: {
               ...process.env,
-              GIT_WORK_TREE: repository,
+              GIT_WORK_TREE: selectedWorktree,
               [name]: join("..", "external-objects"),
               PATH: [binaries, process.env["PATH"] ?? ""].join(delimiter),
             },

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -11,7 +11,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { delimiter, join, normalize } from "node:path";
+import { delimiter, join, normalize, parse } from "node:path";
 import { Writable } from "node:stream";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { stripVTControlCharacters } from "node:util";
@@ -321,12 +321,7 @@ describe("CLI", () => {
       const hook = join(root, ".custom hooks", "pre-commit");
       const deps = dependencies({
         currentDirectory: root,
-        environment: {
-          ...process.env,
-          GIT_CONFIG_COUNT: "1",
-          GIT_CONFIG_KEY_0: "core.hooksPath",
-          GIT_CONFIG_VALUE_0: join(root, "injected-hooks"),
-        },
+        environment: { ...process.env },
         onRun: () => (started = true),
       });
       for (let attempt = 0; attempt < 2; attempt += 1) {
@@ -349,9 +344,6 @@ describe("CLI", () => {
       expect(await readFile(hook, "utf8")).toContain(
         "--working-tree --fail-on-severity medium",
       );
-      await expect(stat(join(root, "injected-hooks"))).rejects.toMatchObject({
-        code: "ENOENT",
-      });
       expect(started).toBe(false);
 
       const trustedHook = await readFile(hook, "utf8");
@@ -473,6 +465,210 @@ describe("CLI", () => {
           fileURLToPath(new URL("../src/cli.ts", import.meta.url)),
         ),
       );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("installs the hook at Git's effective configured hook path", async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), "codex-security-cli-configured-hook-")),
+    );
+    try {
+      execFileSync("git", ["init", "-q", root], { timeout: 10_000 });
+      execFileSync(
+        "git",
+        ["-C", root, "config", "core.hooksPath", ".repository hooks"],
+        { timeout: 10_000 },
+      );
+      const hookDirectory = join(root, ".environment hooks");
+      const hook = join(hookDirectory, "pre-commit");
+      const environment = {
+        ...process.env,
+        GIT_CONFIG_COUNT: "1",
+        GIT_CONFIG_KEY_0: "core.hooksPath",
+        GIT_CONFIG_VALUE_0: hookDirectory,
+      };
+      const stdout = capture();
+      const stderr = capture();
+
+      expect(
+        await main(
+          ["install-hook", ".", "--json"],
+          stdout.stream,
+          stderr.stream,
+          dependencies({ currentDirectory: root, environment }),
+        ),
+      ).toBe(0);
+      expect(stderr.text()).toBe("");
+      expect(
+        normalize((JSON.parse(stdout.text()) as { hook: string }).hook),
+      ).toBe(hook);
+      expect(await readFile(hook, "utf8")).toContain(
+        "scan . --working-tree --fail-on-severity high",
+      );
+      expect(
+        normalize(
+          execFileSync(
+            "git",
+            [
+              "-C",
+              root,
+              "rev-parse",
+              "--path-format=absolute",
+              "--git-path",
+              "hooks/pre-commit",
+            ],
+            { encoding: "utf8", env: environment, timeout: 10_000 },
+          ).trim(),
+        ),
+      ).toBe(hook);
+      await expect(
+        stat(join(root, ".repository hooks", "pre-commit")),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("preserves the operator's Git repository discovery ceiling", async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), "codex-security-cli-git-ceiling-")),
+    );
+    try {
+      execFileSync("git", ["init", "-q", root], { timeout: 10_000 });
+      execFileSync(
+        "git",
+        ["-C", root, "config", "core.hooksPath", ".repository hooks"],
+        { timeout: 10_000 },
+      );
+      const nested = join(root, "nested");
+      await mkdir(nested);
+      const stdout = capture();
+      const stderr = capture();
+
+      expect(
+        await main(
+          ["install-hook", nested, "--json"],
+          stdout.stream,
+          stderr.stream,
+          dependencies({
+            currentDirectory: root,
+            environment: {
+              ...process.env,
+              GIT_CEILING_DIRECTORIES: root,
+            },
+          }),
+        ),
+      ).toBe(2);
+      expect(stdout.text()).toBe("");
+      expect(stderr.text()).toContain("not a git repository");
+      await expect(
+        stat(join(root, ".repository hooks", "pre-commit")),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("installs a hook when invoked from a filesystem root", async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), "codex-security-cli-root-hook-")),
+    );
+    try {
+      execFileSync("git", ["init", "-q", root], { timeout: 10_000 });
+      execFileSync(
+        "git",
+        ["-C", root, "config", "core.hooksPath", ".repository hooks"],
+        { timeout: 10_000 },
+      );
+      const stdout = capture();
+      const stderr = capture();
+
+      expect(
+        await main(
+          ["install-hook", root, "--json"],
+          stdout.stream,
+          stderr.stream,
+          dependencies({
+            currentDirectory: parse(root).root,
+            environment: { ...process.env },
+          }),
+        ),
+      ).toBe(0);
+      expect(stderr.text()).toBe("");
+      expect(
+        normalize((JSON.parse(stdout.text()) as { hook: string }).hook),
+      ).toBe(join(root, ".repository hooks", "pre-commit"));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("ignores Git shims in both invoking and target checkouts", async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), "codex-security-cli-trusted-git-")),
+    );
+    try {
+      const invocation = join(root, "invocation");
+      const repository = join(root, "repository");
+      const invocationBinaries = join(invocation, "node_modules", ".bin");
+      const repositoryBinaries = join(repository, "node_modules", ".bin");
+      await Promise.all([
+        mkdir(invocationBinaries, { recursive: true }),
+        mkdir(repositoryBinaries, { recursive: true }),
+      ]);
+      execFileSync("git", ["init", "-q", invocation], { timeout: 10_000 });
+      execFileSync("git", ["init", "-q", repository], { timeout: 10_000 });
+      execFileSync(
+        "git",
+        ["-C", repository, "config", "core.hooksPath", ".repository hooks"],
+        { timeout: 10_000 },
+      );
+
+      const marker = join(root, "git-shim-executed");
+      const gitName = process.platform === "win32" ? "git.cmd" : "git";
+      const maliciousGit =
+        process.platform === "win32"
+          ? `@echo off\r\n> "${marker}" echo hijacked\r\nexit /b 1\r\n`
+          : `#!/bin/sh\nprintf '%s' hijacked > '${marker.replaceAll("'", `'"'"'`)}'\nexit 1\n`;
+      await Promise.all([
+        writeFile(join(invocationBinaries, gitName), maliciousGit, {
+          mode: 0o755,
+        }),
+        writeFile(join(repositoryBinaries, gitName), maliciousGit, {
+          mode: 0o755,
+        }),
+      ]);
+      const path = Object.entries(process.env).find(
+        ([name]) => name.toUpperCase() === "PATH",
+      )?.[1];
+      const environment = Object.fromEntries(
+        Object.entries(process.env).filter(
+          ([name]) => name.toUpperCase() !== "PATH",
+        ),
+      );
+      environment["PATH"] = [
+        invocationBinaries,
+        repositoryBinaries,
+        path ?? "",
+      ].join(delimiter);
+      const stdout = capture();
+      const stderr = capture();
+
+      expect(
+        await main(
+          ["install-hook", repository, "--json"],
+          stdout.stream,
+          stderr.stream,
+          dependencies({ currentDirectory: invocation, environment }),
+        ),
+      ).toBe(0);
+      expect(stderr.text()).toBe("");
+      expect(
+        normalize((JSON.parse(stdout.text()) as { hook: string }).hook),
+      ).toBe(join(repository, ".repository hooks", "pre-commit"));
+      await expect(stat(marker)).rejects.toMatchObject({ code: "ENOENT" });
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -11,7 +11,7 @@ import {
   symlink,
   writeFile,
 } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir, userInfo } from "node:os";
 import {
   delimiter,
   dirname,
@@ -38,7 +38,12 @@ import {
   ScanInterruptedError,
   VERSION,
 } from "../src/index.js";
-import { main, parseCodexOverrides, Progress } from "../src/cli.js";
+import {
+  expandGitConfigIncludePath,
+  main,
+  parseCodexOverrides,
+  Progress,
+} from "../src/cli.js";
 import { DEFAULT_CODEX_CONFIG, scanModelConfiguration } from "../src/config.js";
 import {
   FakeSignals,
@@ -1292,9 +1297,12 @@ describe("CLI", () => {
 
     for (const mode of [
       "inactive-include",
+      "uppercase-posix-class-include",
+      "invalid-double-star-include",
       "core-subsection",
       "disabled-worktree-config",
       "overridden-worktree",
+      "late-environment-worktree",
     ] as const) {
       const root = await realpath(
         await mkdtemp(join(tmpdir(), `codex-security-cli-${mode}-`)),
@@ -1303,15 +1311,26 @@ describe("CLI", () => {
         const repository = join(root, "repository");
         execFileSync("git", ["init", "-q", repository], { timeout: 10_000 });
         const config = join(repository, ".git", "config");
-        if (mode === "inactive-include") {
+        if (
+          mode === "inactive-include" ||
+          mode === "uppercase-posix-class-include" ||
+          mode === "invalid-double-star-include"
+        ) {
           const included = join(root, "inactive.gitconfig");
           await writeFile(
             included,
             `[core]\n\tworktree = ${trustedDirectory}\n`,
           );
+          const gitDirectory = join(repository, ".git").replaceAll("\\", "/");
+          const condition =
+            mode === "uppercase-posix-class-include"
+              ? gitDirectory.replace("repository", "repositor[[:ALPHA:]]")
+              : mode === "invalid-double-star-include"
+                ? gitDirectory.replace("repository", "repo**sitory")
+                : "/never/selected";
           await writeFile(
             config,
-            `${await readFile(config, "utf8")}[includeIf "gitdir:/never/selected/"]\n\tpath = ${included.replaceAll("\\", "/")}\n`,
+            `${await readFile(config, "utf8")}[includeIf "gitdir:${condition}/"]\n\tpath = ${included.replaceAll("\\", "/")}\n`,
           );
         } else if (mode === "core-subsection") {
           await writeFile(
@@ -1338,6 +1357,13 @@ describe("CLI", () => {
             currentDirectory: repository,
             environment: {
               ...process.env,
+              ...(mode === "late-environment-worktree"
+                ? {
+                    GIT_CONFIG_COUNT: "1",
+                    GIT_CONFIG_KEY_0: "core.worktree",
+                    GIT_CONFIG_VALUE_0: trustedDirectory,
+                  }
+                : {}),
               PATH: dirname(trustedGit!),
             },
           }),
@@ -1360,6 +1386,7 @@ describe("CLI", () => {
       "posix-character-class-include",
       "environment-config-override",
       "enabled-worktree-config",
+      "integer-worktree-config",
       "implicit-worktree-config",
       "ordered-worktree-config",
       "common-directory",
@@ -1430,7 +1457,12 @@ describe("CLI", () => {
             { timeout: 10_000 },
           );
         } else {
-          if (mode === "ordered-worktree-config") {
+          if (mode === "integer-worktree-config") {
+            await writeFile(
+              config,
+              `${await readFile(config, "utf8")}[extensions]\n\tworktreeConfig = 2\n`,
+            );
+          } else if (mode === "ordered-worktree-config") {
             const included = join(root, "disabled-worktree.gitconfig");
             await writeFile(
               included,
@@ -1499,6 +1531,24 @@ describe("CLI", () => {
       }
     }
   });
+
+  test.skipIf(process.platform === "win32")(
+    "expands current and named-user homes in Git configuration includes",
+    async () => {
+      const current = userInfo().username;
+      expect(await expandGitConfigIncludePath(`~${current}/.gitconfig`)).toBe(
+        join(homedir(), ".gitconfig"),
+      );
+      const root = (await readFile("/etc/passwd", "utf8"))
+        .split(/\r?\n/u)
+        .map((entry) => entry.split(":"))
+        .find((entry) => entry[0] === "root")?.[5];
+      expect(root).toBeDefined();
+      expect(await expandGitConfigIncludePath("~root/.gitconfig")).toBe(
+        join(root!, ".gitconfig"),
+      );
+    },
+  );
 
   test("ignores Git shims in externally selected Git object stores", async () => {
     const root = await realpath(

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -1357,6 +1357,8 @@ describe("CLI", () => {
     for (const mode of [
       "active-include",
       "character-class-include",
+      "posix-character-class-include",
+      "environment-config-override",
       "enabled-worktree-config",
       "implicit-worktree-config",
       "ordered-worktree-config",
@@ -1375,7 +1377,11 @@ describe("CLI", () => {
         const configuredWorktree = worktree.replaceAll("\\", "/");
         const config = join(repository, ".git", "config");
         let selectedCommonDirectory: string | undefined;
-        if (mode === "active-include" || mode === "character-class-include") {
+        if (
+          mode === "active-include" ||
+          mode === "character-class-include" ||
+          mode === "posix-character-class-include"
+        ) {
           const included = join(root, "active.gitconfig");
           await writeFile(
             included,
@@ -1385,10 +1391,18 @@ describe("CLI", () => {
           const condition =
             mode === "character-class-include"
               ? gitDirectory.replace("repository", "repositor[y]")
-              : gitDirectory;
+              : mode === "posix-character-class-include"
+                ? gitDirectory.replace("repository", "repositor[[:alpha:]]")
+                : gitDirectory;
           await writeFile(
             config,
             `${await readFile(config, "utf8")}[includeIf "gitdir:${condition}/"]\n\tpath = ${included.replaceAll("\\", "/")}\n`,
+          );
+        } else if (mode === "environment-config-override") {
+          execFileSync(
+            "git",
+            ["-C", repository, "config", "core.worktree", configuredWorktree],
+            { timeout: 10_000 },
           );
         } else if (mode === "common-directory") {
           selectedCommonDirectory = join(root, "selected-common");
@@ -1463,6 +1477,13 @@ describe("CLI", () => {
               ...(selectedCommonDirectory === undefined
                 ? {}
                 : { GIT_COMMON_DIR: selectedCommonDirectory }),
+              ...(mode === "environment-config-override"
+                ? {
+                    GIT_CONFIG_COUNT: "1",
+                    GIT_CONFIG_KEY_0: "core.worktree",
+                    GIT_CONFIG_VALUE_0: join(root, "other-worktree"),
+                  }
+                : {}),
               PATH: [binaries, process.env["PATH"] ?? ""].join(delimiter),
             },
           }),

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -1066,6 +1066,15 @@ describe("CLI", () => {
         ["-C", gitDirectory, "config", "core.worktree", worktree],
         { timeout: 10_000 },
       );
+      const configPath = join(gitDirectory, "config");
+      const config = await readFile(configPath, "utf8");
+      await writeFile(
+        configPath,
+        config.replace(
+          /^(\s*worktree\s*=\s*.+)$/mu,
+          "$1 ; repository owner configuration",
+        ),
+      );
       const gitName = process.platform === "win32" ? "git.cmd" : "git";
       const maliciousGit =
         process.platform === "win32"
@@ -1128,7 +1137,10 @@ describe("CLI", () => {
             currentDirectory: repository,
             environment: {
               ...process.env,
-              [name]: objectDirectory,
+              [name]:
+                name === "GIT_ALTERNATE_OBJECT_DIRECTORIES"
+                  ? JSON.stringify(objectDirectory)
+                  : objectDirectory,
               PATH: [binaries, process.env["PATH"] ?? ""].join(delimiter),
             },
           }),
@@ -1143,6 +1155,142 @@ describe("CLI", () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  test("ignores Git shims in recursively configured alternate object stores", async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), "codex-security-cli-git-alternates-")),
+    );
+    try {
+      const repository = join(root, "repository");
+      const firstAlternate = join(root, "first-alternate");
+      const secondAlternate = join(root, "second-alternate");
+      const binaries = join(secondAlternate, "node_modules", ".bin");
+      const marker = join(root, "git-shim-executed");
+      execFileSync("git", ["init", "-q", repository], { timeout: 10_000 });
+      await Promise.all([
+        mkdir(join(firstAlternate, "info"), { recursive: true }),
+        mkdir(join(firstAlternate, "pack"), { recursive: true }),
+        mkdir(join(secondAlternate, "info"), { recursive: true }),
+        mkdir(join(secondAlternate, "pack"), { recursive: true }),
+        mkdir(binaries, { recursive: true }),
+      ]);
+      await Promise.all([
+        writeFile(
+          join(repository, ".git", "objects", "info", "alternates"),
+          `${firstAlternate}\n`,
+        ),
+        writeFile(
+          join(firstAlternate, "info", "alternates"),
+          `${secondAlternate}\n`,
+        ),
+      ]);
+      const gitName = process.platform === "win32" ? "git.cmd" : "git";
+      const maliciousGit =
+        process.platform === "win32"
+          ? `@echo off\r\n> "${marker}" echo hijacked\r\nexit /b 1\r\n`
+          : `#!/bin/sh\nprintf '%s' hijacked > '${marker.replaceAll("'", `'"'"'`)}'\nexit 1\n`;
+      await writeFile(join(binaries, gitName), maliciousGit, { mode: 0o755 });
+      const stdout = capture();
+      const stderr = capture();
+      const exitCode = await main(
+        ["install-hook", repository, "--json"],
+        stdout.stream,
+        stderr.stream,
+        dependencies({
+          currentDirectory: repository,
+          environment: {
+            ...process.env,
+            PATH: [binaries, process.env["PATH"] ?? ""].join(delimiter),
+          },
+        }),
+      );
+      expect([0, 2]).toContain(exitCode);
+      if (exitCode === 2) {
+        expect(stderr.text()).toContain("A pre-commit hook already exists");
+      }
+      await expect(stat(marker)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test.skipIf(process.platform === "win32")(
+    "preserves significant whitespace in linked-worktree common Git paths",
+    async () => {
+      const root = await realpath(
+        await mkdtemp(join(tmpdir(), "codex-security-cli-spaced-common-git-")),
+      );
+      try {
+        const primary = join(root, "primary");
+        const linked = join(root, "linked");
+        const commonDirectory = join(root, "shared-git ");
+        execFileSync(
+          "git",
+          ["init", "-q", "--separate-git-dir", commonDirectory, primary],
+          { timeout: 10_000 },
+        );
+        execFileSync(
+          "git",
+          [
+            "-C",
+            primary,
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "user.name=Test",
+            "commit",
+            "--allow-empty",
+            "-qm",
+            "initial",
+          ],
+          { timeout: 10_000 },
+        );
+        execFileSync(
+          "git",
+          ["-C", primary, "worktree", "add", "-q", "--detach", linked],
+          { timeout: 10_000 },
+        );
+        const linkedGitDirectory = execFileSync(
+          "git",
+          ["-C", linked, "rev-parse", "--absolute-git-dir"],
+          { encoding: "utf8", timeout: 10_000 },
+        ).trimEnd();
+        await writeFile(
+          join(linkedGitDirectory, "commondir"),
+          `${commonDirectory}\n`,
+        );
+        const binaries = join(commonDirectory, "node_modules", ".bin");
+        const marker = join(root, "git-shim-executed");
+        await mkdir(binaries, { recursive: true });
+        await writeFile(
+          join(binaries, "git"),
+          `#!/bin/sh\nprintf '%s' hijacked > '${marker.replaceAll("'", `'"'"'`)}'\nexit 1\n`,
+          { mode: 0o755 },
+        );
+        const stdout = capture();
+        const stderr = capture();
+        const exitCode = await main(
+          ["install-hook", linked, "--json"],
+          stdout.stream,
+          stderr.stream,
+          dependencies({
+            currentDirectory: linked,
+            environment: {
+              ...process.env,
+              PATH: [binaries, process.env["PATH"] ?? ""].join(delimiter),
+            },
+          }),
+        );
+        expect([0, 2]).toContain(exitCode);
+        if (exitCode === 2) {
+          expect(stderr.text()).toContain("A pre-commit hook already exists");
+        }
+        await expect(stat(marker)).rejects.toMatchObject({ code: "ENOENT" });
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
 
   test("accepts a selected Git worktree that has not been created yet", async () => {
     const root = await realpath(

--- a/sdk/typescript/tests-ts/trusted-executable.test.ts
+++ b/sdk/typescript/tests-ts/trusted-executable.test.ts
@@ -110,6 +110,28 @@ describe("trusted executable resolution", () => {
     },
   );
 
+  test.skipIf(process.platform === "win32")(
+    "uses only the exact POSIX PATH environment variable",
+    async () => {
+      const root = await temporaryDirectory();
+      const repository = join(root, "repository");
+      const ignored = join(root, "ignored");
+      const trusted = await realpath(dirname(process.execPath));
+      await mkdir(repository);
+
+      expect(
+        await resolveTrustedExecutable(
+          basename(process.execPath),
+          { Path: ignored, PATH: trusted, KEEP: "ok" },
+          repository,
+        ),
+      ).toEqual({
+        executable: await realpath(process.execPath),
+        environment: { Path: ignored, PATH: trusted, KEEP: "ok" },
+      });
+    },
+  );
+
   test("selects runnable Windows executables ahead of extensionless and batch files", async () => {
     const root = await temporaryDirectory();
     const repository = join(root, "repository");

--- a/sdk/typescript/tests-ts/trusted-executable.test.ts
+++ b/sdk/typescript/tests-ts/trusted-executable.test.ts
@@ -185,6 +185,33 @@ describe("trusted executable resolution", () => {
     });
   });
 
+  test("removes PATH entries inside any protected root", async () => {
+    const root = await temporaryDirectory();
+    const invocation = join(root, "invocation");
+    const repository = join(root, "repository");
+    const invocationBin = join(invocation, "node_modules", ".bin");
+    const repositoryBin = join(repository, "node_modules", ".bin");
+    const trusted = await realpath(dirname(process.execPath));
+    await Promise.all([
+      mkdir(invocationBin, { recursive: true }),
+      mkdir(repositoryBin, { recursive: true }),
+    ]);
+
+    const result = await resolveTrustedExecutable(
+      basename(process.execPath),
+      {
+        PATH: [invocationBin, repositoryBin, trusted].join(delimiter),
+        KEEP: "ok",
+      },
+      [invocation, repository],
+    );
+
+    expect(result).toEqual({
+      executable: await realpath(process.execPath),
+      environment: { KEEP: "ok", PATH: trusted },
+    });
+  });
+
   test.skipIf(process.platform !== "win32")(
     "resolves a real Windows executable without trusting PATHEXT, repository junctions, or PATH casing",
     async () => {


### PR DESCRIPTION
## Summary

Builds on #92 by @GautamSharma99 and preserves the original contributor's
commits. This PR adds a separately tested follow-up without rewriting or
force-pushing their work.

Resolve Git through the existing trusted-executable helper when installing a
pre-commit hook, without changing Codex Security's trusted-local threat model.

This is defense in depth against accidentally executing a Git shim provided by
an invoking checkout, the target checkout, or a package-manager-managed
`node_modules/.bin` directory. It does not claim that local Git, `PATH`, Git
configuration, or a repository selected by the operator is a separate security
boundary.

## Changes

- Resolve and invoke Git using its canonical executable path.
- Support more than one protected root in the existing executable resolver.
- Discover the actual Git checkout roots enclosing the invoking directory and
  selected target instead of marking arbitrary parent directories, home
  directories, or the entire filesystem as untrusted.
- Preserve the operator's complete effective Git environment, including
  `GIT_CONFIG_*`, `core.hooksPath`, and `GIT_CEILING_DIRECTORIES`.
- Validate that Git returns a nonempty absolute hook path without control or
  Unicode line-separator characters.
- Document the hook behavior and explain in `SECURITY.md` why trusted
  executable selection is defense in depth, not an untrusted-repository
  isolation guarantee.

## Regression coverage

- A configured hook is written exactly where a real `git commit` will look for
  it, including when `core.hooksPath` is supplied through `GIT_CONFIG_*`.
- Git repository discovery still respects `GIT_CEILING_DIRECTORIES`.
- Installing a hook from a filesystem root still resolves trusted host Git.
- Fake Git executables in both the invoking and target checkouts are never run.
- Existing multi-root and Windows executable-resolution coverage is preserved.

## Verification

- `pnpm run types`
- `pnpm run format`
- `pnpm run build`
- `pnpm run test`: 412 passed, 5 skipped, 0 failed.
- `pnpm exec prettier --check ../../SECURITY.md`
- `git diff --check`
- Built and validated the packed npm artifact: 179 package entries, a fresh
  install, working public SDK and CLI, and all 95 bundled plugin files.
