### PR TITLE
fix: bound knowledge-base discovery and document extraction

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -223,6 +223,10 @@ to
 
 Repeat `--knowledge-base PATH` for multiple files or directories. Directories are
 searched recursively for Markdown, text, PDF, and Word (`.docx`) files.
+Knowledge bases are limited to 128 documents and 4,096 discovered entries across
+16 directory levels. Each input and extracted document is limited to 8 MiB,
+aggregate input and extracted text are each limited to 32 MiB, and PDFs are
+limited to 512 pages.
 
 On macOS/Linux, an existing output directory must be private to the current
 user (`chmod 700`).

--- a/sdk/typescript/src/knowledge-base.ts
+++ b/sdk/typescript/src/knowledge-base.ts
@@ -21,6 +21,7 @@ import {
 import { inflateSync } from "node:zlib";
 import { unzipSync } from "fflate";
 
+const MAX_CODE_POINT = 0x10ffff;
 const SUPPORTED_EXTENSIONS = new Set([
   ".md",
   ".markdown",
@@ -566,9 +567,28 @@ function decodeXml(value: string): string {
     (entity, name: string) => {
       if (!name.startsWith("#")) return entities[name.toLowerCase()] ?? entity;
       const hexadecimal = name[1]?.toLowerCase() === "x";
-      return String.fromCodePoint(
-        Number.parseInt(name.slice(hexadecimal ? 2 : 1), hexadecimal ? 16 : 10),
+      const codePoint = Number.parseInt(
+        name.slice(hexadecimal ? 2 : 1),
+        hexadecimal ? 16 : 10,
       );
+      // A reference that cannot name a Unicode scalar value is left as literal
+      // text, matching the unrecognized-named-entity fallback above. Without the
+      // bound String.fromCodePoint throws RangeError, which surfaced as an
+      // unextractable document and failed the whole knowledge base. Surrogates
+      // are excluded too: XML forbids them and writing one would silently encode
+      // as U+FFFD.
+      return isUnicodeScalarValue(codePoint)
+        ? String.fromCodePoint(codePoint)
+        : entity;
     },
+  );
+}
+
+function isUnicodeScalarValue(codePoint: number): boolean {
+  return (
+    Number.isInteger(codePoint) &&
+    codePoint >= 0 &&
+    codePoint <= MAX_CODE_POINT &&
+    !(codePoint >= 0xd800 && codePoint <= 0xdfff)
   );
 }

--- a/sdk/typescript/src/knowledge-base.ts
+++ b/sdk/typescript/src/knowledge-base.ts
@@ -40,6 +40,7 @@ const MAX_PDF_PAGES = 512;
 const MAX_PDF_XREF_OBJECTS = 65_536;
 const MAX_PDF_DICTIONARY_SCAN_BYTES = 256 * 1024;
 const MAX_PDF_DICTIONARY_WORK_BYTES = 2 * MAX_DOCUMENT_BYTES;
+const MAX_PDF_DECODE_WORK_BYTES = 4 * MAX_EXTRACTED_DOCUMENT_BYTES;
 const MAX_PDF_LZW_CODES = 1_000_000;
 const READ_CHUNK_BYTES = 64 * 1024;
 
@@ -50,6 +51,16 @@ interface DiscoveryState {
 }
 
 class KnowledgeBaseLimitError extends Error {}
+
+type PdfCrossReferenceEntry =
+  | number
+  | { readonly stream: number; readonly index: number }
+  | null;
+
+const pdfObjectStreamCache = new WeakMap<
+  ReadonlyMap<string, PdfCrossReferenceEntry>,
+  { streams: Map<number, Buffer | null>; remaining: number }
+>();
 
 export interface PreparedKnowledgeBase {
   path: string;
@@ -376,8 +387,9 @@ function boundCompressedPdfStreams(
   const contents = source.toString("latin1");
   const streams =
     />>(?:(?:\s+|%[^\r\n]*(?:\r\n|\r|\n))*)stream(?:\r\n|\r|\n)/gu;
-  const indirectObjects = pdfCrossReferenceOffsets(contents);
+  const indirectObjects = pdfCrossReferenceOffsets(contents, path, signal);
   let inflatedBytes = 0;
+  let decodingWorkBytes = 0;
   const dictionaryWork = { remaining: MAX_PDF_DICTIONARY_WORK_BYTES };
   for (const marker of contents.matchAll(streams)) {
     signal?.throwIfAborted();
@@ -389,7 +401,12 @@ function boundCompressedPdfStreams(
       indirectObjects,
     );
     if (dictionary === null) continue;
-    const filters = pdfStreamFilters(contents, dictionary, indirectObjects);
+    const filters = pdfStreamFilters(
+      contents,
+      dictionary,
+      indirectObjects,
+      path,
+    );
     if (filters.length === 0) continue;
 
     const streamStart = marker.index + marker[0].length;
@@ -403,6 +420,7 @@ function boundCompressedPdfStreams(
         declared[1]!,
         declared[2],
         indirectObjects,
+        path,
       );
       if (referenced === undefined) {
         throw new Error(
@@ -421,35 +439,42 @@ function boundCompressedPdfStreams(
     let decoded = source.subarray(streamStart, streamEnd);
     for (const [filterIndex, filter] of filters.entries()) {
       signal?.throwIfAborted();
-      if (inflatedBytes >= MAX_EXTRACTED_DOCUMENT_BYTES) {
+      if (
+        inflatedBytes >= MAX_EXTRACTED_DOCUMENT_BYTES ||
+        decodingWorkBytes >= MAX_PDF_DECODE_WORK_BYTES
+      ) {
         throw oversizedPdfStream(path);
       }
+      const maximumOutput = Math.min(
+        MAX_EXTRACTED_DOCUMENT_BYTES,
+        MAX_PDF_DECODE_WORK_BYTES - decodingWorkBytes,
+      );
       try {
         switch (filter) {
           case "ASCIIHexDecode":
           case "AHx":
-            decoded = decodePdfAsciiHex(decoded, MAX_EXTRACTED_DOCUMENT_BYTES);
+            decoded = decodePdfAsciiHex(decoded, maximumOutput);
             break;
           case "ASCII85Decode":
           case "A85":
-            decoded = decodePdfAscii85(decoded, MAX_EXTRACTED_DOCUMENT_BYTES);
+            decoded = decodePdfAscii85(decoded, maximumOutput);
             break;
           case "RunLengthDecode":
           case "RL":
-            decoded = decodePdfRunLength(decoded, MAX_EXTRACTED_DOCUMENT_BYTES);
+            decoded = decodePdfRunLength(decoded, maximumOutput);
             break;
           case "LZWDecode":
           case "LZW":
             decoded = decodePdfLzw(
               decoded,
-              MAX_EXTRACTED_DOCUMENT_BYTES,
+              maximumOutput,
               pdfLzwEarlyChange(dictionary, filterIndex),
             );
             break;
           case "FlateDecode":
           case "Fl":
             decoded = inflateSync(decoded, {
-              maxOutputLength: MAX_EXTRACTED_DOCUMENT_BYTES,
+              maxOutputLength: maximumOutput,
             });
             break;
           case "DCTDecode":
@@ -478,6 +503,10 @@ function boundCompressedPdfStreams(
           { cause: error },
         );
       }
+      decodingWorkBytes += decoded.byteLength;
+      if (decodingWorkBytes > MAX_PDF_DECODE_WORK_BYTES) {
+        throw oversizedPdfStream(path);
+      }
     }
     inflatedBytes += decoded.byteLength;
     if (inflatedBytes > MAX_EXTRACTED_DOCUMENT_BYTES) {
@@ -491,12 +520,12 @@ function pdfStreamDictionary(
   end: number,
   work: { remaining: number },
   path: string,
-  offsets: ReadonlyMap<string, number | null> | null,
+  offsets: ReadonlyMap<string, PdfCrossReferenceEntry> | null,
 ): string | null {
   let depth = 1;
   let minimum = Math.max(0, end - MAX_PDF_DICTIONARY_SCAN_BYTES);
   for (const offset of offsets?.values() ?? []) {
-    if (offset !== null && offset < end && offset > minimum) {
+    if (typeof offset === "number" && offset < end && offset > minimum) {
       minimum = offset;
     }
   }
@@ -539,19 +568,95 @@ function pdfIndirectValue(
   contents: string,
   object: string,
   generation: string,
-  offsets: ReadonlyMap<string, number | null> | null,
+  offsets: ReadonlyMap<string, PdfCrossReferenceEntry> | null,
+  path: string,
 ): string | undefined {
   const offset = offsets?.get(`${object}:${generation}`);
   if (offset === null || offset === undefined) return undefined;
-  return new RegExp(
-    `^${object}\\s+${generation}\\s+obj\\s*(\\[[^\\]]*\\]|\\/[^\\s<>[\\]()%/]+|\\d+)\\s*endobj`,
-    "u",
-  ).exec(contents.slice(offset))?.[1];
+  if (typeof offset === "number") {
+    return new RegExp(
+      `^${object}\\s+${generation}\\s+obj\\s*(\\[[^\\]]*\\]|\\/[^\\s<>[\\]()%/]+|\\d+)\\s*endobj`,
+      "u",
+    ).exec(contents.slice(offset))?.[1];
+  }
+  if (offsets === null || generation !== "0") return undefined;
+  const streamOffset = offsets.get(`${offset.stream}:0`);
+  if (typeof streamOffset !== "number") return undefined;
+  let cache = pdfObjectStreamCache.get(offsets);
+  if (cache === undefined) {
+    cache = { streams: new Map(), remaining: MAX_PDF_DECODE_WORK_BYTES };
+    pdfObjectStreamCache.set(offsets, cache);
+  }
+  let stream = cache.streams.get(offset.stream);
+  if (stream === null) return undefined;
+  if (stream === undefined) {
+    cache.streams.set(offset.stream, null);
+    const decoded = pdfCrossReferenceStream(
+      contents,
+      streamOffset,
+      offsets,
+      path,
+      cache,
+    );
+    if (decoded === null) return undefined;
+    const dictionary = pdfDictionaryLexicalValues(decoded.dictionary);
+    const count = Number(/\/N\s+(\d+)(?=[\s/>])/u.exec(dictionary)?.[1]);
+    const first = Number(/\/First\s+(\d+)(?=[\s/>])/u.exec(dictionary)?.[1]);
+    if (
+      !Number.isSafeInteger(count) ||
+      count > MAX_PDF_XREF_OBJECTS ||
+      !Number.isSafeInteger(first) ||
+      first > decoded.contents.byteLength
+    ) {
+      return undefined;
+    }
+    stream = decoded.contents;
+    cache.streams.set(offset.stream, stream);
+  }
+  const dictionary = pdfObjectStreamDictionary(contents, streamOffset);
+  if (dictionary === null) return undefined;
+  const lexical = pdfDictionaryLexicalValues(dictionary);
+  const count = Number(/\/N\s+(\d+)(?=[\s/>])/u.exec(lexical)?.[1]);
+  const first = Number(/\/First\s+(\d+)(?=[\s/>])/u.exec(lexical)?.[1]);
+  if (
+    !Number.isSafeInteger(count) ||
+    !Number.isSafeInteger(first) ||
+    offset.index >= count ||
+    first > stream.byteLength
+  ) {
+    return undefined;
+  }
+  const header = stream
+    .subarray(0, first)
+    .toString("latin1")
+    .trim()
+    .split(/\s+/u);
+  if (header.length !== 2 * count) return undefined;
+  const objectNumber = Number(header[offset.index * 2]);
+  const start = Number(header[offset.index * 2 + 1]);
+  const next =
+    offset.index + 1 < count
+      ? Number(header[(offset.index + 1) * 2 + 1])
+      : stream.byteLength - first;
+  if (
+    objectNumber !== Number(object) ||
+    !Number.isSafeInteger(start) ||
+    !Number.isSafeInteger(next) ||
+    start > next ||
+    first + next > stream.byteLength
+  ) {
+    return undefined;
+  }
+  return /^\s*(\[[^\]]*\]|\/[^\s<>[\]()%/]+|\d+)\s*$/u.exec(
+    stream.subarray(first + start, first + next).toString("latin1"),
+  )?.[1];
 }
 
 function pdfCrossReferenceOffsets(
   contents: string,
-): ReadonlyMap<string, number | null> | null {
+  path: string,
+  signal?: AbortSignal,
+): ReadonlyMap<string, PdfCrossReferenceEntry> | null {
   const marker = /startxref\s+(\d+)\s+%%EOF\s*$/u.exec(contents);
   let offset = Number(marker?.[1]);
   if (
@@ -561,15 +666,98 @@ function pdfCrossReferenceOffsets(
   ) {
     return null;
   }
-  const entries = new Map<string, number | null>();
+  const entries = new Map<string, PdfCrossReferenceEntry>();
   const visited = new Set<number>();
+  const pending = [offset];
+  const decodingWork = { remaining: MAX_PDF_DECODE_WORK_BYTES };
   const whitespace = /[\u0000\t\n\f\r ]*/uy;
   const section = /(\d+)[\t ]+(\d+)(?:\r\n|\r|\n)/uy;
   const entry = /(\d+)[\t ]+(\d+)[\t ]+([nf])(?:[\t ]*(?:\r\n|\r|\n)|$)/uy;
 
-  while (!visited.has(offset)) {
+  while (pending.length > 0) {
+    signal?.throwIfAborted();
+    offset = pending.shift()!;
+    if (visited.has(offset)) continue;
     visited.add(offset);
-    if (contents.slice(offset, offset + 4) !== "xref") return null;
+    if (contents.slice(offset, offset + 4) !== "xref") {
+      const stream = pdfCrossReferenceStream(
+        contents,
+        offset,
+        entries,
+        path,
+        decodingWork,
+      );
+      if (stream === null) return null;
+      const dictionary = pdfDictionaryLexicalValues(stream.dictionary);
+      if (!/\/Type\s*\/XRef(?=[\s/>])/u.test(dictionary)) return null;
+      const widths = /\/W\s*\[([^\]]+)\]/u
+        .exec(dictionary)?.[1]
+        ?.trim()
+        .split(/\s+/u)
+        .map(Number);
+      if (
+        widths?.length !== 3 ||
+        widths.some((width) => !Number.isSafeInteger(width) || width > 6)
+      ) {
+        return null;
+      }
+      const rowSize = widths.reduce((total, width) => total + width, 0);
+      if (rowSize === 0) return null;
+      const size = Number(/\/Size\s+(\d+)(?=[\s/>])/u.exec(dictionary)?.[1]);
+      const indices = /\/Index\s*\[([^\]]+)\]/u
+        .exec(dictionary)?.[1]
+        ?.trim()
+        .split(/\s+/u)
+        .map(Number) ?? [0, size];
+      if (
+        !Number.isSafeInteger(size) ||
+        indices.length % 2 !== 0 ||
+        indices.some((index) => !Number.isSafeInteger(index) || index < 0)
+      ) {
+        return null;
+      }
+      let cursor = 0;
+      for (let index = 0; index < indices.length; index += 2) {
+        const first = indices[index]!;
+        const count = indices[index + 1]!;
+        if (count > MAX_PDF_XREF_OBJECTS) return null;
+        for (let row = 0; row < count; row += 1) {
+          if (cursor + rowSize > stream.contents.byteLength) return null;
+          const fields = widths.map((width, field) => {
+            let value = field === 0 && width === 0 ? 1 : 0;
+            for (let byte = 0; byte < width; byte += 1) {
+              value = value * 256 + stream.contents[cursor++]!;
+            }
+            return value;
+          });
+          const key = `${first + row}:${fields[0] === 2 ? 0 : fields[2]}`;
+          if (entries.has(key)) continue;
+          if (entries.size >= MAX_PDF_XREF_OBJECTS) return null;
+          entries.set(
+            key,
+            fields[0] === 0
+              ? null
+              : fields[0] === 1
+                ? fields[1]!
+                : fields[0] === 2
+                  ? { stream: fields[1]!, index: fields[2]! }
+                  : null,
+          );
+        }
+      }
+      const previous = /\/Prev\s+(\d+)(?=[\s/>])/u.exec(dictionary)?.[1];
+      if (previous !== undefined) {
+        const previousOffset = Number(previous);
+        if (
+          !Number.isSafeInteger(previousOffset) ||
+          previousOffset >= contents.length
+        ) {
+          return null;
+        }
+        pending.push(previousOffset);
+      }
+      continue;
+    }
     let cursor = offset + 4;
     while (true) {
       whitespace.lastIndex = cursor;
@@ -580,14 +768,13 @@ function pdfCrossReferenceOffsets(
           contents.slice(cursor + "trailer".length, cursor + 64 * 1024),
         );
         const previous = /\/Prev\s+(\d+)(?=[\s/>])/u.exec(trailer)?.[1];
-        if (previous === undefined) return entries;
-        offset = Number(previous);
-        if (
-          !Number.isSafeInteger(offset) ||
-          offset < 0 ||
-          offset >= contents.length
-        ) {
-          return null;
+        const xrefStream = /\/XRefStm\s+(\d+)(?=[\s/>])/u.exec(trailer)?.[1];
+        for (const value of [xrefStream, previous]) {
+          if (value === undefined) continue;
+          const next = Number(value);
+          if (!Number.isSafeInteger(next) || next >= contents.length)
+            return null;
+          pending.push(next);
         }
         break;
       }
@@ -601,8 +788,7 @@ function pdfCrossReferenceOffsets(
         !Number.isSafeInteger(firstObject) ||
         !Number.isSafeInteger(count) ||
         count < 0 ||
-        count > MAX_PDF_XREF_OBJECTS ||
-        entries.size + count > MAX_PDF_XREF_OBJECTS
+        count > MAX_PDF_XREF_OBJECTS
       ) {
         return null;
       }
@@ -613,12 +799,163 @@ function pdfCrossReferenceOffsets(
         cursor = entry.lastIndex;
         const key = `${firstObject + index}:${Number(value[2])}`;
         if (!entries.has(key)) {
+          if (entries.size >= MAX_PDF_XREF_OBJECTS) return null;
           entries.set(key, value[3] === "n" ? Number(value[1]) : null);
         }
       }
     }
   }
-  return null;
+  return entries;
+}
+
+function pdfObjectStreamDictionary(
+  contents: string,
+  offset: number,
+): string | null {
+  const header = /^\d+\s+\d+\s+obj\s*/u.exec(contents.slice(offset));
+  if (header === null) return null;
+  const tail = contents.slice(offset + header[0].length);
+  const marker =
+    />>(?:(?:\s+|%[^\r\n]*(?:\r\n|\r|\n))*)stream(?:\r\n|\r|\n)/u.exec(tail);
+  return marker === null ? null : tail.slice(0, marker.index + 2);
+}
+
+function pdfCrossReferenceStream(
+  contents: string,
+  offset: number,
+  offsets: ReadonlyMap<string, PdfCrossReferenceEntry>,
+  path: string,
+  work: { remaining: number },
+): { dictionary: string; contents: Buffer } | null {
+  const header = /^\d+\s+\d+\s+obj\s*/u.exec(contents.slice(offset));
+  if (header === null) return null;
+  const tail = contents.slice(offset + header[0].length);
+  const marker =
+    />>(?:(?:\s+|%[^\r\n]*(?:\r\n|\r|\n))*)stream(?:\r\n|\r|\n)/u.exec(tail);
+  if (marker === null || marker.index > MAX_PDF_DICTIONARY_SCAN_BYTES) {
+    return null;
+  }
+  const dictionary = tail.slice(0, marker.index + 2);
+  const length = Number(
+    /\/Length\s+(\d+)(?=[\s/>])/u.exec(
+      pdfDictionaryLexicalValues(dictionary),
+    )?.[1],
+  );
+  const streamOffset =
+    offset + header[0].length + marker.index + marker[0].length;
+  if (
+    !Number.isSafeInteger(length) ||
+    streamOffset + length > contents.length
+  ) {
+    return null;
+  }
+  let decoded: Buffer<ArrayBufferLike> = Buffer.from(
+    contents.slice(streamOffset, streamOffset + length),
+    "latin1",
+  );
+  for (const filter of pdfStreamFilters(contents, dictionary, offsets, path)) {
+    try {
+      switch (filter) {
+        case "FlateDecode":
+        case "Fl":
+          decoded = inflateSync(decoded, {
+            maxOutputLength: Math.min(
+              MAX_EXTRACTED_DOCUMENT_BYTES,
+              work.remaining,
+            ),
+          });
+          break;
+        case "ASCIIHexDecode":
+        case "AHx":
+          decoded = decodePdfAsciiHex(decoded, work.remaining);
+          break;
+        case "ASCII85Decode":
+        case "A85":
+          decoded = decodePdfAscii85(decoded, work.remaining);
+          break;
+        default:
+          return null;
+      }
+    } catch {
+      return null;
+    }
+    work.remaining -= decoded.byteLength;
+    if (work.remaining < 0) return null;
+  }
+  const predictor = Number(
+    /\/Predictor\s+(\d+)(?=[\s/>])/u.exec(
+      pdfDictionaryLexicalValues(dictionary),
+    )?.[1] ?? "1",
+  );
+  if (predictor !== 1) {
+    const columns = Number(
+      /\/Columns\s+(\d+)(?=[\s/>])/u.exec(dictionary)?.[1],
+    );
+    const colors = Number(
+      /\/Colors\s+(\d+)(?=[\s/>])/u.exec(dictionary)?.[1] ?? "1",
+    );
+    const bits = Number(
+      /\/BitsPerComponent\s+(\d+)(?=[\s/>])/u.exec(dictionary)?.[1] ?? "8",
+    );
+    if (
+      predictor < 10 ||
+      predictor > 15 ||
+      !Number.isSafeInteger(columns) ||
+      !Number.isSafeInteger(colors) ||
+      !Number.isSafeInteger(bits) ||
+      columns <= 0 ||
+      colors <= 0 ||
+      bits <= 0
+    ) {
+      return null;
+    }
+    const rowBytes = Math.ceil((columns * colors * bits) / 8);
+    if (
+      !Number.isSafeInteger(rowBytes) ||
+      rowBytes <= 0 ||
+      decoded.byteLength % (rowBytes + 1) !== 0
+    ) {
+      return null;
+    }
+    const reconstructed = Buffer.alloc(
+      (decoded.byteLength / (rowBytes + 1)) * rowBytes,
+    );
+    const pixelBytes = Math.max(1, Math.ceil((colors * bits) / 8));
+    let input = 0;
+    let output = 0;
+    while (input < decoded.byteLength) {
+      const filter = decoded[input++]!;
+      if (filter > 4) return null;
+      for (let column = 0; column < rowBytes; column += 1) {
+        const left =
+          column < pixelBytes ? 0 : reconstructed[output - pixelBytes]!;
+        const above = output < rowBytes ? 0 : reconstructed[output - rowBytes]!;
+        const upperLeft =
+          output < rowBytes || column < pixelBytes
+            ? 0
+            : reconstructed[output - rowBytes - pixelBytes]!;
+        let prediction = 0;
+        if (filter === 1) prediction = left;
+        else if (filter === 2) prediction = above;
+        else if (filter === 3) prediction = Math.floor((left + above) / 2);
+        else if (filter === 4) {
+          const estimate = left + above - upperLeft;
+          const leftDistance = Math.abs(estimate - left);
+          const aboveDistance = Math.abs(estimate - above);
+          const diagonalDistance = Math.abs(estimate - upperLeft);
+          prediction =
+            leftDistance <= aboveDistance && leftDistance <= diagonalDistance
+              ? left
+              : aboveDistance <= diagonalDistance
+                ? above
+                : upperLeft;
+        }
+        reconstructed[output++] = (decoded[input++]! + prediction) & 255;
+      }
+    }
+    decoded = reconstructed;
+  }
+  return { dictionary, contents: decoded };
 }
 
 function pdfDictionaryLexicalValues(dictionary: string): string {
@@ -678,7 +1015,8 @@ function pdfDictionaryLexicalValues(dictionary: string): string {
 function pdfStreamFilters(
   contents: string,
   dictionary: string,
-  offsets: ReadonlyMap<string, number | null> | null,
+  offsets: ReadonlyMap<string, PdfCrossReferenceEntry> | null,
+  path: string,
 ): string[] {
   const match =
     /\/(?:Filter|F)\s+(\[[^\]]*\]|\/[^\s<>[\]()%/]+|\d+\s+\d+\s+R)(?=[\s/>])/u.exec(
@@ -693,6 +1031,7 @@ function pdfStreamFilters(
       reference[1]!,
       reference[2]!,
       offsets,
+      path,
     );
     if (resolved === undefined) {
       throw new Error("Compressed PDF filter cannot be resolved safely.");

--- a/sdk/typescript/src/knowledge-base.ts
+++ b/sdk/typescript/src/knowledge-base.ts
@@ -18,6 +18,7 @@ import {
   resolve,
   sep,
 } from "node:path";
+import { inflateSync } from "node:zlib";
 import { unzipSync } from "fflate";
 
 const SUPPORTED_EXTENSIONS = new Set([
@@ -361,6 +362,59 @@ function decodeText(path: string, bytes: Uint8Array): string {
   }
 }
 
+function boundCompressedPdfStreams(
+  path: string,
+  bytes: Uint8Array,
+  signal?: AbortSignal,
+): void {
+  const source = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const contents = source.toString("latin1");
+  const filters = /\/(?:FlateDecode|Fl)(?=[\s/>[\]])/gu;
+  for (const filter of contents.matchAll(filters)) {
+    signal?.throwIfAborted();
+    const marker = filter.index;
+    const headerEnd = Math.min(contents.length, marker + 64 * 1024);
+    const header = contents.slice(marker, headerEnd);
+    const stream = /\bstream(?:\r\n|\r|\n)/u.exec(header);
+    if (stream?.index === undefined) continue;
+
+    const streamStart = marker + stream.index + stream[0].length;
+    const dictionaryStart = contents.lastIndexOf("<<", marker);
+    const dictionary = contents.slice(
+      Math.max(0, dictionaryStart),
+      streamStart,
+    );
+    const declared = /\/Length\s+(\d+)(?!\s+\d+\s+R)/u.exec(dictionary);
+    const length = declared?.[1] === undefined ? NaN : Number(declared[1]);
+    let streamEnd = Number.isSafeInteger(length)
+      ? streamStart + length
+      : contents.indexOf("\nendstream", streamStart);
+    if (streamEnd === -1)
+      streamEnd = contents.indexOf("\rendstream", streamStart);
+    if (streamEnd < streamStart || streamEnd > source.byteLength) continue;
+
+    try {
+      inflateSync(source.subarray(streamStart, streamEnd), {
+        maxOutputLength: MAX_EXTRACTED_DOCUMENT_BYTES,
+      });
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ERR_BUFFER_TOO_LARGE"
+      ) {
+        throw new KnowledgeBaseLimitError(
+          `Knowledge base document exceeds the ${MAX_EXTRACTED_DOCUMENT_BYTES}-byte extracted-text limit: ${path}`,
+        );
+      }
+      throw new Error(
+        `Knowledge base PDF compressed stream cannot be safely bounded: ${path}`,
+        { cause: error },
+      );
+    }
+  }
+}
+
 async function extractPdf(
   path: string,
   bytes: Uint8Array,
@@ -368,6 +422,7 @@ async function extractPdf(
 ): Promise<string> {
   signal?.throwIfAborted();
   try {
+    boundCompressedPdfStreams(path, bytes, signal);
     const { getDocument, VerbosityLevel } = await import(
       "pdfjs-dist/legacy/build/pdf.mjs"
     );

--- a/sdk/typescript/src/knowledge-base.ts
+++ b/sdk/typescript/src/knowledge-base.ts
@@ -370,23 +370,24 @@ function boundCompressedPdfStreams(
 ): void {
   const source = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
   const contents = source.toString("latin1");
-  const filters = /\/(?:FlateDecode|Fl)(?=[\s/>[\]])/gu;
-  for (const filter of contents.matchAll(filters)) {
+  const streams = />>\s*stream(?:\r\n|\r|\n)/gu;
+  let inflatedBytes = 0;
+  for (const marker of contents.matchAll(streams)) {
     signal?.throwIfAborted();
-    const marker = filter.index;
-    const headerEnd = Math.min(contents.length, marker + 64 * 1024);
-    const header = contents.slice(marker, headerEnd);
-    const stream = /\bstream(?:\r\n|\r|\n)/u.exec(header);
-    if (stream?.index === undefined) continue;
+    const dictionary = pdfStreamDictionary(contents, marker.index + 2);
+    if (dictionary === null) continue;
+    const filters = pdfStreamFilters(contents, dictionary);
+    if (filters.length === 0) continue;
 
-    const streamStart = marker + stream.index + stream[0].length;
-    const dictionaryStart = contents.lastIndexOf("<<", marker);
-    const dictionary = contents.slice(
-      Math.max(0, dictionaryStart),
-      streamStart,
+    const streamStart = marker.index + marker[0].length;
+    const declared = /\/Length\s+(\d+)(?:\s+(\d+)\s+R)?(?=[\s/>])/u.exec(
+      dictionary,
     );
-    const declared = /\/Length\s+(\d+)(?!\s+\d+\s+R)/u.exec(dictionary);
-    const length = declared?.[1] === undefined ? NaN : Number(declared[1]);
+    let length = Number(declared?.[1]);
+    if (declared?.[2] !== undefined) {
+      const referenced = pdfIndirectValue(contents, declared[1]!, declared[2]);
+      length = Number(referenced);
+    }
     let streamEnd = Number.isSafeInteger(length)
       ? streamStart + length
       : contents.indexOf("\nendstream", streamStart);
@@ -394,26 +395,214 @@ function boundCompressedPdfStreams(
       streamEnd = contents.indexOf("\rendstream", streamStart);
     if (streamEnd < streamStart || streamEnd > source.byteLength) continue;
 
-    try {
-      inflateSync(source.subarray(streamStart, streamEnd), {
-        maxOutputLength: MAX_EXTRACTED_DOCUMENT_BYTES,
-      });
-    } catch (error) {
-      if (
-        error instanceof Error &&
-        "code" in error &&
-        error.code === "ERR_BUFFER_TOO_LARGE"
-      ) {
-        throw new KnowledgeBaseLimitError(
-          `Knowledge base document exceeds the ${MAX_EXTRACTED_DOCUMENT_BYTES}-byte extracted-text limit: ${path}`,
+    let decoded = source.subarray(streamStart, streamEnd);
+    for (const filter of filters) {
+      signal?.throwIfAborted();
+      const remaining = MAX_EXTRACTED_DOCUMENT_BYTES - inflatedBytes;
+      if (remaining <= 0) throw oversizedPdfStream(path);
+      try {
+        switch (filter) {
+          case "ASCIIHexDecode":
+          case "AHx":
+            decoded = decodePdfAsciiHex(decoded, remaining);
+            break;
+          case "ASCII85Decode":
+          case "A85":
+            decoded = decodePdfAscii85(decoded, remaining);
+            break;
+          case "RunLengthDecode":
+          case "RL":
+            decoded = decodePdfRunLength(decoded, remaining);
+            break;
+          case "FlateDecode":
+          case "Fl":
+            decoded = inflateSync(decoded, { maxOutputLength: remaining });
+            break;
+          case "DCTDecode":
+          case "DCT":
+          case "JPXDecode":
+          case "JBIG2Decode":
+          case "CCITTFaxDecode":
+          case "CCF":
+            // These image-only codecs are not evaluated while extracting text.
+            decoded = Buffer.alloc(0);
+            continue;
+          default:
+            throw new Error(`Unsupported compressed PDF filter: ${filter}`);
+        }
+        inflatedBytes += decoded.byteLength;
+        if (inflatedBytes > MAX_EXTRACTED_DOCUMENT_BYTES) {
+          throw oversizedPdfStream(path);
+        }
+      } catch (error) {
+        if (error instanceof KnowledgeBaseLimitError) throw error;
+        if (
+          error instanceof Error &&
+          "code" in error &&
+          error.code === "ERR_BUFFER_TOO_LARGE"
+        ) {
+          throw oversizedPdfStream(path);
+        }
+        throw new Error(
+          `Knowledge base PDF compressed stream cannot be safely bounded: ${path}`,
+          { cause: error },
         );
       }
-      throw new Error(
-        `Knowledge base PDF compressed stream cannot be safely bounded: ${path}`,
-        { cause: error },
-      );
     }
   }
+}
+
+function pdfStreamDictionary(contents: string, end: number): string | null {
+  let depth = 1;
+  for (let index = end - 3; index >= 0; index -= 1) {
+    const token = contents.slice(index, index + 2);
+    if (token === ">>") {
+      depth += 1;
+      index -= 1;
+    } else if (token === "<<") {
+      depth -= 1;
+      if (depth === 0) {
+        return contents
+          .slice(index, end)
+          .replace(
+            /\/([^\s<>()\[\]{}/%]+)/gu,
+            (_match, name: string) =>
+              `/${name.replace(/#([0-9a-f]{2})/giu, (_escape, value: string) =>
+                String.fromCharCode(Number.parseInt(value, 16)),
+              )}`,
+          );
+      }
+      index -= 1;
+    }
+  }
+  return null;
+}
+
+function pdfIndirectValue(
+  contents: string,
+  object: string,
+  generation: string,
+): string | undefined {
+  const value = new RegExp(
+    `(?:^|\\s)${object}\\s+${generation}\\s+obj\\s*(\\[[^\\]]*\\]|\\/[^\\s<>[\\]()%/]+|\\d+)\\s*endobj`,
+    "u",
+  ).exec(contents)?.[1];
+  return value;
+}
+
+function pdfStreamFilters(contents: string, dictionary: string): string[] {
+  const match =
+    /\/(?:Filter|F)\s+(\[[^\]]*\]|\/[^\s<>[\]()%/]+|\d+\s+\d+\s+R)(?=[\s/>])/u.exec(
+      dictionary,
+    );
+  if (match?.[1] === undefined) return [];
+  let value = match[1];
+  const reference = /^(\d+)\s+(\d+)\s+R$/u.exec(value);
+  if (reference !== null) {
+    const resolved = pdfIndirectValue(contents, reference[1]!, reference[2]!);
+    if (resolved === undefined) {
+      throw new Error("Compressed PDF filter cannot be resolved safely.");
+    }
+    value = resolved;
+  }
+  return [...value.matchAll(/\/([^\s<>[\]()%/]+)/gu)].map((filter) =>
+    filter[1]!.replace(/#([0-9a-f]{2})/giu, (_match, encoded: string) =>
+      String.fromCharCode(Number.parseInt(encoded, 16)),
+    ),
+  );
+}
+
+function oversizedPdfStream(path: string): KnowledgeBaseLimitError {
+  return new KnowledgeBaseLimitError(
+    `Knowledge base document exceeds the ${MAX_EXTRACTED_DOCUMENT_BYTES}-byte extracted-text limit: ${path}`,
+  );
+}
+
+function decodePdfAsciiHex(value: Buffer, maximum: number): Buffer {
+  const digits = value.toString("latin1").replace(/[\u0000\t\n\f\r ]/gu, "");
+  const end = digits.indexOf(">");
+  const hex = end === -1 ? digits : digits.slice(0, end);
+  if (!/^[0-9a-f]*$/iu.test(hex)) throw new Error("Invalid PDF ASCIIHex data.");
+  if (Math.ceil(hex.length / 2) > maximum) {
+    throw Object.assign(new Error("Decoded PDF stream is too large."), {
+      code: "ERR_BUFFER_TOO_LARGE",
+    });
+  }
+  return Buffer.from(hex.length % 2 === 0 ? hex : `${hex}0`, "hex");
+}
+
+function decodePdfAscii85(value: Buffer, maximum: number): Buffer {
+  const encoded = value.toString("latin1").replace(/[\u0000\t\n\f\r ]/gu, "");
+  const output = Buffer.allocUnsafe(Math.min(maximum, encoded.length * 4));
+  let used = 0;
+  let group: number[] = [];
+  const append = (word: number, count: number): void => {
+    if (used + count > maximum) {
+      throw Object.assign(new Error("Decoded PDF stream is too large."), {
+        code: "ERR_BUFFER_TOO_LARGE",
+      });
+    }
+    for (let index = 0; index < count; index += 1) {
+      output[used++] = Math.floor(word / 256 ** (3 - index)) & 0xff;
+    }
+  };
+  for (let index = 0; index < encoded.length; index += 1) {
+    const character = encoded[index]!;
+    if (character === "~" && encoded[index + 1] === ">") break;
+    if (character === "z" && group.length === 0) {
+      append(0, 4);
+      continue;
+    }
+    const digit = character.charCodeAt(0) - 33;
+    if (digit < 0 || digit > 84) throw new Error("Invalid PDF ASCII85 data.");
+    group.push(digit);
+    if (group.length === 5) {
+      const word = group.reduce((result, part) => result * 85 + part, 0);
+      if (word > 0xffffffff) throw new Error("Invalid PDF ASCII85 group.");
+      append(word, 4);
+      group = [];
+    }
+  }
+  if (group.length === 1) throw new Error("Invalid partial PDF ASCII85 group.");
+  if (group.length > 1) {
+    const count = group.length - 1;
+    while (group.length < 5) group.push(84);
+    append(
+      group.reduce((result, part) => result * 85 + part, 0),
+      count,
+    );
+  }
+  return output.subarray(0, used);
+}
+
+function decodePdfRunLength(value: Buffer, maximum: number): Buffer {
+  const output = Buffer.allocUnsafe(maximum);
+  let written = 0;
+  for (let index = 0; index < value.length; ) {
+    const control = value[index++]!;
+    if (control === 128) break;
+    if (control < 128) {
+      const count = control + 1;
+      if (index + count > value.length || written + count > maximum) {
+        throw Object.assign(new Error("Decoded PDF stream is too large."), {
+          code: "ERR_BUFFER_TOO_LARGE",
+        });
+      }
+      value.copy(output, written, index, index + count);
+      index += count;
+      written += count;
+    } else {
+      const count = 257 - control;
+      if (index >= value.length || written + count > maximum) {
+        throw Object.assign(new Error("Decoded PDF stream is too large."), {
+          code: "ERR_BUFFER_TOO_LARGE",
+        });
+      }
+      output.fill(value[index++]!, written, written + count);
+      written += count;
+    }
+  }
+  return output.subarray(0, written);
 }
 
 async function extractPdf(
@@ -517,9 +706,16 @@ function extractDocx(
 ): string {
   signal?.throwIfAborted();
   try {
+    let seenDocument = false;
     const files = unzipSync(bytes, {
       filter: (file) => {
         if (file.name !== "word/document.xml") return false;
+        if (seenDocument) {
+          throw new KnowledgeBaseLimitError(
+            `Knowledge base DOCX contains duplicate word/document.xml entries: ${path}`,
+          );
+        }
+        seenDocument = true;
         if (file.originalSize > MAX_EXTRACTED_DOCUMENT_BYTES) {
           throw new KnowledgeBaseLimitError(
             `Knowledge base document exceeds the ${MAX_EXTRACTED_DOCUMENT_BYTES}-byte extracted-text limit: ${path}`,

--- a/sdk/typescript/src/knowledge-base.ts
+++ b/sdk/typescript/src/knowledge-base.ts
@@ -411,12 +411,16 @@ function boundCompressedPdfStreams(
     signal?.throwIfAborted();
     if (marker.index < streamBodyEnd) continue;
     const object = pdfObjectBeforeOffset(objectOffsets, marker.index);
+    const lexicalStart =
+      object?.[1] ?? Math.max(0, marker.index - MAX_PDF_DICTIONARY_SCAN_BYTES);
+    dictionaryWork.remaining -= marker.index + 2 - lexicalStart;
+    if (dictionaryWork.remaining < 0) {
+      throw new KnowledgeBaseLimitError(
+        `Knowledge base PDF exceeds the ${MAX_PDF_DICTIONARY_WORK_BYTES}-byte dictionary scan limit: ${path}`,
+      );
+    }
     const lexicalPrefix = pdfDictionaryLexicalValues(
-      contents.slice(
-        object?.[1] ??
-          Math.max(0, marker.index - MAX_PDF_DICTIONARY_SCAN_BYTES),
-        marker.index + 2,
-      ),
+      contents.slice(lexicalStart, marker.index + 2),
       false,
     );
     if (!lexicalPrefix.endsWith(">>")) continue;
@@ -644,14 +648,42 @@ function pdfIndirectValue(
   const offset = offsets?.get(`${object}:${generation}`);
   if (offset === null || offset === undefined) return undefined;
   if (typeof offset === "number") {
-    const value = new RegExp(
-      `^${object}\\s+${generation}\\s+obj(?:\\s+|%[^\\r\\n]*(?:\\r\\n|\\r|\\n))*(<<[\\s\\S]*?>>|\\[[^\\]]*\\]|\\/[^\\s<>[\\]()%/]+|\\d+)`,
+    const header = new RegExp(
+      `^${object}\\s+${generation}\\s+obj(?:\\s+|%[^\\r\\n]*(?:\\r\\n|\\r|\\n))*`,
       "u",
     ).exec(contents.slice(offset));
-    if (value?.[1] === undefined) return undefined;
-    const remainder = contents.slice(offset + value[0].length);
+    if (header === null) return undefined;
+    const valueStart = offset + header[0].length;
+    let value: string | undefined;
+    if (contents.startsWith("<<", valueStart)) {
+      const lexical = pdfDictionaryLexicalValues(
+        contents.slice(valueStart, valueStart + MAX_PDF_DICTIONARY_SCAN_BYTES),
+        false,
+      );
+      let depth = 0;
+      for (let index = 0; index < lexical.length - 1; index += 1) {
+        const token = lexical.slice(index, index + 2);
+        if (token === "<<") {
+          depth += 1;
+          index += 1;
+        } else if (token === ">>") {
+          depth -= 1;
+          index += 1;
+          if (depth === 0) {
+            value = contents.slice(valueStart, valueStart + index + 1);
+            break;
+          }
+        }
+      }
+    } else {
+      value = /^(\[[^\]]*\]|\/[^\s<>[\]()%/]+|\d+)/u.exec(
+        contents.slice(valueStart),
+      )?.[1];
+    }
+    if (value === undefined) return undefined;
+    const remainder = contents.slice(valueStart + value.length);
     return /^(?:\s+|%[^\r\n]*(?:\r\n|\r|\n))*endobj(?=\s|$)/u.test(remainder)
-      ? value[1]
+      ? value
       : undefined;
   }
   if (offsets === null || generation !== "0") return undefined;
@@ -1419,24 +1451,35 @@ function pdfFilterDecodeParameters(
       lexical,
     )?.[1];
   if (parameters === undefined) return undefined;
-  const selected = parameters.startsWith("[")
+  let selected = parameters.startsWith("[")
     ? [...parameters.matchAll(/null|<<[\s\S]*?>>|\d+\s+\d+\s+R/gu)][
         filterIndex
       ]?.[0]
     : parameters;
-  if (selected === undefined || selected === "null") return undefined;
-  const reference = /^(\d+)\s+(\d+)\s+R$/u.exec(selected);
-  if (reference === null) return selected;
-  const resolved = pdfIndirectValue(
-    contents,
-    reference[1]!,
-    reference[2]!,
-    offsets,
-    path,
-  );
-  return resolved?.startsWith("<<") && resolved.endsWith(">>")
-    ? resolved
-    : undefined;
+  for (let references = 0; references < 8; references += 1) {
+    if (selected === undefined || selected === "null") return undefined;
+    const reference = /^(\d+)\s+(\d+)\s+R$/u.exec(selected);
+    if (reference === null) {
+      return selected.startsWith("<<") && selected.endsWith(">>")
+        ? selected
+        : undefined;
+    }
+    const resolved = pdfIndirectValue(
+      contents,
+      reference[1]!,
+      reference[2]!,
+      offsets,
+      path,
+    );
+    if (resolved?.startsWith("[") && resolved.endsWith("]")) {
+      selected = [...resolved.matchAll(/null|<<[\s\S]*?>>|\d+\s+\d+\s+R/gu)][
+        filterIndex
+      ]?.[0];
+    } else {
+      selected = resolved;
+    }
+  }
+  return undefined;
 }
 
 function oversizedPdfStream(path: string): KnowledgeBaseLimitError {

--- a/sdk/typescript/src/knowledge-base.ts
+++ b/sdk/typescript/src/knowledge-base.ts
@@ -411,6 +411,15 @@ function boundCompressedPdfStreams(
     signal?.throwIfAborted();
     if (marker.index < streamBodyEnd) continue;
     const object = pdfObjectBeforeOffset(objectOffsets, marker.index);
+    const lexicalPrefix = pdfDictionaryLexicalValues(
+      contents.slice(
+        object?.[1] ??
+          Math.max(0, marker.index - MAX_PDF_DICTIONARY_SCAN_BYTES),
+        marker.index + 2,
+      ),
+      false,
+    );
+    if (!lexicalPrefix.endsWith(">>")) continue;
     const dictionary = pdfStreamDictionary(
       contents,
       marker.index + 2,
@@ -492,7 +501,13 @@ function boundCompressedPdfStreams(
             decoded = decodePdfLzw(
               decoded,
               maximumOutput,
-              pdfLzwEarlyChange(dictionary, filterIndex),
+              pdfLzwEarlyChange(
+                dictionary,
+                filterIndex,
+                contents,
+                indirectObjects,
+                path,
+              ),
             );
             break;
           case "FlateDecode":
@@ -527,23 +542,30 @@ function boundCompressedPdfStreams(
           { cause: error },
         );
       }
-      const predictorWork = {
-        remaining: MAX_PDF_DECODE_WORK_BYTES - decodingWorkBytes,
-      };
-      const predicted = pdfApplyPredictor(
-        dictionary,
-        decoded,
-        predictorWork,
-        filterIndex,
-      );
-      if (predicted === null) {
-        throw new Error(
-          `Knowledge base PDF compressed stream cannot be safely bounded: ${path}`,
+      if (["FlateDecode", "Fl", "LZWDecode", "LZW"].includes(filter)) {
+        const predictorWork = {
+          remaining: MAX_PDF_DECODE_WORK_BYTES - decodingWorkBytes,
+        };
+        const predicted = pdfApplyPredictor(
+          dictionary,
+          decoded,
+          predictorWork,
+          filterIndex,
+          contents,
+          indirectObjects,
+          path,
         );
+        if (predicted === null) {
+          throw new Error(
+            `Knowledge base PDF compressed stream cannot be safely bounded: ${path}`,
+          );
+        }
+        decodingWorkBytes +=
+          MAX_PDF_DECODE_WORK_BYTES -
+          decodingWorkBytes -
+          predictorWork.remaining;
+        decoded = predicted;
       }
-      decodingWorkBytes +=
-        MAX_PDF_DECODE_WORK_BYTES - decodingWorkBytes - predictorWork.remaining;
-      decoded = predicted;
       decodingWorkBytes += decoded.byteLength;
       if (decodingWorkBytes > MAX_PDF_DECODE_WORK_BYTES) {
         throw oversizedPdfStream(path);
@@ -623,7 +645,7 @@ function pdfIndirectValue(
   if (offset === null || offset === undefined) return undefined;
   if (typeof offset === "number") {
     const value = new RegExp(
-      `^${object}\\s+${generation}\\s+obj(?:\\s+|%[^\\r\\n]*(?:\\r\\n|\\r|\\n))*(\\[[^\\]]*\\]|\\/[^\\s<>[\\]()%/]+|\\d+)`,
+      `^${object}\\s+${generation}\\s+obj(?:\\s+|%[^\\r\\n]*(?:\\r\\n|\\r|\\n))*(<<[\\s\\S]*?>>|\\[[^\\]]*\\]|\\/[^\\s<>[\\]()%/]+|\\d+)`,
       "u",
     ).exec(contents.slice(offset));
     if (value?.[1] === undefined) return undefined;
@@ -940,7 +962,7 @@ function pdfCrossReferenceStream(
           decoded = decodePdfLzw(
             decoded,
             work.remaining,
-            pdfLzwEarlyChange(dictionary, filterIndex),
+            pdfLzwEarlyChange(dictionary, filterIndex, contents, offsets, path),
           );
           break;
         default:
@@ -952,9 +974,19 @@ function pdfCrossReferenceStream(
     }
     work.remaining -= decoded.byteLength;
     if (work.remaining < 0) return null;
-    const predicted = pdfApplyPredictor(dictionary, decoded, work, filterIndex);
-    if (predicted === null) return null;
-    decoded = predicted;
+    if (["FlateDecode", "Fl", "LZWDecode", "LZW"].includes(filter)) {
+      const predicted = pdfApplyPredictor(
+        dictionary,
+        decoded,
+        work,
+        filterIndex,
+        contents,
+        offsets,
+        path,
+      );
+      if (predicted === null) return null;
+      decoded = predicted;
+    }
   }
   return { dictionary, contents: decoded };
 }
@@ -964,13 +996,24 @@ function pdfApplyPredictor(
   decoded: Buffer,
   work: { remaining: number },
   filterIndex: number,
+  contents: string,
+  offsets: ReadonlyMap<string, PdfCrossReferenceEntry> | null,
+  path: string,
 ): Buffer | null {
-  const parameters = pdfFilterDecodeParameters(dictionary, filterIndex);
+  const parameters = pdfFilterDecodeParameters(
+    dictionary,
+    filterIndex,
+    contents,
+    offsets,
+    path,
+  );
   const predictor = Number(
     /\/Predictor\s+(\d+)(?=[\s/>])/u.exec(parameters ?? "")?.[1] ?? "1",
   );
   if (predictor === 1) return decoded;
-  const columns = Number(/\/Columns\s+(\d+)(?=[\s/>])/u.exec(parameters!)?.[1]);
+  const columns = Number(
+    /\/Columns\s+(\d+)(?=[\s/>])/u.exec(parameters!)?.[1] ?? "1",
+  );
   const colors = Number(
     /\/Colors\s+(\d+)(?=[\s/>])/u.exec(parameters!)?.[1] ?? "1",
   );
@@ -1344,8 +1387,20 @@ function pdfStreamFilters(
   return filters;
 }
 
-function pdfLzwEarlyChange(dictionary: string, filterIndex: number): 0 | 1 {
-  const selected = pdfFilterDecodeParameters(dictionary, filterIndex);
+function pdfLzwEarlyChange(
+  dictionary: string,
+  filterIndex: number,
+  contents: string,
+  offsets: ReadonlyMap<string, PdfCrossReferenceEntry> | null,
+  path: string,
+): 0 | 1 {
+  const selected = pdfFilterDecodeParameters(
+    dictionary,
+    filterIndex,
+    contents,
+    offsets,
+    path,
+  );
   if (selected === undefined) return 1;
   const value = /\/EarlyChange\s+([01])(?=[\s/>])/u.exec(selected)?.[1];
   return value === "0" ? 0 : 1;
@@ -1354,16 +1409,34 @@ function pdfLzwEarlyChange(dictionary: string, filterIndex: number): 0 | 1 {
 function pdfFilterDecodeParameters(
   dictionary: string,
   filterIndex: number,
+  contents: string,
+  offsets: ReadonlyMap<string, PdfCrossReferenceEntry> | null,
+  path: string,
 ): string | undefined {
   const lexical = pdfDictionaryLexicalValues(dictionary);
-  const parameters = /\/(?:DecodeParms|DP)\s+(\[[\s\S]*?\]|<<[\s\S]*?>>)/u.exec(
-    lexical,
-  )?.[1];
+  const parameters =
+    /\/(?:DecodeParms|DP)\s+(\[[\s\S]*?\]|<<[\s\S]*?>>|\d+\s+\d+\s+R)/u.exec(
+      lexical,
+    )?.[1];
   if (parameters === undefined) return undefined;
   const selected = parameters.startsWith("[")
-    ? [...parameters.matchAll(/null|<<[\s\S]*?>>/gu)][filterIndex]?.[0]
+    ? [...parameters.matchAll(/null|<<[\s\S]*?>>|\d+\s+\d+\s+R/gu)][
+        filterIndex
+      ]?.[0]
     : parameters;
-  return selected === "null" ? undefined : selected;
+  if (selected === undefined || selected === "null") return undefined;
+  const reference = /^(\d+)\s+(\d+)\s+R$/u.exec(selected);
+  if (reference === null) return selected;
+  const resolved = pdfIndirectValue(
+    contents,
+    reference[1]!,
+    reference[2]!,
+    offsets,
+    path,
+  );
+  return resolved?.startsWith("<<") && resolved.endsWith(">>")
+    ? resolved
+    : undefined;
 }
 
 function oversizedPdfStream(path: string): KnowledgeBaseLimitError {

--- a/sdk/typescript/src/knowledge-base.ts
+++ b/sdk/typescript/src/knowledge-base.ts
@@ -9,7 +9,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, extname, join, resolve } from "node:path";
+import { basename, extname, join, resolve, sep } from "node:path";
 import { unzipSync } from "fflate";
 
 const SUPPORTED_EXTENSIONS = new Set([
@@ -30,7 +30,7 @@ const MAX_PDF_PAGES = 512;
 const READ_CHUNK_BYTES = 64 * 1024;
 
 interface DiscoveryState {
-  documents: Set<string>;
+  documents: Map<string, string>;
   entries: number;
   inputBytes: number;
 }
@@ -49,7 +49,7 @@ export async function prepareKnowledgeBase(
 ): Promise<PreparedKnowledgeBase> {
   const sources = new Set<string>();
   const discovery: DiscoveryState = {
-    documents: new Set(),
+    documents: new Map(),
     entries: 0,
     inputBytes: 0,
   };
@@ -74,12 +74,12 @@ export async function prepareKnowledgeBase(
     if (sources.has(source)) continue;
     let selected = false;
     if (metadata.isDirectory()) {
-      selected = await discover(source, 0, discovery, signal);
+      selected = await discover(source, source, 0, discovery, signal);
     } else {
       if (!SUPPORTED_EXTENSIONS.has(extname(source).toLowerCase())) {
         throw new Error(`Unsupported knowledge base document: ${source}`);
       }
-      await addDocument(source, await lstat(source), discovery, signal);
+      await addDocument(source, source, await lstat(source), discovery, signal);
       selected = true;
     }
     if (!selected) {
@@ -96,9 +96,14 @@ export async function prepareKnowledgeBase(
     let index = 0;
     let inputBytes = 0;
     let extractedBytes = 0;
-    for (const document of discovery.documents) {
+    for (const [document, sourceRoot] of discovery.documents) {
       signal?.throwIfAborted();
-      const bytes = await readDocument(document, inputBytes, signal);
+      const bytes = await readDocument(
+        document,
+        sourceRoot,
+        inputBytes,
+        signal,
+      );
       inputBytes += bytes.byteLength;
       const extension = extname(document).toLowerCase();
       const text =
@@ -149,6 +154,7 @@ export async function prepareKnowledgeBase(
 
 async function discover(
   directory: string,
+  sourceRoot: string,
   depth: number,
   state: DiscoveryState,
   signal?: AbortSignal,
@@ -160,9 +166,33 @@ async function discover(
     );
   }
   let selected = false;
+  const initial = await lstat(directory);
+  const canonicalDirectory = await requireContainedSource(
+    directory,
+    sourceRoot,
+  );
+  if (!initial.isDirectory() || initial.isSymbolicLink()) {
+    throw new Error(
+      `Knowledge base directory changed during discovery: ${directory}`,
+    );
+  }
   const entries = await opendir(directory);
   for await (const entry of entries) {
     signal?.throwIfAborted();
+    const currentDirectory = await requireContainedSource(
+      directory,
+      sourceRoot,
+    );
+    const current = await lstat(currentDirectory);
+    if (
+      currentDirectory !== canonicalDirectory ||
+      current.dev !== initial.dev ||
+      current.ino !== initial.ino
+    ) {
+      throw new Error(
+        `Knowledge base directory changed during discovery: ${directory}`,
+      );
+    }
     state.entries += 1;
     if (state.entries > MAX_DISCOVERY_ENTRIES) {
       throw new KnowledgeBaseLimitError(
@@ -172,7 +202,9 @@ async function discover(
     const path = join(directory, entry.name);
     if (entry.isSymbolicLink()) continue;
     if (entry.isDirectory()) {
-      if (await discover(path, depth + 1, state, signal)) selected = true;
+      if (await discover(path, sourceRoot, depth + 1, state, signal)) {
+        selected = true;
+      }
     } else if (
       entry.isFile() &&
       SUPPORTED_EXTENSIONS.has(extname(path).toLowerCase())
@@ -181,7 +213,7 @@ async function discover(
       signal?.throwIfAborted();
       if (metadata.isSymbolicLink() || !metadata.isFile()) continue;
       selected = true;
-      await addDocument(path, metadata, state, signal);
+      await addDocument(path, sourceRoot, metadata, state, signal);
     }
   }
   signal?.throwIfAborted();
@@ -190,6 +222,7 @@ async function discover(
 
 async function addDocument(
   path: string,
+  sourceRoot: string,
   metadata: { size: number },
   state: DiscoveryState,
   signal?: AbortSignal,
@@ -211,19 +244,40 @@ async function addDocument(
       `Knowledge base input exceeds the ${MAX_INPUT_BYTES}-byte aggregate limit.`,
     );
   }
-  state.documents.add(path);
+  await requireContainedSource(path, sourceRoot);
+  state.documents.set(path, sourceRoot);
   state.inputBytes += metadata.size;
+}
+
+async function requireContainedSource(
+  path: string,
+  sourceRoot: string,
+): Promise<string> {
+  const canonical = await realpath(path);
+  if (
+    canonical !== sourceRoot &&
+    !canonical.startsWith(`${sourceRoot}${sep}`)
+  ) {
+    throw new Error(
+      `Knowledge base path escaped the requested source: ${path}`,
+    );
+  }
+  return canonical;
 }
 
 async function readDocument(
   path: string,
+  sourceRoot: string,
   consumedBytes: number,
   signal?: AbortSignal,
 ): Promise<Buffer> {
   signal?.throwIfAborted();
+  const initialPath = await requireContainedSource(path, sourceRoot);
   const file = await open(
     path,
-    constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0),
+    constants.O_RDONLY |
+      (constants.O_NOFOLLOW ?? 0) |
+      (process.platform === "win32" ? 0 : constants.O_NONBLOCK ?? 0),
   );
   try {
     const metadata = await file.stat();
@@ -233,6 +287,15 @@ async function readDocument(
     }
     if (process.platform !== "win32" && (metadata.mode & 0o444) === 0) {
       throw new Error(`Knowledge base document is not readable: ${path}`);
+    }
+    const currentPath = await requireContainedSource(path, sourceRoot);
+    const current = await lstat(currentPath);
+    if (
+      currentPath !== initialPath ||
+      current.dev !== metadata.dev ||
+      current.ino !== metadata.ino
+    ) {
+      throw new Error(`Knowledge base document changed while opening: ${path}`);
     }
     if (metadata.size > MAX_DOCUMENT_BYTES) {
       throw new KnowledgeBaseLimitError(
@@ -326,20 +389,43 @@ async function extractPdf(
       let extractedBytes = 0;
       for (let number = 1; number <= document.numPages; number++) {
         signal?.throwIfAborted();
-        const content = await (await document.getPage(number)).getTextContent();
-        signal?.throwIfAborted();
-        const page = content.items
-          .map((item) => ("str" in item ? item.str : ""))
-          .join(" ");
-        const pageBytes =
-          Buffer.byteLength(page, "utf8") + (pages.length === 0 ? 0 : 1);
-        if (extractedBytes + pageBytes > MAX_EXTRACTED_DOCUMENT_BYTES) {
-          throw new KnowledgeBaseLimitError(
-            `Knowledge base document exceeds the ${MAX_EXTRACTED_DOCUMENT_BYTES}-byte extracted-text limit: ${path}`,
-          );
+        const reader = (await document.getPage(number))
+          .streamTextContent()
+          .getReader();
+        const pieces: string[] = [];
+        try {
+          while (true) {
+            signal?.throwIfAborted();
+            const chunk = await reader.read();
+            signal?.throwIfAborted();
+            if (chunk.done) break;
+            for (const item of chunk.value.items as Array<{ str?: string }>) {
+              const piece = item.str ?? "";
+              const separator = pieces.length === 0 ? 0 : 1;
+              const pageBreak = pages.length === 0 || pieces.length > 0 ? 0 : 1;
+              const pieceBytes =
+                Buffer.byteLength(piece, "utf8") + separator + pageBreak;
+              if (extractedBytes + pieceBytes > MAX_EXTRACTED_DOCUMENT_BYTES) {
+                throw new KnowledgeBaseLimitError(
+                  `Knowledge base document exceeds the ${MAX_EXTRACTED_DOCUMENT_BYTES}-byte extracted-text limit: ${path}`,
+                );
+              }
+              pieces.push(piece);
+              extractedBytes += pieceBytes;
+            }
+          }
+        } finally {
+          reader.releaseLock();
         }
-        pages.push(page);
-        extractedBytes += pageBytes;
+        if (pieces.length === 0 && pages.length > 0) {
+          extractedBytes += 1;
+          if (extractedBytes > MAX_EXTRACTED_DOCUMENT_BYTES) {
+            throw new KnowledgeBaseLimitError(
+              `Knowledge base document exceeds the ${MAX_EXTRACTED_DOCUMENT_BYTES}-byte extracted-text limit: ${path}`,
+            );
+          }
+        }
+        pages.push(pieces.join(" "));
       }
       return pages.join("\n");
     } finally {

--- a/sdk/typescript/src/knowledge-base.ts
+++ b/sdk/typescript/src/knowledge-base.ts
@@ -59,7 +59,13 @@ type PdfCrossReferenceEntry =
 
 const pdfObjectStreamCache = new WeakMap<
   ReadonlyMap<string, PdfCrossReferenceEntry>,
-  { streams: Map<number, Buffer | null>; remaining: number }
+  {
+    streams: Map<
+      number,
+      ReadonlyArray<{ number: number; value: string | undefined }> | null
+    >;
+    remaining: number;
+  }
 >();
 
 export interface PreparedKnowledgeBase {
@@ -529,7 +535,10 @@ function pdfStreamDictionary(
       minimum = offset;
     }
   }
-  const lexical = pdfDictionaryLexicalValues(contents.slice(minimum, end));
+  const lexical = pdfDictionaryLexicalValues(
+    contents.slice(minimum, end),
+    false,
+  );
   for (let index = lexical.length - 3; index >= 0; index -= 1) {
     if (--work.remaining < 0) {
       throw new KnowledgeBaseLimitError(
@@ -543,15 +552,7 @@ function pdfStreamDictionary(
     } else if (token === "<<") {
       depth -= 1;
       if (depth === 0) {
-        return contents
-          .slice(minimum + index, end)
-          .replace(
-            /\/([^\s<>()\[\]{}/%]+)/gu,
-            (_match, name: string) =>
-              `/${name.replace(/#([0-9a-f]{2})/giu, (_escape, value: string) =>
-                String.fromCharCode(Number.parseInt(value, 16)),
-              )}`,
-          );
+        return contents.slice(minimum + index, end);
       }
       index -= 1;
     }
@@ -574,10 +575,15 @@ function pdfIndirectValue(
   const offset = offsets?.get(`${object}:${generation}`);
   if (offset === null || offset === undefined) return undefined;
   if (typeof offset === "number") {
-    return new RegExp(
-      `^${object}\\s+${generation}\\s+obj\\s*(\\[[^\\]]*\\]|\\/[^\\s<>[\\]()%/]+|\\d+)\\s*endobj`,
+    const value = new RegExp(
+      `^${object}\\s+${generation}\\s+obj\\s*(\\[[^\\]]*\\]|\\/[^\\s<>[\\]()%/]+|\\d+)`,
       "u",
-    ).exec(contents.slice(offset))?.[1];
+    ).exec(contents.slice(offset));
+    if (value?.[1] === undefined) return undefined;
+    const remainder = contents.slice(offset + value[0].length);
+    return /^(?:\s+|%[^\r\n]*(?:\r\n|\r|\n))*endobj(?=\s|$)/u.test(remainder)
+      ? value[1]
+      : undefined;
   }
   if (offsets === null || generation !== "0") return undefined;
   const streamOffset = offsets.get(`${offset.stream}:0`);
@@ -587,9 +593,9 @@ function pdfIndirectValue(
     cache = { streams: new Map(), remaining: MAX_PDF_DECODE_WORK_BYTES };
     pdfObjectStreamCache.set(offsets, cache);
   }
-  let stream = cache.streams.get(offset.stream);
-  if (stream === null) return undefined;
-  if (stream === undefined) {
+  let objects = cache.streams.get(offset.stream);
+  if (objects === null) return undefined;
+  if (objects === undefined) {
     cache.streams.set(offset.stream, null);
     const decoded = pdfCrossReferenceStream(
       contents,
@@ -610,46 +616,45 @@ function pdfIndirectValue(
     ) {
       return undefined;
     }
-    stream = decoded.contents;
-    cache.streams.set(offset.stream, stream);
+    const stream = decoded.contents;
+    const header = stream
+      .subarray(0, first)
+      .toString("latin1")
+      .trim()
+      .split(/\s+/u);
+    if (header.length !== 2 * count) return undefined;
+    const parsed: Array<{ number: number; value: string | undefined }> = [];
+    for (let index = 0; index < count; index += 1) {
+      const number = Number(header[index * 2]);
+      const start = Number(header[index * 2 + 1]);
+      const next =
+        index + 1 < count
+          ? Number(header[(index + 1) * 2 + 1])
+          : stream.byteLength - first;
+      if (
+        !Number.isSafeInteger(number) ||
+        !Number.isSafeInteger(start) ||
+        !Number.isSafeInteger(next) ||
+        number < 0 ||
+        start < 0 ||
+        next < 0 ||
+        start > next ||
+        first + next > stream.byteLength
+      ) {
+        return undefined;
+      }
+      parsed.push({
+        number,
+        value: /^\s*(\[[^\]]*\]|\/[^\s<>[\]()%/]+|\d+)\s*$/u.exec(
+          stream.subarray(first + start, first + next).toString("latin1"),
+        )?.[1],
+      });
+    }
+    objects = parsed;
+    cache.streams.set(offset.stream, objects);
   }
-  const dictionary = pdfObjectStreamDictionary(contents, streamOffset);
-  if (dictionary === null) return undefined;
-  const lexical = pdfDictionaryLexicalValues(dictionary);
-  const count = Number(/\/N\s+(\d+)(?=[\s/>])/u.exec(lexical)?.[1]);
-  const first = Number(/\/First\s+(\d+)(?=[\s/>])/u.exec(lexical)?.[1]);
-  if (
-    !Number.isSafeInteger(count) ||
-    !Number.isSafeInteger(first) ||
-    offset.index >= count ||
-    first > stream.byteLength
-  ) {
-    return undefined;
-  }
-  const header = stream
-    .subarray(0, first)
-    .toString("latin1")
-    .trim()
-    .split(/\s+/u);
-  if (header.length !== 2 * count) return undefined;
-  const objectNumber = Number(header[offset.index * 2]);
-  const start = Number(header[offset.index * 2 + 1]);
-  const next =
-    offset.index + 1 < count
-      ? Number(header[(offset.index + 1) * 2 + 1])
-      : stream.byteLength - first;
-  if (
-    objectNumber !== Number(object) ||
-    !Number.isSafeInteger(start) ||
-    !Number.isSafeInteger(next) ||
-    start > next ||
-    first + next > stream.byteLength
-  ) {
-    return undefined;
-  }
-  return /^\s*(\[[^\]]*\]|\/[^\s<>[\]()%/]+|\d+)\s*$/u.exec(
-    stream.subarray(first + start, first + next).toString("latin1"),
-  )?.[1];
+  const selected = objects[offset.index];
+  return selected?.number === Number(object) ? selected.value : undefined;
 }
 
 function pdfCrossReferenceOffsets(
@@ -697,7 +702,9 @@ function pdfCrossReferenceOffsets(
         .map(Number);
       if (
         widths?.length !== 3 ||
-        widths.some((width) => !Number.isSafeInteger(width) || width > 6)
+        widths.some(
+          (width) => !Number.isSafeInteger(width) || width < 0 || width > 6,
+        )
       ) {
         return null;
       }
@@ -806,18 +813,6 @@ function pdfCrossReferenceOffsets(
     }
   }
   return entries;
-}
-
-function pdfObjectStreamDictionary(
-  contents: string,
-  offset: number,
-): string | null {
-  const header = /^\d+\s+\d+\s+obj\s*/u.exec(contents.slice(offset));
-  if (header === null) return null;
-  const tail = contents.slice(offset + header[0].length);
-  const marker =
-    />>(?:(?:\s+|%[^\r\n]*(?:\r\n|\r|\n))*)stream(?:\r\n|\r|\n)/u.exec(tail);
-  return marker === null ? null : tail.slice(0, marker.index + 2);
 }
 
 function pdfCrossReferenceStream(
@@ -958,7 +953,10 @@ function pdfCrossReferenceStream(
   return { dictionary, contents: decoded };
 }
 
-function pdfDictionaryLexicalValues(dictionary: string): string {
+function pdfDictionaryLexicalValues(
+  dictionary: string,
+  normalizeNames = true,
+): string {
   let output = "";
   let literalDepth = 0;
   let escaped = false;
@@ -1009,7 +1007,15 @@ function pdfDictionaryLexicalValues(dictionary: string): string {
       output += character;
     }
   }
-  return output;
+  return normalizeNames
+    ? output.replace(
+        /\/([^\s<>()\[\]{}/%]+)/gu,
+        (_match, name: string) =>
+          `/${name.replace(/#([0-9a-f]{2})/giu, (_escape, value: string) =>
+            String.fromCharCode(Number.parseInt(value, 16)),
+          )}`,
+      )
+    : output;
 }
 
 function pdfStreamFilters(

--- a/sdk/typescript/src/knowledge-base.ts
+++ b/sdk/typescript/src/knowledge-base.ts
@@ -37,6 +37,9 @@ const MAX_INPUT_BYTES = 32 * 1024 * 1024;
 const MAX_EXTRACTED_DOCUMENT_BYTES = 8 * 1024 * 1024;
 const MAX_EXTRACTED_BYTES = 32 * 1024 * 1024;
 const MAX_PDF_PAGES = 512;
+const MAX_PDF_DICTIONARY_SCAN_BYTES = 256 * 1024;
+const MAX_PDF_DICTIONARY_WORK_BYTES = 2 * MAX_DOCUMENT_BYTES;
+const MAX_PDF_LZW_CODES = 1_000_000;
 const READ_CHUNK_BYTES = 64 * 1024;
 
 interface DiscoveryState {
@@ -373,9 +376,15 @@ function boundCompressedPdfStreams(
   const streams =
     />>(?:(?:\s+|%[^\r\n]*(?:\r\n|\r|\n))*)stream(?:\r\n|\r|\n)/gu;
   let inflatedBytes = 0;
+  const dictionaryWork = { remaining: MAX_PDF_DICTIONARY_WORK_BYTES };
   for (const marker of contents.matchAll(streams)) {
     signal?.throwIfAborted();
-    const dictionary = pdfStreamDictionary(contents, marker.index + 2);
+    const dictionary = pdfStreamDictionary(
+      contents,
+      marker.index + 2,
+      dictionaryWork,
+      path,
+    );
     if (dictionary === null) continue;
     const filters = pdfStreamFilters(contents, dictionary);
     if (filters.length === 0) continue;
@@ -397,7 +406,7 @@ function boundCompressedPdfStreams(
     if (streamEnd < streamStart || streamEnd > source.byteLength) continue;
 
     let decoded = source.subarray(streamStart, streamEnd);
-    for (const filter of filters) {
+    for (const [filterIndex, filter] of filters.entries()) {
       signal?.throwIfAborted();
       const remaining = MAX_EXTRACTED_DOCUMENT_BYTES - inflatedBytes;
       if (remaining <= 0) throw oversizedPdfStream(path);
@@ -417,7 +426,11 @@ function boundCompressedPdfStreams(
             break;
           case "LZWDecode":
           case "LZW":
-            decoded = decodePdfLzw(decoded, remaining);
+            decoded = decodePdfLzw(
+              decoded,
+              remaining,
+              pdfLzwEarlyChange(dictionary, filterIndex),
+            );
             break;
           case "FlateDecode":
           case "Fl":
@@ -457,9 +470,20 @@ function boundCompressedPdfStreams(
   }
 }
 
-function pdfStreamDictionary(contents: string, end: number): string | null {
+function pdfStreamDictionary(
+  contents: string,
+  end: number,
+  work: { remaining: number },
+  path: string,
+): string | null {
   let depth = 1;
-  for (let index = end - 3; index >= 0; index -= 1) {
+  const minimum = Math.max(0, end - MAX_PDF_DICTIONARY_SCAN_BYTES);
+  for (let index = end - 3; index >= minimum; index -= 1) {
+    if (--work.remaining < 0) {
+      throw new KnowledgeBaseLimitError(
+        `Knowledge base PDF exceeds the ${MAX_PDF_DICTIONARY_WORK_BYTES}-byte dictionary scan limit: ${path}`,
+      );
+    }
     const token = contents.slice(index, index + 2);
     if (token === ">>") {
       depth += 1;
@@ -479,6 +503,11 @@ function pdfStreamDictionary(contents: string, end: number): string | null {
       }
       index -= 1;
     }
+  }
+  if (minimum !== 0) {
+    throw new KnowledgeBaseLimitError(
+      `Knowledge base PDF exceeds the ${MAX_PDF_DICTIONARY_SCAN_BYTES}-byte dictionary limit: ${path}`,
+    );
   }
   return null;
 }
@@ -536,6 +565,9 @@ function pdfDictionaryLexicalValues(dictionary: string): string {
     } else if (character === "(") {
       literalDepth = 1;
       output += " ";
+    } else if (character === "<" && dictionary[index + 1] === "<") {
+      output += "<<";
+      index += 1;
     } else if (character === "<" && dictionary[index + 1] !== "<") {
       hex = true;
       output += " ";
@@ -549,7 +581,7 @@ function pdfDictionaryLexicalValues(dictionary: string): string {
 function pdfStreamFilters(contents: string, dictionary: string): string[] {
   const match =
     /\/(?:Filter|F)\s+(\[[^\]]*\]|\/[^\s<>[\]()%/]+|\d+\s+\d+\s+R)(?=[\s/>])/u.exec(
-      dictionary,
+      pdfDictionaryLexicalValues(dictionary),
     );
   if (match?.[1] === undefined) return [];
   let value = match[1];
@@ -566,6 +598,20 @@ function pdfStreamFilters(contents: string, dictionary: string): string[] {
       String.fromCharCode(Number.parseInt(encoded, 16)),
     ),
   );
+}
+
+function pdfLzwEarlyChange(dictionary: string, filterIndex: number): 0 | 1 {
+  const lexical = pdfDictionaryLexicalValues(dictionary);
+  const parameters = /\/(?:DecodeParms|DP)\s+(\[[\s\S]*?\]|<<[\s\S]*?>>)/u.exec(
+    lexical,
+  )?.[1];
+  if (parameters === undefined) return 1;
+  const selected = parameters.startsWith("[")
+    ? [...parameters.matchAll(/null|<<[\s\S]*?>>/gu)][filterIndex]?.[0]
+    : parameters;
+  if (selected === undefined || selected === "null") return 1;
+  const value = /\/EarlyChange\s+([01])(?=[\s/>])/u.exec(selected)?.[1];
+  return value === "0" ? 0 : 1;
 }
 
 function oversizedPdfStream(path: string): KnowledgeBaseLimitError {
@@ -661,8 +707,12 @@ function decodePdfRunLength(value: Buffer, maximum: number): Buffer {
   return output.subarray(0, written);
 }
 
-function decodePdfLzw(value: Buffer, maximum: number): Buffer {
-  let dictionary = Array.from({ length: 256 }, (_unused, code) =>
+function decodePdfLzw(
+  value: Buffer,
+  maximum: number,
+  earlyChange: 0 | 1,
+): Buffer {
+  const dictionary = Array.from({ length: 256 }, (_unused, code) =>
     Buffer.from([code]),
   );
   let nextCode = 258;
@@ -671,7 +721,13 @@ function decodePdfLzw(value: Buffer, maximum: number): Buffer {
   let previous: Buffer | undefined;
   const chunks: Buffer[] = [];
   let outputBytes = 0;
+  let decodedCodes = 0;
   while (bitOffset + codeBits <= value.byteLength * 8) {
+    if (++decodedCodes > MAX_PDF_LZW_CODES) {
+      throw Object.assign(new Error("PDF LZW stream requires too much work."), {
+        code: "ERR_BUFFER_TOO_LARGE",
+      });
+    }
     let code = 0;
     for (let bit = 0; bit < codeBits; bit += 1) {
       const offset = bitOffset + bit;
@@ -681,9 +737,7 @@ function decodePdfLzw(value: Buffer, maximum: number): Buffer {
     }
     bitOffset += codeBits;
     if (code === 256) {
-      dictionary = Array.from({ length: 256 }, (_unused, item) =>
-        Buffer.from([item]),
-      );
+      dictionary.length = 256;
       nextCode = 258;
       codeBits = 9;
       previous = undefined;
@@ -705,7 +759,9 @@ function decodePdfLzw(value: Buffer, maximum: number): Buffer {
     outputBytes += entry.byteLength;
     if (previous !== undefined && nextCode < 4_096) {
       dictionary[nextCode++] = Buffer.concat([previous, entry.subarray(0, 1)]);
-      if (nextCode + 1 === 1 << codeBits && codeBits < 12) codeBits += 1;
+      if (nextCode + earlyChange === 1 << codeBits && codeBits < 12) {
+        codeBits += 1;
+      }
     }
     previous = entry;
   }

--- a/sdk/typescript/src/knowledge-base.ts
+++ b/sdk/typescript/src/knowledge-base.ts
@@ -2,8 +2,8 @@ import { constants } from "node:fs";
 import {
   lstat,
   mkdtemp,
-  readFile,
-  readdir,
+  open,
+  opendir,
   realpath,
   rm,
   writeFile,
@@ -19,6 +19,23 @@ const SUPPORTED_EXTENSIONS = new Set([
   ".pdf",
   ".docx",
 ]);
+const MAX_DOCUMENTS = 128;
+const MAX_DIRECTORY_DEPTH = 16;
+const MAX_DISCOVERY_ENTRIES = 4_096;
+const MAX_DOCUMENT_BYTES = 8 * 1024 * 1024;
+const MAX_INPUT_BYTES = 32 * 1024 * 1024;
+const MAX_EXTRACTED_DOCUMENT_BYTES = 8 * 1024 * 1024;
+const MAX_EXTRACTED_BYTES = 32 * 1024 * 1024;
+const MAX_PDF_PAGES = 512;
+const READ_CHUNK_BYTES = 64 * 1024;
+
+interface DiscoveryState {
+  documents: Set<string>;
+  entries: number;
+  inputBytes: number;
+}
+
+class KnowledgeBaseLimitError extends Error {}
 
 export interface PreparedKnowledgeBase {
   path: string;
@@ -31,7 +48,11 @@ export async function prepareKnowledgeBase(
   signal?: AbortSignal,
 ): Promise<PreparedKnowledgeBase> {
   const sources = new Set<string>();
-  const documents = new Set<string>();
+  const discovery: DiscoveryState = {
+    documents: new Set(),
+    entries: 0,
+    inputBytes: 0,
+  };
 
   for (const requested of paths) {
     signal?.throwIfAborted();
@@ -49,46 +70,61 @@ export async function prepareKnowledgeBase(
     }
 
     const source = await realpath(path);
-    const selected = metadata.isDirectory() ? await discover(source) : [source];
-    if (selected.length === 0) {
+    signal?.throwIfAborted();
+    if (sources.has(source)) continue;
+    let selected = false;
+    if (metadata.isDirectory()) {
+      selected = await discover(source, 0, discovery, signal);
+    } else {
+      if (!SUPPORTED_EXTENSIONS.has(extname(source).toLowerCase())) {
+        throw new Error(`Unsupported knowledge base document: ${source}`);
+      }
+      await addDocument(source, await lstat(source), discovery, signal);
+      selected = true;
+    }
+    if (!selected) {
       throw new Error(
         `Knowledge base directory contains no supported documents: ${path}`,
       );
     }
-    for (const document of selected) {
-      if (!SUPPORTED_EXTENSIONS.has(extname(document).toLowerCase())) {
-        throw new Error(`Unsupported knowledge base document: ${document}`);
-      }
-      documents.add(document);
-    }
     sources.add(source);
   }
 
+  signal?.throwIfAborted();
   const path = await mkdtemp(join(tmpdir(), "codex-security-knowledge-"));
   try {
     let index = 0;
-    for (const document of documents) {
+    let inputBytes = 0;
+    let extractedBytes = 0;
+    for (const document of discovery.documents) {
       signal?.throwIfAborted();
-      const metadata = await lstat(document);
-      if (process.platform !== "win32" && (metadata.mode & 0o444) === 0) {
-        throw new Error(`Knowledge base document is not readable: ${document}`);
-      }
-      const bytes = await readFile(document, {
-        flag: constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0),
-        signal,
-      });
+      const bytes = await readDocument(document, inputBytes, signal);
+      inputBytes += bytes.byteLength;
       const extension = extname(document).toLowerCase();
       const text =
         extension === ".pdf"
-          ? await extractPdf(document, bytes)
+          ? await extractPdf(document, bytes, signal)
           : extension === ".docx"
-            ? extractDocx(document, bytes)
+            ? extractDocx(document, bytes, signal)
             : decodeText(document, bytes);
+      signal?.throwIfAborted();
       if ((extension === ".pdf" || extension === ".docx") && !text.trim()) {
         throw new Error(
           `Knowledge base document contains no extractable text: ${document}`,
         );
       }
+      const textBytes = Buffer.byteLength(text, "utf8");
+      if (textBytes > MAX_EXTRACTED_DOCUMENT_BYTES) {
+        throw new KnowledgeBaseLimitError(
+          `Knowledge base document exceeds the ${MAX_EXTRACTED_DOCUMENT_BYTES}-byte extracted-text limit: ${document}`,
+        );
+      }
+      if (extractedBytes + textBytes > MAX_EXTRACTED_BYTES) {
+        throw new KnowledgeBaseLimitError(
+          `Knowledge base extracted text exceeds the ${MAX_EXTRACTED_BYTES}-byte aggregate limit.`,
+        );
+      }
+      extractedBytes += textBytes;
       await writeFile(
         join(path, `${index++}-${basename(document)}.txt`),
         text,
@@ -111,22 +147,135 @@ export async function prepareKnowledgeBase(
   };
 }
 
-async function discover(directory: string): Promise<string[]> {
-  const documents: string[] = [];
-  const entries = await readdir(directory, { withFileTypes: true });
-  for (const entry of entries) {
+async function discover(
+  directory: string,
+  depth: number,
+  state: DiscoveryState,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  signal?.throwIfAborted();
+  if (depth > MAX_DIRECTORY_DEPTH) {
+    throw new KnowledgeBaseLimitError(
+      `Knowledge base directory exceeds the ${MAX_DIRECTORY_DEPTH}-level nesting limit: ${directory}`,
+    );
+  }
+  let selected = false;
+  const entries = await opendir(directory);
+  for await (const entry of entries) {
+    signal?.throwIfAborted();
+    state.entries += 1;
+    if (state.entries > MAX_DISCOVERY_ENTRIES) {
+      throw new KnowledgeBaseLimitError(
+        `Knowledge base discovery exceeds the ${MAX_DISCOVERY_ENTRIES}-entry limit.`,
+      );
+    }
     const path = join(directory, entry.name);
     if (entry.isSymbolicLink()) continue;
     if (entry.isDirectory()) {
-      documents.push(...(await discover(path)));
+      if (await discover(path, depth + 1, state, signal)) selected = true;
     } else if (
       entry.isFile() &&
       SUPPORTED_EXTENSIONS.has(extname(path).toLowerCase())
     ) {
-      documents.push(path);
+      const metadata = await lstat(path);
+      signal?.throwIfAborted();
+      if (metadata.isSymbolicLink() || !metadata.isFile()) continue;
+      selected = true;
+      await addDocument(path, metadata, state, signal);
     }
   }
-  return documents;
+  signal?.throwIfAborted();
+  return selected;
+}
+
+async function addDocument(
+  path: string,
+  metadata: { size: number },
+  state: DiscoveryState,
+  signal?: AbortSignal,
+): Promise<void> {
+  signal?.throwIfAborted();
+  if (state.documents.has(path)) return;
+  if (state.documents.size >= MAX_DOCUMENTS) {
+    throw new KnowledgeBaseLimitError(
+      `Knowledge base contains more than ${MAX_DOCUMENTS} documents.`,
+    );
+  }
+  if (metadata.size > MAX_DOCUMENT_BYTES) {
+    throw new KnowledgeBaseLimitError(
+      `Knowledge base document exceeds the ${MAX_DOCUMENT_BYTES}-byte input limit: ${path}`,
+    );
+  }
+  if (state.inputBytes + metadata.size > MAX_INPUT_BYTES) {
+    throw new KnowledgeBaseLimitError(
+      `Knowledge base input exceeds the ${MAX_INPUT_BYTES}-byte aggregate limit.`,
+    );
+  }
+  state.documents.add(path);
+  state.inputBytes += metadata.size;
+}
+
+async function readDocument(
+  path: string,
+  consumedBytes: number,
+  signal?: AbortSignal,
+): Promise<Buffer> {
+  signal?.throwIfAborted();
+  const file = await open(
+    path,
+    constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0),
+  );
+  try {
+    const metadata = await file.stat();
+    signal?.throwIfAborted();
+    if (!metadata.isFile()) {
+      throw new Error(`Knowledge base document is not a file: ${path}`);
+    }
+    if (process.platform !== "win32" && (metadata.mode & 0o444) === 0) {
+      throw new Error(`Knowledge base document is not readable: ${path}`);
+    }
+    if (metadata.size > MAX_DOCUMENT_BYTES) {
+      throw new KnowledgeBaseLimitError(
+        `Knowledge base document exceeds the ${MAX_DOCUMENT_BYTES}-byte input limit: ${path}`,
+      );
+    }
+    if (consumedBytes + metadata.size > MAX_INPUT_BYTES) {
+      throw new KnowledgeBaseLimitError(
+        `Knowledge base input exceeds the ${MAX_INPUT_BYTES}-byte aggregate limit.`,
+      );
+    }
+
+    const maximum = Math.min(
+      MAX_DOCUMENT_BYTES,
+      MAX_INPUT_BYTES - consumedBytes,
+    );
+    const chunks: Buffer[] = [];
+    let length = 0;
+    while (length <= maximum) {
+      signal?.throwIfAborted();
+      const chunk = Buffer.allocUnsafe(
+        Math.min(READ_CHUNK_BYTES, maximum + 1 - length),
+      );
+      const { bytesRead } = await file.read(chunk, 0, chunk.byteLength, null);
+      signal?.throwIfAborted();
+      if (bytesRead === 0) break;
+      chunks.push(chunk.subarray(0, bytesRead));
+      length += bytesRead;
+    }
+    if (length > MAX_DOCUMENT_BYTES) {
+      throw new KnowledgeBaseLimitError(
+        `Knowledge base document exceeds the ${MAX_DOCUMENT_BYTES}-byte input limit: ${path}`,
+      );
+    }
+    if (consumedBytes + length > MAX_INPUT_BYTES) {
+      throw new KnowledgeBaseLimitError(
+        `Knowledge base input exceeds the ${MAX_INPUT_BYTES}-byte aggregate limit.`,
+      );
+    }
+    return Buffer.concat(chunks, length);
+  } finally {
+    await file.close();
+  }
 }
 
 function decodeText(path: string, bytes: Uint8Array): string {
@@ -139,49 +288,95 @@ function decodeText(path: string, bytes: Uint8Array): string {
   }
 }
 
-async function extractPdf(path: string, bytes: Uint8Array): Promise<string> {
+async function extractPdf(
+  path: string,
+  bytes: Uint8Array,
+  signal?: AbortSignal,
+): Promise<string> {
+  signal?.throwIfAborted();
   try {
     const { getDocument, VerbosityLevel } = await import(
       "pdfjs-dist/legacy/build/pdf.mjs"
     );
-    const document = await getDocument({
+    const loadingTask = getDocument({
       data: new Uint8Array(bytes),
       isEvalSupported: false,
       stopAtErrors: true,
       verbosity: VerbosityLevel.ERRORS,
-    }).promise;
+    });
+    let document: Awaited<typeof loadingTask.promise> | undefined;
+    let destroying: Promise<void> | null = null;
+    const destroy = (): Promise<void> =>
+      (destroying ??=
+        document === undefined ? loadingTask.destroy() : document.destroy());
+    const onAbort = (): void => {
+      void destroy().catch(() => {});
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    if (signal?.aborted === true) onAbort();
     try {
-      const pages: string[] = [];
-      for (let number = 1; number <= document.numPages; number++) {
-        const content = await (await document.getPage(number)).getTextContent();
-        pages.push(
-          content.items
-            .map((item) => ("str" in item ? item.str : ""))
-            .join(" "),
+      document = await loadingTask.promise;
+      signal?.throwIfAborted();
+      if (document.numPages > MAX_PDF_PAGES) {
+        throw new KnowledgeBaseLimitError(
+          `Knowledge base PDF exceeds the ${MAX_PDF_PAGES}-page limit: ${path}`,
         );
+      }
+      const pages: string[] = [];
+      let extractedBytes = 0;
+      for (let number = 1; number <= document.numPages; number++) {
+        signal?.throwIfAborted();
+        const content = await (await document.getPage(number)).getTextContent();
+        signal?.throwIfAborted();
+        const page = content.items
+          .map((item) => ("str" in item ? item.str : ""))
+          .join(" ");
+        const pageBytes =
+          Buffer.byteLength(page, "utf8") + (pages.length === 0 ? 0 : 1);
+        if (extractedBytes + pageBytes > MAX_EXTRACTED_DOCUMENT_BYTES) {
+          throw new KnowledgeBaseLimitError(
+            `Knowledge base document exceeds the ${MAX_EXTRACTED_DOCUMENT_BYTES}-byte extracted-text limit: ${path}`,
+          );
+        }
+        pages.push(page);
+        extractedBytes += pageBytes;
       }
       return pages.join("\n");
     } finally {
-      await document.destroy();
+      signal?.removeEventListener("abort", onAbort);
+      await destroy().catch((error: unknown) => {
+        signal?.throwIfAborted();
+        throw error;
+      });
     }
   } catch (error) {
+    signal?.throwIfAborted();
+    if (error instanceof KnowledgeBaseLimitError) throw error;
     throw new Error(`Cannot extract text from knowledge base PDF: ${path}`, {
       cause: error,
     });
   }
 }
 
-function extractDocx(path: string, bytes: Uint8Array): string {
+function extractDocx(
+  path: string,
+  bytes: Uint8Array,
+  signal?: AbortSignal,
+): string {
+  signal?.throwIfAborted();
   try {
     const files = unzipSync(bytes, {
       filter: (file) => {
         if (file.name !== "word/document.xml") return false;
-        if (file.originalSize > 25 * 1024 * 1024) {
-          throw new Error("DOCX document text exceeds 25 MB.");
+        if (file.originalSize > MAX_EXTRACTED_DOCUMENT_BYTES) {
+          throw new KnowledgeBaseLimitError(
+            `Knowledge base document exceeds the ${MAX_EXTRACTED_DOCUMENT_BYTES}-byte extracted-text limit: ${path}`,
+          );
         }
         return true;
       },
     });
+    signal?.throwIfAborted();
     const document = files["word/document.xml"];
     if (document === undefined) throw new Error("Missing word/document.xml.");
     const xml = decodeText(path, document);
@@ -190,13 +385,17 @@ function extractDocx(path: string, bytes: Uint8Array): string {
     ) {
       throw new Error("Malformed word/document.xml.");
     }
-    return decodeXml(
+    const text = decodeXml(
       xml
         .replace(/<\/(?:\w+:)?p\s*>/gu, "\n")
         .replace(/<(?:\w+:)?tab\b[^>]*\/>/gu, "\t")
         .replace(/<[^>]+>/gu, ""),
     );
+    signal?.throwIfAborted();
+    return text;
   } catch (error) {
+    signal?.throwIfAborted();
+    if (error instanceof KnowledgeBaseLimitError) throw error;
     throw new Error(`Cannot extract text from knowledge base DOCX: ${path}`, {
       cause: error,
     });

--- a/sdk/typescript/src/knowledge-base.ts
+++ b/sdk/typescript/src/knowledge-base.ts
@@ -676,12 +676,17 @@ function pdfIndirectValue(
         .subarray(first + start, first + next)
         .toString("latin1")
         .trim();
-      const primitive = /^(\[[^\]]*\]|\/[^\s<>[\]()%/]+|\d+)$/u.exec(raw)?.[1];
+      const lexical = pdfDictionaryLexicalValues(raw, false).trim();
+      const primitive = /^(\[[^\]]*\]|\/[^\s<>[\]()%/]+|\d+)$/u.exec(
+        lexical,
+      )?.[1];
       parsed.push({
         number,
         value:
           primitive ??
-          (raw.startsWith("<<") && raw.endsWith(">>") ? raw : undefined),
+          (lexical.startsWith("<<") && lexical.endsWith(">>")
+            ? lexical
+            : undefined),
       });
     }
     objects = parsed;
@@ -882,7 +887,12 @@ function pdfCrossReferenceStream(
     contents.slice(streamOffset, streamOffset + length),
     "latin1",
   );
-  for (const filter of pdfStreamFilters(contents, dictionary, offsets, path)) {
+  for (const [filterIndex, filter] of pdfStreamFilters(
+    contents,
+    dictionary,
+    offsets,
+    path,
+  ).entries()) {
     try {
       switch (filter) {
         case "FlateDecode":
@@ -902,10 +912,23 @@ function pdfCrossReferenceStream(
         case "A85":
           decoded = decodePdfAscii85(decoded, work.remaining);
           break;
+        case "RunLengthDecode":
+        case "RL":
+          decoded = decodePdfRunLength(decoded, work.remaining);
+          break;
+        case "LZWDecode":
+        case "LZW":
+          decoded = decodePdfLzw(
+            decoded,
+            work.remaining,
+            pdfLzwEarlyChange(dictionary, filterIndex),
+          );
+          break;
         default:
           return null;
       }
-    } catch {
+    } catch (error) {
+      if (error instanceof KnowledgeBaseLimitError) throw error;
       return null;
     }
     work.remaining -= decoded.byteLength;
@@ -1172,11 +1195,9 @@ function pdfPageContentReferences(
       path,
     );
     if (dictionary === undefined || !dictionary.startsWith("<<")) continue;
-    const lexical = pdfDictionaryLexicalValues(dictionary, false);
+    const lexical = pdfDictionaryLexicalValues(dictionary);
     if (pdfTopLevelDictionaryName(lexical, "Type") !== "Page") continue;
-    const contentsValue = /\/Contents\s+(\[[^\]]*\]|\d+\s+\d+\s+R)/u.exec(
-      lexical,
-    )?.[1];
+    const contentsValue = pdfTopLevelDictionaryReference(lexical, "Contents");
     if (contentsValue !== undefined) pending.push(contentsValue);
   }
   const selected = new Set<string>();
@@ -1201,6 +1222,49 @@ function pdfPageContentReferences(
     }
   }
   return selected;
+}
+
+function pdfTopLevelDictionaryReference(
+  dictionary: string,
+  key: string,
+): string | undefined {
+  let dictionaryDepth = 0;
+  let arrayDepth = 0;
+  for (let index = 0; index < dictionary.length; index += 1) {
+    if (dictionary.startsWith("<<", index)) {
+      dictionaryDepth += 1;
+      index += 1;
+      continue;
+    }
+    if (dictionary.startsWith(">>", index)) {
+      dictionaryDepth -= 1;
+      index += 1;
+      continue;
+    }
+    if (dictionary[index] === "[") {
+      arrayDepth += 1;
+      continue;
+    }
+    if (dictionary[index] === "]") {
+      arrayDepth -= 1;
+      continue;
+    }
+    if (
+      dictionaryDepth !== 1 ||
+      arrayDepth !== 0 ||
+      dictionary[index] !== "/"
+    ) {
+      continue;
+    }
+    const value =
+      /^\/([^\s<>[\]()%/]+)\s+(\[[^\]]*\]|\d+\s+\d+\s+R)(?=[\s/>])/u.exec(
+        dictionary.slice(index),
+      );
+    if (value?.[1] !== undefined && pdfDecodedName(value[1]) === key) {
+      return value[2];
+    }
+  }
+  return undefined;
 }
 
 function pdfStreamFilters(

--- a/sdk/typescript/src/knowledge-base.ts
+++ b/sdk/typescript/src/knowledge-base.ts
@@ -394,6 +394,9 @@ function boundCompressedPdfStreams(
   const streams =
     />>(?:(?:\s+|%[^\r\n]*(?:\r\n|\r|\n))*)stream(?:\r\n|\r|\n)/gu;
   const indirectObjects = pdfCrossReferenceOffsets(contents, path, signal);
+  const objectOffsets = [...(indirectObjects?.entries() ?? [])]
+    .filter((entry): entry is [string, number] => typeof entry[1] === "number")
+    .sort((left, right) => left[1] - right[1]);
   let inflatedBytes = 0;
   let decodingWorkBytes = 0;
   const dictionaryWork = { remaining: MAX_PDF_DICTIONARY_WORK_BYTES };
@@ -407,6 +410,26 @@ function boundCompressedPdfStreams(
       indirectObjects,
     );
     if (dictionary === null) continue;
+    const lexicalDictionary = pdfDictionaryLexicalValues(dictionary);
+    if (/\/Subtype\s*\/Image(?=[\s/>])/u.test(lexicalDictionary)) {
+      let low = 0;
+      let high = objectOffsets.length;
+      while (low < high) {
+        const middle = Math.floor((low + high) / 2);
+        if (objectOffsets[middle]![1] < marker.index) low = middle + 1;
+        else high = middle;
+      }
+      const entry = objectOffsets[low - 1];
+      const [number, generation] = entry?.[0].split(":") ?? [];
+      const pageContent =
+        number !== undefined &&
+        generation !== undefined &&
+        new RegExp(
+          `/Contents\\s+(?:${number}\\s+${generation}\\s+R|\\[[^\\]]*\\b${number}\\s+${generation}\\s+R)`,
+          "u",
+        ).test(contents);
+      if (!pageContent) continue;
+    }
     const filters = pdfStreamFilters(
       contents,
       dictionary,
@@ -576,7 +599,7 @@ function pdfIndirectValue(
   if (offset === null || offset === undefined) return undefined;
   if (typeof offset === "number") {
     const value = new RegExp(
-      `^${object}\\s+${generation}\\s+obj\\s*(\\[[^\\]]*\\]|\\/[^\\s<>[\\]()%/]+|\\d+)`,
+      `^${object}\\s+${generation}\\s+obj(?:\\s+|%[^\\r\\n]*(?:\\r\\n|\\r|\\n))*(\\[[^\\]]*\\]|\\/[^\\s<>[\\]()%/]+|\\d+)`,
       "u",
     ).exec(contents.slice(offset));
     if (value?.[1] === undefined) return undefined;
@@ -620,6 +643,7 @@ function pdfIndirectValue(
     const header = stream
       .subarray(0, first)
       .toString("latin1")
+      .replace(/%[^\r\n]*/gu, " ")
       .trim()
       .split(/\s+/u);
     if (header.length !== 2 * count) return undefined;
@@ -893,8 +917,7 @@ function pdfCrossReferenceStream(
       /\/BitsPerComponent\s+(\d+)(?=[\s/>])/u.exec(dictionary)?.[1] ?? "8",
     );
     if (
-      predictor < 10 ||
-      predictor > 15 ||
+      (predictor !== 2 && (predictor < 10 || predictor > 15)) ||
       !Number.isSafeInteger(columns) ||
       !Number.isSafeInteger(colors) ||
       !Number.isSafeInteger(bits) ||
@@ -905,19 +928,56 @@ function pdfCrossReferenceStream(
       return null;
     }
     const rowBytes = Math.ceil((columns * colors * bits) / 8);
+    const encodedRowBytes = rowBytes + (predictor === 2 ? 0 : 1);
     if (
       !Number.isSafeInteger(rowBytes) ||
       rowBytes <= 0 ||
-      decoded.byteLength % (rowBytes + 1) !== 0
+      decoded.byteLength % encodedRowBytes !== 0 ||
+      (predictor === 2 && ![1, 2, 4, 8, 16].includes(bits))
     ) {
       return null;
     }
-    const reconstructed = Buffer.alloc(
-      (decoded.byteLength / (rowBytes + 1)) * rowBytes,
-    );
+    const reconstructed =
+      predictor === 2
+        ? Buffer.from(decoded)
+        : Buffer.alloc((decoded.byteLength / encodedRowBytes) * rowBytes);
     const pixelBytes = Math.max(1, Math.ceil((colors * bits) / 8));
     let input = 0;
     let output = 0;
+    if (predictor === 2) {
+      const samples = columns * colors;
+      const sampleMask = 2 ** bits - 1;
+      for (let row = 0; row < reconstructed.byteLength; row += rowBytes) {
+        for (let sample = colors; sample < samples; sample += 1) {
+          if (bits === 16) {
+            const current = row + sample * 2;
+            const previous = row + (sample - colors) * 2;
+            reconstructed.writeUInt16BE(
+              (reconstructed.readUInt16BE(current) +
+                reconstructed.readUInt16BE(previous)) &
+                sampleMask,
+              current,
+            );
+          } else {
+            const bit = sample * bits;
+            const previousBit = (sample - colors) * bits;
+            const current = row + Math.floor(bit / 8);
+            const previous = row + Math.floor(previousBit / 8);
+            const shift = 8 - bits - (bit % 8);
+            const previousShift = 8 - bits - (previousBit % 8);
+            const next =
+              (((reconstructed[current]! >> shift) & sampleMask) +
+                ((reconstructed[previous]! >> previousShift) & sampleMask)) &
+              sampleMask;
+            reconstructed[current] =
+              (reconstructed[current]! & ~(sampleMask << shift)) |
+              (next << shift);
+          }
+        }
+      }
+      decoded = reconstructed;
+      return { dictionary, contents: decoded };
+    }
     while (input < decoded.byteLength) {
       const filter = decoded[input++]!;
       if (filter > 4) return null;
@@ -1044,11 +1104,32 @@ function pdfStreamFilters(
     }
     value = resolved;
   }
-  return [...value.matchAll(/\/([^\s<>[\]()%/]+)/gu)].map((filter) =>
-    filter[1]!.replace(/#([0-9a-f]{2})/giu, (_match, encoded: string) =>
-      String.fromCharCode(Number.parseInt(encoded, 16)),
-    ),
-  );
+  const filters: string[] = [];
+  for (const filter of value.matchAll(
+    /\/([^\s<>[\]()%/]+)|(\d+)\s+(\d+)\s+R/gu,
+  )) {
+    let name = filter[1];
+    if (name === undefined) {
+      const resolved = pdfIndirectValue(
+        contents,
+        filter[2]!,
+        filter[3]!,
+        offsets,
+        path,
+      );
+      const reference = /^\/([^\s<>[\]()%/]+)$/u.exec(resolved ?? "");
+      if (reference?.[1] === undefined) {
+        throw new Error("Compressed PDF filter cannot be resolved safely.");
+      }
+      name = reference[1];
+    }
+    filters.push(
+      name.replace(/#([0-9a-f]{2})/giu, (_match, encoded: string) =>
+        String.fromCharCode(Number.parseInt(encoded, 16)),
+      ),
+    );
+  }
+  return filters;
 }
 
 function pdfLzwEarlyChange(dictionary: string, filterIndex: number): 0 | 1 {

--- a/sdk/typescript/src/knowledge-base.ts
+++ b/sdk/typescript/src/knowledge-base.ts
@@ -411,7 +411,7 @@ function boundCompressedPdfStreams(
     );
     if (dictionary === null) continue;
     const lexicalDictionary = pdfDictionaryLexicalValues(dictionary);
-    if (/\/Subtype\s*\/Image(?=[\s/>])/u.test(lexicalDictionary)) {
+    if (pdfTopLevelDictionaryName(lexicalDictionary, "Subtype") === "Image") {
       let low = 0;
       let high = objectOffsets.length;
       while (low < high) {
@@ -424,10 +424,13 @@ function boundCompressedPdfStreams(
       const pageContent =
         number !== undefined &&
         generation !== undefined &&
-        new RegExp(
-          `/Contents\\s+(?:${number}\\s+${generation}\\s+R|\\[[^\\]]*\\b${number}\\s+${generation}\\s+R)`,
-          "u",
-        ).test(contents);
+        pdfContentsReferencesObject(
+          contents,
+          number,
+          generation,
+          indirectObjects,
+          path,
+        );
       if (!pageContent) continue;
     }
     const filters = pdfStreamFilters(
@@ -946,6 +949,15 @@ function pdfCrossReferenceStream(
     let output = 0;
     if (predictor === 2) {
       const samples = columns * colors;
+      const rows = decoded.byteLength / rowBytes;
+      const reconstructionWork = rows * Math.max(0, samples - colors);
+      if (
+        !Number.isSafeInteger(reconstructionWork) ||
+        reconstructionWork > work.remaining
+      ) {
+        return null;
+      }
+      work.remaining -= reconstructionWork;
       const sampleMask = 2 ** bits - 1;
       for (let row = 0; row < reconstructed.byteLength; row += rowBytes) {
         for (let sample = colors; sample < samples; sample += 1) {
@@ -1078,6 +1090,83 @@ function pdfDictionaryLexicalValues(
     : output;
 }
 
+function pdfTopLevelDictionaryName(
+  dictionary: string,
+  key: string,
+): string | undefined {
+  let dictionaryDepth = 0;
+  let arrayDepth = 0;
+  for (let index = 0; index < dictionary.length; index += 1) {
+    if (dictionary.startsWith("<<", index)) {
+      dictionaryDepth += 1;
+      index += 1;
+      continue;
+    }
+    if (dictionary.startsWith(">>", index)) {
+      dictionaryDepth -= 1;
+      index += 1;
+      continue;
+    }
+    if (dictionary[index] === "[") {
+      arrayDepth += 1;
+      continue;
+    }
+    if (dictionary[index] === "]") {
+      arrayDepth -= 1;
+      continue;
+    }
+    if (
+      dictionaryDepth !== 1 ||
+      arrayDepth !== 0 ||
+      !dictionary.startsWith(`/${key}`, index)
+    ) {
+      continue;
+    }
+    const value = new RegExp(
+      `^/${key}\\s*/([^\\s<>[\\]()%/]+)(?=[\\s/>])`,
+      "u",
+    ).exec(dictionary.slice(index));
+    if (value?.[1] !== undefined) return value[1];
+  }
+  return undefined;
+}
+
+function pdfContentsReferencesObject(
+  contents: string,
+  number: string,
+  generation: string,
+  offsets: ReadonlyMap<string, PdfCrossReferenceEntry> | null,
+  path: string,
+): boolean {
+  const references = /\/(?:Contents)\s+(\[[^\]]*\]|\d+\s+\d+\s+R)/gu;
+  for (const entry of contents.matchAll(references)) {
+    const pending = [entry[1]!];
+    const visited = new Set<string>();
+    while (pending.length > 0) {
+      const current = pdfDictionaryLexicalValues(pending.pop()!);
+      for (const reference of current.matchAll(/(\d+)\s+(\d+)\s+R/gu)) {
+        const key = `${reference[1]}:${reference[2]}`;
+        if (reference[1] === number && reference[2] === generation) {
+          return true;
+        }
+        if (visited.has(key) || visited.size >= MAX_PDF_XREF_OBJECTS) continue;
+        visited.add(key);
+        const resolved = pdfIndirectValue(
+          contents,
+          reference[1]!,
+          reference[2]!,
+          offsets,
+          path,
+        );
+        if (resolved?.trimStart().startsWith("[") === true) {
+          pending.push(resolved);
+        }
+      }
+    }
+  }
+  return false;
+}
+
 function pdfStreamFilters(
   contents: string,
   dictionary: string,
@@ -1102,7 +1191,7 @@ function pdfStreamFilters(
     if (resolved === undefined) {
       throw new Error("Compressed PDF filter cannot be resolved safely.");
     }
-    value = resolved;
+    value = pdfDictionaryLexicalValues(resolved);
   }
   const filters: string[] = [];
   for (const filter of value.matchAll(
@@ -1117,7 +1206,9 @@ function pdfStreamFilters(
         offsets,
         path,
       );
-      const reference = /^\/([^\s<>[\]()%/]+)$/u.exec(resolved ?? "");
+      const reference = /^\/([^\s<>[\]()%/]+)$/u.exec(
+        pdfDictionaryLexicalValues(resolved ?? "").trim(),
+      );
       if (reference?.[1] === undefined) {
         throw new Error("Compressed PDF filter cannot be resolved safely.");
       }

--- a/sdk/typescript/src/knowledge-base.ts
+++ b/sdk/typescript/src/knowledge-base.ts
@@ -37,6 +37,7 @@ const MAX_INPUT_BYTES = 32 * 1024 * 1024;
 const MAX_EXTRACTED_DOCUMENT_BYTES = 8 * 1024 * 1024;
 const MAX_EXTRACTED_BYTES = 32 * 1024 * 1024;
 const MAX_PDF_PAGES = 512;
+const MAX_PDF_XREF_OBJECTS = 65_536;
 const MAX_PDF_DICTIONARY_SCAN_BYTES = 256 * 1024;
 const MAX_PDF_DICTIONARY_WORK_BYTES = 2 * MAX_DOCUMENT_BYTES;
 const MAX_PDF_LZW_CODES = 1_000_000;
@@ -375,6 +376,7 @@ function boundCompressedPdfStreams(
   const contents = source.toString("latin1");
   const streams =
     />>(?:(?:\s+|%[^\r\n]*(?:\r\n|\r|\n))*)stream(?:\r\n|\r|\n)/gu;
+  const indirectObjects = pdfCrossReferenceOffsets(contents);
   let inflatedBytes = 0;
   const dictionaryWork = { remaining: MAX_PDF_DICTIONARY_WORK_BYTES };
   for (const marker of contents.matchAll(streams)) {
@@ -384,9 +386,10 @@ function boundCompressedPdfStreams(
       marker.index + 2,
       dictionaryWork,
       path,
+      indirectObjects,
     );
     if (dictionary === null) continue;
-    const filters = pdfStreamFilters(contents, dictionary);
+    const filters = pdfStreamFilters(contents, dictionary, indirectObjects);
     if (filters.length === 0) continue;
 
     const streamStart = marker.index + marker[0].length;
@@ -395,7 +398,17 @@ function boundCompressedPdfStreams(
     );
     let length = Number(declared?.[1]);
     if (declared?.[2] !== undefined) {
-      const referenced = pdfIndirectValue(contents, declared[1]!, declared[2]);
+      const referenced = pdfIndirectValue(
+        contents,
+        declared[1]!,
+        declared[2],
+        indirectObjects,
+      );
+      if (referenced === undefined) {
+        throw new Error(
+          "Compressed PDF stream length cannot be resolved safely.",
+        );
+      }
       length = Number(referenced);
     }
     let streamEnd = Number.isSafeInteger(length)
@@ -408,33 +421,36 @@ function boundCompressedPdfStreams(
     let decoded = source.subarray(streamStart, streamEnd);
     for (const [filterIndex, filter] of filters.entries()) {
       signal?.throwIfAborted();
-      const remaining = MAX_EXTRACTED_DOCUMENT_BYTES - inflatedBytes;
-      if (remaining <= 0) throw oversizedPdfStream(path);
+      if (inflatedBytes >= MAX_EXTRACTED_DOCUMENT_BYTES) {
+        throw oversizedPdfStream(path);
+      }
       try {
         switch (filter) {
           case "ASCIIHexDecode":
           case "AHx":
-            decoded = decodePdfAsciiHex(decoded, remaining);
+            decoded = decodePdfAsciiHex(decoded, MAX_EXTRACTED_DOCUMENT_BYTES);
             break;
           case "ASCII85Decode":
           case "A85":
-            decoded = decodePdfAscii85(decoded, remaining);
+            decoded = decodePdfAscii85(decoded, MAX_EXTRACTED_DOCUMENT_BYTES);
             break;
           case "RunLengthDecode":
           case "RL":
-            decoded = decodePdfRunLength(decoded, remaining);
+            decoded = decodePdfRunLength(decoded, MAX_EXTRACTED_DOCUMENT_BYTES);
             break;
           case "LZWDecode":
           case "LZW":
             decoded = decodePdfLzw(
               decoded,
-              remaining,
+              MAX_EXTRACTED_DOCUMENT_BYTES,
               pdfLzwEarlyChange(dictionary, filterIndex),
             );
             break;
           case "FlateDecode":
           case "Fl":
-            decoded = inflateSync(decoded, { maxOutputLength: remaining });
+            decoded = inflateSync(decoded, {
+              maxOutputLength: MAX_EXTRACTED_DOCUMENT_BYTES,
+            });
             break;
           case "DCTDecode":
           case "DCT":
@@ -447,10 +463,6 @@ function boundCompressedPdfStreams(
             continue;
           default:
             throw new Error(`Unsupported compressed PDF filter: ${filter}`);
-        }
-        inflatedBytes += decoded.byteLength;
-        if (inflatedBytes > MAX_EXTRACTED_DOCUMENT_BYTES) {
-          throw oversizedPdfStream(path);
         }
       } catch (error) {
         if (error instanceof KnowledgeBaseLimitError) throw error;
@@ -467,6 +479,10 @@ function boundCompressedPdfStreams(
         );
       }
     }
+    inflatedBytes += decoded.byteLength;
+    if (inflatedBytes > MAX_EXTRACTED_DOCUMENT_BYTES) {
+      throw oversizedPdfStream(path);
+    }
   }
 }
 
@@ -475,16 +491,23 @@ function pdfStreamDictionary(
   end: number,
   work: { remaining: number },
   path: string,
+  offsets: ReadonlyMap<string, number | null> | null,
 ): string | null {
   let depth = 1;
-  const minimum = Math.max(0, end - MAX_PDF_DICTIONARY_SCAN_BYTES);
-  for (let index = end - 3; index >= minimum; index -= 1) {
+  let minimum = Math.max(0, end - MAX_PDF_DICTIONARY_SCAN_BYTES);
+  for (const offset of offsets?.values() ?? []) {
+    if (offset !== null && offset < end && offset > minimum) {
+      minimum = offset;
+    }
+  }
+  const lexical = pdfDictionaryLexicalValues(contents.slice(minimum, end));
+  for (let index = lexical.length - 3; index >= 0; index -= 1) {
     if (--work.remaining < 0) {
       throw new KnowledgeBaseLimitError(
         `Knowledge base PDF exceeds the ${MAX_PDF_DICTIONARY_WORK_BYTES}-byte dictionary scan limit: ${path}`,
       );
     }
-    const token = contents.slice(index, index + 2);
+    const token = lexical.slice(index, index + 2);
     if (token === ">>") {
       depth += 1;
       index -= 1;
@@ -492,7 +515,7 @@ function pdfStreamDictionary(
       depth -= 1;
       if (depth === 0) {
         return contents
-          .slice(index, end)
+          .slice(minimum + index, end)
           .replace(
             /\/([^\s<>()\[\]{}/%]+)/gu,
             (_match, name: string) =>
@@ -516,12 +539,86 @@ function pdfIndirectValue(
   contents: string,
   object: string,
   generation: string,
+  offsets: ReadonlyMap<string, number | null> | null,
 ): string | undefined {
-  const value = new RegExp(
-    `(?:^|\\s)${object}\\s+${generation}\\s+obj\\s*(\\[[^\\]]*\\]|\\/[^\\s<>[\\]()%/]+|\\d+)\\s*endobj`,
+  const offset = offsets?.get(`${object}:${generation}`);
+  if (offset === null || offset === undefined) return undefined;
+  return new RegExp(
+    `^${object}\\s+${generation}\\s+obj\\s*(\\[[^\\]]*\\]|\\/[^\\s<>[\\]()%/]+|\\d+)\\s*endobj`,
     "u",
-  ).exec(contents)?.[1];
-  return value;
+  ).exec(contents.slice(offset))?.[1];
+}
+
+function pdfCrossReferenceOffsets(
+  contents: string,
+): ReadonlyMap<string, number | null> | null {
+  const marker = /startxref\s+(\d+)\s+%%EOF\s*$/u.exec(contents);
+  let offset = Number(marker?.[1]);
+  if (
+    !Number.isSafeInteger(offset) ||
+    offset < 0 ||
+    offset >= contents.length
+  ) {
+    return null;
+  }
+  const entries = new Map<string, number | null>();
+  const visited = new Set<number>();
+  const whitespace = /[\u0000\t\n\f\r ]*/uy;
+  const section = /(\d+)[\t ]+(\d+)(?:\r\n|\r|\n)/uy;
+  const entry = /(\d+)[\t ]+(\d+)[\t ]+([nf])(?:[\t ]*(?:\r\n|\r|\n)|$)/uy;
+
+  while (!visited.has(offset)) {
+    visited.add(offset);
+    if (contents.slice(offset, offset + 4) !== "xref") return null;
+    let cursor = offset + 4;
+    while (true) {
+      whitespace.lastIndex = cursor;
+      cursor = whitespace.exec(contents)?.index ?? cursor;
+      cursor = whitespace.lastIndex;
+      if (contents.startsWith("trailer", cursor)) {
+        const trailer = pdfDictionaryLexicalValues(
+          contents.slice(cursor + "trailer".length, cursor + 64 * 1024),
+        );
+        const previous = /\/Prev\s+(\d+)(?=[\s/>])/u.exec(trailer)?.[1];
+        if (previous === undefined) return entries;
+        offset = Number(previous);
+        if (
+          !Number.isSafeInteger(offset) ||
+          offset < 0 ||
+          offset >= contents.length
+        ) {
+          return null;
+        }
+        break;
+      }
+      section.lastIndex = cursor;
+      const subsection = section.exec(contents);
+      if (subsection === null) return null;
+      cursor = section.lastIndex;
+      const firstObject = Number(subsection[1]);
+      const count = Number(subsection[2]);
+      if (
+        !Number.isSafeInteger(firstObject) ||
+        !Number.isSafeInteger(count) ||
+        count < 0 ||
+        count > MAX_PDF_XREF_OBJECTS ||
+        entries.size + count > MAX_PDF_XREF_OBJECTS
+      ) {
+        return null;
+      }
+      for (let index = 0; index < count; index += 1) {
+        entry.lastIndex = cursor;
+        const value = entry.exec(contents);
+        if (value === null) return null;
+        cursor = entry.lastIndex;
+        const key = `${firstObject + index}:${Number(value[2])}`;
+        if (!entries.has(key)) {
+          entries.set(key, value[3] === "n" ? Number(value[1]) : null);
+        }
+      }
+    }
+  }
+  return null;
 }
 
 function pdfDictionaryLexicalValues(dictionary: string): string {
@@ -578,7 +675,11 @@ function pdfDictionaryLexicalValues(dictionary: string): string {
   return output;
 }
 
-function pdfStreamFilters(contents: string, dictionary: string): string[] {
+function pdfStreamFilters(
+  contents: string,
+  dictionary: string,
+  offsets: ReadonlyMap<string, number | null> | null,
+): string[] {
   const match =
     /\/(?:Filter|F)\s+(\[[^\]]*\]|\/[^\s<>[\]()%/]+|\d+\s+\d+\s+R)(?=[\s/>])/u.exec(
       pdfDictionaryLexicalValues(dictionary),
@@ -587,7 +688,12 @@ function pdfStreamFilters(contents: string, dictionary: string): string[] {
   let value = match[1];
   const reference = /^(\d+)\s+(\d+)\s+R$/u.exec(value);
   if (reference !== null) {
-    const resolved = pdfIndirectValue(contents, reference[1]!, reference[2]!);
+    const resolved = pdfIndirectValue(
+      contents,
+      reference[1]!,
+      reference[2]!,
+      offsets,
+    );
     if (resolved === undefined) {
       throw new Error("Compressed PDF filter cannot be resolved safely.");
     }

--- a/sdk/typescript/src/knowledge-base.ts
+++ b/sdk/typescript/src/knowledge-base.ts
@@ -370,7 +370,8 @@ function boundCompressedPdfStreams(
 ): void {
   const source = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
   const contents = source.toString("latin1");
-  const streams = />>\s*stream(?:\r\n|\r|\n)/gu;
+  const streams =
+    />>(?:(?:\s+|%[^\r\n]*(?:\r\n|\r|\n))*)stream(?:\r\n|\r|\n)/gu;
   let inflatedBytes = 0;
   for (const marker of contents.matchAll(streams)) {
     signal?.throwIfAborted();
@@ -381,7 +382,7 @@ function boundCompressedPdfStreams(
 
     const streamStart = marker.index + marker[0].length;
     const declared = /\/Length\s+(\d+)(?:\s+(\d+)\s+R)?(?=[\s/>])/u.exec(
-      dictionary,
+      pdfDictionaryLexicalValues(dictionary),
     );
     let length = Number(declared?.[1]);
     if (declared?.[2] !== undefined) {
@@ -413,6 +414,10 @@ function boundCompressedPdfStreams(
           case "RunLengthDecode":
           case "RL":
             decoded = decodePdfRunLength(decoded, remaining);
+            break;
+          case "LZWDecode":
+          case "LZW":
+            decoded = decodePdfLzw(decoded, remaining);
             break;
           case "FlateDecode":
           case "Fl":
@@ -488,6 +493,57 @@ function pdfIndirectValue(
     "u",
   ).exec(contents)?.[1];
   return value;
+}
+
+function pdfDictionaryLexicalValues(dictionary: string): string {
+  let output = "";
+  let literalDepth = 0;
+  let escaped = false;
+  let comment = false;
+  let hex = false;
+  for (let index = 0; index < dictionary.length; index += 1) {
+    const character = dictionary[index]!;
+    if (comment) {
+      if (character === "\r" || character === "\n") {
+        comment = false;
+        output += character;
+      } else {
+        output += " ";
+      }
+      continue;
+    }
+    if (literalDepth > 0) {
+      output += " ";
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === "(") {
+        literalDepth += 1;
+      } else if (character === ")") {
+        literalDepth -= 1;
+      }
+      continue;
+    }
+    if (hex) {
+      output += " ";
+      if (character === ">") hex = false;
+      continue;
+    }
+    if (character === "%") {
+      comment = true;
+      output += " ";
+    } else if (character === "(") {
+      literalDepth = 1;
+      output += " ";
+    } else if (character === "<" && dictionary[index + 1] !== "<") {
+      hex = true;
+      output += " ";
+    } else {
+      output += character;
+    }
+  }
+  return output;
 }
 
 function pdfStreamFilters(contents: string, dictionary: string): string[] {
@@ -576,7 +632,7 @@ function decodePdfAscii85(value: Buffer, maximum: number): Buffer {
 }
 
 function decodePdfRunLength(value: Buffer, maximum: number): Buffer {
-  const output = Buffer.allocUnsafe(maximum);
+  const output = Buffer.allocUnsafe(Math.min(maximum, value.length * 128));
   let written = 0;
   for (let index = 0; index < value.length; ) {
     const control = value[index++]!;
@@ -603,6 +659,57 @@ function decodePdfRunLength(value: Buffer, maximum: number): Buffer {
     }
   }
   return output.subarray(0, written);
+}
+
+function decodePdfLzw(value: Buffer, maximum: number): Buffer {
+  let dictionary = Array.from({ length: 256 }, (_unused, code) =>
+    Buffer.from([code]),
+  );
+  let nextCode = 258;
+  let codeBits = 9;
+  let bitOffset = 0;
+  let previous: Buffer | undefined;
+  const chunks: Buffer[] = [];
+  let outputBytes = 0;
+  while (bitOffset + codeBits <= value.byteLength * 8) {
+    let code = 0;
+    for (let bit = 0; bit < codeBits; bit += 1) {
+      const offset = bitOffset + bit;
+      code =
+        (code << 1) |
+        ((value[Math.floor(offset / 8)]! >> (7 - (offset % 8))) & 1);
+    }
+    bitOffset += codeBits;
+    if (code === 256) {
+      dictionary = Array.from({ length: 256 }, (_unused, item) =>
+        Buffer.from([item]),
+      );
+      nextCode = 258;
+      codeBits = 9;
+      previous = undefined;
+      continue;
+    }
+    if (code === 257) break;
+    const entry =
+      dictionary[code] ??
+      (code === nextCode && previous !== undefined
+        ? Buffer.concat([previous, previous.subarray(0, 1)])
+        : undefined);
+    if (entry === undefined) throw new Error("Invalid PDF LZW stream.");
+    if (outputBytes + entry.byteLength > maximum) {
+      throw Object.assign(new Error("Decoded PDF stream is too large."), {
+        code: "ERR_BUFFER_TOO_LARGE",
+      });
+    }
+    chunks.push(entry);
+    outputBytes += entry.byteLength;
+    if (previous !== undefined && nextCode < 4_096) {
+      dictionary[nextCode++] = Buffer.concat([previous, entry.subarray(0, 1)]);
+      if (nextCode + 1 === 1 << codeBits && codeBits < 12) codeBits += 1;
+    }
+    previous = entry;
+  }
+  return Buffer.concat(chunks, outputBytes);
 }
 
 async function extractPdf(

--- a/sdk/typescript/src/knowledge-base.ts
+++ b/sdk/typescript/src/knowledge-base.ts
@@ -405,9 +405,11 @@ function boundCompressedPdfStreams(
   );
   let inflatedBytes = 0;
   let decodingWorkBytes = 0;
+  let streamBodyEnd = 0;
   const dictionaryWork = { remaining: MAX_PDF_DICTIONARY_WORK_BYTES };
   for (const marker of contents.matchAll(streams)) {
     signal?.throwIfAborted();
+    if (marker.index < streamBodyEnd) continue;
     const object = pdfObjectBeforeOffset(objectOffsets, marker.index);
     const dictionary = pdfStreamDictionary(
       contents,
@@ -417,20 +419,6 @@ function boundCompressedPdfStreams(
       object?.[1],
     );
     if (dictionary === null) continue;
-    const lexicalDictionary = pdfDictionaryLexicalValues(dictionary, false);
-    if (pdfTopLevelDictionaryName(lexicalDictionary, "Subtype") === "Image") {
-      const pageContent =
-        object !== undefined && pageContentReferences.has(object[0]);
-      if (!pageContent) continue;
-    }
-    const filters = pdfStreamFilters(
-      contents,
-      dictionary,
-      indirectObjects,
-      path,
-    );
-    if (filters.length === 0) continue;
-
     const streamStart = marker.index + marker[0].length;
     const declared = /\/Length\s+(\d+)(?:\s+(\d+)\s+R)?(?=[\s/>])/u.exec(
       pdfDictionaryLexicalValues(dictionary),
@@ -457,6 +445,20 @@ function boundCompressedPdfStreams(
     if (streamEnd === -1)
       streamEnd = contents.indexOf("\rendstream", streamStart);
     if (streamEnd < streamStart || streamEnd > source.byteLength) continue;
+    streamBodyEnd = streamEnd;
+    const lexicalDictionary = pdfDictionaryLexicalValues(dictionary, false);
+    if (pdfTopLevelDictionaryName(lexicalDictionary, "Subtype") === "Image") {
+      const pageContent =
+        object !== undefined && pageContentReferences.has(object[0]);
+      if (!pageContent) continue;
+    }
+    const filters = pdfStreamFilters(
+      contents,
+      dictionary,
+      indirectObjects,
+      path,
+    );
+    if (filters.length === 0) continue;
 
     let decoded = source.subarray(streamStart, streamEnd);
     for (const [filterIndex, filter] of filters.entries()) {
@@ -525,6 +527,23 @@ function boundCompressedPdfStreams(
           { cause: error },
         );
       }
+      const predictorWork = {
+        remaining: MAX_PDF_DECODE_WORK_BYTES - decodingWorkBytes,
+      };
+      const predicted = pdfApplyPredictor(
+        dictionary,
+        decoded,
+        predictorWork,
+        filterIndex,
+      );
+      if (predicted === null) {
+        throw new Error(
+          `Knowledge base PDF compressed stream cannot be safely bounded: ${path}`,
+        );
+      }
+      decodingWorkBytes +=
+        MAX_PDF_DECODE_WORK_BYTES - decodingWorkBytes - predictorWork.remaining;
+      decoded = predicted;
       decodingWorkBytes += decoded.byteLength;
       if (decodingWorkBytes > MAX_PDF_DECODE_WORK_BYTES) {
         throw oversizedPdfStream(path);
@@ -933,126 +952,132 @@ function pdfCrossReferenceStream(
     }
     work.remaining -= decoded.byteLength;
     if (work.remaining < 0) return null;
-  }
-  const predictor = Number(
-    /\/Predictor\s+(\d+)(?=[\s/>])/u.exec(
-      pdfDictionaryLexicalValues(dictionary),
-    )?.[1] ?? "1",
-  );
-  if (predictor !== 1) {
-    const columns = Number(
-      /\/Columns\s+(\d+)(?=[\s/>])/u.exec(dictionary)?.[1],
-    );
-    const colors = Number(
-      /\/Colors\s+(\d+)(?=[\s/>])/u.exec(dictionary)?.[1] ?? "1",
-    );
-    const bits = Number(
-      /\/BitsPerComponent\s+(\d+)(?=[\s/>])/u.exec(dictionary)?.[1] ?? "8",
-    );
-    if (
-      (predictor !== 2 && (predictor < 10 || predictor > 15)) ||
-      !Number.isSafeInteger(columns) ||
-      !Number.isSafeInteger(colors) ||
-      !Number.isSafeInteger(bits) ||
-      columns <= 0 ||
-      colors <= 0 ||
-      bits <= 0
-    ) {
-      return null;
-    }
-    const rowBytes = Math.ceil((columns * colors * bits) / 8);
-    const encodedRowBytes = rowBytes + (predictor === 2 ? 0 : 1);
-    if (
-      !Number.isSafeInteger(rowBytes) ||
-      rowBytes <= 0 ||
-      decoded.byteLength % encodedRowBytes !== 0 ||
-      (predictor === 2 && ![1, 2, 4, 8, 16].includes(bits))
-    ) {
-      return null;
-    }
-    const reconstructed =
-      predictor === 2
-        ? Buffer.from(decoded)
-        : Buffer.alloc((decoded.byteLength / encodedRowBytes) * rowBytes);
-    const pixelBytes = Math.max(1, Math.ceil((colors * bits) / 8));
-    let input = 0;
-    let output = 0;
-    if (predictor === 2) {
-      const samples = columns * colors;
-      const rows = decoded.byteLength / rowBytes;
-      const reconstructionWork = rows * Math.max(0, samples - colors);
-      if (
-        !Number.isSafeInteger(reconstructionWork) ||
-        reconstructionWork > work.remaining
-      ) {
-        return null;
-      }
-      work.remaining -= reconstructionWork;
-      const sampleMask = 2 ** bits - 1;
-      for (let row = 0; row < reconstructed.byteLength; row += rowBytes) {
-        for (let sample = colors; sample < samples; sample += 1) {
-          if (bits === 16) {
-            const current = row + sample * 2;
-            const previous = row + (sample - colors) * 2;
-            reconstructed.writeUInt16BE(
-              (reconstructed.readUInt16BE(current) +
-                reconstructed.readUInt16BE(previous)) &
-                sampleMask,
-              current,
-            );
-          } else {
-            const bit = sample * bits;
-            const previousBit = (sample - colors) * bits;
-            const current = row + Math.floor(bit / 8);
-            const previous = row + Math.floor(previousBit / 8);
-            const shift = 8 - bits - (bit % 8);
-            const previousShift = 8 - bits - (previousBit % 8);
-            const next =
-              (((reconstructed[current]! >> shift) & sampleMask) +
-                ((reconstructed[previous]! >> previousShift) & sampleMask)) &
-              sampleMask;
-            reconstructed[current] =
-              (reconstructed[current]! & ~(sampleMask << shift)) |
-              (next << shift);
-          }
-        }
-      }
-      decoded = reconstructed;
-      return { dictionary, contents: decoded };
-    }
-    while (input < decoded.byteLength) {
-      const filter = decoded[input++]!;
-      if (filter > 4) return null;
-      for (let column = 0; column < rowBytes; column += 1) {
-        const left =
-          column < pixelBytes ? 0 : reconstructed[output - pixelBytes]!;
-        const above = output < rowBytes ? 0 : reconstructed[output - rowBytes]!;
-        const upperLeft =
-          output < rowBytes || column < pixelBytes
-            ? 0
-            : reconstructed[output - rowBytes - pixelBytes]!;
-        let prediction = 0;
-        if (filter === 1) prediction = left;
-        else if (filter === 2) prediction = above;
-        else if (filter === 3) prediction = Math.floor((left + above) / 2);
-        else if (filter === 4) {
-          const estimate = left + above - upperLeft;
-          const leftDistance = Math.abs(estimate - left);
-          const aboveDistance = Math.abs(estimate - above);
-          const diagonalDistance = Math.abs(estimate - upperLeft);
-          prediction =
-            leftDistance <= aboveDistance && leftDistance <= diagonalDistance
-              ? left
-              : aboveDistance <= diagonalDistance
-                ? above
-                : upperLeft;
-        }
-        reconstructed[output++] = (decoded[input++]! + prediction) & 255;
-      }
-    }
-    decoded = reconstructed;
+    const predicted = pdfApplyPredictor(dictionary, decoded, work, filterIndex);
+    if (predicted === null) return null;
+    decoded = predicted;
   }
   return { dictionary, contents: decoded };
+}
+
+function pdfApplyPredictor(
+  dictionary: string,
+  decoded: Buffer,
+  work: { remaining: number },
+  filterIndex: number,
+): Buffer | null {
+  const parameters = pdfFilterDecodeParameters(dictionary, filterIndex);
+  const predictor = Number(
+    /\/Predictor\s+(\d+)(?=[\s/>])/u.exec(parameters ?? "")?.[1] ?? "1",
+  );
+  if (predictor === 1) return decoded;
+  const columns = Number(/\/Columns\s+(\d+)(?=[\s/>])/u.exec(parameters!)?.[1]);
+  const colors = Number(
+    /\/Colors\s+(\d+)(?=[\s/>])/u.exec(parameters!)?.[1] ?? "1",
+  );
+  const bits = Number(
+    /\/BitsPerComponent\s+(\d+)(?=[\s/>])/u.exec(parameters!)?.[1] ?? "8",
+  );
+  if (
+    (predictor !== 2 && (predictor < 10 || predictor > 15)) ||
+    !Number.isSafeInteger(columns) ||
+    !Number.isSafeInteger(colors) ||
+    !Number.isSafeInteger(bits) ||
+    columns <= 0 ||
+    colors <= 0 ||
+    bits <= 0
+  ) {
+    return null;
+  }
+  const rowBytes = Math.ceil((columns * colors * bits) / 8);
+  const encodedRowBytes = rowBytes + (predictor === 2 ? 0 : 1);
+  if (
+    !Number.isSafeInteger(rowBytes) ||
+    rowBytes <= 0 ||
+    decoded.byteLength % encodedRowBytes !== 0 ||
+    (predictor === 2 && ![1, 2, 4, 8, 16].includes(bits))
+  ) {
+    return null;
+  }
+  const reconstructed =
+    predictor === 2
+      ? Buffer.from(decoded)
+      : Buffer.alloc((decoded.byteLength / encodedRowBytes) * rowBytes);
+  const pixelBytes = Math.max(1, Math.ceil((colors * bits) / 8));
+  let input = 0;
+  let output = 0;
+  if (predictor === 2) {
+    const samples = columns * colors;
+    const rows = decoded.byteLength / rowBytes;
+    const reconstructionWork = rows * Math.max(0, samples - colors);
+    if (
+      !Number.isSafeInteger(reconstructionWork) ||
+      reconstructionWork > work.remaining
+    ) {
+      return null;
+    }
+    work.remaining -= reconstructionWork;
+    const sampleMask = 2 ** bits - 1;
+    for (let row = 0; row < reconstructed.byteLength; row += rowBytes) {
+      for (let sample = colors; sample < samples; sample += 1) {
+        if (bits === 16) {
+          const current = row + sample * 2;
+          const previous = row + (sample - colors) * 2;
+          reconstructed.writeUInt16BE(
+            (reconstructed.readUInt16BE(current) +
+              reconstructed.readUInt16BE(previous)) &
+              sampleMask,
+            current,
+          );
+        } else {
+          const bit = sample * bits;
+          const previousBit = (sample - colors) * bits;
+          const current = row + Math.floor(bit / 8);
+          const previous = row + Math.floor(previousBit / 8);
+          const shift = 8 - bits - (bit % 8);
+          const previousShift = 8 - bits - (previousBit % 8);
+          const next =
+            (((reconstructed[current]! >> shift) & sampleMask) +
+              ((reconstructed[previous]! >> previousShift) & sampleMask)) &
+            sampleMask;
+          reconstructed[current] =
+            (reconstructed[current]! & ~(sampleMask << shift)) |
+            (next << shift);
+        }
+      }
+    }
+    return reconstructed;
+  }
+  while (input < decoded.byteLength) {
+    const filter = decoded[input++]!;
+    if (filter > 4) return null;
+    for (let column = 0; column < rowBytes; column += 1) {
+      const left =
+        column < pixelBytes ? 0 : reconstructed[output - pixelBytes]!;
+      const above = output < rowBytes ? 0 : reconstructed[output - rowBytes]!;
+      const upperLeft =
+        output < rowBytes || column < pixelBytes
+          ? 0
+          : reconstructed[output - rowBytes - pixelBytes]!;
+      let prediction = 0;
+      if (filter === 1) prediction = left;
+      else if (filter === 2) prediction = above;
+      else if (filter === 3) prediction = Math.floor((left + above) / 2);
+      else if (filter === 4) {
+        const estimate = left + above - upperLeft;
+        const leftDistance = Math.abs(estimate - left);
+        const aboveDistance = Math.abs(estimate - above);
+        const diagonalDistance = Math.abs(estimate - upperLeft);
+        prediction =
+          leftDistance <= aboveDistance && leftDistance <= diagonalDistance
+            ? left
+            : aboveDistance <= diagonalDistance
+              ? above
+              : upperLeft;
+      }
+      reconstructed[output++] = (decoded[input++]! + prediction) & 255;
+    }
+  }
+  return reconstructed;
 }
 
 function pdfDictionaryLexicalValues(
@@ -1195,7 +1220,7 @@ function pdfPageContentReferences(
       path,
     );
     if (dictionary === undefined || !dictionary.startsWith("<<")) continue;
-    const lexical = pdfDictionaryLexicalValues(dictionary);
+    const lexical = pdfDictionaryLexicalValues(dictionary, false);
     if (pdfTopLevelDictionaryName(lexical, "Type") !== "Page") continue;
     const contentsValue = pdfTopLevelDictionaryReference(lexical, "Contents");
     if (contentsValue !== undefined) pending.push(contentsValue);
@@ -1257,7 +1282,7 @@ function pdfTopLevelDictionaryReference(
       continue;
     }
     const value =
-      /^\/([^\s<>[\]()%/]+)\s+(\[[^\]]*\]|\d+\s+\d+\s+R)(?=[\s/>])/u.exec(
+      /^\/([^\s<>[\]()%/]+)\s*(\[[^\]]*\]|\d+\s+\d+\s+R)(?=[\s/>])/u.exec(
         dictionary.slice(index),
       );
     if (value?.[1] !== undefined && pdfDecodedName(value[1]) === key) {
@@ -1320,17 +1345,25 @@ function pdfStreamFilters(
 }
 
 function pdfLzwEarlyChange(dictionary: string, filterIndex: number): 0 | 1 {
+  const selected = pdfFilterDecodeParameters(dictionary, filterIndex);
+  if (selected === undefined) return 1;
+  const value = /\/EarlyChange\s+([01])(?=[\s/>])/u.exec(selected)?.[1];
+  return value === "0" ? 0 : 1;
+}
+
+function pdfFilterDecodeParameters(
+  dictionary: string,
+  filterIndex: number,
+): string | undefined {
   const lexical = pdfDictionaryLexicalValues(dictionary);
   const parameters = /\/(?:DecodeParms|DP)\s+(\[[\s\S]*?\]|<<[\s\S]*?>>)/u.exec(
     lexical,
   )?.[1];
-  if (parameters === undefined) return 1;
+  if (parameters === undefined) return undefined;
   const selected = parameters.startsWith("[")
     ? [...parameters.matchAll(/null|<<[\s\S]*?>>/gu)][filterIndex]?.[0]
     : parameters;
-  if (selected === undefined || selected === "null") return 1;
-  const value = /\/EarlyChange\s+([01])(?=[\s/>])/u.exec(selected)?.[1];
-  return value === "0" ? 0 : 1;
+  return selected === "null" ? undefined : selected;
 }
 
 function oversizedPdfStream(path: string): KnowledgeBaseLimitError {

--- a/sdk/typescript/src/knowledge-base.ts
+++ b/sdk/typescript/src/knowledge-base.ts
@@ -397,40 +397,30 @@ function boundCompressedPdfStreams(
   const objectOffsets = [...(indirectObjects?.entries() ?? [])]
     .filter((entry): entry is [string, number] => typeof entry[1] === "number")
     .sort((left, right) => left[1] - right[1]);
+  const pageContentReferences = pdfPageContentReferences(
+    contents,
+    indirectObjects,
+    path,
+    signal,
+  );
   let inflatedBytes = 0;
   let decodingWorkBytes = 0;
   const dictionaryWork = { remaining: MAX_PDF_DICTIONARY_WORK_BYTES };
   for (const marker of contents.matchAll(streams)) {
     signal?.throwIfAborted();
+    const object = pdfObjectBeforeOffset(objectOffsets, marker.index);
     const dictionary = pdfStreamDictionary(
       contents,
       marker.index + 2,
       dictionaryWork,
       path,
-      indirectObjects,
+      object?.[1],
     );
     if (dictionary === null) continue;
-    const lexicalDictionary = pdfDictionaryLexicalValues(dictionary);
+    const lexicalDictionary = pdfDictionaryLexicalValues(dictionary, false);
     if (pdfTopLevelDictionaryName(lexicalDictionary, "Subtype") === "Image") {
-      let low = 0;
-      let high = objectOffsets.length;
-      while (low < high) {
-        const middle = Math.floor((low + high) / 2);
-        if (objectOffsets[middle]![1] < marker.index) low = middle + 1;
-        else high = middle;
-      }
-      const entry = objectOffsets[low - 1];
-      const [number, generation] = entry?.[0].split(":") ?? [];
       const pageContent =
-        number !== undefined &&
-        generation !== undefined &&
-        pdfContentsReferencesObject(
-          contents,
-          number,
-          generation,
-          indirectObjects,
-          path,
-        );
+        object !== undefined && pageContentReferences.has(object[0]);
       if (!pageContent) continue;
     }
     const filters = pdfStreamFilters(
@@ -552,14 +542,12 @@ function pdfStreamDictionary(
   end: number,
   work: { remaining: number },
   path: string,
-  offsets: ReadonlyMap<string, PdfCrossReferenceEntry> | null,
+  objectOffset?: number,
 ): string | null {
   let depth = 1;
   let minimum = Math.max(0, end - MAX_PDF_DICTIONARY_SCAN_BYTES);
-  for (const offset of offsets?.values() ?? []) {
-    if (typeof offset === "number" && offset < end && offset > minimum) {
-      minimum = offset;
-    }
+  if (objectOffset !== undefined && objectOffset > minimum) {
+    minimum = objectOffset;
   }
   const lexical = pdfDictionaryLexicalValues(
     contents.slice(minimum, end),
@@ -589,6 +577,20 @@ function pdfStreamDictionary(
     );
   }
   return null;
+}
+
+function pdfObjectBeforeOffset(
+  offsets: ReadonlyArray<readonly [string, number]>,
+  selected: number,
+): readonly [string, number] | undefined {
+  let low = 0;
+  let high = offsets.length;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    if (offsets[middle]![1] < selected) low = middle + 1;
+    else high = middle;
+  }
+  return offsets[low - 1];
 }
 
 function pdfIndirectValue(
@@ -670,11 +672,16 @@ function pdfIndirectValue(
       ) {
         return undefined;
       }
+      const raw = stream
+        .subarray(first + start, first + next)
+        .toString("latin1")
+        .trim();
+      const primitive = /^(\[[^\]]*\]|\/[^\s<>[\]()%/]+|\d+)$/u.exec(raw)?.[1];
       parsed.push({
         number,
-        value: /^\s*(\[[^\]]*\]|\/[^\s<>[\]()%/]+|\d+)\s*$/u.exec(
-          stream.subarray(first + start, first + next).toString("latin1"),
-        )?.[1],
+        value:
+          primitive ??
+          (raw.startsWith("<<") && raw.endsWith(">>") ? raw : undefined),
       });
     }
     objects = parsed;
@@ -1118,53 +1125,82 @@ function pdfTopLevelDictionaryName(
     if (
       dictionaryDepth !== 1 ||
       arrayDepth !== 0 ||
-      !dictionary.startsWith(`/${key}`, index)
+      dictionary[index] !== "/"
     ) {
       continue;
     }
-    const value = new RegExp(
-      `^/${key}\\s*/([^\\s<>[\\]()%/]+)(?=[\\s/>])`,
-      "u",
-    ).exec(dictionary.slice(index));
-    if (value?.[1] !== undefined) return value[1];
+    const value = /^\/([^\s<>[\]()%/]+)\s*\/([^\s<>[\]()%/]+)(?=[\s/>])/u.exec(
+      dictionary.slice(index),
+    );
+    if (value?.[1] !== undefined && pdfDecodedName(value[1]) === key) {
+      return pdfDecodedName(value[2]!);
+    }
   }
   return undefined;
 }
 
-function pdfContentsReferencesObject(
+function pdfDecodedName(value: string): string {
+  return value.replace(/#([0-9a-f]{2})/giu, (_match, encoded: string) =>
+    String.fromCharCode(Number.parseInt(encoded, 16)),
+  );
+}
+
+function pdfPageContentReferences(
   contents: string,
-  number: string,
-  generation: string,
   offsets: ReadonlyMap<string, PdfCrossReferenceEntry> | null,
   path: string,
-): boolean {
+  signal?: AbortSignal,
+): ReadonlySet<string> {
   const references = /\/(?:Contents)\s+(\[[^\]]*\]|\d+\s+\d+\s+R)/gu;
+  const pending: string[] = [];
+  let remaining = MAX_PDF_XREF_OBJECTS;
   for (const entry of contents.matchAll(references)) {
-    const pending = [entry[1]!];
-    const visited = new Set<string>();
-    while (pending.length > 0) {
-      const current = pdfDictionaryLexicalValues(pending.pop()!);
-      for (const reference of current.matchAll(/(\d+)\s+(\d+)\s+R/gu)) {
-        const key = `${reference[1]}:${reference[2]}`;
-        if (reference[1] === number && reference[2] === generation) {
-          return true;
-        }
-        if (visited.has(key) || visited.size >= MAX_PDF_XREF_OBJECTS) continue;
-        visited.add(key);
-        const resolved = pdfIndirectValue(
-          contents,
-          reference[1]!,
-          reference[2]!,
-          offsets,
-          path,
-        );
-        if (resolved?.trimStart().startsWith("[") === true) {
-          pending.push(resolved);
-        }
+    signal?.throwIfAborted();
+    if (--remaining < 0) throw oversizedPdfStream(path);
+    pending.push(entry[1]!);
+  }
+  for (const [key, offset] of offsets ?? []) {
+    if (offset === null || typeof offset === "number") continue;
+    signal?.throwIfAborted();
+    if (--remaining < 0) throw oversizedPdfStream(path);
+    const [object, generation] = key.split(":");
+    const dictionary = pdfIndirectValue(
+      contents,
+      object!,
+      generation!,
+      offsets,
+      path,
+    );
+    if (dictionary === undefined || !dictionary.startsWith("<<")) continue;
+    const lexical = pdfDictionaryLexicalValues(dictionary, false);
+    if (pdfTopLevelDictionaryName(lexical, "Type") !== "Page") continue;
+    const contentsValue = /\/Contents\s+(\[[^\]]*\]|\d+\s+\d+\s+R)/u.exec(
+      lexical,
+    )?.[1];
+    if (contentsValue !== undefined) pending.push(contentsValue);
+  }
+  const selected = new Set<string>();
+  while (pending.length > 0) {
+    signal?.throwIfAborted();
+    if (--remaining < 0) throw oversizedPdfStream(path);
+    const current = pdfDictionaryLexicalValues(pending.pop()!);
+    for (const reference of current.matchAll(/(\d+)\s+(\d+)\s+R/gu)) {
+      const key = `${reference[1]}:${reference[2]}`;
+      if (selected.has(key)) continue;
+      selected.add(key);
+      const resolved = pdfIndirectValue(
+        contents,
+        reference[1]!,
+        reference[2]!,
+        offsets,
+        path,
+      );
+      if (resolved?.trimStart().startsWith("[") === true) {
+        pending.push(resolved);
       }
     }
   }
-  return false;
+  return selected;
 }
 
 function pdfStreamFilters(
@@ -1214,11 +1250,7 @@ function pdfStreamFilters(
       }
       name = reference[1];
     }
-    filters.push(
-      name.replace(/#([0-9a-f]{2})/giu, (_match, encoded: string) =>
-        String.fromCharCode(Number.parseInt(encoded, 16)),
-      ),
-    );
+    filters.push(pdfDecodedName(name));
   }
   return filters;
 }

--- a/sdk/typescript/src/knowledge-base.ts
+++ b/sdk/typescript/src/knowledge-base.ts
@@ -9,7 +9,15 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, extname, join, resolve, sep } from "node:path";
+import {
+  basename,
+  extname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from "node:path";
 import { unzipSync } from "fflate";
 
 const SUPPORTED_EXTENSIONS = new Set([
@@ -254,9 +262,11 @@ async function requireContainedSource(
   sourceRoot: string,
 ): Promise<string> {
   const canonical = await realpath(path);
+  const remaining = relative(sourceRoot, canonical);
   if (
-    canonical !== sourceRoot &&
-    !canonical.startsWith(`${sourceRoot}${sep}`)
+    remaining === ".." ||
+    remaining.startsWith(`..${sep}`) ||
+    isAbsolute(remaining)
   ) {
     throw new Error(
       `Knowledge base path escaped the requested source: ${path}`,

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -3914,6 +3914,7 @@ if (args === "login --with-api-key") {
   }
 } else if (args === "login") {
   console.error("Open https://auth.example.test/login");
+  process.exit(0);
 } else {
   process.exitCode = 2;
 }

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -3901,7 +3901,7 @@ if (process.argv.slice(2).join(" ") !== "login status") {
     await writeFile(
       fakeCodex,
       `
-import { appendFileSync } from "node:fs";
+import { appendFileSync, writeSync } from "node:fs";
 
 const args = process.argv.slice(2).join(" ");
 if (args === "login --with-api-key") {
@@ -3913,7 +3913,7 @@ if (args === "login --with-api-key") {
     appendFileSync(${JSON.stringify(keyLog)}, apiKey);
   }
 } else if (args === "login") {
-  console.error("Open https://auth.example.test/login");
+  writeSync(2, "Open https://auth.example.test/login\\n");
   process.exit(0);
 } else {
   process.exitCode = 2;

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -3901,12 +3901,11 @@ if (process.argv.slice(2).join(" ") !== "login status") {
     await writeFile(
       fakeCodex,
       `
-import { appendFileSync, writeSync } from "node:fs";
+import { appendFileSync, readFileSync, writeSync } from "node:fs";
 
 const args = process.argv.slice(2).join(" ");
 if (args === "login --with-api-key") {
-  let apiKey = "";
-  for await (const chunk of process.stdin) apiKey += chunk;
+  const apiKey = readFileSync(0, "utf8");
   if (!["secret-key", "ambient-key"].includes(apiKey.trim())) {
     process.exitCode = 3;
   } else {
@@ -3914,10 +3913,10 @@ if (args === "login --with-api-key") {
   }
 } else if (args === "login") {
   writeSync(2, "Open https://auth.example.test/login\\n");
-  process.exit(0);
 } else {
   process.exitCode = 2;
 }
+process.exit(process.exitCode ?? 0);
 `,
     );
     let codexOptions: CodexOptions | null = null;

--- a/sdk/typescript/tests-ts/knowledge-base.test.ts
+++ b/sdk/typescript/tests-ts/knowledge-base.test.ts
@@ -148,7 +148,7 @@ function pdf(
     ...(options.formBytes === undefined
       ? []
       : [
-          `<< /Type /XObject /Subtype /Form /Foo << /Subtype /Image >> /BBox [0 0 1 1] /Length ${deflateSync(options.formBytes).byteLength} /Filter /FlateDecode >>\nstream\n${deflateSync(options.formBytes).toString("latin1")}\nendstream`,
+          `<< /Type /XObject /Foo /#3E#3E /Bar << /Subtype /Image >> /Subtype /Form /BBox [0 0 1 1] /Length ${deflateSync(options.formBytes).byteLength} /Filter /FlateDecode >>\nstream\n${deflateSync(options.formBytes).toString("latin1")}\nendstream`,
         ]),
   ];
   let output = `%PDF-1.4\n${options.headerComment === undefined ? "" : `% ${options.headerComment}\n`}`;
@@ -170,7 +170,11 @@ function xrefStreamPdf(
   document: Uint8Array,
   compressIndirectObjects = false,
   objectHeaderPadding = 0,
-  options: { objectHeaderComments?: boolean; tiffPredictor?: boolean } = {},
+  options: {
+    objectHeaderComments?: boolean;
+    tiffPredictor?: boolean;
+    compressPageObjects?: boolean;
+  } = {},
 ): Buffer {
   const original = Buffer.from(document).toString("latin1");
   const table = original.lastIndexOf("\nxref\n");
@@ -184,6 +188,13 @@ function xrefStreamPdf(
       ),
     ),
   ];
+  if (options.compressPageObjects) {
+    for (const page of body.matchAll(
+      /(?:^|\n)(\d+) 0 obj\n<< \/Type \/Page(?=[\s/>])/gu,
+    )) {
+      references.push(Number(page[1]));
+    }
+  }
   let maximumObject = Math.max(
     ...[...body.matchAll(/^(\d+)\s+0\s+obj$/gmu)].map((match) =>
       Number(match[1]),
@@ -909,6 +920,56 @@ describe("scan knowledge bases", () => {
       pdf("Small document text", 1, true, "/Fm1 Do ", {
         formBytes: Buffer.alloc(9 * 1024 * 1024, 32),
       }),
+    );
+
+    await expect(prepareKnowledgeBase([document])).rejects.toThrow(
+      "8388608-byte extracted-text limit",
+    );
+  });
+
+  test("bounds cumulative indirect PDF contents references", async () => {
+    const root = await temporaryDirectory();
+    const document = join(root, "contents-reference-budget.pdf");
+    await writeFile(
+      document,
+      pdf("Bound repeated contents references", 1, true, "", {
+        headerComment: "/Contents 5 0 R ".repeat(70_000),
+      }),
+    );
+
+    await expect(prepareKnowledgeBase([document])).rejects.toThrow(
+      "8388608-byte extracted-text limit",
+    );
+  });
+
+  test("indexes cross-reference ownership across many compressed streams", async () => {
+    const root = await temporaryDirectory();
+    const document = join(root, "many-streams.pdf");
+    await writeFile(
+      document,
+      pdf("Indexed stream ownership", 1, true, "", { extraStreams: 1_024 }),
+    );
+
+    const knowledgeBase = await prepareKnowledgeBase([document]);
+    temporaryDirectories.push(knowledgeBase.path);
+    expect(await extractedDocuments(knowledgeBase.path)).toEqual([
+      "Indexed stream ownership",
+    ]);
+  });
+
+  test("bounds image-tagged content streams referenced by compressed page objects", async () => {
+    const root = await temporaryDirectory();
+    const document = join(root, "compressed-page-content.pdf");
+    await writeFile(
+      document,
+      xrefStreamPdf(
+        pdf("reviewable", 1, true, " ".repeat(9 * 1024 * 1024), {
+          dictionaryPrefix: "/Subtype /Image ",
+        }),
+        true,
+        0,
+        { compressPageObjects: true },
+      ),
     );
 
     await expect(prepareKnowledgeBase([document])).rejects.toThrow(

--- a/sdk/typescript/tests-ts/knowledge-base.test.ts
+++ b/sdk/typescript/tests-ts/knowledge-base.test.ts
@@ -157,10 +157,28 @@ function encodeRunLength(bytes: Buffer): Buffer {
   return Buffer.from(encoded);
 }
 
-function encodePdfLzwLiterals(bytes: Buffer): Buffer {
+function encodePdfLzwLiterals(bytes: Buffer, earlyChange: 0 | 1 = 1): Buffer {
   const codes = [256, ...bytes, 257];
   let bits = "";
-  for (const code of codes) bits += code.toString(2).padStart(9, "0");
+  let nextCode = 258;
+  let codeBits = 9;
+  let previous = false;
+  for (const code of codes) {
+    bits += code.toString(2).padStart(codeBits, "0");
+    if (code === 256) {
+      nextCode = 258;
+      codeBits = 9;
+      previous = false;
+    } else if (code !== 257) {
+      if (previous && nextCode < 4_096) {
+        nextCode += 1;
+        if (nextCode + earlyChange === 1 << codeBits && codeBits < 12) {
+          codeBits += 1;
+        }
+      }
+      previous = true;
+    }
+  }
   bits = bits.padEnd(Math.ceil(bits.length / 8) * 8, "0");
   return Buffer.from(
     Array.from({ length: bits.length / 8 }, (_unused, index) =>
@@ -465,6 +483,7 @@ describe("scan knowledge bases", () => {
     const indirect = join(root, "indirect.pdf");
     const escaped = join(root, "escaped.pdf");
     const lzw = join(root, "lzw.pdf");
+    const earlyChange = join(root, "lzw-early-change.pdf");
     await writeFile(
       chained,
       pdf("ASCII85 then Flate", 1, true, "", {
@@ -487,6 +506,15 @@ describe("scan knowledge bases", () => {
         encode: encodePdfLzwLiterals,
       }),
     );
+    const earlyChangeText = `LZW early change ${"x".repeat(350)}`;
+    await writeFile(
+      earlyChange,
+      pdf(earlyChangeText, 1, false, "", {
+        filter: "/LZWDecode",
+        dictionaryPrefix: "/DecodeParms << /EarlyChange 0 >> ",
+        encode: (bytes) => encodePdfLzwLiterals(bytes, 0),
+      }),
+    );
 
     const knowledgeBase = await prepareKnowledgeBase([root]);
     temporaryDirectories.push(knowledgeBase.path);
@@ -496,6 +524,7 @@ describe("scan knowledge bases", () => {
         "Escaped PDF filter",
         "Indirect stream length",
         "LZW encoded text",
+        earlyChangeText,
       ].sort(),
     );
   });
@@ -525,6 +554,10 @@ describe("scan knowledge bases", () => {
         "literal-length-token",
         { dictionaryPrefix: "/Note (/Length 999999999) " },
       ],
+      [
+        "literal-filter-token",
+        { dictionaryPrefix: "/Note (/Filter /DCTDecode) " },
+      ],
     ] as const) {
       const document = join(root, `${name}.pdf`);
       await writeFile(
@@ -535,6 +568,48 @@ describe("scan knowledge bases", () => {
         "8388608-byte extracted-text limit",
       );
     }
+  });
+
+  test("bounds repeated PDF LZW clear codes without allocating fresh dictionaries", async () => {
+    const root = await temporaryDirectory();
+    const document = join(root, "lzw-clears.pdf");
+    const clearCodes = 1_000_001;
+    const encoded = Buffer.alloc(Math.ceil(((clearCodes + 1) * 9) / 8));
+    let offset = 0;
+    for (let index = 0; index <= clearCodes; index += 1) {
+      const code = index === clearCodes ? 257 : 256;
+      for (let bit = 8; bit >= 0; bit -= 1) {
+        encoded[Math.floor(offset / 8)]! |=
+          ((code >> bit) & 1) << (7 - (offset % 8));
+        offset += 1;
+      }
+    }
+    await writeFile(
+      document,
+      pdf("reviewable", 1, false, "", {
+        filter: "/LZWDecode",
+        encode: () => encoded,
+      }),
+    );
+
+    await expect(prepareKnowledgeBase([document])).rejects.toThrow(
+      "8388608-byte extracted-text limit",
+    );
+  });
+
+  test("bounds adversarial backward PDF stream-dictionary scans", async () => {
+    const root = await temporaryDirectory();
+    const document = join(root, "dictionary-work.pdf");
+    await writeFile(
+      document,
+      pdf("reviewable", 1, false, "", {
+        headerComment: ">>stream\n".repeat(6_000),
+      }),
+    );
+
+    await expect(prepareKnowledgeBase([document])).rejects.toThrow(
+      "dictionary scan limit",
+    );
   });
 
   test("rejects duplicate DOCX document entries before repeated inflation", async () => {

--- a/sdk/typescript/tests-ts/knowledge-base.test.ts
+++ b/sdk/typescript/tests-ts/knowledge-base.test.ts
@@ -142,6 +142,63 @@ describe("scan knowledge bases", () => {
     expect(documents).toContain("SSRF & IDOR\n");
   });
 
+  test("keeps DOCX numeric references that cannot name a code point as literal text", async () => {
+    // https://github.com/openai/codex-security/issues/40 -- an out-of-range
+    // reference used to raise RangeError out of String.fromCodePoint, which
+    // surfaced as an unextractable document and failed the whole knowledge base.
+    const cases: Array<[string, string, string]> = [
+      [
+        "above-max-hex",
+        "Boundary &#x110000; case.",
+        "Boundary &#x110000; case.",
+      ],
+      [
+        "above-max-decimal",
+        "Boundary &#1114112; case.",
+        "Boundary &#1114112; case.",
+      ],
+      [
+        "huge-decimal",
+        "Huge &#99999999999999; case.",
+        "Huge &#99999999999999; case.",
+      ],
+      [
+        "lone-surrogate",
+        "Surrogate &#xD800; case.",
+        "Surrogate &#xD800; case.",
+      ],
+      ["valid-ascii", "Valid &#65; case.", "Valid A case."],
+      ["valid-astral", "Valid &#128512; case.", "Valid \u{1F600} case."],
+      ["max-code-point", "Valid &#x10FFFF; case.", "Valid \u{10FFFF} case."],
+    ];
+
+    for (const [name, body, expected] of cases) {
+      const root = await temporaryDirectory();
+      await writeFile(join(root, `${name}.docx`), docx(body));
+      const knowledgeBase = await prepareKnowledgeBase([root]);
+      temporaryDirectories.push(knowledgeBase.path);
+      const documents = await extractedDocuments(knowledgeBase.path);
+      expect(documents).toEqual([`${expected}\n`]);
+    }
+  });
+
+  test("keeps one unusable reference from failing the other knowledge-base documents", async () => {
+    const root = await temporaryDirectory();
+    await writeFile(join(root, "notes.md"), "Authentication boundary notes");
+    await writeFile(
+      join(root, "threat-model.docx"),
+      docx("Boundary &#x110000; case."),
+    );
+
+    const knowledgeBase = await prepareKnowledgeBase([root]);
+    temporaryDirectories.push(knowledgeBase.path);
+    const documents = await extractedDocuments(knowledgeBase.path);
+
+    expect(documents).toHaveLength(2);
+    expect(documents).toContain("Authentication boundary notes");
+    expect(documents).toContain("Boundary &#x110000; case.\n");
+  });
+
   test("cleans up documents and rediscovers directory contents on later runs", async () => {
     const root = await temporaryDirectory();
     const source = join(root, "scope.md");

--- a/sdk/typescript/tests-ts/knowledge-base.test.ts
+++ b/sdk/typescript/tests-ts/knowledge-base.test.ts
@@ -70,6 +70,7 @@ function pdf(
     indirectValuePrefix?: string;
     indirectValueComment?: string;
     imageBytes?: Buffer;
+    uncompressedImage?: boolean;
     formBytes?: Buffer;
     headerComment?: string;
     dictionaryPrefix?: string;
@@ -143,7 +144,12 @@ function pdf(
     ...(options.imageBytes === undefined
       ? []
       : [
-          `<< /Type /XObject /Subtype /Image /Width 1024 /Height ${Math.ceil(options.imageBytes.byteLength / 1024)} /ColorSpace /DeviceGray /BitsPerComponent 8 /Length ${deflateSync(options.imageBytes).byteLength} /Filter /FlateDecode >>\nstream\n${deflateSync(options.imageBytes).toString("latin1")}\nendstream`,
+          (() => {
+            const image = options.uncompressedImage
+              ? options.imageBytes!
+              : deflateSync(options.imageBytes!);
+            return `<< /Type /XObject /Subtype /Image /Width 1024 /Height ${Math.ceil(options.imageBytes!.byteLength / 1024)} /ColorSpace /DeviceGray /BitsPerComponent 8 /Length ${image.byteLength}${options.uncompressedImage ? "" : " /Filter /FlateDecode"} >>\nstream\n${image.toString("latin1")}\nendstream`;
+          })(),
         ]),
     ...(options.formBytes === undefined
       ? []
@@ -176,7 +182,9 @@ function xrefStreamPdf(
     compressPageObjects?: boolean;
     compressedPagePrefix?: string;
     compressedPageSuffix?: string;
+    compressedPageDictionaryPrefix?: string;
     escapedCompressedPageContents?: boolean;
+    compressedPageContentsArray?: boolean;
     objectStreamFilter?: {
       name: string;
       encode: (bytes: Buffer) => Buffer;
@@ -225,6 +233,15 @@ function xrefStreamPdf(
       let value = match[1];
       if (page && options.escapedCompressedPageContents === true) {
         value = value.replace("/Contents ", "/Cont#65nts ");
+      }
+      if (page && options.compressedPageContentsArray === true) {
+        value = value.replace(/\/Contents (\d+ \d+ R)/u, "/Contents[$1]");
+      }
+      if (page && options.compressedPageDictionaryPrefix !== undefined) {
+        value = value.replace(
+          /^<</u,
+          `<< ${options.compressedPageDictionaryPrefix} `,
+        );
       }
       if (page) {
         value = `${options.compressedPagePrefix ?? ""}${value}${options.compressedPageSuffix ?? ""}`;
@@ -1008,6 +1025,11 @@ describe("scan knowledge bases", () => {
         },
       ],
       ["escaped-contents", { escapedCompressedPageContents: true }],
+      [
+        "escaped-structural-name",
+        { compressedPageDictionaryPrefix: "/Foo /#3C#3C" },
+      ],
+      ["delimiter-adjacent-array", { compressedPageContentsArray: true }],
     ] as const) {
       const root = await temporaryDirectory();
       const document = join(root, `${name}.pdf`);
@@ -1055,6 +1077,55 @@ describe("scan knowledge bases", () => {
         "8388608-byte extracted-text limit",
       );
     }
+  });
+
+  test("applies an LZW predictor before the next compressed object-stream filter", async () => {
+    const root = await temporaryDirectory();
+    const document = join(root, "predicted-lzw-object-stream.pdf");
+    await writeFile(
+      document,
+      xrefStreamPdf(pdf("Predicted compressed page", 1, true), true, 0, {
+        compressPageObjects: true,
+        objectStreamFilter: {
+          name: "[/LZWDecode /ASCII85Decode] /DecodeParms [<< /Predictor 12 /Columns 1 >> null]",
+          encode: (contents) =>
+            encodePdfLzwLiterals(
+              Buffer.from(
+                [...encodeAscii85(contents)].flatMap((byte) => [0, byte]),
+              ),
+            ),
+        },
+      }),
+    );
+
+    const knowledgeBase = await prepareKnowledgeBase([document]);
+    temporaryDirectories.push(knowledgeBase.path);
+    expect(await extractedDocuments(knowledgeBase.path)).toEqual([
+      "Predicted compressed page",
+    ]);
+  });
+
+  test("ignores stream-shaped bytes inside declared uncompressed image data", async () => {
+    const root = await temporaryDirectory();
+    const document = join(root, "stream-shaped-image-data.pdf");
+    const pixels = Buffer.alloc(1024);
+    pixels.write(
+      "<< /Length 1 /Filter /FlateDecode >>\nstream\nX\nendstream\n",
+      "latin1",
+    );
+    await writeFile(
+      document,
+      pdf("Image payload remains data", 1, false, "", {
+        imageBytes: pixels,
+        uncompressedImage: true,
+      }),
+    );
+
+    const knowledgeBase = await prepareKnowledgeBase([document]);
+    temporaryDirectories.push(knowledgeBase.path);
+    expect(await extractedDocuments(knowledgeBase.path)).toEqual([
+      "Image payload remains data",
+    ]);
   });
 
   test("rejects negative cross-reference stream field widths", async () => {

--- a/sdk/typescript/tests-ts/knowledge-base.test.ts
+++ b/sdk/typescript/tests-ts/knowledge-base.test.ts
@@ -64,6 +64,8 @@ function pdf(
     extraStreams?: number;
     indirectLength?: boolean;
     headerComment?: string;
+    dictionaryPrefix?: string;
+    streamComment?: string;
   } = {},
 ): Uint8Array {
   const escaped = text.replace(/[\\()]/gu, "\\$&");
@@ -83,7 +85,7 @@ function pdf(
   const length = options.indirectLength
     ? `${content + extraStreams + 1} 0 R`
     : String(streamBytes.byteLength);
-  const streamObject = `<< /Length ${length}${filter === undefined ? "" : ` /Filter ${filter}`} >>\nstream\n${streamBytes.toString("latin1")}\nendstream`;
+  const streamObject = `<< ${options.dictionaryPrefix ?? ""}/Length ${length}${filter === undefined ? "" : ` /Filter ${filter}`} >>${options.streamComment === undefined ? "\n" : ` ${options.streamComment}\n`}stream\n${streamBytes.toString("latin1")}\nendstream`;
   const objects = [
     "<< /Type /Catalog /Pages 2 0 R >>",
     `<< /Type /Pages /Kids [${pageObjects.map((number) => `${number} 0 R`).join(" ")}] /Count ${pages} >>`,
@@ -153,6 +155,18 @@ function encodeRunLength(bytes: Buffer): Buffer {
   }
   encoded.push(128);
   return Buffer.from(encoded);
+}
+
+function encodePdfLzwLiterals(bytes: Buffer): Buffer {
+  const codes = [256, ...bytes, 257];
+  let bits = "";
+  for (const code of codes) bits += code.toString(2).padStart(9, "0");
+  bits = bits.padEnd(Math.ceil(bits.length / 8) * 8, "0");
+  return Buffer.from(
+    Array.from({ length: bits.length / 8 }, (_unused, index) =>
+      Number.parseInt(bits.slice(index * 8, index * 8 + 8), 2),
+    ),
+  );
 }
 
 describe("scan knowledge bases", () => {
@@ -450,6 +464,7 @@ describe("scan knowledge bases", () => {
     const chained = join(root, "chained.pdf");
     const indirect = join(root, "indirect.pdf");
     const escaped = join(root, "escaped.pdf");
+    const lzw = join(root, "lzw.pdf");
     await writeFile(
       chained,
       pdf("ASCII85 then Flate", 1, true, "", {
@@ -465,6 +480,13 @@ describe("scan knowledge bases", () => {
       escaped,
       pdf("Escaped PDF filter", 1, true, "", { filter: "/#46lateDecode" }),
     );
+    await writeFile(
+      lzw,
+      pdf("LZW encoded text", 1, false, "", {
+        filter: "/LZWDecode",
+        encode: encodePdfLzwLiterals,
+      }),
+    );
 
     const knowledgeBase = await prepareKnowledgeBase([root]);
     temporaryDirectories.push(knowledgeBase.path);
@@ -473,6 +495,7 @@ describe("scan knowledge bases", () => {
         "ASCII85 then Flate",
         "Escaped PDF filter",
         "Indirect stream length",
+        "LZW encoded text",
       ].sort(),
     );
   });
@@ -492,6 +515,26 @@ describe("scan knowledge bases", () => {
     expect(await extractedDocuments(knowledgeBase.path)).toEqual([
       "Uncompressed PDF",
     ]);
+  });
+
+  test("bounds compressed streams after PDF comments and ignores fake literal lengths", async () => {
+    const root = await temporaryDirectory();
+    for (const [name, options] of [
+      ["comment-before-stream", { streamComment: "% comment before stream" }],
+      [
+        "literal-length-token",
+        { dictionaryPrefix: "/Note (/Length 999999999) " },
+      ],
+    ] as const) {
+      const document = join(root, `${name}.pdf`);
+      await writeFile(
+        document,
+        pdf("reviewable", 1, true, " ".repeat(9 * 1024 * 1024), options),
+      );
+      await expect(prepareKnowledgeBase([document])).rejects.toThrow(
+        "8388608-byte extracted-text limit",
+      );
+    }
   });
 
   test("rejects duplicate DOCX document entries before repeated inflation", async () => {

--- a/sdk/typescript/tests-ts/knowledge-base.test.ts
+++ b/sdk/typescript/tests-ts/knowledge-base.test.ts
@@ -64,6 +64,7 @@ function pdf(
     extraStreams?: number;
     indirectLength?: boolean;
     indirectFilter?: boolean;
+    indirectValueComment?: string;
     headerComment?: string;
     dictionaryPrefix?: string;
     streamComment?: string;
@@ -101,8 +102,14 @@ function pdf(
     "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
     streamObject,
     ...Array.from({ length: extraStreams }, () => streamObject),
-    ...(options.indirectLength ? [String(streamBytes.byteLength)] : []),
-    ...(options.indirectFilter ? [directFilter ?? "/FlateDecode"] : []),
+    ...(options.indirectLength
+      ? [`${streamBytes.byteLength}${options.indirectValueComment ?? ""}`]
+      : []),
+    ...(options.indirectFilter
+      ? [
+          `${directFilter ?? "/FlateDecode"}${options.indirectValueComment ?? ""}`,
+        ]
+      : []),
   ];
   let output = `%PDF-1.4\n${options.headerComment === undefined ? "" : `% ${options.headerComment}\n`}`;
   const offsets = [0];
@@ -122,6 +129,7 @@ function pdf(
 function xrefStreamPdf(
   document: Uint8Array,
   compressIndirectObjects = false,
+  objectHeaderPadding = 0,
 ): Buffer {
   const original = Buffer.from(document).toString("latin1");
   const table = original.lastIndexOf("\nxref\n");
@@ -165,6 +173,7 @@ function xrefStreamPdf(
       header += `${number} ${objectBody.length} `;
       objectBody += `${values[index]} `;
     }
+    header += " ".repeat(objectHeaderPadding);
     const encoded = deflateSync(Buffer.from(header + objectBody, "latin1"));
     body += `${streamObject} 0 obj\n<< /Type /ObjStm /N ${references.length} /First ${header.length} /Length ${encoded.byteLength} /Filter /FlateDecode >>\nstream\n${encoded.toString("latin1")}\nendstream\nendobj\n`;
   }
@@ -599,6 +608,7 @@ describe("scan knowledge bases", () => {
     const chained = join(root, "chained.pdf");
     const indirect = join(root, "indirect.pdf");
     const indirectFilter = join(root, "indirect-filter.pdf");
+    const commentedIndirect = join(root, "commented-indirect.pdf");
     const escaped = join(root, "escaped.pdf");
     const lzw = join(root, "lzw.pdf");
     const earlyChange = join(root, "lzw-early-change.pdf");
@@ -616,6 +626,14 @@ describe("scan knowledge bases", () => {
     await writeFile(
       indirectFilter,
       pdf("Indirect stream filter", 1, true, "", { indirectFilter: true }),
+    );
+    await writeFile(
+      commentedIndirect,
+      pdf("Commented indirect values", 1, true, "", {
+        indirectLength: true,
+        indirectFilter: true,
+        indirectValueComment: " % valid comment\n",
+      }),
     );
     await writeFile(
       escaped,
@@ -643,6 +661,7 @@ describe("scan knowledge bases", () => {
     expect((await extractedDocuments(knowledgeBase.path)).sort()).toEqual(
       [
         "ASCII85 then Flate",
+        "Commented indirect values",
         "Escaped PDF filter",
         "Indirect stream length",
         "Indirect stream filter",
@@ -676,6 +695,48 @@ describe("scan knowledge bases", () => {
       "PDF object-stream.pdf",
       "PDF xref-stream.pdf",
     ]);
+  });
+
+  test("caches large compressed object-stream headers across repeated references", async () => {
+    const root = await temporaryDirectory();
+    const document = join(root, "large-object-header.pdf");
+    await writeFile(
+      document,
+      xrefStreamPdf(
+        pdf("Cached object stream header", 1, true, "", {
+          extraStreams: 12,
+          indirectLength: true,
+          indirectFilter: true,
+        }),
+        true,
+        512 * 1024,
+      ),
+    );
+
+    const knowledgeBase = await prepareKnowledgeBase([document]);
+    temporaryDirectories.push(knowledgeBase.path);
+    expect(await extractedDocuments(knowledgeBase.path)).toEqual([
+      "Cached object stream header",
+    ]);
+  });
+
+  test("rejects negative cross-reference stream field widths", async () => {
+    const root = await temporaryDirectory();
+    const document = join(root, "negative-xref-width.pdf");
+    const malformed = xrefStreamPdf(
+      pdf("Malformed cross-reference", 1, true, "", {
+        indirectLength: true,
+        indirectFilter: true,
+      }),
+      true,
+    )
+      .toString("latin1")
+      .replace("/W [1 4 2]", "/W [-1 0 0]");
+    await writeFile(document, Buffer.from(malformed, "latin1"));
+
+    await expect(prepareKnowledgeBase([document])).rejects.toThrow(
+      "Cannot extract text from knowledge base PDF",
+    );
   });
 
   test("counts unique objects across overlapping incremental cross-reference tables", async () => {
@@ -728,6 +789,10 @@ describe("scan knowledge bases", () => {
       ],
       ["literal-dictionary-close", { dictionaryPrefix: "/Note (>>) " }],
       ["literal-dictionary-open", { dictionaryPrefix: "/Note (<<) " }],
+      [
+        "escaped-literal-dictionary-close",
+        { dictionaryPrefix: "/Note (/A#29 /Filter /DCTDecode) " },
+      ],
       [
         "comment-dictionary-delimiters",
         { dictionaryPrefix: "% << >> ignored\n" },

--- a/sdk/typescript/tests-ts/knowledge-base.test.ts
+++ b/sdk/typescript/tests-ts/knowledge-base.test.ts
@@ -1093,10 +1093,27 @@ describe("scan knowledge bases", () => {
   });
 
   test("applies an LZW predictor before the next compressed object-stream filter", async () => {
-    for (const [name, parameter, indirect] of [
-      ["explicit columns", "<< /Predictor 12 /Columns 1 >>", false],
-      ["default columns", "<< /Predictor 12 >>", false],
-      ["indirect parameters", "@DECODE_PARAMETERS@", true],
+    for (const [name, parameter, indirectValue, indirectArray] of [
+      ["explicit columns", "<< /Predictor 12 /Columns 1 >>", undefined, false],
+      ["default columns", "<< /Predictor 12 >>", undefined, false],
+      [
+        "indirect parameters",
+        "@DECODE_PARAMETERS@",
+        "<< /Predictor 12 >>",
+        false,
+      ],
+      [
+        "nested indirect parameters",
+        "@DECODE_PARAMETERS@",
+        "<< /Metadata << /Label (>> literal) >> /Predictor 12 >>",
+        false,
+      ],
+      [
+        "indirect parameter array",
+        "@DECODE_PARAMETERS@",
+        "[<< /Predictor 12 >> null]",
+        true,
+      ],
     ] as const) {
       const root = await temporaryDirectory();
       const document = join(root, `${name}.pdf`);
@@ -1104,11 +1121,11 @@ describe("scan knowledge bases", () => {
         document,
         xrefStreamPdf(pdf("Predicted compressed page", 1, true), true, 0, {
           compressPageObjects: true,
-          ...(indirect
-            ? { objectStreamDecodeParametersObject: "<< /Predictor 12 >>" }
+          ...(indirectValue !== undefined
+            ? { objectStreamDecodeParametersObject: indirectValue }
             : {}),
           objectStreamFilter: {
-            name: `[/LZWDecode /ASCII85Decode] /DecodeParms [${parameter} null]`,
+            name: `[/LZWDecode /ASCII85Decode] /DecodeParms ${indirectArray ? parameter : `[${parameter} null]`}`,
             encode: (contents) =>
               encodePdfLzwLiterals(
                 Buffer.from(
@@ -1161,6 +1178,21 @@ describe("scan knowledge bases", () => {
 
     await expect(prepareKnowledgeBase([document])).rejects.toThrow(
       "8388608-byte extracted-text limit",
+    );
+  });
+
+  test("bounds lexical work across repeated stream-shaped literal data", async () => {
+    const root = await temporaryDirectory();
+    const document = join(root, "many-literal-stream-markers.pdf");
+    await writeFile(
+      document,
+      pdf("reviewable", 1, true, "", {
+        catalogPrefix: `/Decoy (${">>\nstream\n".repeat(3_000)}) `,
+      }),
+    );
+
+    await expect(prepareKnowledgeBase([document])).rejects.toThrow(
+      "dictionary scan limit",
     );
   });
 

--- a/sdk/typescript/tests-ts/knowledge-base.test.ts
+++ b/sdk/typescript/tests-ts/knowledge-base.test.ts
@@ -65,9 +65,12 @@ function pdf(
     indirectLength?: boolean;
     indirectFilter?: boolean;
     indirectFilterArray?: boolean;
+    indirectCommentedFilterArray?: boolean;
+    indirectContentsArray?: boolean;
     indirectValuePrefix?: string;
     indirectValueComment?: string;
     imageBytes?: Buffer;
+    formBytes?: Buffer;
     headerComment?: string;
     dictionaryPrefix?: string;
     streamComment?: string;
@@ -88,29 +91,39 @@ function pdf(
   const directFilter =
     options.filter ?? (compressed ? "/FlateDecode" : undefined);
   const extraStreams = options.extraStreams ?? 0;
-  const length = options.indirectLength
-    ? `${content + extraStreams + 1} 0 R`
-    : String(streamBytes.byteLength);
-  const indirectFilter = options.indirectFilter || options.indirectFilterArray;
-  const filterReference = `${content + extraStreams + 1 + (options.indirectLength ? 1 : 0)} 0 R`;
+  let nextObject = content + extraStreams + 1;
+  const lengthObject = options.indirectLength ? nextObject++ : undefined;
+  const indirectFilter =
+    options.indirectFilter ||
+    options.indirectFilterArray ||
+    options.indirectCommentedFilterArray;
+  const filterObject = indirectFilter ? nextObject++ : undefined;
+  const filterNameObject = options.indirectCommentedFilterArray
+    ? nextObject++
+    : undefined;
+  const contentsArrayObject = options.indirectContentsArray
+    ? nextObject++
+    : undefined;
+  const imageObject =
+    options.imageBytes === undefined ? undefined : nextObject++;
+  const formObject = options.formBytes === undefined ? undefined : nextObject++;
+  const length =
+    lengthObject === undefined
+      ? String(streamBytes.byteLength)
+      : `${lengthObject} 0 R`;
+  const filterReference = `${filterObject} 0 R`;
   const filter = options.indirectFilterArray
     ? `[${filterReference}]`
-    : options.indirectFilter
+    : options.indirectFilter || options.indirectCommentedFilterArray
       ? filterReference
       : directFilter;
-  const imageObject =
-    content +
-    extraStreams +
-    1 +
-    (options.indirectLength ? 1 : 0) +
-    (indirectFilter ? 1 : 0);
   const streamObject = `<< ${options.dictionaryPrefix ?? ""}/Length ${length}${filter === undefined ? "" : ` /Filter ${filter}`} >>${options.streamComment === undefined ? "\n" : ` ${options.streamComment}\n`}stream\n${streamBytes.toString("latin1")}\nendstream`;
   const objects = [
     "<< /Type /Catalog /Pages 2 0 R >>",
     `<< /Type /Pages /Kids [${pageObjects.map((number) => `${number} 0 R`).join(" ")}] /Count ${pages} >>`,
     ...pageObjects.map(
       () =>
-        `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 2000000 792] /Resources << /Font << /F1 ${font} 0 R >>${options.imageBytes === undefined ? "" : ` /XObject << /Im1 ${imageObject} 0 R >>`} >> /Contents ${content} 0 R >>`,
+        `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 2000000 792] /Resources << /Font << /F1 ${font} 0 R >>${imageObject === undefined && formObject === undefined ? "" : ` /XObject <<${imageObject === undefined ? "" : ` /Im1 ${imageObject} 0 R`}${formObject === undefined ? "" : ` /Fm1 ${formObject} 0 R`} >>`} >> /Contents ${contentsArrayObject ?? content} 0 R >>`,
     ),
     "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
     streamObject,
@@ -122,13 +135,20 @@ function pdf(
       : []),
     ...(indirectFilter
       ? [
-          `${options.indirectValuePrefix ?? ""}${directFilter ?? "/FlateDecode"}${options.indirectValueComment ?? ""}`,
+          `${options.indirectValuePrefix ?? ""}${filterNameObject === undefined ? directFilter ?? "/FlateDecode" : `[${filterNameObject} % valid filter comment\n0 R]`}${options.indirectValueComment ?? ""}`,
         ]
       : []),
+    ...(filterNameObject === undefined ? [] : [directFilter ?? "/FlateDecode"]),
+    ...(contentsArrayObject === undefined ? [] : [`[${content} 0 R]`]),
     ...(options.imageBytes === undefined
       ? []
       : [
           `<< /Type /XObject /Subtype /Image /Width 1024 /Height ${Math.ceil(options.imageBytes.byteLength / 1024)} /ColorSpace /DeviceGray /BitsPerComponent 8 /Length ${deflateSync(options.imageBytes).byteLength} /Filter /FlateDecode >>\nstream\n${deflateSync(options.imageBytes).toString("latin1")}\nendstream`,
+        ]),
+    ...(options.formBytes === undefined
+      ? []
+      : [
+          `<< /Type /XObject /Subtype /Form /Foo << /Subtype /Image >> /BBox [0 0 1 1] /Length ${deflateSync(options.formBytes).byteLength} /Filter /FlateDecode >>\nstream\n${deflateSync(options.formBytes).toString("latin1")}\nendstream`,
         ]),
   ];
   let output = `%PDF-1.4\n${options.headerComment === undefined ? "" : `% ${options.headerComment}\n`}`;
@@ -639,6 +659,10 @@ describe("scan knowledge bases", () => {
     const indirect = join(root, "indirect.pdf");
     const indirectFilter = join(root, "indirect-filter.pdf");
     const indirectFilterArray = join(root, "indirect-filter-array.pdf");
+    const commentedIndirectFilterArray = join(
+      root,
+      "commented-indirect-filter-array.pdf",
+    );
     const commentedIndirect = join(root, "commented-indirect.pdf");
     const leadingCommentedIndirect = join(root, "leading-comment-indirect.pdf");
     const escaped = join(root, "escaped.pdf");
@@ -663,6 +687,12 @@ describe("scan knowledge bases", () => {
       indirectFilterArray,
       pdf("Indirect array stream filter", 1, true, "", {
         indirectFilterArray: true,
+      }),
+    );
+    await writeFile(
+      commentedIndirectFilterArray,
+      pdf("Commented indirect array filter", 1, true, "", {
+        indirectCommentedFilterArray: true,
       }),
     );
     await writeFile(
@@ -707,6 +737,7 @@ describe("scan knowledge bases", () => {
     expect((await extractedDocuments(knowledgeBase.path)).sort()).toEqual(
       [
         "ASCII85 then Flate",
+        "Commented indirect array filter",
         "Commented indirect values",
         "Escaped PDF filter",
         "Indirect array stream filter",
@@ -814,6 +845,45 @@ describe("scan knowledge bases", () => {
     ]);
   });
 
+  test("bounds sample-level work in bit-packed TIFF cross-reference predictors", async () => {
+    const root = await temporaryDirectory();
+    const document = join(root, "bit-packed-tiff-predictor.pdf");
+    const original = xrefStreamPdf(
+      pdf("Bound the packed predictor", 1, true, "", {
+        indirectLength: true,
+        indirectFilter: true,
+      }),
+      false,
+      0,
+      { tiffPredictor: true },
+    ).toString("latin1");
+    const start = original.lastIndexOf("\nstream\n");
+    const end = original.indexOf("\nendstream", start);
+    const packed = deflateSync(Buffer.alloc(5 * 1024 * 1024));
+    const header = original
+      .slice(0, start)
+      .replace(
+        /\/Length \d+(?= \/Filter \/FlateDecode \/DecodeParms)/u,
+        `/Length ${packed.byteLength}`,
+      )
+      .replace(
+        "/Columns 7 /Colors 1 /BitsPerComponent 8",
+        "/Columns 8 /Colors 1 /BitsPerComponent 1",
+      );
+    await writeFile(
+      document,
+      Buffer.concat([
+        Buffer.from(`${header}\nstream\n`, "latin1"),
+        packed,
+        Buffer.from(original.slice(end), "latin1"),
+      ]),
+    );
+
+    await expect(prepareKnowledgeBase([document])).rejects.toThrow(
+      "Cannot extract text from knowledge base PDF",
+    );
+  });
+
   test("excludes compressed image pixels from the extracted-text budget", async () => {
     const root = await temporaryDirectory();
     const document = join(root, "large-image.pdf");
@@ -829,6 +899,21 @@ describe("scan knowledge bases", () => {
     expect(await extractedDocuments(knowledgeBase.path)).toEqual([
       "Small document text",
     ]);
+  });
+
+  test("bounds compressed form streams with nested image-subtype decoys", async () => {
+    const root = await temporaryDirectory();
+    const document = join(root, "nested-image-decoy.pdf");
+    await writeFile(
+      document,
+      pdf("Small document text", 1, true, "/Fm1 Do ", {
+        formBytes: Buffer.alloc(9 * 1024 * 1024, 32),
+      }),
+    );
+
+    await expect(prepareKnowledgeBase([document])).rejects.toThrow(
+      "8388608-byte extracted-text limit",
+    );
   });
 
   test("rejects negative cross-reference stream field widths", async () => {
@@ -924,8 +1009,19 @@ describe("scan knowledge bases", () => {
       ],
       ["indirect-filter-array", { indirectFilterArray: true }],
       [
+        "commented-indirect-filter-array",
+        { indirectCommentedFilterArray: true },
+      ],
+      [
         "page-content-marked-as-image",
         { dictionaryPrefix: "/Subtype /Image " },
+      ],
+      [
+        "indirect-page-content-marked-as-image",
+        {
+          dictionaryPrefix: "/Subtype /Image ",
+          indirectContentsArray: true,
+        },
       ],
     ] as const) {
       const document = join(root, `${name}.pdf`);

--- a/sdk/typescript/tests-ts/knowledge-base.test.ts
+++ b/sdk/typescript/tests-ts/knowledge-base.test.ts
@@ -53,10 +53,15 @@ function docx(text: string): Uint8Array {
   });
 }
 
-function pdf(text: string, pages = 1, compressed = false): Uint8Array {
+function pdf(
+  text: string,
+  pages = 1,
+  compressed = false,
+  streamPrefix = "",
+): Uint8Array {
   const escaped = text.replace(/[\\()]/gu, "\\$&");
   const chunks = escaped.match(/.{1,512}/gu) ?? [""];
-  const stream = `BT /F1 12 Tf 72 720 Td ${chunks
+  const stream = `${streamPrefix}BT /F1 12 Tf 72 720 Td ${chunks
     .map((chunk) => `(${chunk}) Tj`)
     .join(" ")} ET`;
   const streamBytes = compressed
@@ -277,6 +282,18 @@ describe("scan knowledge bases", () => {
     const root = await temporaryDirectory();
     const oversized = join(root, "compressed.pdf");
     const compressed = pdf("x".repeat(300 * 1024), 32, true);
+    expect(compressed.byteLength).toBeLessThan(8 * 1024 * 1024);
+    await writeFile(oversized, compressed);
+
+    await expect(prepareKnowledgeBase([oversized])).rejects.toThrow(
+      "8388608-byte extracted-text limit",
+    );
+  });
+
+  test("rejects oversized compressed PDF streams before parsing operands", async () => {
+    const root = await temporaryDirectory();
+    const oversized = join(root, "compressed-operand.pdf");
+    const compressed = pdf("reviewable", 1, true, " ".repeat(9 * 1024 * 1024));
     expect(compressed.byteLength).toBeLessThan(8 * 1024 * 1024);
     await writeFile(oversized, compressed);
 

--- a/sdk/typescript/tests-ts/knowledge-base.test.ts
+++ b/sdk/typescript/tests-ts/knowledge-base.test.ts
@@ -73,6 +73,7 @@ function pdf(
     uncompressedImage?: boolean;
     formBytes?: Buffer;
     headerComment?: string;
+    catalogPrefix?: string;
     dictionaryPrefix?: string;
     streamComment?: string;
   } = {},
@@ -120,7 +121,7 @@ function pdf(
       : directFilter;
   const streamObject = `<< ${options.dictionaryPrefix ?? ""}/Length ${length}${filter === undefined ? "" : ` /Filter ${filter}`} >>${options.streamComment === undefined ? "\n" : ` ${options.streamComment}\n`}stream\n${streamBytes.toString("latin1")}\nendstream`;
   const objects = [
-    "<< /Type /Catalog /Pages 2 0 R >>",
+    `<< ${options.catalogPrefix ?? ""}/Type /Catalog /Pages 2 0 R >>`,
     `<< /Type /Pages /Kids [${pageObjects.map((number) => `${number} 0 R`).join(" ")}] /Count ${pages} >>`,
     ...pageObjects.map(
       () =>
@@ -189,6 +190,7 @@ function xrefStreamPdf(
       name: string;
       encode: (bytes: Buffer) => Buffer;
     };
+    objectStreamDecodeParametersObject?: string;
   } = {},
 ): Buffer {
   const original = Buffer.from(document).toString("latin1");
@@ -218,6 +220,10 @@ function xrefStreamPdf(
   const compressed = new Map<number, { stream: number; index: number }>();
   if (compressIndirectObjects && references.length > 0) {
     const streamObject = ++maximumObject;
+    const decodeParametersObject =
+      options.objectStreamDecodeParametersObject === undefined
+        ? undefined
+        : ++maximumObject;
     const values: string[] = [];
     for (const number of references) {
       const expression = new RegExp(
@@ -265,7 +271,14 @@ function xrefStreamPdf(
     const encoded = objectStreamFilter.encode(
       Buffer.from(header + objectBody, "latin1"),
     );
-    body += `${streamObject} 0 obj\n<< /Type /ObjStm /N ${references.length} /First ${header.length} /Length ${encoded.byteLength} /Filter ${objectStreamFilter.name} >>\nstream\n${encoded.toString("latin1")}\nendstream\nendobj\n`;
+    if (decodeParametersObject !== undefined) {
+      body += `${decodeParametersObject} 0 obj\n${options.objectStreamDecodeParametersObject}\nendobj\n`;
+    }
+    const filterName = objectStreamFilter.name.replaceAll(
+      "@DECODE_PARAMETERS@",
+      `${decodeParametersObject} 0 R`,
+    );
+    body += `${streamObject} 0 obj\n<< /Type /ObjStm /N ${references.length} /First ${header.length} /Length ${encoded.byteLength} /Filter ${filterName} >>\nstream\n${encoded.toString("latin1")}\nendstream\nendobj\n`;
   }
   const xrefObject = ++maximumObject;
   const xrefOffset = Buffer.byteLength(body, "latin1");
@@ -1080,20 +1093,50 @@ describe("scan knowledge bases", () => {
   });
 
   test("applies an LZW predictor before the next compressed object-stream filter", async () => {
+    for (const [name, parameter, indirect] of [
+      ["explicit columns", "<< /Predictor 12 /Columns 1 >>", false],
+      ["default columns", "<< /Predictor 12 >>", false],
+      ["indirect parameters", "@DECODE_PARAMETERS@", true],
+    ] as const) {
+      const root = await temporaryDirectory();
+      const document = join(root, `${name}.pdf`);
+      await writeFile(
+        document,
+        xrefStreamPdf(pdf("Predicted compressed page", 1, true), true, 0, {
+          compressPageObjects: true,
+          ...(indirect
+            ? { objectStreamDecodeParametersObject: "<< /Predictor 12 >>" }
+            : {}),
+          objectStreamFilter: {
+            name: `[/LZWDecode /ASCII85Decode] /DecodeParms [${parameter} null]`,
+            encode: (contents) =>
+              encodePdfLzwLiterals(
+                Buffer.from(
+                  [...encodeAscii85(contents)].flatMap((byte) => [0, byte]),
+                ),
+              ),
+          },
+        }),
+      );
+
+      const knowledgeBase = await prepareKnowledgeBase([document]);
+      temporaryDirectories.push(knowledgeBase.path);
+      expect(await extractedDocuments(knowledgeBase.path)).toEqual([
+        "Predicted compressed page",
+      ]);
+    }
+  });
+
+  test("ignores predictor parameters on filters without predictor support", async () => {
     const root = await temporaryDirectory();
-    const document = join(root, "predicted-lzw-object-stream.pdf");
+    const document = join(root, "non-predictor-object-stream.pdf");
     await writeFile(
       document,
-      xrefStreamPdf(pdf("Predicted compressed page", 1, true), true, 0, {
+      xrefStreamPdf(pdf("Non-predictor compressed page", 1, true), true, 0, {
         compressPageObjects: true,
         objectStreamFilter: {
-          name: "[/LZWDecode /ASCII85Decode] /DecodeParms [<< /Predictor 12 /Columns 1 >> null]",
-          encode: (contents) =>
-            encodePdfLzwLiterals(
-              Buffer.from(
-                [...encodeAscii85(contents)].flatMap((byte) => [0, byte]),
-              ),
-            ),
+          name: "[/RunLengthDecode /ASCII85Decode] /DecodeParms [<< /Predictor 12 >> null]",
+          encode: (contents) => encodeRunLength(encodeAscii85(contents)),
         },
       }),
     );
@@ -1101,8 +1144,24 @@ describe("scan knowledge bases", () => {
     const knowledgeBase = await prepareKnowledgeBase([document]);
     temporaryDirectories.push(knowledgeBase.path);
     expect(await extractedDocuments(knowledgeBase.path)).toEqual([
-      "Predicted compressed page",
+      "Non-predictor compressed page",
     ]);
+  });
+
+  test("does not let literal stream markers suppress later compressed streams", async () => {
+    const root = await temporaryDirectory();
+    const document = join(root, "literal-stream-marker.pdf");
+    await writeFile(
+      document,
+      pdf("reviewable", 1, true, " ".repeat(9 * 1024 * 1024), {
+        catalogPrefix:
+          "/Length 10000000 /Decoy (>>\nstream\nnot a real stream) ",
+      }),
+    );
+
+    await expect(prepareKnowledgeBase([document])).rejects.toThrow(
+      "8388608-byte extracted-text limit",
+    );
   });
 
   test("ignores stream-shaped bytes inside declared uncompressed image data", async () => {

--- a/sdk/typescript/tests-ts/knowledge-base.test.ts
+++ b/sdk/typescript/tests-ts/knowledge-base.test.ts
@@ -58,18 +58,32 @@ function pdf(
   pages = 1,
   compressed = false,
   streamPrefix = "",
+  options: {
+    filter?: string;
+    encode?: (bytes: Buffer) => Buffer;
+    extraStreams?: number;
+    indirectLength?: boolean;
+    headerComment?: string;
+  } = {},
 ): Uint8Array {
   const escaped = text.replace(/[\\()]/gu, "\\$&");
   const chunks = escaped.match(/.{1,512}/gu) ?? [""];
   const stream = `${streamPrefix}BT /F1 12 Tf 72 720 Td ${chunks
     .map((chunk) => `(${chunk}) Tj`)
     .join(" ")} ET`;
-  const streamBytes = compressed
+  let streamBytes: Buffer = compressed
     ? deflateSync(Buffer.from(stream))
     : Buffer.from(stream);
+  if (options.encode !== undefined) streamBytes = options.encode(streamBytes);
   const pageObjects = Array.from({ length: pages }, (_, index) => index + 3);
   const font = pages + 3;
   const content = pages + 4;
+  const filter = options.filter ?? (compressed ? "/FlateDecode" : undefined);
+  const extraStreams = options.extraStreams ?? 0;
+  const length = options.indirectLength
+    ? `${content + extraStreams + 1} 0 R`
+    : String(streamBytes.byteLength);
+  const streamObject = `<< /Length ${length}${filter === undefined ? "" : ` /Filter ${filter}`} >>\nstream\n${streamBytes.toString("latin1")}\nendstream`;
   const objects = [
     "<< /Type /Catalog /Pages 2 0 R >>",
     `<< /Type /Pages /Kids [${pageObjects.map((number) => `${number} 0 R`).join(" ")}] /Count ${pages} >>`,
@@ -78,9 +92,11 @@ function pdf(
         `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 2000000 792] /Resources << /Font << /F1 ${font} 0 R >> >> /Contents ${content} 0 R >>`,
     ),
     "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
-    `<< /Length ${streamBytes.byteLength}${compressed ? " /Filter /FlateDecode" : ""} >>\nstream\n${streamBytes.toString("latin1")}\nendstream`,
+    streamObject,
+    ...Array.from({ length: extraStreams }, () => streamObject),
+    ...(options.indirectLength ? [String(streamBytes.byteLength)] : []),
   ];
-  let output = "%PDF-1.4\n";
+  let output = `%PDF-1.4\n${options.headerComment === undefined ? "" : `% ${options.headerComment}\n`}`;
   const offsets = [0];
   for (const [index, object] of objects.entries()) {
     offsets.push(Buffer.byteLength(output, "latin1"));
@@ -93,6 +109,50 @@ function pdf(
   }
   output += `trailer\n<< /Size ${offsets.length} /Root 1 0 R >>\nstartxref\n${xref}\n%%EOF\n`;
   return Buffer.from(output, "latin1");
+}
+
+function encodeAscii85(bytes: Buffer): Buffer {
+  let encoded = "";
+  for (let index = 0; index < bytes.length; index += 4) {
+    const group = bytes.subarray(index, index + 4);
+    let value = 0;
+    for (let position = 0; position < 4; position += 1) {
+      value = value * 256 + (group[position] ?? 0);
+    }
+    if (value === 0 && group.length === 4) {
+      encoded += "z";
+      continue;
+    }
+    let word = "";
+    for (let digit = 0; digit < 5; digit += 1) {
+      word = String.fromCharCode((value % 85) + 33) + word;
+      value = Math.floor(value / 85);
+    }
+    encoded += word.slice(0, group.length + 1);
+  }
+  return Buffer.from(`${encoded}~>`, "latin1");
+}
+
+function encodeRunLength(bytes: Buffer): Buffer {
+  const encoded: number[] = [];
+  for (let index = 0; index < bytes.length; ) {
+    let count = 1;
+    while (
+      count < 128 &&
+      index + count < bytes.length &&
+      bytes[index + count] === bytes[index]
+    ) {
+      count += 1;
+    }
+    if (count > 1) {
+      encoded.push(257 - count, bytes[index]!);
+      index += count;
+    } else {
+      encoded.push(0, bytes[index++]!);
+    }
+  }
+  encoded.push(128);
+  return Buffer.from(encoded);
 }
 
 describe("scan knowledge bases", () => {
@@ -356,6 +416,104 @@ describe("scan knowledge bases", () => {
 
     await expect(prepareKnowledgeBase([oversized])).rejects.toThrow(
       "8388608-byte extracted-text limit",
+    );
+  });
+
+  test("bounds every PDF compression pipeline and cumulative stream output", async () => {
+    const root = await temporaryDirectory();
+    const runLength = join(root, "run-length.pdf");
+    await writeFile(
+      runLength,
+      pdf("reviewable", 1, false, " ".repeat(9 * 1024 * 1024), {
+        filter: "/RunLengthDecode",
+        encode: encodeRunLength,
+      }),
+    );
+    await expect(prepareKnowledgeBase([runLength])).rejects.toThrow(
+      "8388608-byte extracted-text limit",
+    );
+
+    const cumulative = join(root, "cumulative.pdf");
+    await writeFile(
+      cumulative,
+      pdf("reviewable", 1, true, " ".repeat(3 * 1024 * 1024), {
+        extraStreams: 2,
+      }),
+    );
+    await expect(prepareKnowledgeBase([cumulative])).rejects.toThrow(
+      "8388608-byte extracted-text limit",
+    );
+  });
+
+  test("accepts PDF filter chains, indirect lengths, and escaped filter names", async () => {
+    const root = await temporaryDirectory();
+    const chained = join(root, "chained.pdf");
+    const indirect = join(root, "indirect.pdf");
+    const escaped = join(root, "escaped.pdf");
+    await writeFile(
+      chained,
+      pdf("ASCII85 then Flate", 1, true, "", {
+        filter: "[/ASCII85Decode /FlateDecode]",
+        encode: encodeAscii85,
+      }),
+    );
+    await writeFile(
+      indirect,
+      pdf("Indirect stream length", 1, true, "", { indirectLength: true }),
+    );
+    await writeFile(
+      escaped,
+      pdf("Escaped PDF filter", 1, true, "", { filter: "/#46lateDecode" }),
+    );
+
+    const knowledgeBase = await prepareKnowledgeBase([root]);
+    temporaryDirectories.push(knowledgeBase.path);
+    expect((await extractedDocuments(knowledgeBase.path)).sort()).toEqual(
+      [
+        "ASCII85 then Flate",
+        "Escaped PDF filter",
+        "Indirect stream length",
+      ].sort(),
+    );
+  });
+
+  test("does not mistake a PDF comment for a stream compression filter", async () => {
+    const root = await temporaryDirectory();
+    const document = join(root, "comment.pdf");
+    await writeFile(
+      document,
+      pdf("Uncompressed PDF", 1, false, "", {
+        headerComment: "This metadata mentions /FlateDecode.",
+      }),
+    );
+
+    const knowledgeBase = await prepareKnowledgeBase([document]);
+    temporaryDirectories.push(knowledgeBase.path);
+    expect(await extractedDocuments(knowledgeBase.path)).toEqual([
+      "Uncompressed PDF",
+    ]);
+  });
+
+  test("rejects duplicate DOCX document entries before repeated inflation", async () => {
+    const root = await temporaryDirectory();
+    const document = join(root, "duplicate.docx");
+    const alternate = "word/decument.xml";
+    const archive = Buffer.from(
+      zipSync({
+        "word/document.xml": strToU8("<w:document>safe</w:document>"),
+        [alternate]: strToU8("<w:document>duplicate</w:document>"),
+      }),
+    );
+    const replacement = Buffer.from("word/document.xml");
+    for (let offset = 0; ; offset += replacement.length) {
+      offset = archive.indexOf(alternate, offset);
+      if (offset < 0) break;
+      replacement.copy(archive, offset);
+    }
+    await writeFile(document, archive);
+
+    await expect(prepareKnowledgeBase([document])).rejects.toThrow(
+      "duplicate word/document.xml entries",
     );
   });
 

--- a/sdk/typescript/tests-ts/knowledge-base.test.ts
+++ b/sdk/typescript/tests-ts/knowledge-base.test.ts
@@ -1,3 +1,5 @@
+import { spawnSync } from "node:child_process";
+import { renameSync, symlinkSync } from "node:fs";
 import {
   chmod,
   mkdir,
@@ -13,6 +15,7 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { deflateSync } from "node:zlib";
 import { afterEach, describe, expect, test } from "bun:test";
 import { strToU8, zipSync } from "fflate";
 import { prepareKnowledgeBase } from "../src/knowledge-base.js";
@@ -50,9 +53,15 @@ function docx(text: string): Uint8Array {
   });
 }
 
-function pdf(text: string, pages = 1): Uint8Array {
+function pdf(text: string, pages = 1, compressed = false): Uint8Array {
   const escaped = text.replace(/[\\()]/gu, "\\$&");
-  const stream = `BT /F1 12 Tf 72 720 Td (${escaped}) Tj ET`;
+  const chunks = escaped.match(/.{1,512}/gu) ?? [""];
+  const stream = `BT /F1 12 Tf 72 720 Td ${chunks
+    .map((chunk) => `(${chunk}) Tj`)
+    .join(" ")} ET`;
+  const streamBytes = compressed
+    ? deflateSync(Buffer.from(stream))
+    : Buffer.from(stream);
   const pageObjects = Array.from({ length: pages }, (_, index) => index + 3);
   const font = pages + 3;
   const content = pages + 4;
@@ -61,24 +70,24 @@ function pdf(text: string, pages = 1): Uint8Array {
     `<< /Type /Pages /Kids [${pageObjects.map((number) => `${number} 0 R`).join(" ")}] /Count ${pages} >>`,
     ...pageObjects.map(
       () =>
-        `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 ${font} 0 R >> >> /Contents ${content} 0 R >>`,
+        `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 2000000 792] /Resources << /Font << /F1 ${font} 0 R >> >> /Contents ${content} 0 R >>`,
     ),
     "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
-    `<< /Length ${Buffer.byteLength(stream)} >>\nstream\n${stream}\nendstream`,
+    `<< /Length ${streamBytes.byteLength}${compressed ? " /Filter /FlateDecode" : ""} >>\nstream\n${streamBytes.toString("latin1")}\nendstream`,
   ];
   let output = "%PDF-1.4\n";
   const offsets = [0];
   for (const [index, object] of objects.entries()) {
-    offsets.push(Buffer.byteLength(output));
+    offsets.push(Buffer.byteLength(output, "latin1"));
     output += `${index + 1} 0 obj\n${object}\nendobj\n`;
   }
-  const xref = Buffer.byteLength(output);
+  const xref = Buffer.byteLength(output, "latin1");
   output += `xref\n0 ${offsets.length}\n0000000000 65535 f \n`;
   for (const offset of offsets.slice(1)) {
     output += `${String(offset).padStart(10, "0")} 00000 n \n`;
   }
   output += `trailer\n<< /Size ${offsets.length} /Root 1 0 R >>\nstartxref\n${xref}\n%%EOF\n`;
-  return new TextEncoder().encode(output);
+  return Buffer.from(output, "latin1");
 }
 
 describe("scan knowledge bases", () => {
@@ -264,6 +273,18 @@ describe("scan knowledge bases", () => {
     );
   });
 
+  test("bounds streamed text from a compressed PDF page", async () => {
+    const root = await temporaryDirectory();
+    const oversized = join(root, "compressed.pdf");
+    const compressed = pdf("x".repeat(300 * 1024), 32, true);
+    expect(compressed.byteLength).toBeLessThan(8 * 1024 * 1024);
+    await writeFile(oversized, compressed);
+
+    await expect(prepareKnowledgeBase([oversized])).rejects.toThrow(
+      "8388608-byte extracted-text limit",
+    );
+  });
+
   test("observes cancellation while discovering directories", async () => {
     const root = await temporaryDirectory();
     const nested = join(root, "one", "two");
@@ -303,6 +324,59 @@ describe("scan knowledge bases", () => {
       "cannot be symbolic links",
     );
   });
+
+  testPosix(
+    "rejects a directory replaced with an escaping symbolic link",
+    async () => {
+      const source = await temporaryDirectory();
+      const nested = join(source, "nested");
+      const outside = await temporaryDirectory();
+      await mkdir(nested);
+      await writeFile(join(nested, "scope.md"), "Internal scope");
+      await writeFile(
+        join(outside, "external.md"),
+        "Never ingest this document",
+      );
+      const controller = new AbortController();
+      let checks = 0;
+      controller.signal.throwIfAborted = (): void => {
+        checks += 1;
+        if (checks === 5) {
+          renameSync(nested, join(source, "replaced"));
+          symlinkSync(outside, nested);
+        }
+      };
+
+      await expect(
+        prepareKnowledgeBase([source], controller.signal),
+      ).rejects.toThrow(
+        /escaped the requested source|changed during discovery/u,
+      );
+    },
+  );
+
+  testPosix(
+    "does not block when a discovered document becomes a FIFO",
+    async () => {
+      const root = await temporaryDirectory();
+      const document = join(root, "scope.md");
+      await writeFile(document, "Internal scope");
+      const controller = new AbortController();
+      let checks = 0;
+      controller.signal.throwIfAborted = (): void => {
+        checks += 1;
+        if (checks === 6) {
+          renameSync(document, join(root, "replaced.md"));
+          const result = spawnSync("mkfifo", [document], { encoding: "utf8" });
+          expect(result.status, result.stderr).toBe(0);
+        }
+      };
+
+      await expect(
+        prepareKnowledgeBase([document], controller.signal),
+      ).rejects.toThrow("not a file");
+    },
+  );
 
   testPosix("rejects unreadable source documents", async () => {
     const root = await temporaryDirectory();

--- a/sdk/typescript/tests-ts/knowledge-base.test.ts
+++ b/sdk/typescript/tests-ts/knowledge-base.test.ts
@@ -174,6 +174,13 @@ function xrefStreamPdf(
     objectHeaderComments?: boolean;
     tiffPredictor?: boolean;
     compressPageObjects?: boolean;
+    compressedPagePrefix?: string;
+    compressedPageSuffix?: string;
+    escapedCompressedPageContents?: boolean;
+    objectStreamFilter?: {
+      name: string;
+      encode: (bytes: Buffer) => Buffer;
+    };
   } = {},
 ): Buffer {
   const original = Buffer.from(document).toString("latin1");
@@ -214,7 +221,15 @@ function xrefStreamPdf(
         throw new Error("Indirect PDF fixture object is missing.");
       }
       compressed.set(number, { stream: streamObject, index: values.length });
-      values.push(match[1]);
+      const page = /<<\s*\/Type\s+\/Page(?=[\s/>])/u.test(match[1]);
+      let value = match[1];
+      if (page && options.escapedCompressedPageContents === true) {
+        value = value.replace("/Contents ", "/Cont#65nts ");
+      }
+      if (page) {
+        value = `${options.compressedPagePrefix ?? ""}${value}${options.compressedPageSuffix ?? ""}`;
+      }
+      values.push(value);
       body =
         body.slice(0, match.index + 1) +
         body.slice(match.index + match[0].length);
@@ -226,8 +241,14 @@ function xrefStreamPdf(
       objectBody += `${values[index]} `;
     }
     header += " ".repeat(objectHeaderPadding);
-    const encoded = deflateSync(Buffer.from(header + objectBody, "latin1"));
-    body += `${streamObject} 0 obj\n<< /Type /ObjStm /N ${references.length} /First ${header.length} /Length ${encoded.byteLength} /Filter /FlateDecode >>\nstream\n${encoded.toString("latin1")}\nendstream\nendobj\n`;
+    const objectStreamFilter = options.objectStreamFilter ?? {
+      name: "/FlateDecode",
+      encode: deflateSync,
+    };
+    const encoded = objectStreamFilter.encode(
+      Buffer.from(header + objectBody, "latin1"),
+    );
+    body += `${streamObject} 0 obj\n<< /Type /ObjStm /N ${references.length} /First ${header.length} /Length ${encoded.byteLength} /Filter ${objectStreamFilter.name} >>\nstream\n${encoded.toString("latin1")}\nendstream\nendobj\n`;
   }
   const xrefObject = ++maximumObject;
   const xrefOffset = Buffer.byteLength(body, "latin1");
@@ -975,6 +996,65 @@ describe("scan knowledge bases", () => {
     await expect(prepareKnowledgeBase([document])).rejects.toThrow(
       "8388608-byte extracted-text limit",
     );
+  });
+
+  test("bounds compressed page contents behind PDF comments and escaped dictionary names", async () => {
+    for (const [name, options] of [
+      [
+        "comments",
+        {
+          compressedPagePrefix: "% valid leading page comment\n",
+          compressedPageSuffix: " % valid trailing page comment\n",
+        },
+      ],
+      ["escaped-contents", { escapedCompressedPageContents: true }],
+    ] as const) {
+      const root = await temporaryDirectory();
+      const document = join(root, `${name}.pdf`);
+      await writeFile(
+        document,
+        xrefStreamPdf(
+          pdf("reviewable", 1, true, " ".repeat(9 * 1024 * 1024), {
+            dictionaryPrefix: "/Subtype /Image ",
+          }),
+          true,
+          0,
+          { compressPageObjects: true, ...options },
+        ),
+      );
+
+      await expect(prepareKnowledgeBase([document])).rejects.toThrow(
+        "8388608-byte extracted-text limit",
+      );
+    }
+  });
+
+  test("bounds page contents in LZW- and run-length-compressed object streams", async () => {
+    for (const [name, encode] of [
+      ["/LZWDecode", encodePdfLzwLiterals],
+      ["/RunLengthDecode", encodeRunLength],
+    ] as const) {
+      const root = await temporaryDirectory();
+      const document = join(root, `${name.slice(1)}.pdf`);
+      await writeFile(
+        document,
+        xrefStreamPdf(
+          pdf("reviewable", 1, true, " ".repeat(9 * 1024 * 1024), {
+            dictionaryPrefix: "/Subtype /Image ",
+          }),
+          true,
+          0,
+          {
+            compressPageObjects: true,
+            objectStreamFilter: { name, encode },
+          },
+        ),
+      );
+
+      await expect(prepareKnowledgeBase([document])).rejects.toThrow(
+        "8388608-byte extracted-text limit",
+      );
+    }
   });
 
   test("rejects negative cross-reference stream field widths", async () => {

--- a/sdk/typescript/tests-ts/knowledge-base.test.ts
+++ b/sdk/typescript/tests-ts/knowledge-base.test.ts
@@ -119,6 +119,105 @@ function pdf(
   return Buffer.from(output, "latin1");
 }
 
+function xrefStreamPdf(
+  document: Uint8Array,
+  compressIndirectObjects = false,
+): Buffer {
+  const original = Buffer.from(document).toString("latin1");
+  const table = original.lastIndexOf("\nxref\n");
+  if (table < 0)
+    throw new Error("PDF fixture does not contain a classic xref.");
+  let body = original.slice(0, table + 1).replace("%PDF-1.4", "%PDF-1.5");
+  const references = [
+    ...new Set(
+      [...body.matchAll(/\/(?:Length|Filter)\s+(\d+)\s+0\s+R/gu)].map((match) =>
+        Number(match[1]),
+      ),
+    ),
+  ];
+  let maximumObject = Math.max(
+    ...[...body.matchAll(/^(\d+)\s+0\s+obj$/gmu)].map((match) =>
+      Number(match[1]),
+    ),
+  );
+  const compressed = new Map<number, { stream: number; index: number }>();
+  if (compressIndirectObjects && references.length > 0) {
+    const streamObject = ++maximumObject;
+    const values: string[] = [];
+    for (const number of references) {
+      const expression = new RegExp(
+        `(?:^|\\n)${number} 0 obj\\n([\\s\\S]*?)\\nendobj\\n`,
+        "u",
+      );
+      const match = expression.exec(body);
+      if (match?.[1] === undefined) {
+        throw new Error("Indirect PDF fixture object is missing.");
+      }
+      compressed.set(number, { stream: streamObject, index: values.length });
+      values.push(match[1]);
+      body =
+        body.slice(0, match.index + 1) +
+        body.slice(match.index + match[0].length);
+    }
+    let objectBody = "";
+    let header = "";
+    for (const [index, number] of references.entries()) {
+      header += `${number} ${objectBody.length} `;
+      objectBody += `${values[index]} `;
+    }
+    const encoded = deflateSync(Buffer.from(header + objectBody, "latin1"));
+    body += `${streamObject} 0 obj\n<< /Type /ObjStm /N ${references.length} /First ${header.length} /Length ${encoded.byteLength} /Filter /FlateDecode >>\nstream\n${encoded.toString("latin1")}\nendstream\nendobj\n`;
+  }
+  const xrefObject = ++maximumObject;
+  const xrefOffset = Buffer.byteLength(body, "latin1");
+  const objects = new Map<number, number>();
+  for (const match of body.matchAll(/^(\d+)\s+0\s+obj$/gmu)) {
+    objects.set(Number(match[1]), match.index!);
+  }
+  objects.set(xrefObject, xrefOffset);
+  const records = Buffer.alloc((xrefObject + 1) * 7);
+  for (let number = 0; number <= xrefObject; number += 1) {
+    const position = number * 7;
+    const compact = compressed.get(number);
+    if (compact !== undefined) {
+      records[position] = 2;
+      records.writeUInt32BE(compact.stream, position + 1);
+      records.writeUInt16BE(compact.index, position + 5);
+    } else if (objects.has(number)) {
+      records[position] = 1;
+      records.writeUInt32BE(objects.get(number)!, position + 1);
+    } else {
+      records.writeUInt16BE(65535, position + 5);
+    }
+  }
+  const encoded = deflateSync(records);
+  body += `${xrefObject} 0 obj\n<< /Type /XRef /Size ${xrefObject + 1} /Root 1 0 R /W [1 4 2] /Length ${encoded.byteLength} /Filter /FlateDecode >>\nstream\n${encoded.toString("latin1")}\nendstream\nendobj\nstartxref\n${xrefOffset}\n%%EOF\n`;
+  return Buffer.from(body, "latin1");
+}
+
+function incrementallyUpdatedPdf(document: Uint8Array): Buffer {
+  const original = Buffer.from(document).toString("latin1");
+  const table = original.lastIndexOf("\nxref\n");
+  if (table < 0)
+    throw new Error("PDF fixture does not contain a classic xref.");
+  let body = original.slice(0, table + 1);
+  const objects = new Map<number, number>();
+  for (const match of body.matchAll(/^(\d+)\s+0\s+obj$/gmu)) {
+    objects.set(Number(match[1]), match.index!);
+  }
+  const size = 40_000;
+  const entries = Array.from({ length: size }, (_unused, number) =>
+    objects.has(number)
+      ? `${String(objects.get(number)).padStart(10, "0")} 00000 n \n`
+      : "0000000000 65535 f \n",
+  ).join("");
+  const previous = Buffer.byteLength(body, "latin1");
+  body += `xref\n0 ${size}\n${entries}trailer\n<< /Size ${size} /Root 1 0 R >>\n`;
+  const latest = Buffer.byteLength(body, "latin1");
+  body += `xref\n0 ${size}\n${entries}trailer\n<< /Size ${size} /Root 1 0 R /Prev ${previous} >>\nstartxref\n${latest}\n%%EOF\n`;
+  return Buffer.from(body, "latin1");
+}
+
 function encodeAscii85(bytes: Buffer): Buffer {
   let encoded = "";
   for (let index = 0; index < bytes.length; index += 4) {
@@ -481,6 +580,18 @@ describe("scan knowledge bases", () => {
     await expect(prepareKnowledgeBase([cumulative])).rejects.toThrow(
       "8388608-byte extracted-text limit",
     );
+
+    const intermediate = join(root, "cumulative-intermediate.pdf");
+    await writeFile(
+      intermediate,
+      pdf("reviewable", 1, true, `>${" ".repeat(4 * 1024 * 1024)}`, {
+        filter: "[/FlateDecode /ASCIIHexDecode]",
+        extraStreams: 8,
+      }),
+    );
+    await expect(prepareKnowledgeBase([intermediate])).rejects.toThrow(
+      "8388608-byte extracted-text limit",
+    );
   });
 
   test("accepts PDF filter chains, indirect lengths, and escaped filter names", async () => {
@@ -539,6 +650,51 @@ describe("scan knowledge bases", () => {
         earlyChangeText,
       ].sort(),
     );
+  });
+
+  test("resolves indirect PDF values from compressed cross-reference and object streams", async () => {
+    const root = await temporaryDirectory();
+    for (const compressIndirectObjects of [false, true]) {
+      const name = compressIndirectObjects
+        ? "object-stream.pdf"
+        : "xref-stream.pdf";
+      await writeFile(
+        join(root, name),
+        xrefStreamPdf(
+          pdf(`PDF ${name}`, 1, true, "", {
+            indirectLength: true,
+            indirectFilter: true,
+          }),
+          compressIndirectObjects,
+        ),
+      );
+    }
+
+    const knowledgeBase = await prepareKnowledgeBase([root]);
+    temporaryDirectories.push(knowledgeBase.path);
+    expect((await extractedDocuments(knowledgeBase.path)).sort()).toEqual([
+      "PDF object-stream.pdf",
+      "PDF xref-stream.pdf",
+    ]);
+  });
+
+  test("counts unique objects across overlapping incremental cross-reference tables", async () => {
+    const root = await temporaryDirectory();
+    const document = join(root, "incremental.pdf");
+    await writeFile(
+      document,
+      incrementallyUpdatedPdf(
+        pdf("Incremental cross-reference tables", 1, true, "", {
+          indirectFilter: true,
+        }),
+      ),
+    );
+
+    const knowledgeBase = await prepareKnowledgeBase([document]);
+    temporaryDirectories.push(knowledgeBase.path);
+    expect(await extractedDocuments(knowledgeBase.path)).toEqual([
+      "Incremental cross-reference tables",
+    ]);
   });
 
   test("does not mistake a PDF comment for a stream compression filter", async () => {

--- a/sdk/typescript/tests-ts/knowledge-base.test.ts
+++ b/sdk/typescript/tests-ts/knowledge-base.test.ts
@@ -63,6 +63,7 @@ function pdf(
     encode?: (bytes: Buffer) => Buffer;
     extraStreams?: number;
     indirectLength?: boolean;
+    indirectFilter?: boolean;
     headerComment?: string;
     dictionaryPrefix?: string;
     streamComment?: string;
@@ -80,11 +81,15 @@ function pdf(
   const pageObjects = Array.from({ length: pages }, (_, index) => index + 3);
   const font = pages + 3;
   const content = pages + 4;
-  const filter = options.filter ?? (compressed ? "/FlateDecode" : undefined);
+  const directFilter =
+    options.filter ?? (compressed ? "/FlateDecode" : undefined);
   const extraStreams = options.extraStreams ?? 0;
   const length = options.indirectLength
     ? `${content + extraStreams + 1} 0 R`
     : String(streamBytes.byteLength);
+  const filter = options.indirectFilter
+    ? `${content + extraStreams + 1 + (options.indirectLength ? 1 : 0)} 0 R`
+    : directFilter;
   const streamObject = `<< ${options.dictionaryPrefix ?? ""}/Length ${length}${filter === undefined ? "" : ` /Filter ${filter}`} >>${options.streamComment === undefined ? "\n" : ` ${options.streamComment}\n`}stream\n${streamBytes.toString("latin1")}\nendstream`;
   const objects = [
     "<< /Type /Catalog /Pages 2 0 R >>",
@@ -97,6 +102,7 @@ function pdf(
     streamObject,
     ...Array.from({ length: extraStreams }, () => streamObject),
     ...(options.indirectLength ? [String(streamBytes.byteLength)] : []),
+    ...(options.indirectFilter ? [directFilter ?? "/FlateDecode"] : []),
   ];
   let output = `%PDF-1.4\n${options.headerComment === undefined ? "" : `% ${options.headerComment}\n`}`;
   const offsets = [0];
@@ -481,6 +487,7 @@ describe("scan knowledge bases", () => {
     const root = await temporaryDirectory();
     const chained = join(root, "chained.pdf");
     const indirect = join(root, "indirect.pdf");
+    const indirectFilter = join(root, "indirect-filter.pdf");
     const escaped = join(root, "escaped.pdf");
     const lzw = join(root, "lzw.pdf");
     const earlyChange = join(root, "lzw-early-change.pdf");
@@ -494,6 +501,10 @@ describe("scan knowledge bases", () => {
     await writeFile(
       indirect,
       pdf("Indirect stream length", 1, true, "", { indirectLength: true }),
+    );
+    await writeFile(
+      indirectFilter,
+      pdf("Indirect stream filter", 1, true, "", { indirectFilter: true }),
     );
     await writeFile(
       escaped,
@@ -523,6 +534,7 @@ describe("scan knowledge bases", () => {
         "ASCII85 then Flate",
         "Escaped PDF filter",
         "Indirect stream length",
+        "Indirect stream filter",
         "LZW encoded text",
         earlyChangeText,
       ].sort(),
@@ -558,6 +570,26 @@ describe("scan knowledge bases", () => {
         "literal-filter-token",
         { dictionaryPrefix: "/Note (/Filter /DCTDecode) " },
       ],
+      ["literal-dictionary-close", { dictionaryPrefix: "/Note (>>) " }],
+      ["literal-dictionary-open", { dictionaryPrefix: "/Note (<<) " }],
+      [
+        "comment-dictionary-delimiters",
+        { dictionaryPrefix: "% << >> ignored\n" },
+      ],
+      [
+        "decoy-indirect-filter",
+        {
+          indirectFilter: true,
+          headerComment: "6 0 obj /DCTDecode endobj",
+        },
+      ],
+      [
+        "decoy-indirect-length",
+        {
+          indirectLength: true,
+          headerComment: "6 0 obj 0 endobj",
+        },
+      ],
     ] as const) {
       const document = join(root, `${name}.pdf`);
       await writeFile(
@@ -568,6 +600,35 @@ describe("scan knowledge bases", () => {
         "8388608-byte extracted-text limit",
       );
     }
+  });
+
+  test("counts only the final output of chained PDF compression filters", async () => {
+    const root = await temporaryDirectory();
+    const document = join(root, "multi-stage-limit.pdf");
+    const noise = Buffer.allocUnsafe(5 * 1024 * 1024);
+    let state = 1;
+    for (let index = 0; index < noise.length; index += 1) {
+      state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+      noise[index] = 33 + ((state >>> 16) % 90);
+    }
+    const compressed = pdf(
+      "A bounded multi-stage PDF stream",
+      1,
+      true,
+      `%${noise.toString("latin1")}\n`,
+      {
+        filter: "[/ASCII85Decode /FlateDecode]",
+        encode: encodeAscii85,
+      },
+    );
+    expect(compressed.byteLength).toBeLessThan(8 * 1024 * 1024);
+    await writeFile(document, compressed);
+
+    const knowledgeBase = await prepareKnowledgeBase([document]);
+    temporaryDirectories.push(knowledgeBase.path);
+    expect(await extractedDocuments(knowledgeBase.path)).toEqual([
+      "A bounded multi-stage PDF stream",
+    ]);
   });
 
   test("bounds repeated PDF LZW clear codes without allocating fresh dictionaries", async () => {

--- a/sdk/typescript/tests-ts/knowledge-base.test.ts
+++ b/sdk/typescript/tests-ts/knowledge-base.test.ts
@@ -64,7 +64,10 @@ function pdf(
     extraStreams?: number;
     indirectLength?: boolean;
     indirectFilter?: boolean;
+    indirectFilterArray?: boolean;
+    indirectValuePrefix?: string;
     indirectValueComment?: string;
+    imageBytes?: Buffer;
     headerComment?: string;
     dictionaryPrefix?: string;
     streamComment?: string;
@@ -88,28 +91,45 @@ function pdf(
   const length = options.indirectLength
     ? `${content + extraStreams + 1} 0 R`
     : String(streamBytes.byteLength);
-  const filter = options.indirectFilter
-    ? `${content + extraStreams + 1 + (options.indirectLength ? 1 : 0)} 0 R`
-    : directFilter;
+  const indirectFilter = options.indirectFilter || options.indirectFilterArray;
+  const filterReference = `${content + extraStreams + 1 + (options.indirectLength ? 1 : 0)} 0 R`;
+  const filter = options.indirectFilterArray
+    ? `[${filterReference}]`
+    : options.indirectFilter
+      ? filterReference
+      : directFilter;
+  const imageObject =
+    content +
+    extraStreams +
+    1 +
+    (options.indirectLength ? 1 : 0) +
+    (indirectFilter ? 1 : 0);
   const streamObject = `<< ${options.dictionaryPrefix ?? ""}/Length ${length}${filter === undefined ? "" : ` /Filter ${filter}`} >>${options.streamComment === undefined ? "\n" : ` ${options.streamComment}\n`}stream\n${streamBytes.toString("latin1")}\nendstream`;
   const objects = [
     "<< /Type /Catalog /Pages 2 0 R >>",
     `<< /Type /Pages /Kids [${pageObjects.map((number) => `${number} 0 R`).join(" ")}] /Count ${pages} >>`,
     ...pageObjects.map(
       () =>
-        `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 2000000 792] /Resources << /Font << /F1 ${font} 0 R >> >> /Contents ${content} 0 R >>`,
+        `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 2000000 792] /Resources << /Font << /F1 ${font} 0 R >>${options.imageBytes === undefined ? "" : ` /XObject << /Im1 ${imageObject} 0 R >>`} >> /Contents ${content} 0 R >>`,
     ),
     "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
     streamObject,
     ...Array.from({ length: extraStreams }, () => streamObject),
     ...(options.indirectLength
-      ? [`${streamBytes.byteLength}${options.indirectValueComment ?? ""}`]
-      : []),
-    ...(options.indirectFilter
       ? [
-          `${directFilter ?? "/FlateDecode"}${options.indirectValueComment ?? ""}`,
+          `${options.indirectValuePrefix ?? ""}${streamBytes.byteLength}${options.indirectValueComment ?? ""}`,
         ]
       : []),
+    ...(indirectFilter
+      ? [
+          `${options.indirectValuePrefix ?? ""}${directFilter ?? "/FlateDecode"}${options.indirectValueComment ?? ""}`,
+        ]
+      : []),
+    ...(options.imageBytes === undefined
+      ? []
+      : [
+          `<< /Type /XObject /Subtype /Image /Width 1024 /Height ${Math.ceil(options.imageBytes.byteLength / 1024)} /ColorSpace /DeviceGray /BitsPerComponent 8 /Length ${deflateSync(options.imageBytes).byteLength} /Filter /FlateDecode >>\nstream\n${deflateSync(options.imageBytes).toString("latin1")}\nendstream`,
+        ]),
   ];
   let output = `%PDF-1.4\n${options.headerComment === undefined ? "" : `% ${options.headerComment}\n`}`;
   const offsets = [0];
@@ -130,6 +150,7 @@ function xrefStreamPdf(
   document: Uint8Array,
   compressIndirectObjects = false,
   objectHeaderPadding = 0,
+  options: { objectHeaderComments?: boolean; tiffPredictor?: boolean } = {},
 ): Buffer {
   const original = Buffer.from(document).toString("latin1");
   const table = original.lastIndexOf("\nxref\n");
@@ -170,7 +191,7 @@ function xrefStreamPdf(
     let objectBody = "";
     let header = "";
     for (const [index, number] of references.entries()) {
-      header += `${number} ${objectBody.length} `;
+      header += `${number} ${objectBody.length}${options.objectHeaderComments ? " % compressed object\n" : " "}`;
       objectBody += `${values[index]} `;
     }
     header += " ".repeat(objectHeaderPadding);
@@ -199,8 +220,17 @@ function xrefStreamPdf(
       records.writeUInt16BE(65535, position + 5);
     }
   }
-  const encoded = deflateSync(records);
-  body += `${xrefObject} 0 obj\n<< /Type /XRef /Size ${xrefObject + 1} /Root 1 0 R /W [1 4 2] /Length ${encoded.byteLength} /Filter /FlateDecode >>\nstream\n${encoded.toString("latin1")}\nendstream\nendobj\nstartxref\n${xrefOffset}\n%%EOF\n`;
+  const predicted = Buffer.from(records);
+  if (options.tiffPredictor) {
+    for (let position = 0; position < predicted.byteLength; position += 7) {
+      for (let column = 6; column >= 1; column -= 1) {
+        predicted[position + column] =
+          (records[position + column]! - records[position + column - 1]!) & 255;
+      }
+    }
+  }
+  const encoded = deflateSync(predicted);
+  body += `${xrefObject} 0 obj\n<< /Type /XRef /Size ${xrefObject + 1} /Root 1 0 R /W [1 4 2] /Length ${encoded.byteLength} /Filter /FlateDecode${options.tiffPredictor ? " /DecodeParms << /Predictor 2 /Columns 7 /Colors 1 /BitsPerComponent 8 >>" : ""} >>\nstream\n${encoded.toString("latin1")}\nendstream\nendobj\nstartxref\n${xrefOffset}\n%%EOF\n`;
   return Buffer.from(body, "latin1");
 }
 
@@ -608,7 +638,9 @@ describe("scan knowledge bases", () => {
     const chained = join(root, "chained.pdf");
     const indirect = join(root, "indirect.pdf");
     const indirectFilter = join(root, "indirect-filter.pdf");
+    const indirectFilterArray = join(root, "indirect-filter-array.pdf");
     const commentedIndirect = join(root, "commented-indirect.pdf");
+    const leadingCommentedIndirect = join(root, "leading-comment-indirect.pdf");
     const escaped = join(root, "escaped.pdf");
     const lzw = join(root, "lzw.pdf");
     const earlyChange = join(root, "lzw-early-change.pdf");
@@ -628,11 +660,25 @@ describe("scan knowledge bases", () => {
       pdf("Indirect stream filter", 1, true, "", { indirectFilter: true }),
     );
     await writeFile(
+      indirectFilterArray,
+      pdf("Indirect array stream filter", 1, true, "", {
+        indirectFilterArray: true,
+      }),
+    );
+    await writeFile(
       commentedIndirect,
       pdf("Commented indirect values", 1, true, "", {
         indirectLength: true,
         indirectFilter: true,
         indirectValueComment: " % valid comment\n",
+      }),
+    );
+    await writeFile(
+      leadingCommentedIndirect,
+      pdf("Leading commented indirect values", 1, true, "", {
+        indirectLength: true,
+        indirectFilter: true,
+        indirectValuePrefix: "% valid leading comment\n",
       }),
     );
     await writeFile(
@@ -663,8 +709,10 @@ describe("scan knowledge bases", () => {
         "ASCII85 then Flate",
         "Commented indirect values",
         "Escaped PDF filter",
+        "Indirect array stream filter",
         "Indirect stream length",
         "Indirect stream filter",
+        "Leading commented indirect values",
         "LZW encoded text",
         earlyChangeText,
       ].sort(),
@@ -717,6 +765,69 @@ describe("scan knowledge bases", () => {
     temporaryDirectories.push(knowledgeBase.path);
     expect(await extractedDocuments(knowledgeBase.path)).toEqual([
       "Cached object stream header",
+    ]);
+  });
+
+  test("parses comments inside compressed PDF object-stream headers", async () => {
+    const root = await temporaryDirectory();
+    const document = join(root, "commented-object-header.pdf");
+    await writeFile(
+      document,
+      xrefStreamPdf(
+        pdf("Commented object-stream header", 1, true, "", {
+          indirectLength: true,
+          indirectFilter: true,
+        }),
+        true,
+        0,
+        { objectHeaderComments: true },
+      ),
+    );
+
+    const knowledgeBase = await prepareKnowledgeBase([document]);
+    temporaryDirectories.push(knowledgeBase.path);
+    expect(await extractedDocuments(knowledgeBase.path)).toEqual([
+      "Commented object-stream header",
+    ]);
+  });
+
+  test("decodes TIFF-predicted PDF cross-reference streams", async () => {
+    const root = await temporaryDirectory();
+    const document = join(root, "tiff-predicted-cross-reference.pdf");
+    await writeFile(
+      document,
+      xrefStreamPdf(
+        pdf("TIFF-predicted cross reference", 1, true, "", {
+          indirectLength: true,
+          indirectFilter: true,
+        }),
+        false,
+        0,
+        { tiffPredictor: true },
+      ),
+    );
+
+    const knowledgeBase = await prepareKnowledgeBase([document]);
+    temporaryDirectories.push(knowledgeBase.path);
+    expect(await extractedDocuments(knowledgeBase.path)).toEqual([
+      "TIFF-predicted cross reference",
+    ]);
+  });
+
+  test("excludes compressed image pixels from the extracted-text budget", async () => {
+    const root = await temporaryDirectory();
+    const document = join(root, "large-image.pdf");
+    await writeFile(
+      document,
+      pdf("Small document text", 1, true, "/Im1 Do ", {
+        imageBytes: Buffer.alloc(9 * 1024 * 1024, 1),
+      }),
+    );
+
+    const knowledgeBase = await prepareKnowledgeBase([document]);
+    temporaryDirectories.push(knowledgeBase.path);
+    expect(await extractedDocuments(knowledgeBase.path)).toEqual([
+      "Small document text",
     ]);
   });
 
@@ -810,6 +921,11 @@ describe("scan knowledge bases", () => {
           indirectLength: true,
           headerComment: "6 0 obj 0 endobj",
         },
+      ],
+      ["indirect-filter-array", { indirectFilterArray: true }],
+      [
+        "page-content-marked-as-image",
+        { dictionaryPrefix: "/Subtype /Image " },
       ],
     ] as const) {
       const document = join(root, `${name}.pdf`);

--- a/sdk/typescript/tests-ts/knowledge-base.test.ts
+++ b/sdk/typescript/tests-ts/knowledge-base.test.ts
@@ -8,6 +8,7 @@ import {
   rm,
   stat,
   symlink,
+  truncate,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -49,13 +50,19 @@ function docx(text: string): Uint8Array {
   });
 }
 
-function pdf(text: string): Uint8Array {
+function pdf(text: string, pages = 1): Uint8Array {
   const escaped = text.replace(/[\\()]/gu, "\\$&");
   const stream = `BT /F1 12 Tf 72 720 Td (${escaped}) Tj ET`;
+  const pageObjects = Array.from({ length: pages }, (_, index) => index + 3);
+  const font = pages + 3;
+  const content = pages + 4;
   const objects = [
     "<< /Type /Catalog /Pages 2 0 R >>",
-    "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
-    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+    `<< /Type /Pages /Kids [${pageObjects.map((number) => `${number} 0 R`).join(" ")}] /Count ${pages} >>`,
+    ...pageObjects.map(
+      () =>
+        `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 ${font} 0 R >> >> /Contents ${content} 0 R >>`,
+    ),
     "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
     `<< /Length ${Buffer.byteLength(stream)} >>\nstream\n${stream}\nendstream`,
   ];
@@ -185,6 +192,99 @@ describe("scan knowledge bases", () => {
     await expect(prepareKnowledgeBase([invalidXml])).rejects.toThrow(
       "Cannot extract text from knowledge base DOCX",
     );
+  });
+
+  test("bounds document count, nesting depth, and individual input size", async () => {
+    const countRoot = await temporaryDirectory();
+    const documents = Array.from({ length: 129 }, (_, index) =>
+      join(countRoot, `${index}.md`),
+    );
+    await Promise.all(documents.map((path) => writeFile(path, "scope")));
+    await expect(prepareKnowledgeBase(documents)).rejects.toThrow(
+      "more than 128 documents",
+    );
+
+    const depthRoot = await temporaryDirectory();
+    let nested = depthRoot;
+    for (let depth = 0; depth < 17; depth += 1) {
+      nested = join(nested, "nested");
+      await mkdir(nested);
+    }
+    await writeFile(join(nested, "scope.md"), "scope");
+    await expect(prepareKnowledgeBase([depthRoot])).rejects.toThrow(
+      "16-level nesting limit",
+    );
+
+    const sizeRoot = await temporaryDirectory();
+    const oversized = join(sizeRoot, "oversized.md");
+    await writeFile(oversized, "");
+    await truncate(oversized, 8 * 1024 * 1024 + 1);
+    await expect(prepareKnowledgeBase([oversized])).rejects.toThrow(
+      "8388608-byte input limit",
+    );
+  });
+
+  test("bounds aggregate input and extracted text", async () => {
+    const inputRoot = await temporaryDirectory();
+    const inputs = Array.from({ length: 5 }, (_, index) =>
+      join(inputRoot, `${index}.md`),
+    );
+    for (const [index, path] of inputs.entries()) {
+      await writeFile(path, "");
+      await truncate(path, index === inputs.length - 1 ? 1 : 8 * 1024 * 1024);
+    }
+    await expect(prepareKnowledgeBase(inputs)).rejects.toThrow(
+      "33554432-byte aggregate limit",
+    );
+
+    const documentOutputRoot = await temporaryDirectory();
+    const oversizedOutput = join(documentOutputRoot, "oversized.docx");
+    await writeFile(oversizedOutput, docx("x".repeat(8 * 1024 * 1024)));
+    await expect(prepareKnowledgeBase([oversizedOutput])).rejects.toThrow(
+      "8388608-byte extracted-text limit",
+    );
+
+    const outputRoot = await temporaryDirectory();
+    const compressedText = "x".repeat(7 * 1024 * 1024);
+    for (let index = 0; index < 5; index += 1) {
+      await writeFile(join(outputRoot, `${index}.docx`), docx(compressedText));
+    }
+    await expect(prepareKnowledgeBase([outputRoot])).rejects.toThrow(
+      "extracted text exceeds the 33554432-byte aggregate limit",
+    );
+  });
+
+  test("limits PDF page extraction", async () => {
+    const root = await temporaryDirectory();
+    const oversized = join(root, "oversized.pdf");
+    await writeFile(oversized, pdf("scope", 513));
+
+    await expect(prepareKnowledgeBase([oversized])).rejects.toThrow(
+      "512-page limit",
+    );
+  });
+
+  test("observes cancellation while discovering directories", async () => {
+    const root = await temporaryDirectory();
+    const nested = join(root, "one", "two");
+    await mkdir(nested, { recursive: true });
+    await writeFile(join(nested, "scope.md"), "scope");
+    const controller = new AbortController();
+    const reason = new DOMException("cancel discovery", "AbortError");
+    const throwIfAborted = controller.signal.throwIfAborted.bind(
+      controller.signal,
+    );
+    let checks = 0;
+    controller.signal.throwIfAborted = (): void => {
+      checks += 1;
+      if (checks === 5) controller.abort(reason);
+      throwIfAborted();
+    };
+
+    await expect(prepareKnowledgeBase([root], controller.signal)).rejects.toBe(
+      reason,
+    );
+    expect(checks).toBe(5);
   });
 
   testPosix("does not follow symbolic links", async () => {


### PR DESCRIPTION
## Summary

- Adopt the original knowledge-base hardening contribution from PR #95 while preserving the original substantive commit author, kartikshukla17, and acknowledging GautamSharma99 for submitting and maintaining the source PR.
- Bound discovery depth, entries, document count, per-document and aggregate input, extracted text, PDF pages, and cancellation.
- Preserve secure source handling, private temporary outputs, and existing public SDK behavior.

## Verification

- Full current-main SDK suite: 474 passed, six expected platform/integration skips, zero failures.
- Focused knowledge-base and orchestration coverage: 78 passed.
- TypeScript and formatting checks passed.