### PR TITLE
fix: read container manifest digests without broken pipes

### DIFF
--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -463,7 +463,7 @@ jobs:
             --tag "$candidate" \
             "${references[@]}"
 
-          manifest_digest="$(docker buildx imagetools inspect "$candidate" | awk '/^Digest:/{print $2; exit}')"
+          manifest_digest="$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$candidate")"
           if [[ ! "$manifest_digest" =~ ^sha256:[[:xdigit:]]{64}$ ]]; then
             echo 'The registry did not return a valid multiarchitecture image digest.' >&2
             exit 1
@@ -590,7 +590,7 @@ jobs:
             --tag "$IMAGE:latest" \
             "$IMAGE@$MANIFEST_DIGEST"
 
-          actual_digest="$(docker buildx imagetools inspect "$IMAGE:$VERSION" | awk '/^Digest:/{print $2; exit}')"
+          actual_digest="$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$IMAGE:$VERSION")"
           if [[ "$actual_digest" != "$MANIFEST_DIGEST" ]]; then
             echo '::error::The promoted stable tag does not reference the verified and attested candidate digest.'
             exit 1


### PR DESCRIPTION
## Summary

Fix the first protected container release, which successfully published and verified both platform images but exited while extracting the provisional multi-architecture manifest digest.

- Replace both early-exiting `awk` pipelines with Docker Buildx's native `--format "{{.Manifest.Digest}}"` output.
- Preserve the existing immutable digest validation, protected release approval, provenance job, and promotion order.
- Failed production run: https://github.com/openai/codex-security/actions/runs/30580885348

## Verification

- `actionlint .github/workflows/container-release.yml`
- `prettier --check .github/workflows/container-release.yml`
- 10 focused container entrypoint and immutable-release tests passed.
- The exact formatter returned `sha256:ed65aa21030a21063795fe5410a6c2612e443cb932e27bcce217603848906f66` for the publicly pullable amd64/arm64 candidate.
- The candidate reports CLI/SDK `0.1.4` and runs as nonroot UID `10001`.