### PR TITLE
fix: keep scan cleanup failures from replacing the scan result

### DIFF
--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -311,6 +311,7 @@ export class CodexSecurity {
     let knowledgeBase: PreparedKnowledgeBase | null = null;
     let costTracker: ScanCostTracker | null = null;
     let releaseCredentialHome: (() => Promise<void>) | null = null;
+    let scanFailure = false;
     let completionCost: ScanCost | null = null;
     let activeScan: {
       id: string;
@@ -832,6 +833,9 @@ export class CodexSecurity {
       }
       return result;
     } catch (error) {
+      // Recorded first: everything below can throw a different error for this same failed
+      // scan, and cleanup must treat all of those as a failure it is not allowed to mask.
+      scanFailure = true;
       const snapshot = await costTracker?.stop().catch(() => null);
       const failure =
         signal.reason instanceof ScanCostLimitExceededError
@@ -860,13 +864,37 @@ export class CodexSecurity {
       }
       throw failure;
     } finally {
+      // Removing the temporary scan inputs is best effort. A throw here would replace the
+      // outcome the try and catch blocks already produced, so these failures are reported
+      // as warnings: a scan that failed has to say why it failed, not why its temporary
+      // files outlived it. The whole step is guarded so that a cleanup which rejects, or
+      // throws synchronously, still cannot skip the credential lock release below.
       try {
-        await Promise.all([
+        for (const cleanup of await Promise.allSettled([
           knowledgeBase?.cleanup(),
           removeTargetPathsFile(targetPathsFile),
-        ]);
+        ])) {
+          if (cleanup.status === "rejected") {
+            warnCleanupFailed(options, cleanup.reason);
+          }
+        }
+      } catch (error) {
+        warnCleanupFailed(options, error);
       } finally {
-        await releaseCredentialHome?.();
+        // Releasing the credential home lock is not best effort, so it keeps its own
+        // finally and runs even if reporting the failures above went wrong. The release
+        // only marks itself done once the lock directory is gone, so a failure leaves an
+        // owner.json naming this still-running process; recoverStaleCredentialHomeLock
+        // then refuses to reclaim it because that pid is alive, and later scans in this
+        // process wait on a lock nothing frees. Reporting success while leaving the client
+        // in that state is worse than failing, so the failure is only downgraded to a
+        // warning when the scan already failed and that error is the one worth keeping.
+        try {
+          await releaseCredentialHome?.();
+        } catch (error) {
+          if (!scanFailure) throw error;
+          warnCleanupFailed(options, error);
+        }
       }
     }
   }
@@ -1317,6 +1345,28 @@ export async function initialCredentialsAvailable(
   }
   if (await codexSecurityHasStoredFileCredentials(isolatedHome)) return true;
   return await importer(ambientHome, isolatedHome);
