### PR TITLE
[codex-security] Support nested Git repositories in scan snapshots

### DIFF
--- a/sdk/typescript/_bundled_plugin/scripts/workbench_target.py
+++ b/sdk/typescript/_bundled_plugin/scripts/workbench_target.py
@@ -146,7 +146,9 @@ def worktree_content_digest_for_context(
         elif stat.S_ISDIR(metadata.st_mode):
             update_digest_field(digest, b"untracked-kind", b"directory")
             update_digest_field(
-                digest, b"untracked-content", directory_content_digest(path).encode()
+                digest,
+                b"untracked-content",
+                directory_content_digest(path.resolve()).encode(),
             )
         elif stat.S_ISREG(metadata.st_mode):
             content_digest = hashlib.sha256()
@@ -424,7 +426,13 @@ def copy_git_worktree_files(source: Path, destination: Path, excluded: tuple[Pat
             destination_path.symlink_to(os.readlink(source_path))
         elif stat.S_ISREG(metadata.st_mode):
             shutil.copy2(source_path, destination_path, follow_symlinks=False)
-        elif not stat.S_ISDIR(metadata.st_mode):
+        elif stat.S_ISDIR(metadata.st_mode):
+            nested_git_dir = git_output(source_path, "rev-parse", "--absolute-git-dir")
+            if nested_git_dir is None:
+                raise SystemExit(f"Could not inspect nested Git working tree: {relative}")
+            copy_git_worktree_files(source_path, destination_path, excluded)
+            (destination_path / ".git").write_text(f"gitdir: {nested_git_dir}\n")
+        else:
             raise SystemExit(f"Unsupported Git working-tree file type: {relative}")
     copied_target = destination if pathspec == "." else destination / pathspec
     copied_target.mkdir(parents=True, exist_ok=True)

--- a/sdk/typescript/_bundled_plugin/scripts/workbench_target.py
+++ b/sdk/typescript/_bundled_plugin/scripts/workbench_target.py
@@ -120,12 +120,29 @@ def worktree_content_digest_for_context(
     )
     if tracked is None or untracked is None:
         raise SystemExit("Could not snapshot the selected working-tree changes.")
+    root = work_tree or repository
+    untracked_paths = [path for path in untracked.split(b"\0") if path]
+    for raw_path in tuple(untracked_paths):
+        relative_path = os.fsdecode(raw_path)
+        path = root / relative_path
+        try:
+            metadata = path.lstat()
+        except OSError as exc:
+            raise SystemExit(f"Could not read untracked file: {relative_path}") from exc
+        if stat.S_ISDIR(metadata.st_mode):
+            nested_paths = git_directory_snapshot_paths(path)
+            if nested_paths is None:
+                raise SystemExit(f"Could not inspect untracked directory: {relative_path}")
+            untracked_paths.extend(
+                os.fsencode(nested_path.relative_to(root).as_posix())
+                for nested_path in nested_paths
+            )
     digest = hashlib.sha256()
     update_digest_field(digest, b"format", b"codex-security-snapshot/v1")
     update_digest_field(digest, b"tracked-diff", tracked)
-    for raw_path in sorted(path for path in untracked.split(b"\0") if path):
+    for raw_path in sorted(set(untracked_paths)):
         relative_path = os.fsdecode(raw_path)
-        path = (work_tree or repository) / relative_path
+        path = root / relative_path
         try:
             metadata = path.lstat()
         except OSError as exc:
@@ -143,6 +160,8 @@ def worktree_content_digest_for_context(
                 b"untracked-content",
                 os.fsencode(os.readlink(path)),
             )
+        elif stat.S_ISDIR(metadata.st_mode):
+            update_digest_field(digest, b"untracked-kind", b"directory")
         elif stat.S_ISREG(metadata.st_mode):
             content_digest = hashlib.sha256()
             content_size = 0

--- a/sdk/typescript/_bundled_plugin/scripts/workbench_target.py
+++ b/sdk/typescript/_bundled_plugin/scripts/workbench_target.py
@@ -120,29 +120,12 @@ def worktree_content_digest_for_context(
     )
     if tracked is None or untracked is None:
         raise SystemExit("Could not snapshot the selected working-tree changes.")
-    root = work_tree or repository
-    untracked_paths = [path for path in untracked.split(b"\0") if path]
-    for raw_path in tuple(untracked_paths):
-        relative_path = os.fsdecode(raw_path)
-        path = root / relative_path
-        try:
-            metadata = path.lstat()
-        except OSError as exc:
-            raise SystemExit(f"Could not read untracked file: {relative_path}") from exc
-        if stat.S_ISDIR(metadata.st_mode):
-            nested_paths = git_directory_snapshot_paths(path)
-            if nested_paths is None:
-                raise SystemExit(f"Could not inspect untracked directory: {relative_path}")
-            untracked_paths.extend(
-                os.fsencode(nested_path.relative_to(root).as_posix())
-                for nested_path in nested_paths
-            )
     digest = hashlib.sha256()
     update_digest_field(digest, b"format", b"codex-security-snapshot/v1")
     update_digest_field(digest, b"tracked-diff", tracked)
-    for raw_path in sorted(set(untracked_paths)):
+    for raw_path in sorted(path for path in untracked.split(b"\0") if path):
         relative_path = os.fsdecode(raw_path)
-        path = root / relative_path
+        path = (work_tree or repository) / relative_path
         try:
             metadata = path.lstat()
         except OSError as exc:
@@ -162,6 +145,9 @@ def worktree_content_digest_for_context(
             )
         elif stat.S_ISDIR(metadata.st_mode):
             update_digest_field(digest, b"untracked-kind", b"directory")
+            update_digest_field(
+                digest, b"untracked-content", directory_content_digest(path).encode()
+            )
         elif stat.S_ISREG(metadata.st_mode):
             content_digest = hashlib.sha256()
             content_size = 0

--- a/sdk/typescript/tests-ts/scan-recovery.test.ts
+++ b/sdk/typescript/tests-ts/scan-recovery.test.ts
@@ -285,6 +285,31 @@ describe("malformed scan artifact recovery", () => {
           /^codex-security-snapshot\/v1:sha256:[a-f0-9]{64}$/,
         );
       }
+      if (kind === "nested") {
+        const copied = spawnSync(
+          fixture.python,
+          [
+            "-I",
+            "-B",
+            "-c",
+            [
+              "import sys",
+              "from pathlib import Path",
+              "sys.path.insert(0, sys.argv[1])",
+              "import workbench_target as target",
+              "source = Path(sys.argv[2])",
+              "checkout = target.copy_git_worktree_files(source, Path(sys.argv[3]), ())",
+              "git_dir = Path(target.git_output(source, 'rev-parse', '--absolute-git-dir'))",
+              "assert target.worktree_content_digest_for_context(checkout, '.', git_dir=git_dir, work_tree=checkout) == target.worktree_content_digest(source)",
+            ].join("\n"),
+            join(PLUGIN_ROOT, "scripts"),
+            fixture.repository,
+            join(fixture.stateDir, "checkout"),
+          ],
+          { encoding: "utf8" },
+        );
+        expect(copied.status, copied.stderr).toBe(0);
+      }
     }
   });
 

