### PR TITLE
fix: guarantee bounded authentication and skill shutdown

### DIFF
--- a/sdk/typescript/src/auth.ts
+++ b/sdk/typescript/src/auth.ts
@@ -3,6 +3,8 @@ import { isIP } from "node:net";
 import { PluginBootstrapError } from "./errors.js";
 import type { CodexCommand, ProcessEnvironment } from "./runtime.js";
 
+const LOGIN_CHILD_TERMINATION_GRACE_MS = 1_000;
+
 export interface LoginResult {
   success: boolean;
   exitCode: number | null;
@@ -27,6 +29,8 @@ export class CodexLoginHandle {
   #urlReadySettled = false;
   #deviceReadySettled = false;
   #canceled = false;
+  #forcedTermination: ReturnType<typeof setTimeout> | undefined;
+  #forceCompletion: (() => void) | null = null;
   #stdout = "";
   #stderr = "";
 
@@ -63,21 +67,15 @@ export class CodexLoginHandle {
       this.#notifyInstructions();
     });
     this.#completion = new Promise((resolve, reject) => {
-      this.#child.once("error", (error) => {
-        this.#settleInstructionWaiters({
-          success: false,
-          exitCode: null,
-          stdout: this.#stdout,
-          stderr: error.message,
-        });
-        reject(error);
-      });
       let fallback: ReturnType<typeof setTimeout> | undefined;
       let completed = false;
       const complete = (exitCode: number | null): void => {
         if (completed) return;
         completed = true;
         if (fallback !== undefined) clearTimeout(fallback);
+        this.#clearForcedTermination();
+        this.#forceCompletion = null;
+        this.#destroyPipes();
         const result = {
           success: exitCode === 0 && !this.#canceled,
           exitCode,
@@ -88,14 +86,28 @@ export class CodexLoginHandle {
         if (result.success) onSuccess();
         resolve(result);
       };
+      this.#forceCompletion = () => complete(this.#child.exitCode);
+      this.#child.once("error", (error) => {
+        if (completed) return;
+        completed = true;
+        if (fallback !== undefined) clearTimeout(fallback);
+        this.#clearForcedTermination();
+        this.#forceCompletion = null;
+        this.#destroyPipes();
+        this.#settleInstructionWaiters({
+          success: false,
+          exitCode: null,
+          stdout: this.#stdout,
+          stderr: error.message,
+        });
+        reject(error);
+      });
       this.#child.once("close", complete);
       this.#child.once("exit", (exitCode) => {
-        if (process.platform !== "win32") return;
         fallback = setTimeout(() => {
-          this.#child.stdout.destroy();
-          this.#child.stderr.destroy();
+          this.#destroyPipes();
           complete(exitCode);
-        }, 1_000);
+        }, LOGIN_CHILD_TERMINATION_GRACE_MS);
       });
     });
   }
@@ -132,10 +144,38 @@ export class CodexLoginHandle {
   }
 
   public cancel(): void {
-    if (this.#child.exitCode === null) {
-      this.#canceled = true;
-      this.#child.kill("SIGTERM");
+    this.#canceled = true;
+    if (
+      this.#child.exitCode !== null ||
+      this.#child.signalCode !== null ||
+      this.#forceCompletion === null
+    ) {
+      this.#destroyPipes();
+      this.#forceCompletion?.();
+      return;
     }
+    this.#child.kill("SIGTERM");
+    if (this.#forcedTermination !== undefined) return;
+    this.#forcedTermination = setTimeout(() => {
+      this.#forcedTermination = undefined;
+      if (this.#child.exitCode === null && this.#child.signalCode === null) {
+        this.#child.kill("SIGKILL");
+      }
+      this.#destroyPipes();
+      this.#forceCompletion?.();
+    }, LOGIN_CHILD_TERMINATION_GRACE_MS);
+  }
+
+  #clearForcedTermination(): void {
+    if (this.#forcedTermination === undefined) return;
+    clearTimeout(this.#forcedTermination);
+    this.#forcedTermination = undefined;
+  }
+
+  #destroyPipes(): void {
+    this.#child.stdin.destroy();
+    this.#child.stdout.destroy();
+    this.#child.stderr.destroy();
   }
 
   #notifyInstructions(): void {

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -108,6 +108,7 @@ const SCAN_HISTORY_OUTPUT_OPTION =
   /^--(?:format|filter-output|full-output|token-count|token-limit|token-offset)(?:=|$)/u;
 const HIDE_CURSOR = "\u001B[?25l";
 const SHOW_CURSOR = "\u001B[?25h";
+const CHILD_TERMINATION_GRACE_MS = 1_000;
 
 type Writable = Pick<NodeJS.WriteStream, "write"> & {
   readonly isTTY?: boolean;
@@ -433,13 +434,29 @@ export async function runCodexSkillCommand(
     windowsHide: true,
   });
   let requestedSignal: SignalName | null = null;
