### PR TITLE
fix: bound authentication and skill subprocess output

### DIFF
--- a/sdk/typescript/src/auth.ts
+++ b/sdk/typescript/src/auth.ts
@@ -3,6 +3,13 @@ import { isIP } from "node:net";
 import { PluginBootstrapError } from "./errors.js";
 import type { CodexCommand, ProcessEnvironment } from "./runtime.js";
 
+const MAX_CODEX_AUTH_OUTPUT_BYTES = 64 * 1024;
+const LOGIN_OUTPUT_LIMIT_MESSAGE =
+  "Codex login output exceeded the 64 KiB safety limit.";
+const COMMAND_OUTPUT_LIMIT_MESSAGE =
+  "Codex authentication command output exceeded the 64 KiB safety limit.";
+const INSTRUCTION_TAIL_BYTES = 4 * 1024;
+
 export interface LoginResult {
   success: boolean;
   exitCode: number | null;
@@ -29,6 +36,13 @@ export class CodexLoginHandle {
   #canceled = false;
   #stdout = "";
   #stderr = "";
+  #stdoutInstructionTail = "";
+  #stderrInstructionTail = "";
+  #stdoutAuthUrl: string | null = null;
+  #stderrAuthUrl: string | null = null;
+  #stdoutUserCode: string | null = null;
+  #stderrUserCode: string | null = null;
+  #outputLimitExceeded = false;
 
   public constructor(
     command: CodexCommand,
@@ -55,12 +69,10 @@ export class CodexLoginHandle {
     this.#child.stdout.setEncoding("utf8");
     this.#child.stderr.setEncoding("utf8");
     this.#child.stdout.on("data", (chunk: string) => {
-      this.#stdout += chunk;
-      this.#notifyInstructions();
+      this.#recordOutput("stdout", chunk);
     });
     this.#child.stderr.on("data", (chunk: string) => {
-      this.#stderr += chunk;
-      this.#notifyInstructions();
+      this.#recordOutput("stderr", chunk);
     });
     this.#completion = new Promise((resolve, reject) => {
       this.#child.once("error", (error) => {
