### PR TITLE
fix: bind immutable diff scans to snapshot digests

### DIFF
--- a/sdk/typescript/_bundled_plugin/scripts/workbench_db.py
+++ b/sdk/typescript/_bundled_plugin/scripts/workbench_db.py
@@ -97,6 +97,7 @@ from workbench_target import (
     directory_content_digest,
     directory_snapshot_regular_file_count,
     git_command,
+    git_diff_content_digest,
     git_output,
     git_revision,
     git_submodule_paths,
@@ -413,12 +414,28 @@ def require_diff_target(
             )
             if supplied_base != parent:
                 raise SystemExit("Commit base revision must match the selected commit's parent.")
-        return {"kind": kind, "baseRevision": parent, "headRevision": head}
+        current_digest = git_diff_content_digest(target, parent, head)
+        if content_digest and content_digest != current_digest:
+            raise SystemExit("The selected commit contents changed. Select the commit again.")
+        return {
+            "kind": kind,
+            "baseRevision": parent,
+            "headRevision": head,
+            "contentDigest": current_digest,
+        }
     base = resolve_git_commit(target, base_revision or "", "Base revision")
     head = resolve_git_commit(target, head_revision or "", "Head revision")
     if base == head:
         raise SystemExit("Base and head revisions must identify different commits.")
-    return {"kind": kind, "baseRevision": base, "headRevision": head}
+    current_digest = git_diff_content_digest(target, base, head)
+    if content_digest and content_digest != current_digest:
+        raise SystemExit("The selected range contents changed. Select the range again.")
+    return {
+        "kind": kind,
+        "baseRevision": base,
+        "headRevision": head,
+        "contentDigest": current_digest,
+    }
 
 
 def inspect_setup_values(
@@ -582,7 +599,7 @@ def workbench_completion_binding(scan: sqlite3.Row, completed_at: str) -> dict[s
     if scan["mode"] == "diff":
         target["baseRevision"] = scan["diff_base_revision"]
         target["headRevision"] = scan["diff_head_revision"]
-        if scan["diff_target_kind"] == "working_tree" and scan["diff_content_digest"]:
+        if scan["diff_content_digest"]:
             target["snapshotDigest"] = scan["diff_content_digest"]
     else:
         if scan["target_revision"] != "unversioned":
@@ -650,13 +667,9 @@ def verify_manifest_binding(scan: sqlite3.Row, manifest: dict[str, Any]) -> None
             raise SystemExit(
                 "scan-manifest.json target headRevision must match the workbench diff target."
             )
-        if (
-            scan["diff_target_kind"] == "working_tree"
-            and target.get("snapshotDigest") != scan["diff_content_digest"]
-        ):
+        if target.get("snapshotDigest") != scan["diff_content_digest"]:
             raise SystemExit(
-                "scan-manifest.json target snapshotDigest must match the selected "
-                "working-tree contents."
+                "scan-manifest.json target snapshotDigest must match the selected diff contents."
             )
     scope = manifest_scan.get("scope")
     if not isinstance(scope, dict):
@@ -1539,6 +1552,8 @@ def register_cli_scan(connection: sqlite3.Connection, args: argparse.Namespace) 
             if head != current_head:
                 raise SystemExit("Working-tree HEAD changed before the scan started.")
             diff_target["contentDigest"] = worktree_content_digest(repository)
+        else:
+            diff_target["contentDigest"] = git_diff_content_digest(repository, base, head)
     mode = "diff" if diff_target is not None else recipe["mode"]
     target_identity = scan_target_identity(repository, diff_target)
     scope_file_count = (

--- a/sdk/typescript/_bundled_plugin/scripts/workbench_target.py
+++ b/sdk/typescript/_bundled_plugin/scripts/workbench_target.py
@@ -80,6 +80,30 @@ def update_digest_field(digest: Any, label: bytes, value: bytes) -> None:
     digest.update(value)
 
 
+def git_diff_content_digest(target: Path, base_revision: str, head_revision: str) -> str:
+    diff = git_bytes(
+        target,
+        "diff",
+        "--binary",
+        "--full-index",
+        "--no-color",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--no-renames",
+        "--ignore-submodules=none",
+        base_revision,
+        head_revision,
+        "--",
+        ".",
+    )
+    if diff is None:
+        raise SystemExit("Could not snapshot the selected Git diff.")
+    digest = hashlib.sha256()
+    update_digest_field(digest, b"format", b"codex-security-snapshot/v1")
+    update_digest_field(digest, b"git-diff", diff)
+    return f"codex-security-snapshot/v1:sha256:{digest.hexdigest()}"
+
+
 def worktree_content_digest(target: Path) -> str:
     require_clean_submodule_worktrees(target)
     repository, pathspec = git_worktree_context(target)

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -1184,6 +1184,54 @@ describe("plugin runtime preparation", () => {
 });
 
 describe("runtime directories and plugin Python boundary", () => {
+  test("binds immutable Git diffs to a deterministic snapshot digest", async () => {
+    const root = await temporaryDirectory();
+    const repository = join(root, "repository");
+    await mkdir(repository);
+    const runGit = (...args: string[]): string => {
+      const result = Bun.spawnSync(["git", ...args], { cwd: repository });
+      expect(result.exitCode).toBe(0);
+      return result.stdout.toString().trim();
+    };
+    runGit("init", "-b", "main");
+    runGit("config", "user.email", "test@example.com");
+    runGit("config", "user.name", "Test");
+    await writeFile(join(repository, "app.ts"), "export const value = 1;\n");
+    runGit("add", "app.ts");
+    runGit("commit", "-m", "initial");
+    const base = runGit("rev-parse", "HEAD");
+    await writeFile(join(repository, "app.ts"), "export const value = 2;\n");
+    runGit("add", "app.ts");
+    runGit("commit", "-m", "change");
+    const head = runGit("rev-parse", "HEAD");
+
+    const python = Bun.which("python3") ?? Bun.which("python");
+    expect(python).not.toBeNull();
+    const scripts = join(await bundledPluginRoot(), "scripts");
+    const source = [
+      "import pathlib, sys",
+      "sys.path.insert(0, sys.argv[1])",
+      "from workbench_target import git_diff_content_digest",
+      "print(git_diff_content_digest(pathlib.Path(sys.argv[2]), sys.argv[3], sys.argv[4]))",
+    ].join("\n");
+    const digest = (): string => {
+      const result = Bun.spawnSync(
+        [python!, "-I", "-c", source, scripts, repository, base, head],
+        { cwd: repository },
+      );
+      expect(result.exitCode).toBe(0);
+      return result.stdout.toString().trim();
+    };
+
+    const first = digest();
+    expect(first).toMatch(/^codex-security-snapshot\/v1:sha256:[a-f0-9]{64}$/);
+    await writeFile(
+      join(repository, "untracked.txt"),
+      "outside immutable diff\n",
+    );
+    expect(digest()).toBe(first);
+  });
+
   test("prepares one private, reusable managed-credential home", async () => {
     const root = await temporaryDirectory();
     const environment = { CODEX_SECURITY_STATE_DIR: join(root, "state") };

--- a/sdk/typescript/tests-ts/scan-recovery.test.ts
+++ b/sdk/typescript/tests-ts/scan-recovery.test.ts
@@ -279,6 +279,107 @@ describe("malformed scan artifact recovery", () => {
     }
   });
 
+  test("persists an immutable diff digest during CLI scan registration", async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), "codex-security-diff-registration-")),
+    );
+    temporaryDirectories.push(root);
+    const repository = join(root, "repository");
+    const scanDir = join(root, "scan");
+    await mkdir(repository);
+    await mkdir(scanDir, { mode: 0o700 });
+    const runGit = (args: string[]) => {
+      const result = spawnSync("git", ["-C", repository, ...args], {
+        encoding: "utf8",
+      });
+      expect(result.status, result.stderr).toBe(0);
+      return result.stdout.trim();
+    };
+    runGit(["init", "--quiet"]);
+    runGit(["config", "user.name", "Codex Security"]);
+    runGit(["config", "user.email", "codex-security@example.invalid"]);
+    await writeFile(join(repository, "app.ts"), "export const value = 1;\n");
+    runGit(["add", "app.ts"]);
+    runGit(["commit", "--quiet", "-m", "base"]);
+    const base = runGit(["rev-parse", "HEAD"]);
+    await writeFile(join(repository, "app.ts"), "export const value = 2;\n");
+    runGit(["add", "app.ts"]);
+    runGit(["commit", "--quiet", "-m", "head"]);
+    const head = runGit(["rev-parse", "HEAD"]);
+    const python = Bun.which("python3") ?? Bun.which("python");
+    expect(python).not.toBeNull();
+    const fixture: ScanFixture = {
+      python: python!,
+      repository,
+      stateDir: join(root, "state"),
+      scanDir,
+      scanId: "",
+      registration: {},
+    };
+
+    const registration = await workbench(fixture, [
+      "register-cli-scan",
+      "--repository",
+      repository,
+      "--scan-dir",
+      scanDir,
+      "--recipe-json",
+      JSON.stringify({
+        config: {},
+        mode: "standard",
+        repository,
+        target: { kind: "refs", paths: [], base, head },
+      }),
+    ]);
+    const contract = registration["contract"] as {
+      diffTarget: { contentDigest?: string };
+    };
+
+    expect(contract.diffTarget.contentDigest).toMatch(
+      /^codex-security-snapshot\/v1:sha256:[a-f0-9]{64}$/,
+    );
+
+    fixture.scanId = String(registration["scanId"]);
+    fixture.registration = registration;
+    await cp(join(PLUGIN_ROOT, "examples", "completed-scan"), scanDir, {
+      recursive: true,
+    });
+    const manifestPath = join(scanDir, "scan-manifest.json");
+    const manifest = await readJson<{
+      scan: {
+        id: string;
+        target: { kind: string };
+        sealedAt?: string;
+        artifacts?: unknown[];
+      };
+    }>(manifestPath);
+    manifest.scan.id = fixture.scanId;
+    manifest.scan.target.kind = "git_diff";
+    delete manifest.scan.sealedAt;
+    delete manifest.scan.artifacts;
+    await writeJson(manifestPath, manifest);
+    for (const name of ["findings.json", "coverage.json"] as const) {
+      const path = join(scanDir, name);
+      const document = await readJson<{ scanId: string }>(path);
+      document.scanId = fixture.scanId;
+      await writeJson(path, document);
+    }
+    await writeFile(join(scanDir, "report.md"), "# Draft report\n");
+
+    await workbench(fixture, [
+      "prepare-scan-completion",
+      "--scan-id",
+      fixture.scanId,
+    ]);
+    const preparedManifest = await readJson<{
+      scan: { target: { snapshotDigest?: string } };
+    }>(manifestPath);
+    expect(preparedManifest.scan.target.snapshotDigest).toBe(
+      contract.diffTarget.contentDigest,
+    );
+    expect((await completeScan(fixture)).progress.status).toBe("complete");
+  });
+
   test("seals a prepared scan without publishing it before acceptance", async () => {
     const fixture = await startDraftScan();
 


### PR DESCRIPTION
## Summary

- compute a deterministic binary Git diff digest for immutable commit and range targets
- persist that digest during both setup and direct CLI scan registration
- require the same snapshot digest when completing and verifying scan manifests
- cover stability against unrelated untracked files and the real CLI registration path

## Why

Two real exact-commit scans completed 52-56 minutes of model work but could not save because scan.target.snapshotDigest was empty. Working-tree diffs already carried a digest; immutable commit and range diffs did not. The first implementation exposed a second missing handoff: direct CLI registration constructed the immutable target without persisting the computed digest. The added registration regression failed with an undefined digest before the fix.

## Validation

- pnpm types
- pnpm format
- pnpm test: 470 passed, 6 skipped, 0 failed
- focused immutable-digest and CLI-registration regressions passed