### PR TITLE
fix: redact credentials before storing scan failures

### DIFF
--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -32,6 +32,7 @@ import {
   OutputDirectoryError,
   OutputInsideProtectedRootError,
   type ProtectedScanPathKind,
+  redactedErrorMessage,
   ScanCostLimitExceededError,
   ScanInterruptedError,
 } from "./errors.js";
@@ -843,11 +844,10 @@ export class CodexSecurity {
             "fail-scan",
             "--scan-id",
             activeScan.id,
+            // Redact before truncating: the stored message is read back by
+            // `scans show` and travels inside the results directory.
             "--message",
-            (failure instanceof Error
-              ? failure.message
-              : String(failure)
-            ).slice(0, 2400),
+            redactedErrorMessage(failure).slice(0, 2400),
             ...(snapshot?.cost
               ? ["--cost-json", JSON.stringify(snapshot.cost)]
               : []),

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -57,6 +57,7 @@ import { formatUsd } from "./cost.js";
 import {
   CodexSecurityError,
   OutputInsideProtectedRootError,
+  redactedErrorMessage,
   ScanInterruptedError,
 } from "./errors.js";
 import type { SeverityLevel } from "./models.js";
@@ -606,7 +607,7 @@ export async function main(
     try {
       return await select(await dependencies.runWorkbench(args));
     } catch (error) {
-      errorOutput.write(`codex-security: ${cliErrorMessage(error)}\n`);
+      errorOutput.write(`codex-security: ${redactedErrorMessage(error)}\n`);
       exitCode = 2;
       return undefined;
     }
@@ -805,7 +806,7 @@ export async function main(
           ]);
           scanArguments = scanArgumentsFromRecipe(recipe, args.scanId);
         } catch (error) {
-          const message = cliErrorMessage(error);
+          const message = redactedErrorMessage(error);
           errorOutput.write(`codex-security: ${message}\n`);
           exitCode = 2;
           return incurError({
@@ -868,7 +869,7 @@ export async function main(
             format,
           );
         } catch (error) {
-          errorOutput.write(`codex-security: ${cliErrorMessage(error)}\n`);
+          errorOutput.write(`codex-security: ${redactedErrorMessage(error)}\n`);
           exitCode = 2;
           return undefined;
         }
@@ -1146,7 +1147,7 @@ export async function main(
             failOnSeverity: options.failOnSeverity,
           };
         } catch (error) {
-          errorOutput.write(`codex-security: ${cliErrorMessage(error)}\n`);
+          errorOutput.write(`codex-security: ${redactedErrorMessage(error)}\n`);
           exitCode = 2;
           return undefined;
         }
@@ -1307,7 +1308,7 @@ export async function main(
             signal: controller.signal,
             onProgress: ({ repository, status, attempt, error }) => {
               errorOutput.write(
-                `codex-security: ${repository} ${status} (attempt ${attempt})${error === undefined ? "" : `: ${cliErrorMessage(error)}`}\n`,
+                `codex-security: ${repository} ${status} (attempt ${attempt})${error === undefined ? "" : `: ${redactedErrorMessage(error)}`}\n`,
               );
             },
           });
@@ -1319,7 +1320,7 @@ export async function main(
             (error instanceof Error && error.name === "ExitPromptError"
               ? 130
               : 2);
-          errorOutput.write(`codex-security: ${cliErrorMessage(error)}\n`);
+          errorOutput.write(`codex-security: ${redactedErrorMessage(error)}\n`);
         } finally {
           dependencies.removeSignalListener("SIGINT", onInterrupt);
           dependencies.removeSignalListener("SIGTERM", onTerminate);
@@ -1423,7 +1424,7 @@ export async function main(
           );
         } catch (error) {
           exitCode = 2;
-          errorOutput.write(`codex-security: ${cliErrorMessage(error)}\n`);
+          errorOutput.write(`codex-security: ${redactedErrorMessage(error)}\n`);
         }
       },
     })
@@ -1459,7 +1460,7 @@ export async function main(
           );
         } catch (error) {
           exitCode = 2;
-          errorOutput.write(`codex-security: ${cliErrorMessage(error)}\n`);
+          errorOutput.write(`codex-security: ${redactedErrorMessage(error)}\n`);
         }
       },
     })
