### PR TITLE
fix: keep scan output dirs private across shared parents

### DIFF
--- a/sdk/typescript/_bundled_plugin/scripts/workbench_db.py
+++ b/sdk/typescript/_bundled_plugin/scripts/workbench_db.py
@@ -3469,6 +3469,16 @@ def require_canonical_scan_directory(scan_dir: Path) -> Path:
         scan_dir
     ):
         raise SystemExit("Scan directory must be an existing canonical non-symlink directory.")
+    # Re-check privacy on every resolution so a mid-scan rename/replace under a
+    # shared parent cannot substitute another user's forged artifact tree.
+    if os.name != "nt":
+        if stat.S_IMODE(metadata.st_mode) & 0o077:
+            raise SystemExit(
+                "Scan directory must not be accessible to other users (chmod 700)."
+            )
+        geteuid = getattr(os, "geteuid", None)
+        if geteuid is not None and metadata.st_uid != geteuid():
+            raise SystemExit("Scan directory must be owned by the current user.")
     return scan_dir
 
 

--- a/sdk/typescript/src/contract.ts
+++ b/sdk/typescript/src/contract.ts
@@ -17,6 +17,7 @@ import type {
   FindingsDocument,
   ScanManifest,
 } from "./models.js";
+import { requirePrivateOutputDirectory } from "./runtime.js";
 import type { NormalizedTarget, ScanMode } from "./targets.js";
 
 const DOCUMENTS = {
@@ -581,9 +582,20 @@ async function requireScanRoot(
     ) {
       throw new Error("not a directory");
     }
+    try {
+      requirePrivateOutputDirectory(returned, canonical);
+    } catch (error) {
+      throw new ContractValidationError(
+        error instanceof Error
+          ? error.message
+          : "Scan directory must remain private to the current user.",
+        { cause: error },
+      );
+    }
     return { path: canonical, metadata: returned };
   } catch (error) {
     throwIfAborted(signal);
+    if (error instanceof ContractValidationError) throw error;
     throw new ContractValidationError(
       "Scan directory must be an existing non-symlink directory.",
       { cause: error },

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -233,6 +233,7 @@ export async function validateOutputDir(
         );
       }
       requirePrivateOutputDirectory(metadata, path);
+      await requireSecureOutputAncestry(path);
       const canonical = await realpath(path);
       requireModelSafeOutputDir(canonical);
       return canonical;
@@ -247,6 +248,7 @@ export async function validateOutputDir(
             relative(parent, path),
           );
           requireModelSafeOutputDir(canonical);
+          await requireSecureOutputAncestry(canonical);
           return canonical;
         }
         break;
@@ -370,6 +372,7 @@ export async function validatePreparedOutputDir(
     );
   }
   requirePrivateOutputDirectory(metadata, path);
+  await requireSecureOutputAncestry(canonical);
   return canonical;
 }
 
@@ -388,6 +391,59 @@ export function requirePrivateOutputDirectory(
     throw new OutputDirectoryError(
       `Scan output directory must be owned by the current user: ${path}`,
     );
+  }
+}
+
+/** Reject parents that other users can rename entries out of (non-sticky shared dirs). */
+export async function requireSecureOutputAncestry(path: string): Promise<void> {
+  if (process.platform === "win32") return;
+  let current = dirname(resolve(path));
+  while (true) {
+    try {
+      current = await realpath(current);
+      break;
+    } catch (error) {
+      if (nodeErrorCode(error) !== "ENOENT") {
+        throw new OutputDirectoryError(
+          `Unable to inspect scan output parent directory: ${current}`,
+          { cause: error },
+        );
+      }
+      const parent = dirname(current);
+      if (parent === current) {
+        throw new OutputDirectoryError(
+          `Unable to inspect scan output parent directory: ${current}`,
+          { cause: error },
+        );
+      }
+      current = parent;
+    }
+  }
+  while (true) {
+    let metadata: Stats;
+    try {
+      metadata = await lstat(current);
+    } catch (error) {
+      throw new OutputDirectoryError(
+        `Unable to inspect scan output parent directory: ${current}`,
+        { cause: error },
+      );
+    }
+    if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+      throw new OutputDirectoryError(
+        `Scan output parent must be a non-symlink directory: ${current}`,
+      );
+    }
+    // Group/world-writable parents need the sticky bit so other users cannot
+    // rename or replace the private scan directory mid-scan.
+    if ((metadata.mode & 0o022) !== 0 && (metadata.mode & 0o1000) === 0) {
+      throw new OutputDirectoryError(
+        `Scan output parent must not be group- or world-writable without the sticky bit: ${current}`,
+      );
+    }
+    const parent = dirname(current);
+    if (parent === current) return;
+    current = parent;
   }
 }
 

