### PR TITLE
fix: keep credential homes private under trusted ancestry

### DIFF
--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -1490,7 +1490,9 @@ export async function main(
             ? await dependencies.prepareAuthenticationHome(
                 dependencies.environment,
               )
-            : codexSecurityCredentialHome(dependencies.environment);
+            : await prepareCodexSecurityCredentialHome(
+                dependencies.environment,
+              );
         const authenticationEnvironment = {
           ...dependencies.environment,
           CODEX_HOME: credentialHome,
@@ -1566,7 +1568,9 @@ export async function main(
             ? await dependencies.prepareAuthenticationHome(
                 dependencies.environment,
               )
-            : codexSecurityCredentialHome(dependencies.environment);
+            : await prepareCodexSecurityCredentialHome(
+                dependencies.environment,
+              );
         const authenticationEnvironment = {
           ...dependencies.environment,
           CODEX_HOME: credentialHome,

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -153,7 +153,10 @@ export async function prepareCodexSecurityCredentialHome(
     const canonical = await realpath(path);
     requireModelSafeOutputDir(canonical);
     validateLocation?.(canonical);
-    await requirePrivateCredentialHome(metadata, canonical);
+    await requireSecureCredentialHome(canonical, {
+      applyWindowsAcl: true,
+      metadata,
+    });
     return canonical;
   } catch (error) {
     if (error instanceof OutputDirectoryError) throw error;
@@ -162,6 +165,76 @@ export async function prepareCodexSecurityCredentialHome(
       { cause: error },
     );
   }
+}
+
+/**
+ * Re-verify the credential home before every use.
+ *
+ * Durable cross-process `(st_dev, st_ino)` pins are deferred: there is no
+ * workbench row for credential homes, and path+mode+trusted-ancestry checks on
+ * each use already close the cross-user rename/replace class. Lock acquisition
+ * still pins identity for the duration of a single lock session.
+ */
+export async function requireSecureCredentialHome(
+  path: string,
+  options: {
+    platform?: NodeJS.Platform;
+    secureWindowsHome?: (path: string) => Promise<void>;
+    applyWindowsAcl?: boolean;
+    metadata?: Stats;
+    expectedDevice?: number;
+    expectedInode?: number;
+  } = {},
+): Promise<Stats> {
+  const platform = options.platform ?? process.platform;
+  let metadata = options.metadata;
+  if (metadata === undefined) {
+    try {
+      metadata = await lstat(path);
+    } catch (error) {
+      throw new OutputDirectoryError(
+        `Unable to inspect the Codex Security credential home: ${path}`,
+        { cause: error },
+      );
+    }
+  }
+  if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+    throw new OutputDirectoryError(
+      `Codex Security credential home is not a directory: ${path}`,
+    );
+  }
+  const canonical = await realpath(path);
+  requireModelSafeOutputDir(canonical);
+  if (canonical !== path) {
+    metadata = await lstat(canonical);
+    if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+      throw new OutputDirectoryError(
+        `Codex Security credential home is not a directory: ${path}`,
+      );
+    }
+  }
+  if (
+    options.expectedDevice !== undefined &&
+    options.expectedInode !== undefined &&
+    (metadata.dev !== options.expectedDevice ||
+      metadata.ino !== options.expectedInode)
+  ) {
+    throw new OutputDirectoryError(
+      `Codex Security credential home was replaced: ${canonical}`,
+    );
+  }
+  if (platform === "win32") {
+    if (options.applyWindowsAcl) {
+      await requirePrivateCredentialHome(metadata, canonical, {
+        platform,
+        secureWindowsHome: options.secureWindowsHome,
+      });
+    }
+    return metadata;
+  }
+  await requirePrivateCredentialHome(metadata, canonical, { platform });
+  await requireSecureOutputAncestry(canonical);
+  return metadata;
 }
 
 export async function requirePrivateCredentialHome(
@@ -232,12 +305,19 @@ export async function acquireCodexSecurityCredentialHomeLock(
   codexHome: string,
   signal?: AbortSignal,
 ): Promise<() => Promise<void>> {
+  const homeMetadata = await requireSecureCredentialHome(codexHome);
+  const expectedDevice = homeMetadata.dev;
+  const expectedInode = homeMetadata.ino;
   const lock = join(codexHome, CREDENTIAL_LOCK_NAME);
   const ownerPath = join(lock, "owner.json");
   const token = randomUUID();
 
   while (true) {
     throwIfSignalAborted(signal);
+    await requireSecureCredentialHome(codexHome, {
+      expectedDevice,
+      expectedInode,
+    });
     try {
       await mkdir(lock, { mode: 0o700 });
     } catch (error) {
@@ -261,6 +341,10 @@ export async function acquireCodexSecurityCredentialHomeLock(
     let released = false;
     return async () => {
       if (released) return;
+      await requireSecureCredentialHome(codexHome, {
+        expectedDevice,
+        expectedInode,
+      });
       const owner = JSON.parse(await readFile(ownerPath, "utf8")) as {
         token?: unknown;
       };
@@ -334,6 +418,7 @@ export async function setCodexSecurityCredentialLogout(
   codexHome: string,
   loggedOut: boolean,
 ): Promise<void> {
+  await requireSecureCredentialHome(codexHome);
   const marker = join(codexHome, CREDENTIAL_LOGOUT_MARKER);
   if (!loggedOut) {
     await rm(marker, { force: true });
@@ -362,6 +447,7 @@ export async function setCodexSecurityCredentialLogout(
 export async function codexSecurityCredentialAllowsAmbientImport(
   codexHome: string,
 ): Promise<boolean> {
+  await requireSecureCredentialHome(codexHome);
   try {
     const marker = await lstat(join(codexHome, CREDENTIAL_LOGOUT_MARKER));
     if (!marker.isFile() || marker.isSymbolicLink()) {
@@ -379,6 +465,7 @@ export async function codexSecurityCredentialAllowsAmbientImport(
 export async function codexSecurityHasStoredFileCredentials(
   codexHome: string,
 ): Promise<boolean> {
+  await requireSecureCredentialHome(codexHome);
   const path = join(codexHome, "auth.json");
   let metadata: Stats;
   try {
@@ -392,7 +479,26 @@ export async function codexSecurityHasStoredFileCredentials(
       `Codex Security stored authentication is not a regular file: ${path}`,
     );
   }
+  requirePrivateCredentialFile(metadata, path);
   return true;
+}
+
+export function requirePrivateCredentialFile(
+  metadata: Pick<Stats, "mode" | "uid">,
+  path: string,
+  effectiveUid = process.geteuid?.(),
+): void {
+  if (process.platform === "win32") return;
+  if ((metadata.mode & 0o077) !== 0) {
+    throw new OutputDirectoryError(
+      `Codex Security stored authentication must not be accessible to other users: ${path}`,
+    );
+  }
+  if (effectiveUid !== undefined && metadata.uid !== effectiveUid) {
+    throw new OutputDirectoryError(
+      `Codex Security stored authentication must be owned by the current user: ${path}`,
+    );
+  }
 }
 
 export async function preserveCodexSecurityPluginRegistration(
@@ -725,6 +831,78 @@ export function requirePrivateOutputDirectory(
   }
 }
 
+/** Reject shared parents whose owner can rename or replace a private directory. */
+export async function requireSecureOutputAncestry(
+  path: string,
+  effectiveUid = process.geteuid?.(),
+): Promise<void> {
+  if (process.platform === "win32") return;
+  let current = dirname(resolve(path));
+  while (true) {
+    try {
+      current = await realpath(current);
+      break;
+    } catch (error) {
+      if (nodeErrorCode(error) !== "ENOENT") {
+        throw new OutputDirectoryError(
+          `Unable to inspect parent directory: ${current}`,
+          { cause: error },
+        );
+      }
+      const parent = dirname(current);
+      if (parent === current) {
+        throw new OutputDirectoryError(
+          `Unable to inspect parent directory: ${current}`,
+          { cause: error },
+        );
+      }
+      current = parent;
+    }
+  }
+  while (true) {
+    let metadata: Stats;
+    try {
+      metadata = await lstat(current);
+    } catch (error) {
+      throw new OutputDirectoryError(
+        `Unable to inspect parent directory: ${current}`,
+        { cause: error },
+      );
+    }
+    if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+      throw new OutputDirectoryError(
+        `Parent must be a non-symlink directory: ${current}`,
+      );
+    }
+    requireTrustedOutputAncestor(metadata, current, effectiveUid);
+    const parent = dirname(current);
+    if (parent === current) return;
+    current = parent;
+  }
+}
+
+export function requireTrustedOutputAncestor(
+  metadata: Pick<Stats, "mode" | "uid">,
+  path: string,
+  effectiveUid = process.geteuid?.(),
+): void {
+  if (
+    effectiveUid !== undefined &&
+    metadata.uid !== 0 &&
+    metadata.uid !== effectiveUid
+  ) {
+    throw new OutputDirectoryError(
+      `Parent must have a trusted owner: ${path}`,
+    );
+  }
+  if ((metadata.mode & 0o022) === 0) return;
+  if ((metadata.mode & 0o1000) === 0) {
+    throw new OutputDirectoryError(
+      `Parent must not be group- or world-writable without the sticky bit: ${path}`,
+    );
+  }
+}
+
 async function removeEmptyDirectories(
   path: string,
   root: string,
@@ -778,6 +956,9 @@ export async function importAmbientAuth(
     return false;
   }
   await mkdir(isolatedHome, { recursive: true, mode: 0o700 });
+  if (process.platform !== "win32" && (process.umask() & 0o700) !== 0) {
+    await chmod(isolatedHome, 0o700);
+  }
   if (await codexSecurityHasStoredFileCredentials(isolatedHome)) return true;
   const destination = join(isolatedHome, "auth.json");
   const temporary = join(isolatedHome, `.auth-${randomUUID()}.tmp`);

--- a/sdk/typescript/tests-ts/cli-authentication.test.ts
+++ b/sdk/typescript/tests-ts/cli-authentication.test.ts
@@ -55,7 +55,12 @@ describe("CLI authentication", () => {
 
   test("uses the same stable credential home for login, status, and logout", async () => {
     const stateDirectory = join(tmpdir(), "codex-security-managed-auth-state");
-    const expectedHome = join(stateDirectory, "codex-home");
+    await mkdir(stateDirectory, { recursive: true, mode: 0o700 });
+    const expectedHome = await realpath(
+      await prepareCodexSecurityCredentialHome({
+        CODEX_SECURITY_STATE_DIR: stateDirectory,
+      }),
+    );
 
     for (const argv of [["login"], ["login", "status"], ["logout"]] as const) {
       const stdout = capture();

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -9,6 +9,7 @@ import {
   readFile,
   realpath,
   readdir,
+  rename,
   rm,
   stat,
   symlink,
@@ -49,6 +50,7 @@ import {
   bundledPluginCandidates,
   codexSecurityCredentialAllowsAmbientImport,
   codexSecurityCredentialHome,
+  codexSecurityHasStoredFileCredentials,
   codexSecurityStateDirectory,
   codexPlatformPackage,
   isPythonPathCandidate,
@@ -56,7 +58,11 @@ import {
   prepareCodexSecurityCredentialHome,
   preparePersistentScanRoot,
   requirePrivateCredentialHome,
+  requirePrivateCredentialFile,
   requirePrivateOutputDirectory,
+  requireSecureCredentialHome,
+  requireSecureOutputAncestry,
+  requireTrustedOutputAncestor,
   runWorkbench,
   setCodexSecurityCredentialLogout,
 } from "../src/runtime.js";
@@ -743,9 +749,15 @@ describe("plugin runtime preparation", () => {
     const ambient = join(root, "ambient");
     const isolated = join(root, "isolated");
     await mkdir(ambient);
-    await mkdir(isolated);
+    await mkdir(isolated, { mode: 0o700 });
+    if (process.platform !== "win32") await chmod(isolated, 0o700);
     await writeFile(join(ambient, "auth.json"), '{"token":"ambient"}\n');
-    await writeFile(join(isolated, "auth.json"), '{"token":"explicit"}\n');
+    await writeFile(join(isolated, "auth.json"), '{"token":"explicit"}\n', {
+      mode: 0o600,
+    });
+    if (process.platform !== "win32") {
+      await chmod(join(isolated, "auth.json"), 0o600);
+    }
 
     expect(await importAmbientAuth(ambient, isolated)).toBe(true);
     expect(await readFile(join(isolated, "auth.json"), "utf8")).toBe(
@@ -1225,6 +1237,146 @@ describe("runtime directories and plugin Python boundary", () => {
       prepareCodexSecurityCredentialHome(environment),
     ).rejects.toThrow("credential home is not a directory");
   });
+
+  testPosix(
+    "rejects credential homes under a non-sticky shared parent directory",
+    async () => {
+      const root = await temporaryDirectory();
+      const shared = join(root, "shared");
+      await mkdir(shared, { mode: 0o777 });
+      await chmod(shared, 0o777);
+      expect((await lstat(shared)).mode & 0o1000).toBe(0);
+      const environment = { CODEX_SECURITY_STATE_DIR: join(shared, "state") };
+
+      await expect(
+        prepareCodexSecurityCredentialHome(environment),
+      ).rejects.toThrow("sticky bit");
+      await expect(requireSecureOutputAncestry(join(shared, "state"))).rejects.toThrow(
+        "sticky bit",
+      );
+    },
+  );
+
+  testPosix(
+    "accepts credential homes under a sticky shared parent directory",
+    async () => {
+      const root = await temporaryDirectory();
+      // Some filesystems (notably user dirs on macOS APFS) ignore sticky on
+      // chmod; fall back to the process temp root when it is already sticky.
+      let stickyParent = join(root, "shared");
+      await mkdir(stickyParent, { mode: 0o1777 });
+      await chmod(stickyParent, 0o1777);
+      if (((await lstat(stickyParent)).mode & 0o1000) === 0) {
+        stickyParent = await realpath(tmpdir());
+        if (((await lstat(stickyParent)).mode & 0o1000) === 0) {
+          return;
+        }
+      }
+      const stateDirectory = join(
+        stickyParent,
+        `codex-security-sticky-${process.pid}-${Date.now()}`,
+      );
+      temporaryDirectories.push(stateDirectory);
+      await mkdir(stateDirectory, { recursive: true, mode: 0o700 });
+      const home = await prepareCodexSecurityCredentialHome({
+        CODEX_SECURITY_STATE_DIR: stateDirectory,
+      });
+      await expect(requireSecureCredentialHome(home)).resolves.toBeDefined();
+      await expect(
+        requireSecureOutputAncestry(home),
+      ).resolves.toBeUndefined();
+    },
+  );
+
+  testPosix("rejects sticky shared parents controlled by another user", () => {
+    expect(() =>
+      requireTrustedOutputAncestor(
+        { mode: 0o41777, uid: 1001 },
+        "/shared",
+        1000,
+      ),
+    ).toThrow("trusted owner");
+    expect(() =>
+      requireTrustedOutputAncestor(
+        { mode: 0o40755, uid: 1001 },
+        "/shared",
+        1000,
+      ),
+    ).toThrow("trusted owner");
+    expect(() =>
+      requireTrustedOutputAncestor(
+        { mode: 0o41777, uid: 1000 },
+        "/shared",
+        1000,
+      ),
+    ).not.toThrow();
+    expect(() =>
+      requireTrustedOutputAncestor({ mode: 0o41777, uid: 0 }, "/tmp", 1000),
+    ).not.toThrow();
+  });
+
+  testPosix(
+    "rejects a credential home that is no longer private to the current user",
+    async () => {
+      const root = await temporaryDirectory();
+      const home = await prepareCodexSecurityCredentialHome({
+        CODEX_SECURITY_STATE_DIR: join(root, "state"),
+      });
+      await chmod(home, 0o755);
+      await expect(requireSecureCredentialHome(home)).rejects.toThrow(
+        "must not be accessible to other users",
+      );
+      await expect(
+        acquireCodexSecurityCredentialHomeLock(home),
+      ).rejects.toThrow("must not be accessible to other users");
+    },
+  );
+
+  testPosix(
+    "pins credential-home identity for the duration of a lock session",
+    async () => {
+      const root = await temporaryDirectory();
+      const home = await prepareCodexSecurityCredentialHome({
+        CODEX_SECURITY_STATE_DIR: join(root, "state"),
+      });
+      const release = await acquireCodexSecurityCredentialHomeLock(home);
+      const stolen = join(root, "stolen-home");
+      await rename(home, stolen);
+      await mkdir(home, { recursive: true, mode: 0o700 });
+      await chmod(home, 0o700);
+      await expect(release()).rejects.toThrow("credential home was replaced");
+    },
+  );
+
+  testPosix(
+    "rejects world-writable or symlink stored authentication files",
+    async () => {
+      const root = await temporaryDirectory();
+      const home = await prepareCodexSecurityCredentialHome({
+        CODEX_SECURITY_STATE_DIR: join(root, "state"),
+      });
+      const authPath = join(home, "auth.json");
+      await writeFile(authPath, '{"token":"test"}\n', { mode: 0o600 });
+      expect(await codexSecurityHasStoredFileCredentials(home)).toBe(true);
+
+      await chmod(authPath, 0o644);
+      await expect(codexSecurityHasStoredFileCredentials(home)).rejects.toThrow(
+        "must not be accessible to other users",
+      );
+      await rm(authPath);
+
+      const target = join(home, "auth-target.json");
+      await writeFile(target, '{"token":"test"}\n', { mode: 0o600 });
+      await symlink(target, authPath);
+      await expect(codexSecurityHasStoredFileCredentials(home)).rejects.toThrow(
+        "not a regular file",
+      );
+
+      expect(() =>
+        requirePrivateCredentialFile({ mode: 0o100644, uid: 1000 }, authPath, 1000),
+      ).toThrow("must not be accessible to other users");
+    },
+  );
 
   test("identifies a credential home that already exists as a regular file", async () => {
     const root = await temporaryDirectory();


### PR DESCRIPTION
## Summary

- Fixes #157: reject non-sticky / untrusted ancestors for the durable Codex Security credential home (same rename class as #109/#118, for `auth.json` instead of scan output).
- Re-check private leaf + trusted ancestry on prepare **and** every use path: lock acquire/release, stored-auth probe, logout marker writes, ambient-import destination homes, and CLI login/logout fallbacks.
- Harden `auth.json`: regular non-symlink file with private POSIX mode/owner before treating stored credentials as present.
- Pin `(st_dev, st_ino)` for the duration of a credential-home lock session. Durable cross-process pins are deferred (no workbench row for credential homes); every-use re-validation covers the cross-user class.
- Introduces shared `requireSecureOutputAncestry` / `requireTrustedOutputAncestor` helpers (compatible with #118) used for credential-home trust; does **not** change scan-output prepare paths (left to #118).

## Test plan

- [x] `bun test --timeout 60000 ./tests-ts/runtime.test.ts ./tests-ts/cli-authentication.test.ts`
- [x] Posix: reject credential home under non-sticky shared parent
- [x] Posix: accept sticky shared parent owned by self/root
- [x] Posix: reject sticky parent owned by another UID
- [x] Posix: reject leaf that is no longer private after prepare
- [x] Posix: reject replaced credential home (different inode) on lock release
- [x] Posix: reject world-writable or symlink `auth.json`
- [x] CLI login/status/logout still share one canonical credential home

Made with [Cursor](https://cursor.com)