### PR TITLE
fix: recover multiscan locks with missing or malformed owner metadata

### DIFF
--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -28,6 +28,7 @@ const REQUIRED_ARTIFACTS = [
   "coverage.json",
   "report.md",
 ];
+const INCOMPLETE_LOCK_MILLISECONDS = 30_000;
 
 interface MultiscanTask {
   id: string;
@@ -268,29 +269,71 @@ async function appendReceipt(path: string, receipt: string): Promise<void> {
 async function acquireLock(output: string): Promise<() => Promise<void>> {
   const path = join(output, ".lock");
   const ownerPath = join(path, "owner.json");
-  try {
-    await mkdir(path, { mode: 0o700 });
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-    const { pid } = JSON.parse(await readFile(ownerPath, "utf8")) as {
-      pid: number;
-    };
+  for (;;) {
     try {
-      process.kill(pid, 0);
-      throw new Error("A multiscan supervisor is already running.");
-    } catch (failure) {
-      if ((failure as NodeJS.ErrnoException).code !== "ESRCH") throw failure;
+      await mkdir(path, { mode: 0o700 });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      if (!(await recoverStaleLock(output, path, ownerPath))) {
+        throw new Error("A multiscan supervisor is already running.");
+      }
+      continue;
     }
-    const stale = join(output, `.lock.stale-${randomUUID()}`);
-    await rename(path, stale);
-    await rm(stale, { recursive: true });
-    return await acquireLock(output);
+    await writeFile(ownerPath, `${JSON.stringify({ pid: process.pid })}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+    return async () => rm(path, { recursive: true });
   }
-  await writeFile(ownerPath, `${JSON.stringify({ pid: process.pid })}\n`, {
-    flag: "wx",
-    mode: 0o600,
+}
+
+async function recoverStaleLock(
+  output: string,
+  path: string,
+  ownerPath: string,
+): Promise<boolean> {
+  const metadata = await lstat(path).catch((error: unknown) => {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
   });
-  return async () => rm(path, { recursive: true });
+  if (metadata === null) return true;
+
+  let owner: unknown;
+  if (metadata.isDirectory()) {
+    try {
+      owner = JSON.parse(await readFile(ownerPath, "utf8"));
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT" && !(error instanceof SyntaxError)) throw error;
+    }
+  }
+
+  if (isRecord(owner) && typeof owner["pid"] === "number") {
+    try {
+      process.kill(owner["pid"], 0);
+      return false;
+    } catch (failure) {
+      const code = (failure as NodeJS.ErrnoException).code;
+      if (code === "EPERM") return false;
+      if (code !== "ESRCH") throw failure;
+    }
+  } else if (Date.now() - metadata.mtimeMs < INCOMPLETE_LOCK_MILLISECONDS) {
+    return false;
+  }
+
+  const stale = join(output, `.lock.stale-${randomUUID()}`);
+  try {
+    await rename(path, stale);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return true;
+    throw error;
+  }
+  await rm(stale, { recursive: true, force: true });
+  return true;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 async function ensureManifest(

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -8,6 +8,7 @@ import {
   readdir,
   rm,
   symlink,
+  utimes,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -438,6 +439,59 @@ describe("multiscan", () => {
     expect(recovered).toMatchObject({ completed: 1, failed: 0, skipped: 0 });
     expect(await readdir(join(paths.output, "checkouts"))).toEqual([]);
     await expect(access(lock)).rejects.toThrow();
+  });
+
+  test("recovers locks with missing or malformed owner metadata", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "lock-recovery");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\nlock-recovery,${source.path},${source.revision}\n`,
+    );
+    await mkdir(paths.output);
+    const lock = join(paths.output, ".lock");
+    const aged = new Date(Date.now() - 2 * 60_000);
+    let scans = 0;
+    const security = client(async (_repository, scanOptions = {}) => {
+      scans += 1;
+      return await completedScan(scanOptions.outputDir!);
+    });
+
+    for (const owner of [undefined, '{"pid":', '{"pid":"invalid"}']) {
+      await mkdir(lock);
+      if (owner !== undefined) {
+        await writeFile(join(lock, "owner.json"), owner);
+      }
+      await utimes(lock, aged, aged);
+      const result = await runMultiscan(options(paths, security));
+      expect(result).toMatchObject({ completed: 1, failed: 0 });
+      await expect(access(lock)).rejects.toThrow();
+    }
+
+    expect(scans).toBe(1);
+    expect(
+      (await readdir(paths.output)).some((name) =>
+        name.startsWith(".lock.stale-"),
+      ),
+    ).toBe(false);
+  });
+
+  test("treats a fresh lock without owner metadata as an active supervisor", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "lock-fresh");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\nlock-fresh,${source.path},${source.revision}\n`,
+    );
+    await mkdir(paths.output);
+    await mkdir(join(paths.output, ".lock"));
+    const security = client(async (_repository, scanOptions = {}) => {
+      return await completedScan(scanOptions.outputDir!);
+    });
+
+    await expect(runMultiscan(options(paths, security))).rejects.toThrow(
+      /running|locked|supervisor/iu,
+    );
   });
 
   test("retries a failed attempt and records both durable receipts", async () => {


### PR DESCRIPTION
## Summary

Fixes #102.

Bulk scan creates its lock in two steps: create `<output>/.lock`, then write `<output>/.lock/owner.json`. A process kill, machine restart, or write failure between those steps leaves a lock that every later run tries to read unconditionally, so acquisition fails forever with:

```text
codex-security: ENOENT: no such file or directory, open '.../results/.lock/owner.json'
```

Truncated or malformed `owner.json` contents fail the same way through `JSON.parse`. The only escape was deleting `.lock` by hand. The existing recovery path handled a valid owner file with a dead PID, but not missing or invalid owner metadata.

## Changes

`acquireLock` in `src/multiscan.ts` now routes contention through a `recoverStaleLock` helper that mirrors the credential-home lock recovery already shipped in `src/runtime.ts` (`recoverStaleCredentialHomeLock`):

- Missing `owner.json`, malformed JSON, or owner metadata without a numeric `pid` no longer crash acquisition. The lock is treated as incomplete and reclaimed through the existing rename-aside path.
- A lock whose directory was modified within the last 30 seconds is still reported as an active supervisor when its owner metadata is absent or invalid. This protects a concurrent supervisor that has created the directory but not yet published `owner.json`, a window the previous code left unguarded.
- `EPERM` from the `process.kill(pid, 0)` liveness probe now reports an active supervisor instead of crashing, matching the runtime lock. `ESRCH` still means the owner is dead and the lock is reclaimed.
- A lock that disappears mid-recovery (`ENOENT` on rename) retries acquisition instead of failing, and stale quarantine directories are removed with `force: true` so concurrent recovery attempts do not race each other into an error.
- The recursive retry became an acquisition loop; behavior for the existing cases (live owner blocks, dead owner reclaims) is unchanged.

The owner file format is unchanged, so locks written by older versions are still recognized.

## Relationship to #98

#98 proposes a broader redesign of this lock (atomic hard-link publication with ownership tokens). This change instead applies the recovery pattern the codebase already uses for the credential-home lock, keeping the directory-based format and the existing acquisition semantics. If maintainers prefer the redesign, this can serve as the minimal interim fix or be superseded.

## Tests

Two new tests in `tests-ts/multiscan.test.ts`:

- `recovers locks with missing or malformed owner metadata`: iterates the three shapes from the issue (empty `.lock` directory, truncated `'{"pid":'`, and `'{"pid":"invalid"}'`), ages the lock past the publication grace window, and asserts each run completes, removes the lock, and leaves no `.lock.stale-` residue.
- `treats a fresh lock without owner metadata as an active supervisor`: a just-created empty `.lock` is reported as an active supervisor instead of crashing with ENOENT.

Both tests fail against the previous implementation with the exact `ENOENT` error from the issue, and pass with this change. The existing exclusive-lock and dead-owner recovery tests continue to pass.

Verification:

- `pnpm run types`
- `pnpm run test` (708 pass, 0 fail)
- `pnpm run format`
- `pnpm run build`