@@ -78,12 +90,19 @@ export class CodexLoginHandle {
         if (completed) return;
         completed = true;
         if (fallback !== undefined) clearTimeout(fallback);
-        const result = {
-          success: exitCode === 0 && !this.#canceled,
-          exitCode,
-          stdout: this.#stdout,
-          stderr: this.#stderr,
-        };
+        const result = this.#outputLimitExceeded
+          ? {
+              success: false,
+              exitCode,
+              stdout: "",
+              stderr: LOGIN_OUTPUT_LIMIT_MESSAGE,
+            }
+          : {
+              success: exitCode === 0 && !this.#canceled,
+              exitCode,
+              stdout: this.#stdout,
+              stderr: this.#stderr,
+            };
         this.#settleInstructionWaiters(result);
         if (result.success) onSuccess();
         resolve(result);
@@ -105,7 +124,7 @@ export class CodexLoginHandle {
   }
 
   public get authUrl(): string | null {
-    return preferredAuthUrl(`${this.#stdout}\n${this.#stderr}`);
+    return this.#stdoutAuthUrl ?? this.#stderrAuthUrl;
   }
 
   public get verificationUrl(): string | null {
@@ -113,12 +132,7 @@ export class CodexLoginHandle {
   }
 
   public get userCode(): string | null {
-    const output = plainTerminalText(`${this.#stdout}\n${this.#stderr}`);
-    return (
-      output.match(/(?:code|user code)\s*[:=]\s*([A-Z0-9-]{4,})/i)?.[1] ??
-      output.match(/\b[A-Z0-9]{4,}(?:-[A-Z0-9]{4,})+\b/)?.[0] ??
-      null
-    );
+    return this.#stdoutUserCode ?? this.#stderrUserCode;
   }
 
   public async wait(): Promise<LoginResult> {
@@ -136,6 +150,51 @@ export class CodexLoginHandle {
       this.#canceled = true;
       this.#child.kill("SIGTERM");
     }
+  }
+
+  #recordOutput(stream: "stdout" | "stderr", chunk: string): void {
+    if (this.#outputLimitExceeded) return;
+    const current = stream === "stdout" ? this.#stdout : this.#stderr;
+    const appended = appendUtf8Tail(
+      current,
+      chunk,
+      MAX_CODEX_AUTH_OUTPUT_BYTES,
+    );
+    if (stream === "stdout") {
+      this.#stdout = appended.value;
+    } else {
+      this.#stderr = appended.value;
+    }
+    if (appended.exceeded) {
+      this.#outputLimitExceeded = true;
+      this.#stdout = "";
+      this.#stderr = LOGIN_OUTPUT_LIMIT_MESSAGE;
+      this.#child.kill("SIGTERM");
+      return;
+    }
+
+    const tail =
+      stream === "stdout"
+        ? this.#stdoutInstructionTail
+        : this.#stderrInstructionTail;
+    const candidate = `${tail}${chunk}`;
+    const url = preferredAuthUrl(candidate);
+    const userCode = userCodeFromOutput(candidate);
+    const nextTail = appendUtf8Tail(
+      "",
+      candidate,
+      INSTRUCTION_TAIL_BYTES,
+    ).value;
+    if (stream === "stdout") {
+      this.#stdoutAuthUrl ??= url;
+      this.#stdoutUserCode ??= userCode;
+      this.#stdoutInstructionTail = nextTail;
+    } else {
+      this.#stderrAuthUrl ??= url;
+      this.#stderrUserCode ??= userCode;
+      this.#stderrInstructionTail = nextTail;
+    }
+    this.#notifyInstructions();
   }
 
   #notifyInstructions(): void {
@@ -256,18 +315,33 @@ export async function runCodex(
   });
   let stdout = "";
   let stderr = "";
+  let processError: Error | null = null;
+  const recordOutput = (stream: "stdout" | "stderr", chunk: string): void => {
+    if (processError !== null) return;
+    const appended = appendUtf8Tail(
+      stream === "stdout" ? stdout : stderr,
+      chunk,
+      MAX_CODEX_AUTH_OUTPUT_BYTES,
+    );
+    if (stream === "stdout") stdout = appended.value;
+    else stderr = appended.value;
+    if (!appended.exceeded) return;
+    stdout = "";
+    stderr = "";
+    processError = new PluginBootstrapError(COMMAND_OUTPUT_LIMIT_MESSAGE);
+    child.kill("SIGTERM");
+  };
   child.stdout.setEncoding("utf8");
   child.stderr.setEncoding("utf8");
   child.stdout.on("data", (chunk: string) => {
-    stdout += chunk;
+    recordOutput("stdout", chunk);
   });
   child.stderr.on("data", (chunk: string) => {
-    stderr += chunk;
+    recordOutput("stderr", chunk);
   });
   const completion = new Promise<LoginResult>((resolve, reject) => {
-    let processError: Error | null = null;
     child.once("error", (error) => {
-      processError = error;
+      processError ??= error;
     });
     child.stdin.on("error", (error: NodeJS.ErrnoException) => {
       // A short-lived command can close stdin before Node flushes the input.
@@ -295,29 +369,63 @@ export async function runCodex(
 }
 
 function preferredAuthUrl(value: string): string | null {
-  const urls = [
-    ...plainTerminalText(value).matchAll(/https?:\/\/[^\s<>]+/g),
-  ].map((match) => match[0].replace(/[.,;:!?)\]}]+$/, ""));
-  return (
-    urls.find((url) => {
-      try {
-        const hostname = new URL(url).hostname.toLowerCase().replace(/\.$/, "");
-        return (
-          hostname !== "localhost" &&
-          !hostname.endsWith(".localhost") &&
-          !(isIP(hostname) === 4 && hostname.startsWith("127.")) &&
-          hostname !== "0.0.0.0" &&
-          hostname !== "[::1]" &&
-          hostname !== "[::]" &&
-          hostname !== "[::ffff:0:0]" &&
-          !hostname.startsWith("[::ffff:7f") &&
-          !hostname.startsWith("[::7f")
-        );
-      } catch {
-        return false;
+  for (const match of plainTerminalText(value).matchAll(
+    /https?:\/\/[^\s<>]+/g,
+  )) {
+    const url = match[0].replace(/[.,;:!?)\]}]+$/, "");
+    try {
+      const hostname = new URL(url).hostname.toLowerCase().replace(/\.$/, "");
+      if (
+        hostname !== "localhost" &&
+        !hostname.endsWith(".localhost") &&
+        !(isIP(hostname) === 4 && hostname.startsWith("127.")) &&
+        hostname !== "0.0.0.0" &&
+        hostname !== "[::1]" &&
+        hostname !== "[::]" &&
+        hostname !== "[::ffff:0:0]" &&
+        !hostname.startsWith("[::ffff:7f") &&
+        !hostname.startsWith("[::7f")
+      ) {
+        return url;
       }
-    }) ?? null
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+function userCodeFromOutput(value: string): string | null {
+  const output = plainTerminalText(value);
+  return (
+    output.match(/(?:code|user code)\s*[:=]\s*([A-Z0-9-]{4,})/i)?.[1] ??
+    output.match(/\b[A-Z0-9]{4,}(?:-[A-Z0-9]{4,})+\b/)?.[0] ??
+    null
   );
+}
+
+function appendUtf8Tail(
+  current: string,
+  chunk: string,
+  maximumBytes: number,
+): { value: string; exceeded: boolean } {
+  const currentBytes = Buffer.from(current);
+  const chunkBytes = Buffer.from(chunk);
+  const exceeded = currentBytes.length + chunkBytes.length > maximumBytes;
+  if (!exceeded) return { value: `${current}${chunk}`, exceeded: false };
+  if (chunkBytes.length >= maximumBytes) {
+    return {
+      value: chunkBytes.subarray(chunkBytes.length - maximumBytes).toString(),
+      exceeded: true,
+    };
+  }
+  const retained = currentBytes.subarray(
+    Math.max(0, currentBytes.length - (maximumBytes - chunkBytes.length)),
+  );
+  return {
+    value: Buffer.concat([retained, chunkBytes]).toString(),
+    exceeded: true,
+  };
 }
 
 function plainTerminalText(value: string): string {

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -22,8 +22,7 @@ import {
   win32,
 } from "node:path";
 import { cwd } from "node:process";
-import { createInterface } from "node:readline";
-import { Readable, Writable as NodeWritable } from "node:stream";
+import { Writable as NodeWritable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import type { ModelReasoningEffort } from "@openai/codex-sdk";
@@ -101,6 +100,10 @@ const MAX_CODEX_OVERRIDE_VALUE_LENGTH = 64 * 1_024;
 const MAX_CODEX_OVERRIDE_DEPTH = 64;
 const MAX_SKILL_INPUT_BYTES = 1_024 * 1_024;
 const MAX_SKILL_INPUT_COUNT = 64;
+const MAX_SKILL_EVENT_BYTES = 1_024 * 1_024;
+const MAX_SKILL_RESPONSE_BYTES = 256 * 1_024;
+const SKILL_OUTPUT_LIMIT_MESSAGE =
+  "Codex skill output exceeded the 1 MiB event or 256 KiB response safety limit.";
 const WINDOWS_NETWORK_PATH = /^[\\/]{2}/u;
 const WINDOWS_LOCAL_DEVICE_ROOT =
   /^[\\/]{2}[?.][\\/](?:[A-Za-z]:|Volume\{[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}\}|GLOBALROOT[\\/]Device[\\/]HarddiskVolume[0-9]+)(?=[\\/]|$)/iu;
@@ -2195,19 +2198,23 @@ export async function readSkillCommandOutput(
   let message: string | undefined;
   let error: string | undefined;
   let malformed = false;
+  let exceeded = false;
 
-  for await (const line of createInterface({ input: Readable.from(stream) })) {
-    if (line.trim().length === 0) continue;
+  const readLine = (bytes: Buffer): void => {
+    const content =
+      bytes.at(-1) === 0x0d ? bytes.subarray(0, bytes.length - 1) : bytes;
+    const line = content.toString("utf8");
+    if (line.trim().length === 0) return;
     let event: unknown;
     try {
       event = JSON.parse(line);
     } catch {
       malformed = true;
-      continue;
+      return;
     }
     if (typeof event !== "object" || event === null) {
       malformed = true;
-      continue;
+      return;
     }
     const value = event as Record<string, unknown>;
     if (value["type"] === "item.completed") {
@@ -2220,7 +2227,11 @@ export async function readSkillCommandOutput(
         "text" in item &&
         typeof item.text === "string"
       ) {
-        message = item.text;
+        if (Buffer.byteLength(item.text, "utf8") > MAX_SKILL_RESPONSE_BYTES) {
+          exceeded = true;
+        } else {
+          message = item.text;
+        }
       }
     } else if (value["type"] === "turn.failed") {
       const detail = value["error"];
@@ -2230,15 +2241,63 @@ export async function readSkillCommandOutput(
         "message" in detail &&
         typeof detail.message === "string"
       ) {
-        error = detail.message;
+        if (
+          Buffer.byteLength(detail.message, "utf8") > MAX_SKILL_RESPONSE_BYTES
+        ) {
+          exceeded = true;
+        } else {
+          error = detail.message;
+        }
       }
     } else if (
       value["type"] === "error" &&
       typeof value["message"] === "string"
     ) {
-      error = value["message"];
+      if (
+        Buffer.byteLength(value["message"], "utf8") > MAX_SKILL_RESPONSE_BYTES
+      ) {
+        exceeded = true;
+      } else {
+        error = value["message"];
+      }
+    }
+  };
+
+  const pending = Buffer.alloc(MAX_SKILL_EVENT_BYTES);
+  let pendingBytes = 0;
+  let discardingOversizedLine = false;
+  for await (const rawChunk of stream) {
+    const chunk = Buffer.isBuffer(rawChunk)
+      ? rawChunk
+      : Buffer.from(rawChunk, "utf8");
+    let start = 0;
+    while (start < chunk.length) {
+      const newline = chunk.indexOf(0x0a, start);
+      const end = newline === -1 ? chunk.length : newline;
+      const segment = chunk.subarray(start, end);
+      if (!discardingOversizedLine) {
+        if (pendingBytes + segment.length > MAX_SKILL_EVENT_BYTES) {
+          exceeded = true;
+          discardingOversizedLine = true;
+          pendingBytes = 0;
+        } else if (segment.length > 0) {
+          segment.copy(pending, pendingBytes);
+          pendingBytes += segment.length;
+        }
+      }
+      if (newline === -1) break;
+      if (!discardingOversizedLine) {
+        readLine(pending.subarray(0, pendingBytes));
+      }
+      pendingBytes = 0;
+      discardingOversizedLine = false;
+      start = newline + 1;
     }
   }
+  if (!discardingOversizedLine && pendingBytes > 0) {
+    readLine(pending.subarray(0, pendingBytes));
+  }
+  if (exceeded) throw new CodexSecurityError(SKILL_OUTPUT_LIMIT_MESSAGE);
   return {
     ...(message === undefined ? {} : { message }),
     ...(error === undefined ? {} : { error }),

--- a/sdk/typescript/tests-ts/auth.test.ts
+++ b/sdk/typescript/tests-ts/auth.test.ts
@@ -100,6 +100,30 @@ describe("Codex authentication process boundary", () => {
     ).resolves.toMatchObject({ success: false, exitCode: 1 });
   });
 
+  test("rejects oversized noninteractive authentication output", async () => {
+    const root = await mkdtemp(join(tmpdir(), "codex-security-auth-output-"));
+    temporaryDirectories.push(root);
+    const secret = "sk-proj-SYNTHETIC_OVERSIZED_OUTPUT_SECRET";
+    for (const stream of ["stdout", "stderr"] as const) {
+      const script = join(root, `${stream}.mjs`);
+      await writeFile(
+        script,
+        `process.${stream}.write(${JSON.stringify(secret)}.repeat(3_000), () => process.exit(0));\n`,
+      );
+      const failure = await runCodex(
+        { command: process.execPath, prefixArgs: [script] },
+        [],
+        process.env,
+      ).then(
+        () => null,
+        (error: unknown) => error,
+      );
+      expect(failure).toBeInstanceOf(PluginBootstrapError);
+      expect(String(failure)).toContain("64 KiB safety limit");
+      expect(String(failure)).not.toContain(secret);
+    }
+  });
+
   test("reports account state and performs logout", async () => {
     const command = await fakeCodex();
     await expect(accountStatus(command, process.env)).resolves.toMatchObject({
@@ -125,6 +149,44 @@ describe("Codex authentication process boundary", () => {
     expect(handle.verificationUrl).toBe("https://127.auth.example.test/device");
     expect(handle.userCode).toBe("8356-V2EGR");
     expect(succeeded).toBe(true);
+  });
+
+  test("bounds interactive output while retaining discovered instructions", async () => {
+    const root = await mkdtemp(join(tmpdir(), "codex-security-auth-output-"));
+    temporaryDirectories.push(root);
+    const script = join(root, "login.mjs");
+    const secret = "sk-proj-SYNTHETIC_INTERACTIVE_OUTPUT_SECRET";
+    await writeFile(
+      script,
+      `
+console.error("Open https://auth.example.test/device");
+console.error("User code: ABCD-EFGH");
+setTimeout(() => {
+  process.stderr.write(${JSON.stringify(secret)}.repeat(3_000), () => process.exit(0));
+}, 10);
+`,
+    );
+    let succeeded = false;
+    const handle = new CodexLoginHandle(
+      { command: process.execPath, prefixArgs: [script] },
+      ["login", "--device-auth"],
+      process.env,
+      () => {
+        succeeded = true;
+      },
+    );
+
+    await handle.waitForInstructions({ deviceCode: true });
+    expect(handle.verificationUrl).toBe("https://auth.example.test/device");
+    expect(handle.userCode).toBe("ABCD-EFGH");
+    const result = await handle.wait();
+    expect(result).toMatchObject({
+      success: false,
+      stdout: "",
+      stderr: "Codex login output exceeded the 64 KiB safety limit.",
+    });
+    expect(JSON.stringify(result)).not.toContain(secret);
+    expect(succeeded).toBe(false);
   });
 
   test("drains native login stderr before resolving authentication", async () => {

--- a/sdk/typescript/tests-ts/cli-skills.test.ts
+++ b/sdk/typescript/tests-ts/cli-skills.test.ts
@@ -455,6 +455,58 @@ describe("CLI skill commands", () => {
     });
   });
 
+  test("drains and rejects oversized skill events and responses", async () => {
+    let drained = false;
+    async function* oversizedLine(): AsyncGenerator<Buffer> {
+      for (let remaining = 1_024 * 1_024 + 1; remaining > 0; ) {
+        const length = Math.min(64 * 1_024, remaining);
+        yield Buffer.alloc(length, 0x78);
+        remaining -= length;
+      }
+      yield Buffer.from(
+        '\n{"type":"item.completed","item":{"type":"agent_message","text":"must still drain"}}\n',
+      );
+      drained = true;
+    }
+    await expect(readSkillCommandOutput(oversizedLine())).rejects.toThrow(
+      "Codex skill output exceeded the 1 MiB event",
+    );
+    expect(drained).toBe(true);
+
+    async function* oversizedResponse(): AsyncGenerator<Buffer> {
+      yield Buffer.from(
+        `${JSON.stringify({
+          type: "item.completed",
+          item: {
+            type: "agent_message",
+            text: "x".repeat(256 * 1_024 + 1),
+          },
+        })}\n`,
+      );
+    }
+    await expect(readSkillCommandOutput(oversizedResponse())).rejects.toThrow(
+      "Codex skill output exceeded the 1 MiB event",
+    );
+
+    const stdout = capture();
+    const stderr = capture();
+    await expect(
+      runCodexSkillCommand(
+        [],
+        { command: "validate", stdout: stdout.stream, stderr: stderr.stream },
+        {
+          command: process.execPath,
+          prefixArgs: [
+            "-e",
+            'process.stdout.write(JSON.stringify({type:"item.completed",item:{type:"agent_message",text:"x".repeat(256*1024+1)}})+"\\n")',
+          ],
+        },
+      ),
+    ).rejects.toThrow("Codex skill output exceeded the 1 MiB event");
+    expect(stdout.text()).toBe("");
+    expect(stderr.text()).toBe("");
+  });
+
   test("summarizes skill failures without echoing credentials or private paths", () => {
     const cases = [
       ["401 sk-proj-SYNTHETIC_SECRET", "Authentication failed"],


### PR DESCRIPTION
## Summary

Fixes #130.

Bound the output retained from authentication subprocesses and Codex skill JSONL streams so a verbose, malfunctioning, or compromised child process cannot grow the SDK/CLI process's memory usage without limit.

The change also avoids repeatedly reparsing the complete interactive-login transcript while looking for device-auth instructions.

## Changes

### Bounded authentication output

Authentication subprocesses now enforce an independent 64 KiB ceiling for stdout and stderr.

For interactive login:

- stdout and stderr are retained only up to their individual limits;
- authentication URLs and user codes are discovered incrementally from a bounded rolling tail;
- discovered instructions are cached, while preserving the existing preference for stdout over stderr;
- exceeding either limit terminates the child and produces an unsuccessful login result with a fixed diagnostic;
- collected child output is cleared on overflow so credential-like content is not included in the result;
- the successful-login callback is not invoked after an output-limit failure.

For noninteractive authentication commands:

- stdout and stderr use the same independent 64 KiB ceilings;
- exceeding either ceiling terminates the subprocess;
- the command rejects with a `PluginBootstrapError` containing a fixed, redacted message;
- collected output is discarded before the error is reported.

### Incremental login instruction parsing

`CodexLoginHandle` no longer reparses all output collected so far for every incoming chunk.

Instead, each stream keeps a 4 KiB instruction-discovery tail. New chunks are parsed together with that bounded tail, and the first discovered URL and device code are retained. This bounds the parsing work while still recognizing instructions split across normal subprocess chunks.

### Bounded skill JSONL parsing

The skill output reader now uses a byte-bounded incremental newline parser instead of `readline`, which could retain an arbitrarily large unterminated line.

The parser enforces:

- a 1 MiB maximum for each JSONL event;
- a 256 KiB maximum for retained final agent messages and error messages;
- a fixed 1 MiB pending-line buffer, avoiding unbounded chunk accumulation as well as unbounded line content.

When an oversized event is encountered, the remainder of that line is discarded and the stream continues to be drained. After draining, the command fails with a fixed `CodexSecurityError` that does not echo subprocess content. This prevents a child from being left blocked on a full output pipe while still reporting the boundary violation safely.

The parser continues to support CRLF input, a final event without a trailing newline, chunks split at arbitrary byte boundaries, and split UTF-8 sequences.

## Security impact

This prevents untrusted or unexpectedly verbose authentication and skill subprocesses from causing unbounded:

- stdout or stderr retention;
- repeated interactive-login parsing work;
- JSONL line accumulation;
- retained final response or error-message memory.

Overflow diagnostics are constant strings and do not include the offending child output, preserving the existing credential-redaction boundary.

## Tests

Added regression coverage for:

- oversized noninteractive authentication stdout;
- oversized noninteractive authentication stderr;
- oversized interactive login output after valid instructions are discovered;
- preservation of the discovered verification URL and device code;
- suppression of credential-like overflow content;
- rejection without invoking the login success callback;
- a JSONL event larger than 1 MiB across many chunks;
- continued stream draining after an oversized event;
- an agent response larger than 256 KiB;
- end-to-end skill command rejection without writing partial output.

## Verification

- `pnpm run types`
- `pnpm run format`
- `pnpm run build`
- focused authentication and CLI skill tests
- `pnpm run test`

Full test result:

- 473 passed
- 6 expected platform/integration skips
- 0 failed
