### PR TITLE
fix: preserve active profile and project in preflight

### DIFF
--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -397,6 +397,14 @@ export class CodexSecurity {
       ) {
         await this.#refreshPersistentRuntime(runtime, scanEnvironment, signal);
       }
+      const effectiveConfig =
+        runtime.effectiveConfig ?? (await mergedCodexConfig(this.config));
+      if (runtime.configPath !== undefined) {
+        await writeCodexConfig(
+          runtime.configPath,
+          scanPreflightCodexConfig(effectiveConfig, repo),
+        );
+      }
       const runtimeHome = await realpath(runtime.codexHome);
       requireOutputOutsideRepository(protectedRoot, runtimeHome, "runtime");
       if (
@@ -533,8 +541,6 @@ export class CodexSecurity {
         mode,
         pluginVersion: runtime.plugin.version,
       };
-      const effectiveConfig =
-        runtime.effectiveConfig ?? (await mergedCodexConfig(this.config));
       const { model } = scanModelConfiguration(effectiveConfig);
       validateScanCostLimit(options.maxCostUsd, model);
       const tracker = new ScanCostTracker({
@@ -1578,7 +1584,7 @@ function scanRecipe(
     mode,
     ...(repositoryRevision === null ? {} : { repositoryRevision }),
     pluginVersion,
-    config: scanPreflightCodexConfig(effectiveConfig),
+    config: scanPreflightCodexConfig(effectiveConfig, repository),
     ...(failOnSeverity === undefined ? {} : { failOnSeverity }),
     ...(knowledgeBasePaths === undefined ? {} : { knowledgeBasePaths }),
     ...(maxCostUsd === undefined ? {} : { maxCostUsd }),
@@ -1833,7 +1839,10 @@ export function scanRuntimeCodexConfig(
   };
 }
 
-export function scanPreflightCodexConfig(config: JsonObject): JsonObject {
+export function scanPreflightCodexConfig(
+  config: JsonObject,
+  activeProjectPath?: string,
+): JsonObject {
   const safeString = (value: unknown, maxLength: number): value is string =>
     typeof value === "string" &&
     value.length > 0 &&
@@ -1903,18 +1912,41 @@ export function scanPreflightCodexConfig(config: JsonObject): JsonObject {
     }
     return result;
   };
+  const prioritizedEntries = (
+    value: Record<string, unknown>,
+    priority: string | undefined,
+  ): [string, unknown][] => {
+    const entries = Object.entries(value);
+    if (priority === undefined || !Object.hasOwn(value, priority)) {
+      return entries;
+    }
+    return [
+      [priority, value[priority]],
+      ...entries.filter(([key]) => key !== priority),
+    ];
+  };
 
   const result = executionConfig(config);
-  if (safeProfileName(config["profile"])) {
-    result["profile"] = config["profile"];
+  const selectedProfile = safeProfileName(config["profile"])
+    ? config["profile"]
+    : undefined;
+  if (selectedProfile !== undefined) {
+    result["profile"] = selectedProfile;
   }
   const profiles = config["profiles"];
   if (isRecord(profiles)) {
     const sanitized: JsonObject = {};
-    for (const [name, profile] of Object.entries(profiles).slice(0, 256)) {
+    let accepted = 0;
+    for (const [name, profile] of prioritizedEntries(
+      profiles,
+      selectedProfile,
+    )) {
       if (!safeProfileName(name) || !isRecord(profile)) continue;
       const projected = executionConfig(profile as JsonObject);
-      if (Object.keys(projected).length > 0) sanitized[name] = projected;
+      if (Object.keys(projected).length === 0) continue;
+      sanitized[name] = projected;
+      accepted += 1;
+      if (accepted === 256) break;
     }
     if (Object.keys(sanitized).length > 0) result["profiles"] = sanitized;
   }
@@ -1927,13 +1959,19 @@ export function scanPreflightCodexConfig(config: JsonObject): JsonObject {
   const projects = config["projects"];
   if (isRecord(projects)) {
     const sanitized: JsonObject = {};
-    for (const [path, project] of Object.entries(projects).slice(0, 256)) {
+    let accepted = 0;
+    for (const [path, project] of prioritizedEntries(
+      projects,
+      activeProjectPath,
+    )) {
       if (!safeString(path, 4096) || !isAbsolute(path) || !isRecord(project)) {
         continue;
       }
       const trust = project["trust_level"];
       if (trust !== "trusted" && trust !== "untrusted") continue;
       sanitized[path] = { trust_level: trust };
+      accepted += 1;
+      if (accepted === 256) break;
     }
     if (Object.keys(sanitized).length > 0) result["projects"] = sanitized;
   }

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -495,6 +495,93 @@ describe("CodexSecurity orchestration", () => {
     ).resolves.toBeUndefined();
   });
 
+  test("prioritizes the selected profile and active project before projection limits", () => {
+    const activeProject = "/workspace/active";
+    const profiles = Object.fromEntries([
+      ...Array.from({ length: 256 }, (_, index) => [
+        `profile_${index}`,
+        { features: { goals: index % 2 === 0 } },
+      ]),
+      ["selected", { agents: { max_threads: 17 } }],
+    ]);
+    const projects = Object.fromEntries([
+      ...Array.from({ length: 256 }, (_, index) => [
+        `/workspace/project-${index}`,
+        { trust_level: "untrusted" },
+      ]),
+      [activeProject, { trust_level: "trusted" }],
+    ]);
+
+    const prioritized = scanPreflightCodexConfig(
+      {
+        profile: "selected",
+        profiles,
+        projects,
+      },
+      activeProject,
+    );
+
+    expect(prioritized["profile"]).toBe("selected");
+    expect(Object.keys(prioritized["profiles"] as JsonObject)).toHaveLength(
+      256,
+    );
+    expect(prioritized["profiles"]).toMatchObject({
+      selected: { agents: { max_threads: 17 } },
+    });
+    expect(Object.keys(prioritized["projects"] as JsonObject)).toHaveLength(
+      256,
+    );
+    expect(prioritized["projects"]).toMatchObject({
+      [activeProject]: { trust_level: "trusted" },
+    });
+
+    const validProfiles = Object.fromEntries(
+      Array.from({ length: 256 }, (_, index) => [
+        `valid_${index}`,
+        { features: { goals: true } },
+      ]),
+    );
+    const validProjects = Object.fromEntries(
+      Array.from({ length: 256 }, (_, index) => [
+        `/valid/project-${index}`,
+        { trust_level: "trusted" },
+      ]),
+    );
+    const afterInvalid = scanPreflightCodexConfig({
+      profiles: {
+        ...Object.fromEntries(
+          Array.from({ length: 256 }, (_, index) => [
+            `invalid.profile.${index}`,
+            { features: { goals: false } },
+          ]),
+        ),
+        ...validProfiles,
+      },
+      projects: {
+        ...Object.fromEntries(
+          Array.from({ length: 256 }, (_, index) => [
+            `relative-${index}`,
+            { trust_level: "trusted" },
+          ]),
+        ),
+        ...validProjects,
+      },
+    });
+
+    expect(Object.keys(afterInvalid["profiles"] as JsonObject)).toHaveLength(
+      256,
+    );
+    expect(afterInvalid["profiles"]).toMatchObject({
+      valid_255: { features: { goals: true } },
+    });
+    expect(Object.keys(afterInvalid["projects"] as JsonObject)).toHaveLength(
+      256,
+    );
+    expect(afterInvalid["projects"]).toMatchObject({
+      "/valid/project-255": { trust_level: "trusted" },
+    });
+  });
+
   test("selects a real-scan target in the active repository layout", async () => {
     await expect(
       stat(join(REPOSITORY_ROOT, INTEGRATION_TARGET)),
@@ -2268,11 +2355,21 @@ describe("CodexSecurity orchestration", () => {
     expect(interpreter).not.toBeNull();
     let capturedConfigPath: string | undefined;
     let capturedCodexHome: string | undefined;
+    const unrelatedProjects = Object.fromEntries(
+      Array.from({ length: 256 }, (_, index) => [
+        join(root, `unrelated-project-${index}`),
+        { trust_level: "untrusted" },
+      ]),
+    );
     const client = new TestClient(
       {
         pluginPath: PLUGIN_ROOT,
         codexOverrides: {
           features: { goals: true },
+          projects: {
+            ...unrelatedProjects,
+            [repository]: { trust_level: "trusted" },
+          },
           mcp_servers: {
             private: {
               command: "echo",
@@ -2331,6 +2428,11 @@ describe("CodexSecurity orchestration", () => {
               expect(serialized).not.toContain("RUNTIME_SHELL_SECRET");
               expect(serialized).not.toContain("mcp_servers");
               expect(serialized).not.toContain("shell_environment_policy");
+              expect(parseToml(serialized)).toMatchObject({
+                projects: {
+                  [repository]: { trust_level: "trusted" },
+                },
+              });
               expect(input).toContain('--config "$CODEX_SECURITY_CONFIG_PATH"');
               expect(input).toContain("--effective-config");
               const shellEnvironment = options.env as Record<string, string>;


### PR DESCRIPTION
## Summary

Fixes #137.

The readable Codex preflight projection now guarantees that a valid selected profile and the valid active repository trust entry are considered before the 256-entry collection limits are filled.

Previously, `profiles` and `projects` were truncated by raw object insertion order. Entries after position 256 were never validated, even when they were the selected profile or the repository currently being scanned. Invalid early entries also consumed the entire input budget despite producing no projected output.

## Changes

### Priority-aware projection

`scanPreflightCodexConfig` now accepts the active repository path as optional context.

Projection order is now:

1. the selected profile, when it is an own entry in `profiles`;
2. the active repository, when it is an own entry in `projects`;
3. the remaining entries in their existing deterministic insertion order.

The priority entry is still subject to every existing name, path, type, capability, and trust-level validation. It is reserved only when it produces valid projected data.

### Accepted-entry limits

The 256-entry limits now count accepted projected entries rather than raw input entries.

For profiles, an entry counts only when:

- its name passes the safe profile-name boundary;
- its value is an object;
- it contains at least one supported projected execution setting.

For projects, an entry counts only when:

- its path passes the safe-string and absolute-path boundaries;
- its value is an object;
- its trust level is exactly `trusted` or `untrusted`.

Invalid and empty entries no longer prevent later valid entries from reaching preflight.

### Active repository propagation

The normalized repository path is now passed into every scan-specific projection:

- the private readable `config-preflight.toml` used by the capability helper is rewritten for the repository before the scan starts;
- the scan recipe stores the same repository-aware projected configuration.

This also handles a reusable persistent runtime scanning different repositories: each scan refreshes the readable preflight file with its own active project before the helper can consume it.

### Existing safety boundaries preserved

The change retains the existing projection restrictions:

- credentials and credential-like keys or values remain excluded;
- unsupported profile fields remain excluded;
- only capability-related execution settings are projected;
- only trusted/untrusted project metadata is retained;
- project paths must remain safe absolute paths;
- the complete sanitized configuration remains limited to 256 KiB;
- priority lookup uses own properties and does not follow prototype entries.

## Tests

Added regression coverage for:

- 256 valid unrelated profiles followed by the selected profile;
- 256 valid unrelated projects followed by the active repository;
- preserving both priority entries while keeping each collection at 256 accepted entries;
- 256 invalid profile entries before 256 valid profiles;
- 256 invalid project entries before 256 valid projects;
- confirming that invalid entries do not consume the accepted-entry budget;
- an end-to-end scan runtime projection with 256 unrelated projects followed by the current repository;
- parsing the actual private preflight TOML and confirming that the current repository retains its `trusted` value.

Existing secret filtering, capability projection, persistent runtime, config-size, and scan orchestration tests continue to pass.

## Verification

- `pnpm run types`
- `pnpm run format`
- `pnpm run build`
- focused API orchestration tests
- `PATH="/opt/homebrew/bin:$PATH" pnpm run test`

Full suite: 471 passed, 6 expected platform/integration skips, 0 failed.