@@ -1644,7 +1645,7 @@ export async function main(
   if (frameworkExit !== undefined) {
     if (exitCode !== 0) return exitCode;
     errorOutput.write(
-      `codex-security: ${cliErrorMessage(incurErrorMessage(frameworkOutput))}\n`,
+      `codex-security: ${redactedErrorMessage(incurErrorMessage(frameworkOutput))}\n`,
     );
     return 2;
   }
@@ -1653,7 +1654,7 @@ export async function main(
     await writeCliOutput(output, renderedHistory ?? frameworkOutput);
     return exitCode;
   } catch (error) {
-    errorOutput.write(`codex-security: ${cliErrorMessage(error)}\n`);
+    errorOutput.write(`codex-security: ${redactedErrorMessage(error)}\n`);
     return 2;
   }
 }
@@ -2369,7 +2370,7 @@ async function runExport(
     }
     return 0;
   } catch (error) {
-    errorOutput.write(`codex-security: ${cliErrorMessage(error)}\n`);
+    errorOutput.write(`codex-security: ${redactedErrorMessage(error)}\n`);
     return 2;
   }
 }
@@ -2517,7 +2518,7 @@ async function runScan(
       onOutputArchived: (archiveDir) => {
         progress?.stopTimer();
         errorOutput.write(
-          `Moved existing results to: ${cliErrorMessage(archiveDir)}\n`,
+          `Moved existing results to: ${redactedErrorMessage(archiveDir)}\n`,
         );
       },
       signal: preparationAbortController.signal,
@@ -2578,12 +2579,12 @@ async function runScan(
       },
       onWarning: (warning) => {
         errorOutput.write(
-          `codex-security: warning: ${cliErrorMessage(warning)}\n`,
+          `codex-security: warning: ${redactedErrorMessage(warning)}\n`,
         );
       },
       onObserverError: (observer, error) => {
         errorOutput.write(
-          `codex-security: warning: ${observer} observer failed: ${cliErrorMessage(error)}\n`,
+          `codex-security: warning: ${observer} observer failed: ${redactedErrorMessage(error)}\n`,
         );
       },
     };
@@ -2620,7 +2621,7 @@ async function runScan(
   if (failed) {
     const message =
       failure instanceof OutputInsideProtectedRootError
-        ? cliErrorMessage(protectedRootErrorMessage(failure))
+        ? redactedErrorMessage(protectedRootErrorMessage(failure))
         : scanFailureMessage(failure, selectedAuthentication);
     errorOutput.write(`${message}\n`);
     if (failure instanceof ScanInterruptedError) {
@@ -2628,7 +2629,7 @@ async function runScan(
     }
     if (scanDir !== null) {
       errorOutput.write(
-        `Partial output was kept at ${cliErrorMessage(scanDir)}.\n`,
+        `Partial output was kept at ${redactedErrorMessage(scanDir)}.\n`,
       );
     }
     return { exitCode: 2, error: message };
@@ -2697,7 +2698,7 @@ function scanFailureMessage(
     case "network_error":
     case "timeout":
     case "unknown":
-      return cliErrorMessage(error);
+      return redactedErrorMessage(error);
   }
 }
 
@@ -2711,7 +2712,9 @@ function scanScope(arguments_: ScanArguments): string | null {
         portable.startsWith("//")
           ? portable.split("/").at(-1) ?? portable
           : portable;
-      return cliErrorMessage(scoped.replaceAll(/[\u0000-\u001F\u007F]/gu, " "));
+      return redactedErrorMessage(
+        scoped.replaceAll(/[\u0000-\u001F\u007F]/gu, " "),
+      );
     });
     return `${displayed.join(", ")}${arguments_.paths.length > displayed.length ? `, +${arguments_.paths.length - displayed.length} more` : ""}`;
   }
@@ -2773,7 +2776,7 @@ function printScanSummary(
           ? 33
           : 36;
   errorOutput.write(
-    `\n  ${paint("REPORT", "1;36")}    ${paint(cliErrorMessage(result.reportPath), 4)}\n\n` +
+    `\n  ${paint("REPORT", "1;36")}    ${paint(redactedErrorMessage(result.reportPath), 4)}\n\n` +
       `  ${paint("FINDINGS", 1)}  ${paint(`${findingCount}${severitySummary === "" ? "" : ` (${severitySummary})`}`, findingColor)}\n` +
       `  ${paint("COVERAGE", 1)}  ${result.coverage.completeness}\n` +
       `  ${paint("ELAPSED", 1)}   ${duration}\n`,
@@ -2789,7 +2792,7 @@ function printScanSummary(
     );
   }
   errorOutput.write(
-    `  ${paint("RESULTS", 1)}   ${cliErrorMessage(result.scanDir)}\n`,
+    `  ${paint("RESULTS", 1)}   ${redactedErrorMessage(result.scanDir)}\n`,
   );
 }
 
