### PR TITLE
fix: authenticate registry before image attestation

### DIFF
--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -530,6 +530,13 @@ jobs:
       packages: write
 
     steps:
+      - name: Sign in to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Sign verified multiarchitecture candidate provenance
         uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
         with:


### PR DESCRIPTION
## Summary
- authenticate to GHCR before pushing the verified image provenance attestation
- preserve the existing protected release, OIDC signing, immutable digest, and stable-tag promotion gates

## Evidence
- production container-release run 30582841027 passed both native publication jobs and multiarchitecture manifest verification, then failed with `Error: No credentials found for registry ghcr.io`
- validated workflow YAML and Prettier formatting
- regression check confirms GHCR authentication executes before provenance signing
- `git diff --check` passes