### PR TITLE
release: bump Codex Security to 0.1.4

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-security",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "TypeScript SDK and CLI for Codex Security",
   "license": "Apache-2.0",
   "author": "OpenAI",


### PR DESCRIPTION
## Summary

- Bump `@openai/codex-security` from `0.1.3` to `0.1.4` with a one-line change on the latest `main`; keep the frozen dependency lockfile and protected release workflow unchanged.
- Ship the five fixes merged since `npm-v0.1.3`:
  - Preserve authoritative security scan targets ([#103](https://github.com/openai/codex-security/pull/103)).
  - Improve CLI help and deep-scan configuration documentation ([#105](https://github.com/openai/codex-security/pull/105)).
  - Preserve Windows sandbox override compatibility ([#96](https://github.com/openai/codex-security/pull/96)).
  - Harden Node CI and Windows package smoke tests ([#84](https://github.com/openai/codex-security/pull/84)).
  - Support managed Codex credential keyrings ([#101](https://github.com/openai/codex-security/pull/101)).
- Preserve the existing protected, provenance-enabled npm release process.

## Validation

- Confirmed the public npm `latest` and `main` are both `0.1.3`, no `npm-v0.1.4` tag exists, and there is no competing patch-release PR.
- `pnpm install --frozen-lockfile`: passed using the Socket Firewall; dependency lockfile unchanged.
- `pnpm run types`: passed.
- `pnpm run format`: passed.
- Full SDK suite: **465 passed, 6 expected platform/integration skips, 0 failures**.
- Focused CLI and package smoke-timeout regressions: **7 passed, 0 failures**.
- `pnpm run build`: passed.
- Packed `openai-codex-security-0.1.4.tgz` using the release workflow's exact `gitHead` stamping procedure for commit `c58531e06df627690d121f9ea1e47d9951b5368d`; the temporary stamp is not part of the PR.
- Exact-commit `check:package`: **179 validated archive entries**, matching release provenance, all **95** bundled plugin files, and a fresh-install SDK/CLI smoke.
- Independent `test:package`: verified a fresh installation, the public SDK import, `codex-security --help`, and `codex-security --version` returning `0.1.4`.
- Validated artifact SHA-256: `57710aac41fe56acd4cf308c5f166a5c351eb3324a1ccfa527470e9636fd904f`.

## Release

After review and merge, create `npm-v0.1.4` on the resulting `main` merge commit. The existing `node-release` workflow will verify, stamp, and publish that merge commit through the protected `npm` environment with provenance.

Opening or merging this PR does not itself publish the package or create the release tag.
