### PR TITLE
fix: settle login close when children ignore SIGTERM or hold pipes

### DIFF
--- a/.github/workflows/container-ci.yml
+++ b/.github/workflows/container-ci.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -46,7 +46,7 @@ jobs:
           cache_dependency_path: sdk/typescript/pnpm-lock.yaml
 
       - name: Set up Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node }}
           cache: npm

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -38,7 +38,7 @@ jobs:
           firewall-version: "1.15.0"
 
       - name: Set up Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           package-manager-cache: false
@@ -157,7 +157,7 @@ jobs:
 
     steps:
       - name: Set up Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/sdk/typescript/src/auth.ts
+++ b/sdk/typescript/src/auth.ts
@@ -15,6 +15,8 @@ export interface AccountStatus {
   details: string;
 }
 
+const LOGIN_CHILD_SETTLE_MS = 1_000;
+
 export class CodexLoginHandle {
   readonly #child: ChildProcessWithoutNullStreams;
   readonly #completion: Promise<LoginResult>;
@@ -27,6 +29,7 @@ export class CodexLoginHandle {
   #urlReadySettled = false;
   #deviceReadySettled = false;
   #canceled = false;
+  #forceKillTimer: ReturnType<typeof setTimeout> | undefined;
   #stdout = "";
   #stderr = "";
 
@@ -64,6 +67,7 @@ export class CodexLoginHandle {
     });
     this.#completion = new Promise((resolve, reject) => {
       this.#child.once("error", (error) => {
+        this.#clearForceKillTimer();
         this.#settleInstructionWaiters({
           success: false,
           exitCode: null,
@@ -78,6 +82,8 @@ export class CodexLoginHandle {
         if (completed) return;
         completed = true;
         if (fallback !== undefined) clearTimeout(fallback);
+        this.#clearForceKillTimer();
+        this.#destroyStdio();
         const result = {
           success: exitCode === 0 && !this.#canceled,
           exitCode,
@@ -89,13 +95,14 @@ export class CodexLoginHandle {
         resolve(result);
       };
       this.#child.once("close", complete);
+      // A descendant that inherits stdout/stderr can keep the pipes open after
+      // the login child exits. Destroy them after a short grace period so
+      // wait()/close() always settle on every platform.
       this.#child.once("exit", (exitCode) => {
-        if (process.platform !== "win32") return;
         fallback = setTimeout(() => {
-          this.#child.stdout.destroy();
-          this.#child.stderr.destroy();
+          this.#destroyStdio();
           complete(exitCode);
-        }, 1_000);
+        }, LOGIN_CHILD_SETTLE_MS);
       });
     });
   }
@@ -132,10 +139,32 @@ export class CodexLoginHandle {
   }
 
   public cancel(): void {
-    if (this.#child.exitCode === null) {
-      this.#canceled = true;
-      this.#child.kill("SIGTERM");
+    this.#canceled = true;
+    this.#destroyStdio();
+    if (this.#child.exitCode !== null || this.#child.signalCode !== null) {
+      return;
     }
+    this.#child.kill("SIGTERM");
+    if (this.#forceKillTimer !== undefined) return;
+    this.#forceKillTimer = setTimeout(() => {
+      this.#forceKillTimer = undefined;
+      this.#destroyStdio();
+      if (this.#child.exitCode !== null || this.#child.signalCode !== null) {
+        return;
+      }
+      this.#child.kill("SIGKILL");
+    }, LOGIN_CHILD_SETTLE_MS);
+  }
+
+  #clearForceKillTimer(): void {
+    if (this.#forceKillTimer === undefined) return;
+    clearTimeout(this.#forceKillTimer);
+    this.#forceKillTimer = undefined;
+  }
+
+  #destroyStdio(): void {
+    this.#child.stdout.destroy();
+    this.#child.stderr.destroy();
   }
 
   #notifyInstructions(): void {

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -3914,6 +3914,7 @@ if (args === "login --with-api-key") {
   }
 } else if (args === "login") {
   console.error("Open https://auth.example.test/login");
+  process.exit(0);
 } else {
   process.exitCode = 2;
 }

--- a/sdk/typescript/tests-ts/auth.test.ts
+++ b/sdk/typescript/tests-ts/auth.test.ts
@@ -236,15 +236,13 @@ grandchild.once("error", (error) => {
     },
   );
 