@@ -3089,7 +3092,7 @@ function interruptedExit(
   errorOutput.write(
     scanDir === null
       ? "codex-security: No partial output was kept.\n"
-      : `codex-security: Partial output was kept at ${cliErrorMessage(scanDir)}.\n`,
+      : `codex-security: Partial output was kept at ${redactedErrorMessage(scanDir)}.\n`,
   );
   return ctrlC ? 130 : 143;
 }
@@ -3109,34 +3112,13 @@ function invokedAsMain(): boolean {
   }
 }
 
-function cliErrorMessage(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error);
-  return message
-    .replaceAll(
-      /(\b[A-Za-z0-9_-]{0,64}(?:api[_-]?key|access[_-]?key(?:[_-]?id)?|token|secret|credential|signature|sig|password|passwd)\b(?:\\?["'])?\s*[:=]\s*(?:\\?["'])?)[^\s"',;}&\\\]]+/giu,
-      "$1[redacted]",
-    )
-    .replaceAll(/sk-(?:proj-)?[A-Za-z0-9_*=-]{8,}/gu, "[redacted]")
-    .replaceAll(/(?:github_pat_|gh[pousr]_)[A-Za-z0-9_-]{8,}/giu, "[redacted]")
-    .replaceAll(/npm_[A-Za-z0-9_-]{8,}/giu, "[redacted]")
-    .replaceAll(
-      /(^|%20|[^A-Za-z0-9_])(Bearer|Basic|Token)((?:\s|%20|\+)+)[A-Za-z0-9.%_~+/*=-]{8,}/giu,
-      "$1$2$3[redacted]",
-    )
-    .replaceAll(/((?:https?|ssh|git\+ssh):\/\/)[^\s/@]+@/giu, "$1[redacted]@")
-    .replaceAll(
-      /((?:[?&]|%3F|%26)(?:(?!%3F|%26|%3D)(?:[A-Za-z0-9_.%-]|\[|\])){0,64}(?:api[_-]?key|access(?:[_-]|%5F|%2D)?key(?:(?:[_-]|%5F|%2D)?id)?|token|secret|credential|signature|sig|password|passwd)(?:\]|%5D)?(?:=|%3D))(?:(?!%26)[^&\s])+/giu,
-      "$1[redacted]",
-    );
-}
-
 if (invokedAsMain()) {
   void main().then(
     (exitCode) => {
       process.exitCode = exitCode;
     },
     (error: unknown) => {
-      process.stderr.write(`codex-security: ${cliErrorMessage(error)}\n`);
+      process.stderr.write(`codex-security: ${redactedErrorMessage(error)}\n`);
       process.exitCode = 2;
     },
   );

--- a/sdk/typescript/src/errors.ts
+++ b/sdk/typescript/src/errors.ts
@@ -1,5 +1,27 @@
 import { formatUsd, type ScanCost } from "./cost.js";
 
+/** Returns an error message with credential-shaped substrings redacted. */
+export function redactedErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message
+    .replaceAll(
+      /(\b[A-Za-z0-9_-]{0,64}(?:api[_-]?key|access[_-]?key(?:[_-]?id)?|token|secret|credential|signature|sig|password|passwd)\b(?:\\?["'])?\s*[:=]\s*(?:\\?["'])?)[^\s"',;}&\\\]]+/giu,
+      "$1[redacted]",
+    )
+    .replaceAll(/sk-(?:proj-)?[A-Za-z0-9_*=-]{8,}/gu, "[redacted]")
+    .replaceAll(/(?:github_pat_|gh[pousr]_)[A-Za-z0-9_-]{8,}/giu, "[redacted]")
+    .replaceAll(/npm_[A-Za-z0-9_-]{8,}/giu, "[redacted]")
+    .replaceAll(
+      /(^|%20|[^A-Za-z0-9_])(Bearer|Basic|Token)((?:\s|%20|\+)+)[A-Za-z0-9.%_~+/*=-]+/giu,
+      "$1$2$3[redacted]",
+    )
+    .replaceAll(/((?:https?|ssh|git\+ssh):\/\/)[^\s/@]+@/giu, "$1[redacted]@")
+    .replaceAll(
+      /((?:[?&]|%3F|%26)(?:(?!%3F|%26|%3D)(?:[A-Za-z0-9_.%-]|\[|\])){0,64}(?:api[_-]?key|access(?:[_-]|%5F|%2D)?key(?:(?:[_-]|%5F|%2D)?id)?|token|secret|credential|signature|sig|password|passwd)(?:\]|%5D)?(?:=|%3D))(?:(?!%26)[^&\s])+/giu,
+      "$1[redacted]",
+    );
+}
+
 /** Base error for Codex Security SDK failures. */
 export class CodexSecurityError extends Error {
   public constructor(message: string, options?: ErrorOptions) {

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -17,6 +17,7 @@ import Papa from "papaparse";
 import type { CodexSecurity } from "./api.js";
 import type { CodexSecurityConfig } from "./config.js";
 import type { ScanCost } from "./cost.js";
+import { redactedErrorMessage } from "./errors.js";
 import type { ScanMode } from "./targets.js";
 import { resolveTrustedExecutable } from "./trusted-executable.js";
 
@@ -190,7 +191,7 @@ async function runCampaign(
           }
         } catch (error) {
           if (options.signal?.aborted === true) options.signal.throwIfAborted();
-          failure = redactError(error);
+          failure = redactedErrorMessage(error);
         } finally {
           await rm(checkout, { recursive: true, force: true });
         }
@@ -522,17 +523,4 @@ export function buildGitHubCredentialArgs(host: string | undefined): string[] {
   }
   const key = `credential.${url.origin}.helper`;
   return ["-c", `${key}=`, "-c", `${key}=!gh auth git-credential`];
-}
-
-function redactError(error: unknown): string {
-  return (error instanceof Error ? error.message : String(error))
-    .replaceAll(
-      /((?:api[_-]?key|token|secret|credential|password)[A-Za-z0-9_-]*\s*[:=]\s*)[^\s,;]+/giu,
-      "$1[redacted]",
-    )
-    .replaceAll(
-      /\b(?:sk-(?:proj-)?|gh[pousr]_|github_pat_|npm_)[A-Za-z0-9_*=-]{8,}/gu,
-      "[redacted]",
-    )
-    .replaceAll(/\b(Bearer|Basic|Token)\s+[^\s,;]+/giu, "$1 [redacted]");
 }

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -45,6 +45,7 @@ import {
   setCodexSecurityCredentialLogout,
 } from "../src/runtime.js";
 import { normalizeTarget } from "../src/targets.js";
+import { REDACTED_CREDENTIALS, SYNTHETIC_CREDENTIALS } from "./cli-fixtures.js";
 import { INTEGRATION_TARGET, PLUGIN_ROOT } from "./plugin-root.js";
 
 type ScanObserverName = Parameters<
@@ -2161,6 +2162,80 @@ describe("CodexSecurity orchestration", () => {
     expect(history["scans"]).toMatchObject([
       { progress: { status: "failed" } },
     ]);
+    await client.close();
+  });
+
+  test("redacts credentials from the stored scan failure message", async () => {
+    const root = await temporaryDirectory();
+    const repository = join(root, "repository");
+    const codexHome = join(root, "codex-home");
+    const stateDirectory = join(root, "state");
+    const scanDir = join(root, "scan");
+    await mkdir(repository);
+    await mkdir(codexHome);
+    await mkdir(scanDir, { mode: 0o700 });
+    const python = Bun.which("python3") ?? Bun.which("python");
+    expect(python).not.toBeNull();
+    const environment = {
+      PATH: process.env["PATH"],
+      CODEX_SECURITY_STATE_DIR: stateDirectory,
+    };
+    const commands: Array<readonly string[]> = [];
+    const client = new TestClient(
+      {},
+      {
+        environment,
+        prepareRuntime: async () => ({
+          ...preparedRuntime(codexHome),
+          environment,
+        }),
+        resolvePluginPython: async () => python!,
+        prepareOutputDir: async () => scanDir,
+        repositoryRevision: async () => "deadbeef",
+        runWorkbench: async (
+          options: Parameters<typeof runWorkbench>[0],
+          args: readonly string[],
+        ) => {
+          commands.push(args);
+          return await runWorkbench(options, args);
+        },
+        createCodex: () => ({
+          startThread: () => ({
+            id: null,
+            async runStreamed() {
+              async function* failingEvents(): AsyncGenerator<ThreadEvent> {
+                yield { type: "error", message: SYNTHETIC_CREDENTIALS };
+              }
+              return { events: failingEvents() };
+            },
+          }),
+        }),
+      },
+    );
+
+    // The in-memory error keeps its original text; only what leaves the process
+    // is redacted, so the CLI can still classify the upstream failure.
+    await expect(client.run(repository)).rejects.toThrow(SYNTHETIC_CREDENTIALS);
+    const failure = commands.find((args) => args[0] === "fail-scan");
+    const scanId = failure?.[2] ?? "";
+    expect(scanId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(failure?.[3]).toBe("--message");
+    expect(failure?.[4]).toBe(REDACTED_CREDENTIALS);
+
+    // `scans show` reads the stored message back through get-scan.
+    const context = await runWorkbench(
+      { python: python!, pluginRoot: PLUGIN_ROOT, environment },
+      ["get-scan", "--scan-id", scanId],
+    );
+    expect(context["scan"]).toMatchObject({
+      progress: { status: "failed" },
+      failureMessage: REDACTED_CREDENTIALS,
+    });
+
+    // Every synthetic credential is tagged SYNTHETIC, so the database file
+    // itself proves nothing was persisted anywhere on the failure path.
+    const database = await readFile(join(stateDirectory, "workbench.sqlite3"));
+    expect(database.toString("latin1")).not.toContain("SYNTHETIC");
     await client.close();
   });
 

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -444,6 +444,11 @@ describe("multiscan", () => {
     const paths = await fixture();
     const source = await repository(paths.root, "retry");
     const secret = "sk-proj-SYNTHETIC_MULTISCAN_SECRET_123";
+    const proxyUrl =
+      "https://SYNTHETIC_USER:SYNTHETIC_MULTISCAN_PASSWORD@proxy.test/v1/responses";
+    const queryUrl =
+      "https://proxy.test/v1/responses?api_key=SYNTHETIC_MULTISCAN_QUERY_123&safe=1";
+    const shortAuthorization = "Bearer abc123";
     await writeFile(
       paths.input,
       `id,repository,revision\nretry,${source.path},${source.revision}\n`,
@@ -455,7 +460,11 @@ describe("multiscan", () => {
         paths,
         client(async (_repository, scanOptions = {}) => {
           attempts += 1;
-          if (attempts === 1) throw new Error(`temporary failure ${secret}`);
+          if (attempts === 1) {
+            throw new Error(
+              `temporary failure ${secret} ${shortAuthorization} sending request for url (${proxyUrl}) and ${queryUrl}`,
+            );
+          }
           return await completedScan(scanOptions.outputDir!);
         }),
       ),
@@ -467,7 +476,12 @@ describe("multiscan", () => {
       { id: "retry", status: "failed", attempt: 1 },
       { id: "retry", status: "completed", attempt: 2 },
     ]);
-    expect(await readFile(summary.resultsPath, "utf8")).not.toContain(secret);
+    const ledger = await readFile(summary.resultsPath, "utf8");
+    expect(ledger).not.toContain(secret);
+    expect(ledger).not.toContain("SYNTHETIC_MULTISCAN_PASSWORD");
+    expect(ledger).not.toContain("SYNTHETIC_MULTISCAN_QUERY_123");
+    expect(ledger).not.toContain(shortAuthorization);
+    expect(ledger).toContain("https://[redacted]@proxy.test/v1/responses");
   });
 
   test("resumes complete bundles, repairs missing output, and rejects manifest drift", async () => {


### PR DESCRIPTION
## Problem

Issue #43 identifies a credential-handling gap.

Raw model failure messages can reach `fail-scan`, SQLite, and scan history.
Terminal output is redacted, but stored failures and bulk-scan receipts do not
always receive the same protection.

## Fix

- Add one shared credential-redaction helper.
- Redact failures before truncation and storage.
- Use the helper for CLI output and bulk-scan receipts.
- Remove the duplicate bulk-scan redactor.
- Preserve protection for short authorization values.

Tests cover SQLite persistence, bulk-scan receipts, API keys, URL passwords,
query credentials, and short authorization values.
