### PR TITLE
fix: enforce plugin entry limit during discovery

### DIFF
--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -8,6 +8,7 @@ import {
   mkdir,
   mkdtemp,
   open,
+  opendir,
   readFile,
   readdir,
   realpath,
@@ -1108,24 +1109,25 @@ async function pluginProjectionFingerprint(
   } else {
     paths = [];
     const pending = [canonical];
-    let entries = 0;
+    let entries = 1;
     while (pending.length > 0) {
       throwIfSignalAborted(signal);
       const path = pending.pop()!;
       const metadata = await lstat(path);
-      if (++entries > MAX_PLUGIN_COPY_ENTRIES) {
-        throw new PluginBootstrapError(
-          `Plugin source exceeds the copy entry limit: ${path}`,
-        );
-      }
       if (metadata.isSymbolicLink()) {
         throw new PluginBootstrapError(
           `Plugin contains an unsafe source path: ${path}`,
         );
       }
       if (metadata.isDirectory()) {
-        for (const entry of await readdir(path)) {
-          pending.push(join(path, entry));
+        for await (const entry of pluginDirectoryEntries(path, signal)) {
+          const child = join(path, entry);
+          if (++entries > MAX_PLUGIN_COPY_ENTRIES) {
+            throw new PluginBootstrapError(
+              `Plugin source exceeds the copy entry limit: ${child}`,
+            );
+          }
+          pending.push(child);
         }
       } else if (metadata.isFile()) {
         paths.push(relative(canonical, path).split(sep).join("/"));
@@ -1661,7 +1663,7 @@ async function copyPluginTree(
     { source, destination },
   ];
   const directories = new Map<string, Stats>();
-  let entries = 0;
+  let entries = 1;
   let size = 0;
   await mkdir(dirname(destination), { recursive: true, mode: 0o700 });
   try {
@@ -1670,18 +1672,27 @@ async function copyPluginTree(
       const current = pending.pop()!;
       await requirePluginAncestors(source, current.source, directories, signal);
       const metadata = await lstat(current.source);
-      if (++entries > MAX_PLUGIN_COPY_ENTRIES) {
-        throw new PluginBootstrapError(
-          `Plugin source exceeds the copy entry limit: ${current.source}`,
-        );
-      }
       if (metadata.isSymbolicLink()) {
         throw new PluginBootstrapError(
           `Plugin contains an unsafe source path: ${current.source}`,
         );
       }
       if (metadata.isDirectory()) {
-        const children = await readdir(current.source);
+        for await (const entry of pluginDirectoryEntries(
+          current.source,
+          signal,
+        )) {
+          const childSource = join(current.source, entry);
+          if (++entries > MAX_PLUGIN_COPY_ENTRIES) {
+            throw new PluginBootstrapError(
+              `Plugin source exceeds the copy entry limit: ${childSource}`,
+            );
+          }
+          pending.push({
+            source: childSource,
+            destination: join(current.destination, entry),
+          });
+        }
         const afterRead = await lstat(current.source);
         if (!samePluginFile(metadata, afterRead)) {
           throw new PluginBootstrapError(
@@ -1690,12 +1701,6 @@ async function copyPluginTree(
         }
         directories.set(current.source, afterRead);
         await mkdir(current.destination, { mode: 0o700 });
-        for (const child of children) {
-          pending.push({
-            source: join(current.source, child),
-            destination: join(current.destination, child),
-          });
-        }
         continue;
       }
       if (!metadata.isFile()) {
@@ -1764,6 +1769,25 @@ async function copyPluginTree(
   } catch (error) {
     await rm(destination, { recursive: true, force: true });
     throw error;
+  }
+}
+
+async function* pluginDirectoryEntries(
+  path: string,
+  signal?: AbortSignal,
+): AsyncGenerator<string> {
+  throwIfSignalAborted(signal);
+  const directory = await opendir(path);
+  try {
+    for (;;) {
+      throwIfSignalAborted(signal);
+      const entry = await directory.read();
+      throwIfSignalAborted(signal);
+      if (entry === null) return;
+      yield entry.name;
+    }
+  } finally {
+    await directory.close();
   }
 }
 

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -385,6 +385,92 @@ describe("plugin runtime preparation", () => {
     ).toBeDefined();
   });
 
+  test("bounds configured plugin directory discovery", async () => {
+    const overflowRoot = await temporaryDirectory();
+    const overflowSource = await plugin(overflowRoot);
+    const overflowDirectory = join(overflowSource, "many-files");
+    await mkdir(overflowDirectory);
+    for (let offset = 0; offset < 4_096; offset += 128) {
+      await Promise.all(
+        Array.from({ length: 128 }, (_value, index) =>
+          writeFile(join(overflowDirectory, String(offset + index)), ""),
+        ),
+      );
+    }
+    const overflowDestination = join(overflowRoot, "overflow-home");
+    await expect(
+      createMarketplace(overflowDestination, overflowSource),
+    ).rejects.toThrow("copy entry limit");
+    expect(
+      existsSync(
+        join(
+          overflowDestination,
+          "sdk-marketplace",
+          "plugins",
+          "codex-security",
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  test("cancels configured plugin directory discovery", async () => {
+    const cancellationRoot = await temporaryDirectory();
+    const cancellationSource = await plugin(cancellationRoot);
+    const cancellationDirectory = join(cancellationSource, "many-files");
+    await mkdir(cancellationDirectory);
+    await Promise.all(
+      Array.from({ length: 32 }, (_value, index) =>
+        writeFile(join(cancellationDirectory, String(index)), ""),
+      ),
+    );
+    const cancellationDestination = join(cancellationRoot, "canceled-home");
+    const controller = new AbortController();
+    const originalOpendir = fsPromises.opendir;
+    let discovered = 0;
+    mock.module("node:fs/promises", () => ({
+      ...fsPromises,
+      opendir: async (...args: Parameters<typeof originalOpendir>) => {
+        const directory = await originalOpendir(...args);
+        if (String(args[0]) !== cancellationDirectory) return directory;
+        const originalRead = directory.read.bind(directory);
+        directory.read = async () => {
+          const entry = await originalRead();
+          discovered += 1;
+          if (discovered === 2) {
+            controller.abort(new DOMException("canceled", "AbortError"));
+          }
+          return entry;
+        };
+        return directory;
+      },
+    }));
+    try {
+      await expect(
+        createMarketplace(
+          cancellationDestination,
+          cancellationSource,
+          controller.signal,
+        ),
+      ).rejects.toMatchObject({ name: "AbortError" });
+      expect(discovered).toBe(2);
+      expect(
+        existsSync(
+          join(
+            cancellationDestination,
+            "sdk-marketplace",
+            "plugins",
+            "codex-security",
+          ),
+        ),
+      ).toBe(false);
+    } finally {
+      mock.module("node:fs/promises", () => ({
+        ...fsPromises,
+        opendir: originalOpendir,
+      }));
+    }
+  });
+
   testPosix(
     "rejects plugin symlinks and removes the partial marketplace",
     async () => {


### PR DESCRIPTION
## Summary

Fixes #134.

Enforce the configured-plugin 4,096-entry ceiling while directory entries are discovered instead of after an entire directory has already been loaded into memory.

Previously, both plugin fingerprinting and marketplace copying called `readdir()` for each directory. A directory containing hundreds of thousands of children was therefore materialized as one complete name array before any of those children reached the existing entry counter. Cancellation also could not be observed until that full read completed.

## Changes

### Incremental directory iteration

Configured plugin traversal now uses one shared asynchronous `opendir()` iterator for both:

- plugin projection fingerprint discovery;
- plugin marketplace copy discovery.

The iterator reads one `Dirent` at a time with `Dir.read()` and yields only its name. No traversal path creates a complete array of directory children.

### Discovery-time entry enforcement

The traversal root remains counted as the first entry, preserving the existing 4,096-entry semantics.

Each child is now counted immediately after it is yielded and before it is added to the traversal queue. The 4,097th discovered path therefore raises the existing `PluginBootstrapError` immediately, without reading the remaining names in that directory.

This applies identically to fingerprint construction and safe-copy traversal.

### Cancellation during discovery

The abort signal is checked:

- before opening a directory;
- before each individual directory read;
- after each read completes;
- before the discovered entry is yielded to the traversal.

Cancellation can now interrupt a large, flat directory rather than waiting for every name to be allocated first.

### Directory-handle cleanup

The shared iterator closes its directory handle in a `finally` block. Handles are therefore released after:

- normal end-of-directory;
- cancellation;
- entry-limit rejection;
- any other traversal error.

### Existing integrity boundaries preserved

The change retains the existing protections around configured plugin directories:

- source paths are still checked with `lstat()` before processing;
- symbolic links and non-regular files remain rejected;
- copied directories are still re-stat'd after enumeration;
- directory device/inode, size, modification time, mode, and type identity must remain unchanged;
- queued descendants still revalidate every recorded ancestor before copying;
- per-file and aggregate byte limits are unchanged;
- partially created marketplace trees are removed on failure.

Fingerprint paths remain sorted before hashing, so switching to incremental directory iteration does not change fingerprint determinism.

## Security and resource impact

A malicious or accidentally enormous flat plugin directory can no longer bypass the practical value of the configured 4,096-entry limit by forcing one unbounded `readdir()` allocation.

Directory plugins now have the same entry-by-entry resource-boundary behavior already used for ZIP plugin extraction, and cancellation remains responsive throughout discovery.

## Tests

Added regression coverage for:

- a configured plugin containing 4,096 additional siblings in one directory;
- rejection through the existing copy-entry limit;
- removal of the partially created marketplace after overflow;
- cancellation triggered during the second individual directory read;
- preservation of the original `AbortError` reason;
- confirmation that discovery stops immediately at cancellation;
- removal of partial marketplace output after cancellation.

Existing configured-plugin, marketplace projection, symlink rejection, queued-directory identity race, ZIP limit, and runtime tests continue to pass.

## Verification

- `pnpm run types`
- `pnpm run format`
- `pnpm run build`
- complete runtime test file
- `PATH="/opt/homebrew/bin:$PATH" pnpm run test`

Full test result:

- 472 passed
- 6 expected platform/integration skips
- 0 failed