+}
+
+// Reports a cleanup failure without letting it decide the result of the scan. Only the
+// message is forwarded, and it reaches the onWarning observer alone: unlike the fail-scan
+// path it is never written to the workbench, so it adds no persisted, unredacted text.
+function warnCleanupFailed(
+  options: Pick<ScanOptions, "onWarning" | "onObserverError">,
+  reason: unknown,
+): void {
+  // This runs where a throw would replace the scan result, so every step is inside the
+  // guard: reading the reason, coercing it, and reading the observers off the options can
+  // each throw for a sufficiently hostile value, and none of them may become the outcome
+  // of the scan. Losing a warning is the correct trade against losing the result.
+  try {
+    const message = String(reason instanceof Error ? reason.message : reason);
+    notifyObserver(
+      "onWarning",
+      options.onWarning,
+      options.onObserverError,
+      `Could not clean up after the Codex Security scan: ${message}`,
+    );
+  } catch {}
 }
 
 async function removeTargetPathsFile(path: string | null): Promise<void> {

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -1030,6 +1030,59 @@ describe("CodexSecurity orchestration", () => {
     await client.close();
   });
 
+  test("reports the real scan failure when scan cleanup also fails", async () => {
+    const root = await temporaryDirectory();
+    const repository = join(root, "repository");
+    const codexHome = join(root, "codex-home");
+    await mkdir(join(repository, "src"), { recursive: true });
+    await mkdir(codexHome);
+    let failedCleanupPath: string | undefined;
+    const warnings: string[] = [];
+    const client = new TestClient(
+      {},
+      {
+        environment: { OPENAI_API_KEY: "test-key" },
+        prepareRuntime: async () => preparedRuntime(codexHome),
+        resolvePluginPython: async () => "/managed/python",
+        repositoryRevision: async () => "deadbeef",
+        createCodex: (options: CodexOptions) => ({
+          startThread: () => ({
+            id: null,
+            async runStreamed() {
+              // Cleanup removes the target paths file with a non-recursive rm, so
+              // replacing that file with a directory makes cleanup reject on every
+              // platform.
+              failedCleanupPath =
+                options.env?.["CODEX_SECURITY_TARGET_PATHS_FILE"];
+              await rm(failedCleanupPath!, { force: true });
+              await mkdir(failedCleanupPath!);
+              throw new Error("the model refused the scan");
+            },
+          }),
+        }),
+      },
+    );
+
+    await expect(
+      client.run(repository, {
+        target: ["src"],
+        outputDir: join(root, "scan"),
+        onWarning: (warning) => {
+          warnings.push(warning);
+        },
+      }),
+    ).rejects.toThrow("the model refused the scan");
+    expect(failedCleanupPath).toBeDefined();
+    // The cleanup failure is reported rather than discarded.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(
+      warnings.filter((warning) =>
+        warning.startsWith("Could not clean up after the Codex Security scan:"),
+      ),
+    ).toHaveLength(1);
+    await client.close();
+  });
+
   test("rejects scan output inside the repository before runtime initialization", async () => {
     const root = await temporaryDirectory();
     const repository = join(root, "repository");


### PR DESCRIPTION
## Summary

Fixes #38.

The scan `finally` block awaited three cleanup steps without guarding any of them:

```ts
} finally {
  try {
    await Promise.all([
      knowledgeBase?.cleanup(),
      removeTargetPathsFile(targetPathsFile),
    ]);
  } finally {
    await releaseCredentialHome?.();
  }
}
```

A rejection in a `finally` block replaces the pending exception, so a cleanup failure discards
the outcome the `try` and `catch` blocks already produced. The caller is handed an unrelated
filesystem error instead of the reason the scan failed.

These are not hypothetical rejections. `removeTargetPathsFile` rethrows on any non-Windows
platform, and `knowledgeBase.cleanup()` is `rm(path, { recursive: true, force: true })`, where
`force` suppresses only `ENOENT` — `EACCES`, `EBUSY`, and `ENOTEMPTY` still reject.

The failure path also loses information that was recorded correctly: the `catch` block writes the
real message to the workbench through `fail-scan` before the `finally` block runs, so the
persisted scan history and the error the caller receives disagree about why the scan failed.
`ScanCostLimitExceededError` and `ScanInterruptedError` are erased the same way, so a scan
stopped by its own cost ceiling can report a `rm` failure instead.

## Impact

The two kinds of cleanup are treated differently on purpose, because only one of them is
best effort.

| Scan outcome | Failing step | Before | After |
| --- | --- | --- | --- |
| failed | temporary inputs | **cleanup error; real error discarded** | real scan error, cleanup warning |
| failed | credential lock release | **cleanup error; real error discarded** | real scan error, cleanup warning |
| completed | temporary inputs | **rejects; completed scan discarded** | result returned, cleanup warning |
| completed | credential lock release | rejects | rejects (unchanged, deliberate) |

## Changes

- Removing the temporary scan inputs is best effort. Those failures are settled and reported
  through the existing `onWarning` observer instead of deciding the scan result.
- Releasing the credential home lock is **not** best effort, and is deliberately not reduced to a
  warning on an otherwise successful scan. The release closure only marks itself done once the
  lock directory is gone, so a failed release leaves an `owner.json` naming a live process;
  `recoverStaleCredentialHomeLock` then declines to reclaim it because that pid is alive, and
  later scans in the same process wait on a lock nothing frees. Reporting success while leaving
  the client in that state would be worse than failing, so the failure still propagates, and is
  downgraded to a warning only when the scan had already failed and its error is the one worth
  keeping.
- The failed-scan marker is recorded on entry to the `catch` block. `this.#requireOpen()` and
  `throwIfAborted()` raise a *different* error for the same failed scan, so recording it later
  would let a lock-release failure replace a close or interruption error — the same masking this
  change removes.
- The release keeps its own `finally`, so it is still attempted even if constructing, settling, or
  reporting the input cleanups throws.
- `warnCleanupFailed` is total. Reading, coercing, and delivering the reason are all guarded,
  because a throw while *reporting* a cleanup failure would replace the scan result just as
  effectively as the original bug.
- `Promise.allSettled` also surfaces both input failures where `Promise.all` reported only the
  first.

## Verification

- The new test fails against `main` and passes with the change: **67 passed / 1 failed** before,
  **68 passed / 0 failed** after, in `tests-ts/api.test.ts`.
- The pre-change failure is the bug itself, not a different error:

  ```
  Expected substring: "the model refused the scan"
  Received message: "EFAULT: bad address in system call argument, rm '...codex-security-target-paths-....json'"
  ```

- Verified against real `main` source rather than a local revert, by restoring
  `sdk/typescript/src/api.ts` from `upstream/main` and confirming `git diff --stat upstream/main`
  reported no difference for that file before running the test.
- Full public SDK suite with the CI-pinned Bun 1.3.14: **471 passed, 6 expected skips, 0 failed**
  (`main` baseline is 470 passed, 6 skipped; this change adds one test).
- `pnpm run types`, `pnpm run format`, `pnpm run audit:prod`, `pnpm run build`, `pnpm pack`, and
  `pnpm run check:package` all clean.
- The existing test that asserts the target-paths file is removed after a scan still passes, so
  cleanup is still performed rather than skipped.

## Notes

- The test makes cleanup fail by replacing the target-paths file with a directory, so the
  non-recursive `rm` rejects on every platform rather than depending on POSIX permission bits.
  It asserts both that the real scan error survives and that exactly one cleanup warning is
  emitted, so a platform where the cleanup unexpectedly succeeded fails the warning assertion
  rather than passing vacuously.
- The credential-lock branch is structural rather than covered by a new test.
  `releaseCredentialHome` is only assigned for `stored_credentials` when `prepareRuntime` is
  undefined, and the test harness has to inject `prepareRuntime`, so no unit test can reach that
  branch. Flagging this rather than implying coverage it does not have.
- The new warning adds no unredacted disclosure path. It reaches only the `onWarning` observer and
  is never written to the workbench, and the CLI's handler already passes warnings through
  `cliErrorMessage()`. This is the distinction relative to #43, where the `fail-scan --message`
  path persists an unredacted message.
- Deliberately out of scope: a failed lock release still leaves a lock that
  `recoverStaleCredentialHomeLock` will not reclaim while the owning pid is alive. That liveness
  defect is in `acquireCodexSecurityCredentialHomeLock` / `recoverStaleCredentialHomeLock` in
  `src/runtime.ts`, not in this block, and needs its own change. This PR makes the failure
  visible rather than silent; it does not claim to repair the lock.
- Also out of scope: `complete-scan` running before `collectResult`, which lets a persistence
  error hide an incomplete scan. That is the other error-masking path in this file.

Reporter credit: @mariohercules, who identified the `finally` block and the replacement behavior
in #38.
