### PR TITLE
fix: bound bulk-scan inventory loading

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -405,6 +405,11 @@ service,https://github.com/acme/service.git,0123456789abcdef0123456789abcdef0123
 `--workers` limits concurrent scans and `--max-attempts` retries failures.
 Results remain under `--output-dir`; rerun the same command to resume.
 
+Bulk-scan inventories are limited to 8 MiB and 1,000 repositories. Interactive
+GitHub discovery applies the same repository limit and stops before creating an
+inventory if the selected account exceeds it. Split larger campaigns into
+separate repository lists and output directories.
+
 ### Scan history and reruns
 
 `npx @openai/codex-security scans list` lists scans for the current repository. Pass a

--- a/sdk/typescript/src/bulk-scan-discovery.ts
+++ b/sdk/typescript/src/bulk-scan-discovery.ts
@@ -8,6 +8,10 @@ import { promisify } from "node:util";
 import { confirm, input, search } from "@inquirer/prompts";
 import { Octokit } from "@octokit/core";
 import Papa from "papaparse";
+import {
+  bulkScanRepositoryLimitError,
+  MAX_BULK_SCAN_REPOSITORIES,
+} from "./bulk-scan-limits.js";
 import { resolveTrustedExecutable } from "./trusted-executable.js";
 
 const execFile = promisify(execFileCallback);
@@ -270,6 +274,9 @@ async function discoverGitHubRepositories(
         url: `https://${host}/${repository.nameWithOwner}.git`,
         revision: repository.defaultBranchRef.target.oid.toLowerCase(),
       });
+      if (repositories.length > MAX_BULK_SCAN_REPOSITORIES) {
+        throw bulkScanRepositoryLimitError();
+      }
     }
     cursor = connection.pageInfo.hasNextPage
       ? connection.pageInfo.endCursor