--- a/sdk/typescript/tests-ts/scan-recovery.test.ts
+++ b/sdk/typescript/tests-ts/scan-recovery.test.ts
@@ -279,6 +279,43 @@ describe("malformed scan artifact recovery", () => {
     }
   });
 
+  test("registers Git repositories containing untracked nested repositories", async () => {
+    const fixture = await startDraftScan("clean");
+    const nested = join(fixture.repository, "nested");
+    await mkdir(nested);
+    await writeFile(join(nested, "source.py"), "# nested fixture\n");
+    const initialized = spawnSync("git", ["init", "--quiet", nested], {
+      encoding: "utf8",
+    });
+    expect(initialized.status, initialized.stderr).toBe(0);
+
+    const scanDir = join(fixture.stateDir, "..", "nested-scan");
+    await mkdir(scanDir, { mode: 0o700 });
+    const registered = await workbench(fixture, [
+      "register-cli-scan",
+      "--repository",
+      fixture.repository,
+      "--scan-dir",
+      scanDir,
+      "--recipe-json",
+      JSON.stringify({
+        config: {},
+        mode: "standard",
+        repository: fixture.repository,
+        target: { kind: "repository", paths: [] },
+      }),
+    ]);
+
+    expect(registered["contract"]).toMatchObject({
+      target: {
+        allowedKinds: ["git_worktree"],
+        requiredSnapshotDigest: expect.stringMatching(
+          /^codex-security-snapshot\/v1:sha256:[a-f0-9]{64}$/,
+        ),
+      },
+    });
+  });
+
   test("seals a prepared scan without publishing it before acceptance", async () => {
     const fixture = await startDraftScan();
 

--- a/sdk/typescript/tests-ts/scan-recovery.test.ts
+++ b/sdk/typescript/tests-ts/scan-recovery.test.ts
@@ -115,7 +115,7 @@ async function workbench(fixture: ScanFixture, args: readonly string[]) {
 }
 
 async function startDraftScan(
-  repositoryKind: "directory" | "clean" | "dirty" = "directory",
+  repositoryKind: "directory" | "clean" | "dirty" | "nested" = "directory",
 ): Promise<ScanFixture> {
   const root = await realpath(
     await mkdtemp(join(tmpdir(), "codex-security-scan-recovery-")),
@@ -152,6 +152,15 @@ async function startDraftScan(
     }
     if (repositoryKind === "dirty") {
       await writeFile(join(target, "src", "extract.py"), "# changed fixture\n");
+    }
+    if (repositoryKind === "nested") {
+      const nested = join(target, "nested");
+      await mkdir(nested);
+      await writeFile(join(nested, "source.py"), "# nested fixture\n");
+      const initialized = spawnSync("git", ["init", "--quiet", nested], {
+        encoding: "utf8",
+      });
+      expect(initialized.status, initialized.stderr).toBe(0);
     }
   }
 
@@ -246,8 +255,8 @@ describe("malformed scan artifact recovery", () => {
     });
   });
 
-  test("returns authoritative clean and dirty Git target contracts", async () => {
-    for (const kind of ["clean", "dirty"] as const) {
+  test("returns authoritative clean, dirty, and nested Git target contracts", async () => {
+    for (const kind of ["clean", "dirty", "nested"] as const) {
       const fixture = await startDraftScan(kind);
       const registration = fixture.registration;
       const contract = registration["contract"] as {
@@ -277,43 +286,6 @@ describe("malformed scan artifact recovery", () => {
         );
       }
     }
-  });
-
-  test("registers Git repositories containing untracked nested repositories", async () => {
-    const fixture = await startDraftScan("clean");
-    const nested = join(fixture.repository, "nested");
-    await mkdir(nested);
-    await writeFile(join(nested, "source.py"), "# nested fixture\n");
-    const initialized = spawnSync("git", ["init", "--quiet", nested], {
-      encoding: "utf8",
-    });
-    expect(initialized.status, initialized.stderr).toBe(0);
-
-    const scanDir = join(fixture.stateDir, "..", "nested-scan");
-    await mkdir(scanDir, { mode: 0o700 });
-    const registered = await workbench(fixture, [
-      "register-cli-scan",
-      "--repository",
-      fixture.repository,
-      "--scan-dir",
-      scanDir,
-      "--recipe-json",
-      JSON.stringify({
-        config: {},
-        mode: "standard",
-        repository: fixture.repository,
-        target: { kind: "repository", paths: [] },
-      }),
-    ]);
-
-    expect(registered["contract"]).toMatchObject({
-      target: {
-        allowedKinds: ["git_worktree"],
-        requiredSnapshotDigest: expect.stringMatching(
-          /^codex-security-snapshot\/v1:sha256:[a-f0-9]{64}$/,
-        ),
-      },
-    });
   });
 
   test("seals a prepared scan without publishing it before acceptance", async () => {


### PR DESCRIPTION
## Summary

Fix scans of repositories containing an untracked nested Git checkout. Git reports the nested checkout as a directory, which previously made scan registration fail with `Unsupported untracked file type`.

Expand nested repositories using their Git-visible files, include directory entries in the snapshot digest, and retain each nested repository's ignore rules. Add an SDK integration test that registers a repository containing an untracked nested checkout.

## Validation

- All 16 scan-recovery integration tests passed.
- `pnpm run types` passed under Node 22.
- The changed TypeScript test passes Prettier validation.