+  let forcedTermination: ReturnType<typeof setTimeout> | undefined;
+  let forceStatusCompletion: (() => void) | null = null;
+  let forceCaptureCompletion: (() => void) | null = null;
+  const requestTermination = (signal: SignalName): void => {
+    requestedSignal = signal;
+    invocation.kill(signal);
+    if (forcedTermination !== undefined) return;
+    forcedTermination = setTimeout(() => {
+      forcedTermination = undefined;
+      if (invocation.exitCode === null && invocation.signalCode === null) {
+        invocation.kill("SIGKILL");
+      }
+      forceCaptureCompletion?.();
+      invocation.stdout?.destroy();
+      invocation.stderr?.destroy();
+      forceStatusCompletion?.();
+    }, CHILD_TERMINATION_GRACE_MS);
+  };
   const onInterrupt = (): void => {
-    requestedSignal = "SIGINT";
-    invocation.kill("SIGINT");
+    requestTermination("SIGINT");
   };
   const onTerminate = (): void => {
-    requestedSignal = "SIGTERM";
-    invocation.kill("SIGTERM");
+    requestTermination("SIGTERM");
   };
   process.on("SIGINT", onInterrupt);
   process.on("SIGTERM", onTerminate);
@@ -451,22 +468,38 @@ export async function runCodexSkillCommand(
     const captured =
       output === undefined || invocation.stdout === null
         ? Promise.resolve(undefined)
-        : readSkillCommandOutput(invocation.stdout);
+        : Promise.race([
+            readSkillCommandOutput(invocation.stdout),
+            new Promise<undefined>((resolve) => {
+              forceCaptureCompletion = () => resolve(undefined);
+            }),
+          ]);
     const [status, events] = await Promise.all([
       new Promise<number>((resolve, reject) => {
-        invocation.once("error", reject);
-        invocation.once(
-          output === undefined ? "exit" : "close",
-          (code, signal) => {
-            resolve(
-              requestedSignal === "SIGINT" || signal === "SIGINT"
-                ? 130
-                : requestedSignal === "SIGTERM" || signal === "SIGTERM"
-                  ? 143
-                  : code ?? 1,
-            );
-          },
-        );
+        let completed = false;
+        const complete = (
+          code: number | null,
+          signal: NodeJS.Signals | null,
+        ): void => {
+          if (completed) return;
+          completed = true;
+          forceStatusCompletion = null;
+          resolve(
+            requestedSignal === "SIGINT" || signal === "SIGINT"
+              ? 130
+              : requestedSignal === "SIGTERM" || signal === "SIGTERM"
+                ? 143
+                : code ?? 1,
+          );
+        };
+        forceStatusCompletion = () => complete(null, null);
+        invocation.once("error", (error) => {
+          if (completed) return;
+          completed = true;
+          forceStatusCompletion = null;
+          reject(error);
+        });
+        invocation.once(output === undefined ? "exit" : "close", complete);
       }),
       captured,
     ]);
@@ -493,6 +526,9 @@ export async function runCodexSkillCommand(
     invocation.kill();
     throw error;
   } finally {
+    if (forcedTermination !== undefined) clearTimeout(forcedTermination);
+    forceStatusCompletion = null;
+    forceCaptureCompletion = null;
     process.off("SIGINT", onInterrupt);
     process.off("SIGTERM", onTerminate);
   }

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -3846,14 +3846,14 @@ if (process.argv.slice(2).join(" ") !== "login status") {
     }
   });
 
