### PR TITLE
fix: report local scan failures without connectivity advice

### DIFF
--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -56,7 +56,11 @@ import {
 import { formatUsd } from "./cost.js";
 import {
   CodexSecurityError,
+  ConfigurationError,
+  InvalidTargetError,
+  OutputDirectoryError,
   OutputInsideProtectedRootError,
+  PluginPythonUnavailableError,
   ScanInterruptedError,
 } from "./errors.js";
 import type { SeverityLevel } from "./models.js";
@@ -2674,10 +2678,61 @@ async function runScan(
   return { exitCode: blockingCount > 0 ? 1 : 0, data: result.toJSON() };
 }
 
+// Filesystem and OS syscall failures cannot originate from the model transport,
+// so they must never be rewritten as connectivity or credential advice. Network
+// errno codes are deliberately absent: they are genuine transport failures.
+const LOCAL_SYSCALL_CODES = new Set([
+  "EACCES",
+  "EBUSY",
+  "EEXIST",
+  "EFBIG",
+  "EIO",
+  "EISDIR",
+  "ELOOP",
+  "EMFILE",
+  "ENAMETOOLONG",
+  "ENFILE",
+  "ENOENT",
+  "ENOMEM",
+  "ENOSPC",
+  "ENOTDIR",
+  "ENOTEMPTY",
+  "EPERM",
+  "EROFS",
+  "EXDEV",
+]);
+
+function isLocalScanFailure(error: unknown): boolean {
+  if (
+    error instanceof InvalidTargetError ||
+    error instanceof OutputDirectoryError ||
+    error instanceof ConfigurationError ||
+    error instanceof PluginPythonUnavailableError
+  ) {
+    return true;
+  }
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof (error as { code: unknown }).code === "string" &&
+    LOCAL_SYSCALL_CODES.has((error as { code: string }).code)
+  );
+}
+
 function scanFailureMessage(
   error: unknown,
   authentication: ScanAuthentication | null,
 ): string {
+  // A local failure keeps its own message. Classification matches bare words
+  // such as "permission denied" anywhere in the text, so an EACCES from a
+  // read-only TMPDIR would otherwise be reported as a credential problem.
+  //
+  // The advice branches below still replace the underlying text rather than
+  // appending it. That is deliberate: upstream authentication and authorization
+  // errors can name the organization or project, which must not reach stderr or
+  // the JSON error field.
+  if (isLocalScanFailure(error)) return cliErrorMessage(error);
   switch (classifyConnectionFailure(error)) {
     case "unauthorized":
       return authentication?.method === "api_key"

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -25,7 +25,10 @@ import {
   BUNDLED_PLUGIN_VERSION,
   CodexSecurityError,
   DiffTarget,
+  InvalidTargetError,
+  OutputDirectoryError,
   OutputInsideProtectedRootError,
+  PluginPythonUnavailableError,
   ScanCostLimitExceededError,
   ScanInterruptedError,
   VERSION,
@@ -2032,6 +2035,100 @@ describe("CLI", () => {
       expect(stderr.text()).toContain(`${message}\n`);
       expect(stderr.text()).not.toContain("codex-security:");
       expect(stderr.text()).not.toContain("model service could not be reached");
+    }
+  });
+
+  test("reports local input and filesystem failures without connectivity advice", async () => {
+    // https://github.com/openai/codex-security/issues/36 -- classification
+    // matches bare words such as "permission denied" anywhere in the message,
+    // so local failures were reported as credential or connectivity problems
+    // and their own text was discarded.
+    const failures: Array<[string, unknown]> = [
+      [
+        "EACCES from a read-only TMPDIR",
+        Object.assign(
+          new Error(
+            "EACCES: permission denied, mkdtemp '/tmp/openai-codex-security-home-XXXXXX'",
+          ),
+          { code: "EACCES" },
+        ),
+      ],
+      [
+        "EPERM writing the scan directory",
+        Object.assign(
+          new Error("EPERM: operation not permitted, mkdir '/out/scan'"),
+          { code: "EPERM" },
+        ),
+      ],
+      [
+        "output directory rejected",
+        new OutputDirectoryError(
+          "Scan output directory must not be accessible to other users (chmod 700): /out",
+        ),
+      ],
+      [
+        "path target naming a 403 directory",
+        new InvalidTargetError("Path target does not exist: src/403/client.ts"),
+      ],
+      [
+        "git ref naming a forbidden branch",
+        new InvalidTargetError("unknown Git ref: origin/forbidden-paths"),
+      ],
+      [
+        "python interpreter unavailable",
+        new PluginPythonUnavailableError(
+          "The configured plugin Python interpreter is unavailable or unusable: /usr/bin/python3",
+        ),
+      ],
+    ];
+
+    for (const [, failure] of failures) {
+      const stdout = capture();
+      const stderr = capture();
+      const deps = dependencies();
+      deps.createSecurity = () => ({
+        run: async () => {
+          throw failure;
+        },
+        preflight: async () => fakePreflight(),
+        close: async () => {},
+      });
+
+      expect(
+        await main(["scan", "."], stdout.stream, stderr.stream, deps),
+      ).toBe(2);
+      expect(stderr.text()).toContain((failure as Error).message);
+      expect(stderr.text()).not.toContain("cannot access the configured model");
+      expect(stderr.text()).not.toContain("Authentication failed");
+      expect(stderr.text()).not.toContain("reached its rate limit");
+    }
+  });
+
+  test("keeps model authorization advice for genuine transport failures", async () => {
+    // The bypass must not swallow real 401/403 handling, and the advice must
+    // still replace upstream text that can name the organization or project.
+    for (const [detail, expected] of [
+      ["401 invalid API key for org-private", "Authentication failed"],
+      [
+        "403 model access denied for org-private",
+        "cannot access the configured model",
+      ],
+    ] as const) {
+      const stderr = capture();
+      const deps = dependencies();
+      deps.createSecurity = () => ({
+        run: async () => {
+          throw new CodexSecurityError(detail);
+        },
+        preflight: async () => fakePreflight(),
+        close: async () => {},
+      });
+
+      expect(
+        await main(["scan", "."], capture().stream, stderr.stream, deps),
+      ).toBe(2);
+      expect(stderr.text()).toContain(expected);
+      expect(stderr.text()).not.toContain("org-private");
     }
   });
 


### PR DESCRIPTION
Fixes #36.

## Scope correction — two of the three reported reproductions are already fixed

I re-ran all three reproductions from the issue against current `main` (`9c7634b`) before writing anything. The issue was filed against `f22d4a36`, and the `network_error`/`timeout` branches of `scanFailureMessage` now already fall through to `cliErrorMessage`:

| Reported reproduction | Current `main` |
|---|---|
| `Path target does not exist: src/network/client.ts` | **already correct** — shows the real message |
| `unknown Git ref: origin/connection-fix` | **already correct** — shows the real message |
| `EACCES: permission denied, mkdtemp '/tmp/...'` | **still broken** — reports a credentials failure |

So this PR addresses the one surviving case, which is the `unauthorized` / `forbidden` / `rate_limited` branches — the three that still discard the original message. The practical trigger is `permission denied`, the standard `strerror` for `EACCES`, which the `forbidden` pattern matches verbatim:

```
/\b403\b|\bforbidden\b|\bpermission denied\b|.../iu
```

A read-only `TMPDIR` therefore surfaces as *"The stored ChatGPT credentials cannot access the configured model. Use an account or API key with model access."* — sending the user to reconfigure credentials for a `chmod` problem, with the real path never printed.

## What this changes

Classification is skipped for failures that cannot originate from the model transport, so they keep their own message:

- `InvalidTargetError` — path and Git ref validation
- `OutputDirectoryError` — output directory checks
- `ConfigurationError` — local config
- `PluginPythonUnavailableError` — interpreter discovery
- filesystem syscall errno codes (`EACCES`, `EPERM`, `ENOSPC`, `EROFS`, `ENOENT`, …)

Network errno codes (`ECONNRESET`, `ENOTFOUND`, `ETIMEDOUT`, …) are **deliberately excluded** from that set — they are genuine transport failures and must keep classifying. The set is an explicit allowlist rather than a `/^E[A-Z]+$/` test for exactly that reason.

## Why I did *not* take the issue's alternative suggestion

The issue offers a second option: *"always include the original message alongside the advice so no failure is reported without its cause."*

I implemented that first, and the existing suite caught it. `tests-ts/cli-authentication.test.ts` → *"identifies overriding API keys in noninteractive scan auth failures"* deliberately asserts that upstream text must **not** reach stderr:

```ts
["403 model access denied for org-private", "cannot access the configured model"],
...
expect(stderr.text()).not.toContain("org-private");
```

Upstream authentication and authorization errors can name the organization or project, and suppressing that is intentional. Appending the cause would leak it into both stderr and the JSON `error` field. So the advice branches still replace the underlying text, and I added a comment recording why, since the next person to read this will have the same idea I did.

That trade-off means a genuinely *misclassified* transport error still loses its text. Narrowing the `forbidden` pattern itself (for instance requiring `permission denied` to co-occur with model/auth context) would close that too, but it changes retry-versus-fatal behavior in the event stream and felt out of scope here.

## Also out of scope

The issue notes the same classifier gates retry-versus-fatal in the `api.ts` event-stream `error` branch. Those messages come from the Codex transport, where classification is the intended behavior, and changing it risks turning fatal auth failures into retry loops. Worth a separate look, not folded in here.

## Testing / QA instructions

Baseline before this branch: **470 pass / 6 skip / 0 fail**. After: **472 pass / 6 skip / 0 fail** (two added tests).

```bash
cd sdk/typescript          # run pnpm from here, not the repo root
CI=true pnpm install --frozen-lockfile
CI=true pnpm run types
CI=true pnpm run test
CI=true pnpm run format
CI=true pnpm run build
```

### Confirm the test reproduces the bug

```bash
cd sdk/typescript
cp src/cli.ts /tmp/fixed.ts
git checkout main -- src/cli.ts
CI=true bun test --timeout 30000 ./tests-ts/cli.test.ts -t "local input and filesystem failures"
#   expect 1 fail, showing:
#   "The stored ChatGPT credentials cannot access the configured model. Use an ..."
cp /tmp/fixed.ts src/cli.ts
CI=true bun test --timeout 30000 ./tests-ts/cli.test.ts -t "local input and filesystem failures"   # 1 pass
```

### New coverage

1. **`reports local input and filesystem failures without connectivity advice`** — drives real `main()` through the `cli-fixtures` harness with six failures: `EACCES` from `mkdtemp`, `EPERM` from `mkdir`, an `OutputDirectoryError`, an `InvalidTargetError` naming a `src/403/` path, an `InvalidTargetError` naming an `origin/forbidden-paths` ref, and a `PluginPythonUnavailableError`. Each asserts the real message reaches stderr and that no credential, authentication, or rate-limit advice appears.

   The `403` and `forbidden` cases are deliberate: they cover the *other* two words in the `forbidden` pattern that a repository path or branch name can plausibly contain, not just `permission denied`.

2. **`keeps model authorization advice for genuine transport failures`** — the guard against over-correcting. A `CodexSecurityError` carrying `401 invalid API key for org-private` / `403 model access denied for org-private` must still produce advice **and** must still not leak `org-private`.

### Regression surface

The pre-existing tests that pin this area are unmodified and still pass — `cli-authentication.test.ts` *"identifies overriding API keys…"* (the `org-private` suppression above) and the three `cli.test.ts` cases asserting sqlite/database/sandbox errors do not claim a network failure.
