### PR TITLE
[codex-security] Remove scan error prefixes

### DIFF
--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -2622,17 +2622,13 @@ async function runScan(
       failure instanceof OutputInsideProtectedRootError
         ? cliErrorMessage(protectedRootErrorMessage(failure))
         : scanFailureMessage(failure, selectedAuthentication);
-    if (failure instanceof OutputInsideProtectedRootError) {
-      errorOutput.write(`${message}\n`);
-    } else {
-      errorOutput.write(`codex-security: ${message}\n`);
-    }
+    errorOutput.write(`${message}\n`);
     if (failure instanceof ScanInterruptedError) {
       return { exitCode: 2, error: message };
     }
     if (scanDir !== null) {
       errorOutput.write(
-        `codex-security: Partial output was kept at ${cliErrorMessage(scanDir)}.\n`,
+        `Partial output was kept at ${cliErrorMessage(scanDir)}.\n`,
       );
     }
     return { exitCode: 2, error: message };
@@ -2642,7 +2638,7 @@ async function runScan(
     return { exitCode: 0, data: { dryRun: true, ...preflight } };
   }
   if (result === null) {
-    errorOutput.write("codex-security: scan completed without a result\n");
+    errorOutput.write("scan completed without a result\n");
     return { exitCode: 2, error: "Scan completed without a result." };
   }
   const threshold = arguments_.failOnSeverity;
@@ -2844,7 +2840,7 @@ function protectedRootErrorMessage(
         ? "Set TMPDIR (or TEMP on Windows) to a writable directory outside the protected root."
         : `Set TMPDIR (or TEMP on Windows) to ${quoteCliPath(suggestion)} after creating that directory.`;
   return [
-    `codex-security: ${description} must be outside the scanned directory and any enclosing Git worktree.`,
+    `${description} must be outside the scanned directory and any enclosing Git worktree.`,
     `  Resolved path:  ${error.outputDirectory}`,
     `  Protected root: ${error.protectedRoot}`,
     `  Reason:         ${reason}`,

--- a/sdk/typescript/tests-ts/cli-launcher.test.ts
+++ b/sdk/typescript/tests-ts/cli-launcher.test.ts
@@ -57,7 +57,7 @@ describe("CLI launcher", () => {
       expect(child.status).toBe(2);
       expect(child.stdout).toBe("");
       expect(child.stderr).toBe(
-        `codex-security: working directory is unavailable: ${REDACTED_CREDENTIALS}\n`,
+        `working directory is unavailable: ${REDACTED_CREDENTIALS}\n`,
       );
     } finally {
       await rm(root, { recursive: true, force: true });
@@ -183,7 +183,7 @@ describe("CLI launcher", () => {
       expect([failed.status, failed.stdout, failed.stderr]).toEqual([
         2,
         "",
-        "codex-security: working directory is unavailable\n",
+        "working directory is unavailable\n",
       ]);
     } finally {
       await rm(root, { recursive: true, force: true });

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -1430,7 +1430,7 @@ describe("CLI", () => {
       expect([failed.status, failed.stdout, failed.stderr]).toEqual([
         2,
         "",
-        "codex-security: working directory is unavailable\n",
+        "working directory is unavailable\n",
       ]);
     } finally {
       await rm(root, { recursive: true, force: true });
@@ -2029,7 +2029,8 @@ describe("CLI", () => {
         await main(["scan", ".", "--json"], stdout.stream, stderr.stream, deps),
       ).toBe(2);
       expect(stdout.text()).toBe("");
-      expect(stderr.text()).toContain(`codex-security: ${message}\n`);
+      expect(stderr.text()).toContain(`${message}\n`);
+      expect(stderr.text()).not.toContain("codex-security:");
       expect(stderr.text()).not.toContain("model service could not be reached");
     }
   });
@@ -2769,7 +2770,7 @@ describe("CLI", () => {
       await main(["scan", "."], stdout.stream, stderr.stream, failing),
     ).toBe(2);
     expect(stdout.text()).toBe("");
-    expect(stderr.text()).toContain("codex-security: invalid scan request\n");
+    expect(stderr.text()).toContain("invalid scan request\n");
     expect(stderr.text()).not.toContain("Running scan");
     expect(stderr.text()).not.toContain("CodexSecurityError");
   });
@@ -2794,7 +2795,7 @@ describe("CLI", () => {
       ),
     ).toBe(2);
     expect(stdout.text()).toBe("");
-    expect(stderr.text()).toContain("codex-security: invalid scan request\n");
+    expect(stderr.text()).toContain("invalid scan request\n");
 
     const unavailableCwd = dependencies();
     unavailableCwd.currentDirectory = () => {
@@ -2922,6 +2923,7 @@ describe("CLI", () => {
       "Isolated Codex runtime directory must be outside the scanned directory and any enclosing Git worktree.",
     );
     expect(stderr.text()).toContain(`Partial output was kept at ${partial}.`);
+    expect(stderr.text()).not.toContain("codex-security:");
   });
 
   test("redacts credentials embedded in protected-root diagnostics", async () => {
@@ -2982,8 +2984,7 @@ describe("CLI", () => {
       ).toBe(2);
       expect(stdout.text()).toBe("");
       expect(stderr.text()).toBe(
-        "[00:00] Preparing scan\n" +
-          `codex-security: scan failed ${REDACTED_CREDENTIALS}\n`,
+        "[00:00] Preparing scan\n" + `scan failed ${REDACTED_CREDENTIALS}\n`,
       );
     }
   });


### PR DESCRIPTION
Scan failures currently prepend codex-security: to both the underlying error and retained-output guidance, making diagnostics unnecessarily noisy.

Remove that prefix from scan failures, protected-root diagnostics, and retained-output messages while preserving credential redaction and exit behavior. Update the existing CLI regressions to require the unprefixed output.

Validation: 81 focused CLI tests passed; TypeScript and formatting checks passed.