-  test("cancels interactive login children during close", async () => {
+  test("forces interactive login children to settle during close", async () => {
     const root = await temporaryDirectory();
     const codexHome = join(root, "codex-home");
     const fakeCodex = join(root, "codex.mjs");
     await mkdir(codexHome);
     await writeFile(
       fakeCodex,
-      'console.error("Open https://auth.example.test/device");\nconsole.error("User code: ABCD-EFGH");\nsetInterval(() => {}, 1000);\n',
+      'console.error("Open https://auth.example.test/device");\nconsole.error("User code: ABCD-EFGH");\nprocess.on("SIGTERM", () => {});\nsetInterval(() => {}, 1000);\n',
     );
     const client = new TestClient(
       {},
@@ -3884,7 +3884,19 @@ if (process.argv.slice(2).join(" ") !== "login status") {
     const login = await client.loginChatGPTDeviceCode();
     expect(login.verificationUrl).toBe("https://auth.example.test/device");
     expect(login.userCode).toBe("ABCD-EFGH");
-    await client.close();
+    const timeout = AbortSignal.timeout(5_000);
+    await expect(
+      Promise.race([
+        client.close(),
+        new Promise<never>((_, reject) => {
+          timeout.addEventListener(
+            "abort",
+            () => reject(new Error("SDK close did not settle login cleanup.")),
+            { once: true },
+          );
+        }),
+      ]),
+    ).resolves.toBeUndefined();
     await expect(login.wait()).resolves.toMatchObject({ success: false });
   });
 

--- a/sdk/typescript/tests-ts/auth.test.ts
+++ b/sdk/typescript/tests-ts/auth.test.ts
@@ -237,7 +237,7 @@ grandchild.once("error", (error) => {
   );
 
   test.skipIf(process.platform !== "win32")(
-    "releases native login pipes when the Windows fallback fires",
+    "releases native login pipes when the cross-platform fallback fires",
     async () => {
       const root = await mkdtemp(join(tmpdir(), "codex-security-auth-pipes-"));
       temporaryDirectories.push(root);
@@ -350,7 +350,7 @@ grandchild.once("error", (error) => {
           new Promise<never>((_, reject) => {
             timeout.addEventListener(
               "abort",
-              () => reject(new Error("The Windows login fallback timed out.")),
+              () => reject(new Error("The login fallback timed out.")),
               { once: true },
             );
           }),
@@ -380,7 +380,7 @@ grandchild.once("error", (error) => {
             }
             if (Date.now() >= deadline) {
               throw new Error(
-                "The Windows login grandchild did not exit after pipe cleanup.",
+                "The login grandchild did not exit after pipe cleanup.",
               );
             }
             await delay(25);
@@ -389,6 +389,41 @@ grandchild.once("error", (error) => {
       }
     },
   );
+
+  test("escalates cancellation when a login child ignores SIGTERM", async () => {
+    const root = await mkdtemp(join(tmpdir(), "codex-security-auth-sigkill-"));
+    temporaryDirectories.push(root);
+    const script = join(root, "codex.mjs");
+    await writeFile(
+      script,
+      `
+console.error("Open https://auth.example.test/device");
+console.error("User code: ABCD-EFGH");
+process.on("SIGTERM", () => {});
+setInterval(() => {}, 1000);
+`,
+    );
+    let succeeded = false;
+    const handle = new CodexLoginHandle(
+      { command: process.execPath, prefixArgs: [script] },
+      ["login", "--device-auth"],
+      process.env,
+      () => {
+        succeeded = true;
+      },
+    );
+    await handle.waitForInstructions({ deviceCode: true });
+    handle.cancel();
+    await expect(
+      Promise.race([
+        handle.wait(),
+        delay(5_000).then(() => {
+          throw new Error("Login cancellation did not settle.");
+        }),
+      ]),
+    ).resolves.toMatchObject({ success: false });
+    expect(succeeded).toBe(false);
+  });
 
   test("does not report a canceled interactive login as successful", async () => {
     const root = await mkdtemp(join(tmpdir(), "codex-security-auth-cancel-"));

--- a/sdk/typescript/tests-ts/cli-skills.test.ts
+++ b/sdk/typescript/tests-ts/cli-skills.test.ts
@@ -1,6 +1,8 @@
+import { spawn } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { describe, expect, test } from "bun:test";
 import {
   main,
@@ -525,6 +527,94 @@ describe("CLI skill commands", () => {
       }
       expect(stderr.text()).not.toContain("SYNTHETIC_SECRET");
       expect(stderr.text()).not.toContain("/private");
+    }
+  });
+
+  test("forces a skill child to settle when it ignores SIGTERM", async () => {
+    const directory = await mkdtemp(
+      join(tmpdir(), "codex-security-skill-signal-"),
+    );
+    const ready = join(directory, "ready");
+    const child = join(directory, "child.mjs");
+    const wrapper = join(directory, "wrapper.mjs");
+    await writeFile(
+      child,
+      `
+import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
+const descendant = spawn(
+  process.execPath,
+  ["-e", "setInterval(() => {}, 1000)"],
+  { stdio: ["ignore", "inherit", "inherit"], windowsHide: true },
+);
+writeFileSync(${JSON.stringify(ready)}, JSON.stringify({
+  child: process.pid,
+  descendant: descendant.pid,
+}));
+process.on("SIGTERM", () => {});
+setInterval(() => {}, 1000);
+`,
+    );
+    await writeFile(
+      wrapper,
+      `
+import { runCodexSkillCommand } from ${JSON.stringify(new URL("../src/cli.ts", import.meta.url).href)};
+const status = await runCodexSkillCommand(
+  [],
+  { command: "validate", stdout: process.stdout, stderr: process.stderr },
+  { command: process.execPath, prefixArgs: [${JSON.stringify(child)}] },
+);
+process.exit(status);
+`,
+    );
+
+    const invocation = spawn(process.execPath, [wrapper], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    let childPids: number[] = [];
+    try {
+      const deadline = Date.now() + 5_000;
+      while (true) {
+        try {
+          const marker = JSON.parse(await Bun.file(ready).text()) as {
+            child: number;
+            descendant: number;
+          };
+          childPids = [marker.child, marker.descendant];
+          break;
+        } catch (error) {
+          if (Date.now() >= deadline) throw error;
+          await delay(25);
+        }
+      }
+      invocation.kill("SIGTERM");
+      const status = await Promise.race([
+        new Promise<number | null>((resolve, reject) => {
+          invocation.once("error", reject);
+          invocation.once("close", resolve);
+        }),
+        delay(5_000).then(() => {
+          throw new Error("CLI skill cancellation did not settle.");
+        }),
+      ]);
+      expect(status).toBe(143);
+    } finally {
+      invocation.kill("SIGKILL");
+      for (const childPid of childPids) {
+        try {
+          process.kill(childPid, "SIGKILL");
+        } catch (error) {
+          if (
+            !(error instanceof Error) ||
+            !("code" in error) ||
+            error.code !== "ESRCH"
+          ) {
+            throw error;
+          }
+        }
+      }
+      await rm(directory, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## Summary

Fixes #131.

Make authentication and skill subprocess cancellation settle within a bounded deadline, even when the immediate child ignores the cooperative termination signal or a descendant keeps inherited output pipes open.

Previously, `CodexLoginHandle.cancel()` sent `SIGTERM` once and `CodexSecurity.close()` waited on the login handle without a deadline. The CLI skill path used the same one-signal behavior. A non-cooperative child or inherited pipe could therefore leave SDK or CLI cleanup pending indefinitely.

## Changes

### Bounded login cancellation

Interactive login cancellation now uses a two-stage shutdown:

1. mark the login as canceled and send `SIGTERM`;
2. allow a one-second cooperative grace period;
3. if the child is still running, escalate to `SIGKILL`;
4. destroy the remaining stdin, stdout, and stderr streams;
5. force the login completion to settle if process events or inherited pipes still do not do so.

The forced completion remains an unsuccessful canceled login, so the authentication success callback cannot run after cancellation.

Repeated calls to `cancel()` reuse the existing deadline instead of creating additional timers.

### Cross-platform inherited-pipe fallback

The existing post-exit pipe fallback was Windows-only. It now applies on every platform.

After the immediate login child exits, normal pipe draining still receives a one-second grace period. If a descendant continues holding stdout or stderr open after that deadline, the SDK destroys the streams and settles the login using the immediate child's exit status.

This preserves ordinary diagnostic draining while preventing descendants from keeping `login.wait()` and `CodexSecurity.close()` alive forever.

### Timer and listener cleanup

Login completion and spawn failure now clear both the post-exit fallback and forced-termination timer. Process pipes are released on every terminal path, and late `error`, `exit`, or `close` events cannot settle the same login twice.

### Bounded CLI signal forwarding

`runCodexSkillCommand` now applies the same one-second termination deadline when forwarding `SIGINT` or `SIGTERM`:

- the original signal is forwarded first;
- a child that remains alive is escalated with `SIGKILL`;
- captured stdout and stderr are destroyed after the grace period;
- the JSONL capture wait and process-status wait are explicitly released;
- conventional exit status is preserved as 130 for `SIGINT` and 143 for `SIGTERM`;
- signal listeners and forced-termination timers are removed on every exit path.

Explicitly releasing the capture wait is necessary because destroying a stream alone does not reliably settle every parser or inherited-pipe configuration.

## Impact

SDK consumers can now rely on `CodexSecurity.close()` completing after it cancels an interactive login. CLI skill commands also return after cancellation instead of waiting indefinitely for an uncooperative child or inherited output pipe.

The cooperative path is unchanged: children still receive the original signal and have time to clean up normally before forced termination occurs.

## Tests

Added and updated regression coverage for:

- a login child that installs a `SIGTERM` handler and refuses to exit;
- direct `CodexLoginHandle.cancel()` completion within a bounded deadline;
- `CodexSecurity.close()` completion when its active login ignores `SIGTERM`;
- preservation of an unsuccessful login result and suppression of the success callback;
- post-exit inherited login-pipe cleanup through the cross-platform fallback;
- a real CLI wrapper receiving `SIGTERM` while its skill child ignores the signal;
- a descendant retaining the skill child's captured stdout and stderr;
- forced CLI completion with exit code 143;
- cleanup of all fixture subprocesses after the process-level test.

## Verification

- `pnpm run types`
- `pnpm run format`
- `pnpm run build`
- focused authentication, SDK close, and CLI skill tests
- `PATH="/opt/homebrew/bin:$PATH" pnpm run test`

Full test result:

- 472 passed
- 6 expected platform/integration skips
- 0 failed