--- a/sdk/typescript/tests-ts/contract.test.ts
+++ b/sdk/typescript/tests-ts/contract.test.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import {
+  chmod,
   cp,
   mkdir,
   mkdtemp,
@@ -32,6 +33,7 @@ async function copyExample(): Promise<string> {
   temporaryDirectories.push(root);
   const scanDir = join(root, "scan");
   await cp(EXAMPLE, scanDir, { recursive: true });
+  if (process.platform !== "win32") await chmod(scanDir, 0o700);
   return scanDir;
 }
 
@@ -125,6 +127,17 @@ describe("canonical scan contract", () => {
   });
 
   test.skipIf(process.platform === "win32")(
+    "rejects a scan directory that is no longer private to the current user",
+    async () => {
+      const scanDir = await copyExample();
+      await chmod(scanDir, 0o755);
+      await expect(
+        loadContract(scanDir, { pluginRoot: PLUGIN_ROOT }),
+      ).rejects.toThrow("must not be accessible to other users");
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
     "accepts a scan directory beneath a symlinked parent",
     async () => {
       const root = await mkdtemp(
@@ -134,7 +147,9 @@ describe("canonical scan contract", () => {
       const parent = join(root, "actual-parent");
       const linkedParent = join(root, "linked-parent");
       await mkdir(parent);
-      await cp(EXAMPLE, join(parent, "scan"), { recursive: true });
+      const scanDir = join(parent, "scan");
+      await cp(EXAMPLE, scanDir, { recursive: true });
+      if (process.platform !== "win32") await chmod(scanDir, 0o700);
       await symlink(parent, linkedParent);
 
       await expect(

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -52,6 +52,7 @@ import {
   planOutputArchive,
   preparePersistentScanRoot,
   requirePrivateOutputDirectory,
+  requireSecureOutputAncestry,
   runWorkbench,
 } from "../src/runtime.js";
 import { PLUGIN_ROOT } from "./plugin-root.js";
@@ -1100,6 +1101,51 @@ describe("runtime directories and plugin Python boundary", () => {
       ),
     ).not.toThrow();
   });
+
+  testPosix(
+    "rejects scan output under a non-sticky shared parent directory",
+    async () => {
+      const root = await temporaryDirectory();
+      const shared = join(root, "shared");
+      await mkdir(shared, { mode: 0o777 });
+      await chmod(shared, 0o777);
+      const output = join(shared, "results");
+
+      await expect(prepareOutputDir(output, "repo")).rejects.toThrow(
+        "sticky bit",
+      );
+      await expect(requireSecureOutputAncestry(output)).rejects.toThrow(
+        "sticky bit",
+      );
+    },
+  );
+
+  testPosix(
+    "accepts scan output under a sticky shared parent directory",
+    async () => {
+      const root = await temporaryDirectory();
+      const shared = join(root, "shared");
+      await mkdir(shared, { mode: 0o1777 });
+      await chmod(shared, 0o1777);
+      // Some filesystems (notably user dirs on macOS APFS) ignore sticky on
+      // chmod; fall back to the process temp root when it is already sticky.
+      let stickyParent = shared;
+      if (((await lstat(shared)).mode & 0o1000) === 0) {
+        stickyParent = await realpath(tmpdir());
+        if (((await lstat(stickyParent)).mode & 0o1000) === 0) {
+          return;
+        }
+      }
+      const output = join(
+        stickyParent,
+        `codex-security-sticky-${process.pid}-${Date.now()}`,
+      );
+      temporaryDirectories.push(output);
+
+      await expect(requireSecureOutputAncestry(output)).resolves.toBeUndefined();
+      expect(await prepareOutputDir(output, "repo")).toBe(output);
+    },
+  );
 
   test("archives a non-empty private output directory", async () => {
     const root = await temporaryDirectory();


### PR DESCRIPTION
## Summary

- Fixes #109: reject non-sticky group/world-writable output parents at prepare time.
- Re-check scan-directory privacy (mode + owner) in the workbench canonical resolver and TypeScript contract loader so a mid-scan rename/replace under a shared parent cannot supply forged completion artifacts.

## Test plan

- [x] `bun test --timeout 60000 ./tests-ts/runtime.test.ts ./tests-ts/contract.test.ts ./tests-ts/api.test.ts` (129 pass)
- [ ] Confirm CI `node-ci` passes on this branch


Made with [Cursor](https://cursor.com)