-  test.skipIf(process.platform !== "win32")(
-    "releases native login pipes when the Windows fallback fires",
-    async () => {
-      const root = await mkdtemp(join(tmpdir(), "codex-security-auth-pipes-"));
-      temporaryDirectories.push(root);
-      const ready = join(root, "grandchild-ready");
-      const release = join(root, "release-grandchild");
-      const script = join(root, "login-pipes.mjs");
-      const grandchildScript = `
+  test("releases native login pipes when the exit fallback fires", async () => {
+    const root = await mkdtemp(join(tmpdir(), "codex-security-auth-pipes-"));
+    temporaryDirectories.push(root);
+    const ready = join(root, "grandchild-ready");
+    const release = join(root, "release-grandchild");
+    const script = join(root, "login-pipes.mjs");
+    const grandchildScript = `
 import { existsSync, writeFileSync } from "node:fs";
 
 const ready = process.argv[1];
@@ -258,9 +256,9 @@ const watcher = setInterval(() => {
 }, 25);
 writeFileSync(ready, String(process.pid));
 `;
-      await writeFile(
-        script,
-        `
+    await writeFile(
+      script,
+      `
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 
@@ -276,7 +274,7 @@ const grandchild = spawn(
 const readyTimeout = setTimeout(() => {
   clearInterval(readyWatcher);
   grandchild.kill();
-  console.error("Timed out waiting for the Windows login grandchild.");
+  console.error("Timed out waiting for the login grandchild.");
   process.exit(1);
 }, 10_000);
 const readyWatcher = setInterval(() => {
@@ -292,103 +290,147 @@ grandchild.once("error", (error) => {
   process.exit(1);
 });
 `,
+    );
+
+    const originalOnce = ChildProcess.prototype.once;
+    let loginChild: ChildProcess | undefined;
+    const processObserver = spyOn(ChildProcess.prototype, "once");
+    processObserver.mockImplementation(function (
+      this: ChildProcess,
+      event: string,
+      listener: (...eventArguments: never[]) => void,
+    ) {
+      if (event === "exit") loginChild = this;
+      return Reflect.apply(originalOnce, this, [event, listener]);
+    });
+
+    let handle: CodexLoginHandle;
+    try {
+      handle = new CodexLoginHandle(
+        { command: process.execPath, prefixArgs: [script] },
+        ["login"],
+        process.env,
+        () => {},
       );
+    } finally {
+      processObserver.mockRestore();
+    }
 
-      const originalOnce = ChildProcess.prototype.once;
-      let loginChild: ChildProcess | undefined;
-      const processObserver = spyOn(ChildProcess.prototype, "once");
-      processObserver.mockImplementation(function (
-        this: ChildProcess,
-        event: string,
-        listener: (...eventArguments: never[]) => void,
-      ) {
-        if (event === "exit") loginChild = this;
-        return Reflect.apply(originalOnce, this, [event, listener]);
-      });
-
-      let handle: CodexLoginHandle;
-      try {
-        handle = new CodexLoginHandle(
-          { command: process.execPath, prefixArgs: [script] },
-          ["login"],
-          process.env,
-          () => {},
-        );
-      } finally {
-        processObserver.mockRestore();
+    const readMarker = async (path: string): Promise<string> => {
+      const deadline = Date.now() + 5_000;
+      while (true) {
+        try {
+          return await readFile(path, "utf8");
+        } catch (error) {
+          if (
+            !(error instanceof Error) ||
+            !("code" in error) ||
+            error.code !== "ENOENT" ||
+            Date.now() >= deadline
+          ) {
+            throw error;
+          }
+          await delay(25);
+        }
       }
+    };
 
-      const readMarker = async (path: string): Promise<string> => {
+    let grandchildPid: number | undefined;
+    try {
+      const readyMarker = await readMarker(ready);
+      expect(readyMarker).toMatch(/^\d+$/u);
+      grandchildPid = Number(readyMarker);
+      expect(Number.isSafeInteger(grandchildPid)).toBe(true);
+      expect(grandchildPid).toBeGreaterThan(0);
+      const timeout = AbortSignal.timeout(5_000);
+      const completion = Promise.race([
+        handle.wait(),
+        new Promise<never>((_, reject) => {
+          timeout.addEventListener(
+            "abort",
+            () => reject(new Error("The login pipe fallback timed out.")),
+            { once: true },
+          );
+        }),
+      ]);
+      await expect(completion).resolves.toMatchObject({
+        success: true,
+        exitCode: 0,
+      });
+      expect(loginChild?.stdout?.destroyed).toBe(true);
+      expect(loginChild?.stderr?.destroyed).toBe(true);
+    } finally {
+      await writeFile(release, "released");
+      if (grandchildPid !== undefined) {
         const deadline = Date.now() + 5_000;
         while (true) {
           try {
-            return await readFile(path, "utf8");
+            process.kill(grandchildPid, 0);
           } catch (error) {
             if (
-              !(error instanceof Error) ||
-              !("code" in error) ||
-              error.code !== "ENOENT" ||
-              Date.now() >= deadline
+              error instanceof Error &&
+              "code" in error &&
+              error.code === "ESRCH"
             ) {
-              throw error;
+              break;
             }
-            await delay(25);
+            throw error;
           }
-        }
-      };
-
-      let grandchildPid: number | undefined;
-      try {
-        const readyMarker = await readMarker(ready);
-        expect(readyMarker).toMatch(/^\d+$/u);
-        grandchildPid = Number(readyMarker);
-        expect(Number.isSafeInteger(grandchildPid)).toBe(true);
-        expect(grandchildPid).toBeGreaterThan(0);
-        const timeout = AbortSignal.timeout(5_000);
-        const completion = Promise.race([
-          handle.wait(),
-          new Promise<never>((_, reject) => {
-            timeout.addEventListener(
-              "abort",
-              () => reject(new Error("The Windows login fallback timed out.")),
-              { once: true },
+          if (Date.now() >= deadline) {
+            throw new Error(
+              "The login grandchild did not exit after pipe cleanup.",
             );
-          }),
-        ]);
-        await expect(completion).resolves.toMatchObject({
-          success: true,
-          exitCode: 0,
-        });
-        expect(loginChild?.stdout?.destroyed).toBe(true);
-        expect(loginChild?.stderr?.destroyed).toBe(true);
-      } finally {
-        await writeFile(release, "released");
-        if (grandchildPid !== undefined) {
-          const deadline = Date.now() + 5_000;
-          while (true) {
-            try {
-              process.kill(grandchildPid, 0);
-            } catch (error) {
-              if (
-                error instanceof Error &&
-                "code" in error &&
-                error.code === "ESRCH"
-              ) {
-                break;
-              }
-              throw error;
-            }
-            if (Date.now() >= deadline) {
-              throw new Error(
-                "The Windows login grandchild did not exit after pipe cleanup.",
-              );
-            }
-            await delay(25);
           }
+          await delay(25);
         }
       }
-    },
-  );
+    }
+  });
+
+  test("escalates cancellation when a login child ignores SIGTERM", async () => {
+    const root = await mkdtemp(join(tmpdir(), "codex-security-auth-sigkill-"));
+    temporaryDirectories.push(root);
+    const script = join(root, "codex.mjs");
+    await writeFile(
+      script,
+      `
+console.error("Open https://auth.example.test/device");
+console.error("User code: ABCD-EFGH");
+process.on("SIGTERM", () => {});
+setInterval(() => {}, 1000);
+`,
+    );
+    let succeeded = false;
+    const handle = new CodexLoginHandle(
+      { command: process.execPath, prefixArgs: [script] },
+      ["login", "--device-auth"],
+      process.env,
+      () => {
+        succeeded = true;
+      },
+    );
+    await handle.waitForInstructions({ deviceCode: true });
+    handle.cancel();
+    const timeout = AbortSignal.timeout(5_000);
+    await expect(
+      Promise.race([
+        handle.wait(),
+        new Promise<never>((_, reject) => {
+          timeout.addEventListener(
+            "abort",
+            () =>
+              reject(
+                new Error(
+                  "Login cancellation did not settle after ignoring SIGTERM.",
+                ),
+              ),
+            { once: true },
+          );
+        }),
+      ]),
+    ).resolves.toMatchObject({ success: false });
+    expect(succeeded).toBe(false);
+  });
 
   test("does not report a canceled interactive login as successful", async () => {
     const root = await mkdtemp(join(tmpdir(), "codex-security-auth-cancel-"));


### PR DESCRIPTION
## Summary
- Fixes the flaky `node-ci` hang on `main` where `CodexSecurity orchestration > keeps ambient credentials available after successful ChatGPT login` timed out and left orphaned `bun`/`node` processes ([example](https://github.com/openai/codex-security/actions/runs/30521446463)).
- Addresses #131: after `SIGTERM`, escalate to `SIGKILL` and destroy stdio so `login.wait()` / `close()` always settle.
- Enable the exit→destroy-pipes fallback on all platforms (previously Windows-only).
- Harden the ambient ChatGPT login fixture to exit after printing the auth URL.
- Pin GitHub Actions dependencies maintained in this repo: `actions/checkout` → v7.0.1, `actions/setup-node` → v7.0.0.

## Test plan
- [x] `bun test ./tests-ts/auth.test.ts` (includes new SIGTERM-ignore + cross-platform pipe fallback)
- [x] Focused API login/close cases including the previously hanging ambient-credentials test
- [x] `bun test ./tests-ts/cli.test.ts`
- [ ] GitHub Actions `node-ci` / `container-ci` on this PR