--- a/sdk/typescript/src/bulk-scan-limits.ts
+++ b/sdk/typescript/src/bulk-scan-limits.ts
@@ -1,0 +1,8 @@
+export const MAX_BULK_SCAN_INVENTORY_BYTES = 8 * 1_024 * 1_024;
+export const MAX_BULK_SCAN_REPOSITORIES = 1_000;
+
+export function bulkScanRepositoryLimitError(): Error {
+  return new Error(
+    "Bulk scans support at most 1,000 repositories per campaign. Split the repository list into smaller inventories.",
+  );
+}

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -1,5 +1,6 @@
 import { execFile as execFileCallback } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { createReadStream } from "node:fs";
 import {
   lstat,
   mkdir,
@@ -8,13 +9,20 @@ import {
   realpath,
   rename,
   rm,
+  stat,
   truncate,
   writeFile,
 } from "node:fs/promises";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { Transform } from "node:stream";
 import { promisify } from "node:util";
 import Papa from "papaparse";
 import type { CodexSecurity } from "./api.js";
+import {
+  bulkScanRepositoryLimitError,
+  MAX_BULK_SCAN_INVENTORY_BYTES,
+  MAX_BULK_SCAN_REPOSITORIES,
+} from "./bulk-scan-limits.js";
 import type { CodexSecurityConfig } from "./config.js";
 import type { ScanCost } from "./cost.js";
 import type { ScanMode } from "./targets.js";
@@ -82,10 +90,11 @@ export async function runMultiscan(
   if (!Number.isSafeInteger(options.maxAttempts) || options.maxAttempts < 1) {
     throw new Error("Multiscan max attempts must be a positive integer.");
   }
-  const tasks = parseInventory(
-    await readFile(options.inputPath, "utf8"),
+  const tasks = await parseInventory(
+    options.inputPath,
     dirname(resolve(options.inputPath)),
     options.mode,
+    options.signal,
   );
   const output = resolve(options.outputDir);
   await ensureOutputDirectory(output);
@@ -347,19 +356,106 @@ async function hasArtifacts(path: string): Promise<boolean> {
   }
 }
 
-function parseInventory(
-  source: string,
+async function parseInventory(
+  inputPath: string,
   directory: string,
   defaultMode: ScanMode,
-): MultiscanTask[] {
-  const { data: rows, errors } = Papa.parse<string[]>(source, {
-    delimiter: ",",
-    skipEmptyLines: "greedy",
-  });
-  if (errors.length > 0) {
-    throw new Error(`Multiscan CSV could not be parsed: ${errors[0]!.message}`);
+  signal?: AbortSignal,
+): Promise<MultiscanTask[]> {
+  signal?.throwIfAborted();
+  const metadata = await stat(inputPath);
+  signal?.throwIfAborted();
+  if (!metadata.isFile()) {
+    throw new Error("Multiscan inventory must be a regular CSV file.");
   }
-  const headers = rows.shift();
+  if (metadata.size > MAX_BULK_SCAN_INVENTORY_BYTES) {
+    throw new Error("Multiscan CSV must not exceed 8 MiB.");
+  }
+
+  const tasks: MultiscanTask[] = [];
+  const seen = new Set<string>();
+  let headers: string[] | undefined;
+  let bytesRead = 0;
+  const input = createReadStream(inputPath, {
+    highWaterMark: 64 * 1_024,
+    ...(signal === undefined ? {} : { signal }),
+  });
+  const bounded = new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      bytesRead += chunk.length;
+      callback(
+        bytesRead > MAX_BULK_SCAN_INVENTORY_BYTES
+          ? new Error("Multiscan CSV must not exceed 8 MiB.")
+          : null,
+        chunk,
+      );
+    },
+  });
+  input.pipe(bounded);
+
+  return await new Promise<MultiscanTask[]>((resolveTasks, rejectTasks) => {
+    let settled = false;
+    const fail = (error: unknown): void => {
+      if (settled) return;
+      settled = true;
+      const failure = error instanceof Error ? error : new Error(String(error));
+      input.destroy();
+      bounded.destroy();
+      rejectTasks(failure);
+    };
+    input.once("error", fail);
+    bounded.once("error", fail);
+
+    Papa.parse<string[]>(bounded as unknown as Papa.LocalFile, {
+      delimiter: ",",
+      skipEmptyLines: "greedy",
+      beforeFirstChunk: (chunk) =>
+        chunk.charCodeAt(0) === 0xfeff ? chunk.slice(1) : chunk,
+      step: ({ data: fields, errors }) => {
+        try {
+          signal?.throwIfAborted();
+          if (errors.length > 0) {
+            throw new Error(
+              `Multiscan CSV could not be parsed: ${errors[0]!.message}`,
+            );
+          }
+          if (headers === undefined) {
+            headers = fields;
+            validateInventoryHeaders(headers);
+            return;
+          }
+          if (tasks.length >= MAX_BULK_SCAN_REPOSITORIES) {
+            throw bulkScanRepositoryLimitError();
+          }
+          tasks.push(
+            parseInventoryRow(fields, headers, directory, defaultMode, seen),
+          );
+        } catch (error) {
+          fail(error);
+        }
+      },
+      complete: () => {
+        if (settled) return;
+        try {
+          signal?.throwIfAborted();
+          if (headers === undefined) validateInventoryHeaders(undefined);
+          if (tasks.length === 0) {
+            throw new Error(
+              "Multiscan CSV must contain at least one repository.",
+            );
+          }
+          settled = true;
+          resolveTasks(tasks);
+        } catch (error) {
+          fail(error);
+        }
+      },
+      error: fail,
+    });
+  });
+}
+
+function validateInventoryHeaders(headers: string[] | undefined): void {
   if (
     headers === undefined ||
     !["id", "repository", "revision"].every((name) => headers.includes(name)) ||
@@ -369,48 +465,52 @@ function parseInventory(
       "Multiscan CSV requires id, repository, and revision columns.",
     );
   }
-  if (rows.length === 0)
-    throw new Error("Multiscan CSV must contain at least one repository.");
-  const seen = new Set<string>();
-  return rows.map((fields) => {
-    if (fields.length !== headers.length) {
-      throw new Error("Multiscan CSV rows must match their header columns.");
-    }
-    const get = (name: string): string =>
-      fields[headers.indexOf(name)]?.trim() ?? "";
-    const id = get("id");
-    if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u.test(id)) {
-      throw new Error("Multiscan task IDs must be safe, unique path names.");
-    }
-    if (seen.has(id.toLowerCase()))
-      throw new Error("Multiscan task IDs must be unique.");
-    seen.add(id.toLowerCase());
-    const revision = get("revision").toLowerCase();
-    if (!/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u.test(revision)) {
-      throw new Error("Multiscan revisions must be full immutable Git SHAs.");
-    }
-    const mode = get("mode") || defaultMode;
-    if (mode !== "standard" && mode !== "deep") {
-      throw new Error("Multiscan mode must be standard or deep.");
-    }
-    const scope = get("scope");
-    if (
-      scope &&
-      (isAbsolute(scope) ||
-        scope.includes("\\") ||
-        scope.split("/").includes("..") ||
-        scope.includes("\0"))
-    ) {
-      throw new Error("Multiscan scope must stay inside its repository.");
-    }
-    return {
-      id,
-      repository: normalizeRepository(get("repository"), directory),
-      revision,
-      mode,
-      ...(scope ? { scope } : {}),
-    };
-  });
+}
+
+function parseInventoryRow(
+  fields: string[],
+  headers: string[],
+  directory: string,
+  defaultMode: ScanMode,
+  seen: Set<string>,
+): MultiscanTask {
+  if (fields.length !== headers.length) {
+    throw new Error("Multiscan CSV rows must match their header columns.");
+  }
+  const get = (name: string): string =>
+    fields[headers.indexOf(name)]?.trim() ?? "";
+  const id = get("id");
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u.test(id)) {
+    throw new Error("Multiscan task IDs must be safe, unique path names.");
+  }
+  if (seen.has(id.toLowerCase()))
+    throw new Error("Multiscan task IDs must be unique.");
+  seen.add(id.toLowerCase());
+  const revision = get("revision").toLowerCase();
+  if (!/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u.test(revision)) {
+    throw new Error("Multiscan revisions must be full immutable Git SHAs.");
+  }
+  const mode = get("mode") || defaultMode;
+  if (mode !== "standard" && mode !== "deep") {
+    throw new Error("Multiscan mode must be standard or deep.");
+  }
+  const scope = get("scope");
+  if (
+    scope &&
+    (isAbsolute(scope) ||
+      scope.includes("\\") ||
+      scope.split("/").includes("..") ||
+      scope.includes("\0"))
+  ) {
+    throw new Error("Multiscan scope must stay inside its repository.");
+  }
+  return {
+    id,
+    repository: normalizeRepository(get("repository"), directory),
+    revision,
+    mode,
+    ...(scope ? { scope } : {}),
+  };
 }
 
 function normalizeRepository(repository: string, directory: string): string {

--- a/sdk/typescript/tests-ts/bulk-scan-discovery.test.ts
+++ b/sdk/typescript/tests-ts/bulk-scan-discovery.test.ts
@@ -15,6 +15,7 @@ import {
   type BulkScanDiscoveryDependencies,
   type BulkScanPrompt,
 } from "../src/bulk-scan-discovery.js";
+import { MAX_BULK_SCAN_REPOSITORIES } from "../src/bulk-scan-limits.js";
 
 const temporaryDirectories: string[] = [];
 const NOW = Date.parse("2026-07-22T12:00:00.000Z");
@@ -253,6 +254,42 @@ describe("bulk scan repository discovery", () => {
     const csv = await readFile(result!.inputPath, "utf8");
     expect(csv).toContain("acme--service-100");
     expect(csv).not.toContain("acme--old");
+  });
+
+  test("enforces the discovery repository limit before creating an inventory", async () => {
+    const atLimit = Array.from(
+      { length: MAX_BULK_SCAN_REPOSITORIES },
+      (_value, index) => ({ fullName: `acme/service-${index}` }),
+    );
+    const acceptedRoot = await temporaryDirectory();
+    const accepted = discoveryDependencies(acceptedRoot, {
+      repositories: atLimit,
+    });
+    accepted.prompt.confirms = [false];
+    expect(await runBulkScanWizard(accepted.dependencies)).toBeNull();
+    expect(accepted.prompt.messages.join("")).toContain(
+      `Found ${MAX_BULK_SCAN_REPOSITORIES} repositories`,
+    );
+    expect(
+      accepted.requests.filter(({ path }) => path === "/graphql"),
+    ).toHaveLength(10);
+
+    const overflowRoot = await temporaryDirectory();
+    const overflow = discoveryDependencies(overflowRoot, {
+      repositories: [
+        ...atLimit,
+        { fullName: `acme/service-${MAX_BULK_SCAN_REPOSITORIES}` },
+      ],
+    });
+    await expect(runBulkScanWizard(overflow.dependencies)).rejects.toThrow(
+      "at most 1,000 repositories",
+    );
+    expect(
+      overflow.requests.filter(({ path }) => path === "/graphql"),
+    ).toHaveLength(11);
+    await expect(
+      lstat(join(overflowRoot, "security-scans")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   test("shows all repositories and scans only the selected ones", async () => {

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -2,18 +2,24 @@ import { execFileSync } from "node:child_process";
 import {
   access,
   appendFile,
+  lstat,
   mkdir,
   mkdtemp,
   readFile,
   readdir,
   rm,
   symlink,
+  truncate,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 import type { ScanResult } from "../src/result.js";
+import {
+  MAX_BULK_SCAN_INVENTORY_BYTES,
+  MAX_BULK_SCAN_REPOSITORIES,
+} from "../src/bulk-scan-limits.js";
 import { buildGitHubCredentialArgs, runMultiscan } from "../src/multiscan.js";
 import { resolveTrustedExecutable } from "../src/trusted-executable.js";
 
@@ -261,6 +267,47 @@ describe("multiscan", () => {
     }
 
     expect(scans).toBe(0);
+  });
+
+  test("rejects oversized and excessive inventories before creating campaign state", async () => {
+    for (const prepare of [
+      async (path: string) => {
+        await writeFile(path, "id,repository,revision\n");
+        await truncate(path, MAX_BULK_SCAN_INVENTORY_BYTES + 1);
+      },
+      async (path: string) => {
+        const rows = Array.from(
+          { length: MAX_BULK_SCAN_REPOSITORIES + 1 },
+          (_value, index) =>
+            `repository-${index},.,0123456789abcdef0123456789abcdef01234567`,
+        );
+        await writeFile(path, `id,repository,revision\n${rows.join("\n")}\n`);
+      },
+    ]) {
+      const paths = await fixture();
+      await prepare(paths.input);
+      let clients = 0;
+      await expect(
+        runMultiscan({
+          ...options(
+            paths,
+            client(async () => {
+              throw new Error("scan must not start");
+            }),
+          ),
+          createSecurity: () => {
+            clients += 1;
+            return client(async () => {
+              throw new Error("scan must not start");
+            });
+          },
+        }),
+      ).rejects.toThrow(/8 MiB|at most 1,000 repositories/u);
+      expect(clients).toBe(0);
+      await expect(lstat(paths.output)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    }
   });
 
   test("materializes the pinned commit, applies row options, and removes its checkout", async () => {


### PR DESCRIPTION
## Summary

Fixes #132.

Add explicit resource ceilings to bulk-scan inventory loading and interactive GitHub discovery, and replace full CSV materialization with incremental parsing.

Previously, a supplied inventory was read into one complete UTF-8 string, Papa Parse retained a complete row array, and the rows were then mapped into another task array. Interactive discovery similarly accumulated every qualifying GitHub repository without a campaign limit. Both paths could consume excessive memory and create unexpectedly large checkout, scan, and model-cost scope before work began.

## Limits

Bulk scan now enforces shared limits of:

- 8 MiB per CSV inventory;
- 1,000 repositories per campaign.

The same repository ceiling applies to supplied inventories and interactive GitHub discovery.

## Changes

### Metadata validation before campaign state

`runMultiscan` now checks inventory metadata before opening or parsing the CSV.

It rejects:

- inputs that are not regular files;
- files larger than 8 MiB;
- inventories containing more than 1,000 repository rows.

All inventory parsing and validation still happens before the output directory, campaign lock, manifest, checkout directory, artifact directory, or security client is created.

### Incremental CSV parsing

Inventory loading now streams the file through Papa Parse in 64 KiB input chunks.

The parser:

- processes the header once;
- validates and converts one repository row at a time;
- retains only the bounded task list and duplicate-ID set;
- preserves quoted fields, embedded commas, escaped quotes, CRLF input, blank-line skipping, and UTF-8 BOM handling;
- preserves existing header, field-count, ID, revision, mode, scope, and repository validation;
- checks cancellation between rows.

This removes the previous simultaneous retention of the complete source string, complete Papa row array, and mapped task array.

### In-stream byte enforcement

The initial metadata check rejects known oversized files before reading. A byte-counting transform independently enforces the 8 MiB ceiling while the file is read.

This second check prevents a file replacement or growth race after metadata validation from bypassing the input limit.

The source and parser streams are destroyed immediately when parsing, cancellation, byte, or repository-count validation fails.

### Bounded GitHub discovery

Interactive discovery now stops and returns an actionable error as soon as the 1,001st qualifying repository is encountered.

The limit is enforced during pagination, before repository selection, output-directory creation, or inventory writing. Empty repositories and repositories older than the existing 90-day cutoff continue to be excluded before they count toward the campaign limit.

The error recommends splitting the repository list into smaller campaigns.

### Shared limits and documentation

The byte and repository constants, along with the repository-limit diagnostic, are shared by CSV loading and GitHub discovery so the two entry points cannot drift.

The README now documents both limits and advises using separate inventories and output directories for larger campaigns.

## Security and resource impact

This bounds:

- bytes read from a supplied inventory;
- parser source buffering;
- retained repository tasks;
- interactive GitHub repository accumulation;
- the maximum checkout and scan scope of one campaign.

Oversized input is rejected before persistent campaign state or checkout work begins.

## Tests

Added regression coverage for:

- rejecting an inventory whose metadata exceeds 8 MiB;
- rejecting a valid 1,001-row inventory;
- ensuring neither case creates a security client;
- ensuring neither case creates the output directory or campaign state;
- accepting exactly 1,000 repositories during interactive discovery;
- paginating exactly ten 100-repository GitHub pages at the boundary;
- rejecting the 1,001st discovered repository;
- stopping before an interactive inventory or output directory is created;
- preserving the existing quoted CSV, BOM, CRLF, validation, pagination, cutoff, and selection behavior.

## Verification

- `pnpm run types`
- `pnpm run format`
- `pnpm run build`
- focused multiscan and bulk-discovery tests
- `PATH="/opt/homebrew/bin:$PATH" pnpm run test`

Full test result:

- 472 passed
- 6 expected platform/integration skips
- 0 failed
