### PR TITLE
test: stabilize ChatGPT login subprocess on macOS

### DIFF
--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -3913,7 +3913,10 @@ if (args === "login --with-api-key") {
     appendFileSync(${JSON.stringify(keyLog)}, apiKey);
   }
 } else if (args === "login") {
-  console.error("Open https://auth.example.test/login");
+  process.stderr.write(
+    "Open https://auth.example.test/login\\n",
+    (error) => process.exit(error ? 1 : 0),
+  );
 } else {
   process.exitCode = 2;
 }


### PR DESCRIPTION
## Summary
- Flush the synthetic ChatGPT-login URL to stderr before explicitly terminating its child process.
- Prevent the ambient-credential authentication regression test from leaving a dangling Bun/Node subprocess or stalling macOS CI.
- Keep the change limited to the test fixture: no production authentication changes and no unrelated GitHub Actions upgrades.

## Evidence
- The merged-main macOS job timed out in CodexSecurity orchestration > keeps ambient credentials available after successful ChatGPT login: https://github.com/openai/codex-security/actions/runs/30593828967/attempts/1
- Full SDK regression suite: 656 passed, 6 intentionally skipped, 0 failed, across 32 files.
- The exact previously flaky test passed all 12 concurrent stress attempts.
- The complete API authentication suite passed: 67 tests.
- Authentication process-boundary tests, TypeScript typechecking, Prettier, and git diff validation pass.

This intentionally does not claim to fix the broader production child-cancellation issue tracked separately in #131.