### PR TITLE
fix: salvage optional finding fields instead of discarding the finding

### DIFF
--- a/sdk/typescript/_bundled_plugin/scripts/finalize_scan_contract.py
+++ b/sdk/typescript/_bundled_plugin/scripts/finalize_scan_contract.py
@@ -796,11 +796,14 @@ def _recover_unsealed_findings(
     writeup_schema = _require_dict(
         finding_properties, "writeup", "findings.schema.properties.findings.items.properties"
     )
+    code_evidence_schema = _require_dict(
+        finding_properties, "codeEvidence", "findings.schema.properties.findings.items.properties"
+    )
     auxiliary_schemas = {
         name: _require_dict(
             finding_properties, name, "findings.schema.properties.findings.items.properties"
         )
-        for name in ("remediationTests", "preventiveControls", "codeEvidence")
+        for name in ("remediationTests", "preventiveControls")
     }
     scan = _require_dict(manifest, "scan", "manifest")
     scan_id = _require_str(scan, "id", "manifest.scan")
@@ -863,6 +866,63 @@ def _recover_unsealed_findings(
             )
             finding_id = finding["findingId"]
             previous_position = finding_positions.get(finding_id)
+
+            if "codeEvidence" in finding:
+                try:
+                    _validate_schema_node(
+                        finding["codeEvidence"], code_evidence_schema, f"{context}.codeEvidence"
+                    )
+                    seen_evidence_ids: set[str] = set()
+                    for evidence_index, evidence in enumerate(finding["codeEvidence"]):
+                        evidence_id = evidence["id"]
+                        if evidence_id in seen_evidence_ids:
+                            raise ContractError(
+                                f"{context}.codeEvidence[{evidence_index}].id: "
+                                "duplicate code-evidence id"
+                            )
+                        seen_evidence_ids.add(evidence_id)
+                except ContractError as exc:
+                    finding.pop("codeEvidence")
+                    warnings.append(
+                        f"Skipped malformed codeEvidence for finding {index + 1}: {exc}."
+                    )
+
+            taxonomy = finding.get("taxonomy")
+            if isinstance(taxonomy, dict) and "cwe" not in taxonomy:
+                taxonomy["cwe"] = []
+                warnings.append(
+                    f"Recovered finding {index + 1}: backfilled missing taxonomy.cwe with an empty list."
+                )
+
+            known_evidence_ids = {
+                evidence["id"]
+                for evidence in finding.get("codeEvidence") or []
+                if isinstance(evidence, dict) and isinstance(evidence.get("id"), str)
+            }
+            attack_path = finding.get("attackPath")
+            evidence_ref_sections = [
+                (finding.get("rootCause"), "rootCause"),
+                (finding.get("validation"), "validation"),
+                (attack_path, "attackPath"),
+            ]
+            if isinstance(attack_path, dict):
+                evidence_ref_sections.append(
+                    (attack_path.get("dataflow"), "attackPath.dataflow")
+                )
+            for section, section_name in evidence_ref_sections:
+                if not isinstance(section, dict):
+                    continue
+                refs = section.get("evidenceRefs")
+                if not isinstance(refs, list):
+                    continue
+                kept_refs = [ref for ref in refs if ref in known_evidence_ids]
+                if len(kept_refs) != len(refs):
+                    section["evidenceRefs"] = kept_refs
+                    warnings.append(
+                        f"Recovered finding {index + 1}: dropped dangling {section_name}.evidenceRefs "
+                        "after codeEvidence recovery."
+                    )
+
             _validate_finding(finding, context)
             if "writeup" in finding:
                 try:
@@ -893,34 +953,6 @@ def _recover_unsealed_findings(
                     warnings.append(
                         f"Skipped malformed {auxiliary} for finding {index + 1}: {exc}."
                     )
-
-            taxonomy = finding.get("taxonomy")
-            if isinstance(taxonomy, dict) and "cwe" not in taxonomy:
-                taxonomy["cwe"] = []
-                warnings.append(
-                    f"Recovered finding {index + 1}: backfilled missing taxonomy.cwe with an empty list."
-                )
-
-            known_evidence_ids = {
-                evidence["id"]
-                for evidence in finding.get("codeEvidence") or []
-                if isinstance(evidence, dict) and isinstance(evidence.get("id"), str)
-            }
-            for section_name in ("rootCause", "validation", "attackPath"):
-                section = finding.get(section_name)
-                if not isinstance(section, dict):
-                    continue
-                refs = section.get("evidenceRefs")
-                if not isinstance(refs, list):
-                    continue
-                kept_refs = [ref for ref in refs if ref in known_evidence_ids]
-                if len(kept_refs) != len(refs):
-                    section["evidenceRefs"] = kept_refs
-                    warnings.append(
-                        f"Recovered finding {index + 1}: dropped dangling {section_name}.evidenceRefs "
-                        "after codeEvidence recovery."
-                    )
-
             _validate_schema_node(finding, finding_schema, context)
         except ContractError as exc:
             warning = f"Skipped malformed finding {index + 1}: {exc}."

--- a/sdk/typescript/_bundled_plugin/scripts/finalize_scan_contract.py
+++ b/sdk/typescript/_bundled_plugin/scripts/finalize_scan_contract.py
@@ -915,7 +915,9 @@ def _recover_unsealed_findings(
                 refs = section.get("evidenceRefs")
                 if not isinstance(refs, list):
                     continue
-                kept_refs = [ref for ref in refs if ref in known_evidence_ids]
+                kept_refs = [
+                    ref for ref in refs if isinstance(ref, str) and ref in known_evidence_ids
+                ]
                 if len(kept_refs) != len(refs):
                     section["evidenceRefs"] = kept_refs
                     warnings.append(

--- a/sdk/typescript/_bundled_plugin/scripts/finalize_scan_contract.py
+++ b/sdk/typescript/_bundled_plugin/scripts/finalize_scan_contract.py
@@ -800,7 +800,7 @@ def _recover_unsealed_findings(
         name: _require_dict(
             finding_properties, name, "findings.schema.properties.findings.items.properties"
         )
-        for name in ("remediationTests", "preventiveControls")
+        for name in ("remediationTests", "preventiveControls", "codeEvidence")
     }
     scan = _require_dict(manifest, "scan", "manifest")
     scan_id = _require_str(scan, "id", "manifest.scan")
@@ -893,6 +893,34 @@ def _recover_unsealed_findings(
                     warnings.append(
                         f"Skipped malformed {auxiliary} for finding {index + 1}: {exc}."
                     )
+
+            taxonomy = finding.get("taxonomy")
+            if isinstance(taxonomy, dict) and "cwe" not in taxonomy:
+                taxonomy["cwe"] = []
+                warnings.append(
+                    f"Recovered finding {index + 1}: backfilled missing taxonomy.cwe with an empty list."
+                )
+
+            known_evidence_ids = {
+                evidence["id"]
+                for evidence in finding.get("codeEvidence") or []
+                if isinstance(evidence, dict) and isinstance(evidence.get("id"), str)
+            }
+            for section_name in ("rootCause", "validation", "attackPath"):
+                section = finding.get(section_name)
+                if not isinstance(section, dict):
+                    continue
+                refs = section.get("evidenceRefs")
+                if not isinstance(refs, list):
+                    continue
+                kept_refs = [ref for ref in refs if ref in known_evidence_ids]
+                if len(kept_refs) != len(refs):
+                    section["evidenceRefs"] = kept_refs
+                    warnings.append(
+                        f"Recovered finding {index + 1}: dropped dangling {section_name}.evidenceRefs "
+                        "after codeEvidence recovery."
+                    )
+
             _validate_schema_node(finding, finding_schema, context)
         except ContractError as exc:
             warning = f"Skipped malformed finding {index + 1}: {exc}."

--- a/sdk/typescript/tests-ts/scan-recovery.test.ts
+++ b/sdk/typescript/tests-ts/scan-recovery.test.ts
@@ -886,6 +886,83 @@ describe("malformed scan artifact recovery", () => {
     }
   });
 
+  test("keeps findings while recovering missing taxonomy CWE and malformed code evidence", async () => {
+    const fixture = await startDraftScan();
+    const path = join(fixture.scanDir, "findings.json");
+    const document = await readJson<FindingsDocument>(path);
+    const valid = document.findings[0]!;
+
+    const missingCwe = structuredClone(valid);
+    missingCwe.identity.anchor = "missing-cwe";
+    const missingCweTaxonomy = (missingCwe as Record<string, unknown>)[
+      "taxonomy"
+    ] as Partial<{ cwe: string[] }>;
+    delete missingCweTaxonomy.cwe;
+
+    const malformedEvidence = structuredClone(valid);
+    malformedEvidence.identity.anchor = "malformed-evidence";
+    (malformedEvidence as Record<string, unknown>)["codeEvidence"] = [
+      // Missing the required `explanation` field.
+      {
+        id: "ev1",
+        label: "sink",
+        path: "src/extract.py",
+        startLine: 1,
+        code: "x = 1",
+      },
+    ];
+    (malformedEvidence as Record<string, unknown>)["rootCause"] = {
+      summary: "Dangling reference regression check.",
+      evidenceRefs: ["ev1"],
+    };
+
+    document.findings.push(missingCwe, malformedEvidence);
+    await writeJson(path, document);
+
+    const completed = await completeScan(fixture);
+
+    expect(completed.progress.status).toBe("complete");
+    expect(completed.findingCount).toBe(3);
+    expect(completed.warnings).toHaveLength(3);
+    expect(
+      completed.warnings.some(
+        (warning) =>
+          warning.includes("Recovered finding") &&
+          warning.includes("backfilled missing taxonomy.cwe"),
+      ),
+    ).toBe(true);
+    expect(
+      completed.warnings.some((warning) =>
+        warning.startsWith("Skipped malformed codeEvidence for finding"),
+      ),
+    ).toBe(true);
+    expect(
+      completed.warnings.some(
+        (warning) =>
+          warning.includes("Recovered finding") &&
+          warning.includes("dropped dangling rootCause.evidenceRefs"),
+      ),
+    ).toBe(true);
+
+    const recovered = (await readJson<FindingsDocument>(path)).findings;
+    const missingCweRecovered = recovered.find(
+      (finding) => finding?.identity.anchor === "missing-cwe",
+    );
+    expect(missingCweRecovered).toBeDefined();
+    expect(
+      (missingCweRecovered as Record<string, unknown>)?.["taxonomy"],
+    ).toMatchObject({ cwe: [] });
+
+    const malformedEvidenceRecovered = recovered.find(
+      (finding) => finding?.identity.anchor === "malformed-evidence",
+    );
+    expect(malformedEvidenceRecovered).toBeDefined();
+    expect(malformedEvidenceRecovered).not.toHaveProperty("codeEvidence");
+    expect(
+      (malformedEvidenceRecovered as Record<string, unknown>)?.["rootCause"],
+    ).toMatchObject({ evidenceRefs: [] });
+  });
+
   test("keeps verified coverage receipts and downgrades invalid coverage", async () => {
     const fixture = await startDraftScan();
     const path = join(fixture.scanDir, "coverage.json");

--- a/sdk/typescript/tests-ts/scan-recovery.test.ts
+++ b/sdk/typescript/tests-ts/scan-recovery.test.ts
@@ -916,14 +916,49 @@ describe("malformed scan artifact recovery", () => {
       evidenceRefs: ["ev1"],
     };
 
-    document.findings.push(missingCwe, malformedEvidence);
+    // A codeEvidence malformation caught by the hand-rolled validator itself
+    // (duplicate ids), not only by the JSON-schema pass, plus a dangling
+    // reference in the nested `attackPath.dataflow.evidenceRefs` location.
+    const duplicateEvidence = structuredClone(valid);
+    duplicateEvidence.identity.anchor = "duplicate-evidence";
+    (duplicateEvidence as Record<string, unknown>)["codeEvidence"] = [
+      {
+        id: "ev1",
+        label: "a",
+        path: "src/extract.py",
+        startLine: 1,
+        code: "x = 1",
+        explanation: "first",
+      },
+      {
+        id: "ev1",
+        label: "b",
+        path: "src/extract.py",
+        startLine: 2,
+        code: "y = 2",
+        explanation: "second",
+      },
+    ];
+    (duplicateEvidence as Record<string, unknown>)["attackPath"] = {
+      summary: "Nested dangling reference regression check.",
+      dataflow: {
+        summary: "source -> sink",
+        source: "input",
+        sink: "output",
+        outcome: "impact",
+        evidenceRefs: ["ev1"],
+      },
+      evidenceRefs: ["ev1"],
+    };
+
+    document.findings.push(missingCwe, malformedEvidence, duplicateEvidence);
     await writeJson(path, document);
 
     const completed = await completeScan(fixture);
 
     expect(completed.progress.status).toBe("complete");
-    expect(completed.findingCount).toBe(3);
-    expect(completed.warnings).toHaveLength(3);
+    expect(completed.findingCount).toBe(4);
+    expect(completed.warnings).toHaveLength(6);
     expect(
       completed.warnings.some(
         (warning) =>
@@ -932,15 +967,29 @@ describe("malformed scan artifact recovery", () => {
       ),
     ).toBe(true);
     expect(
-      completed.warnings.some((warning) =>
+      completed.warnings.filter((warning) =>
         warning.startsWith("Skipped malformed codeEvidence for finding"),
+      ),
+    ).toHaveLength(2);
+    expect(
+      completed.warnings.some(
+        (warning) =>
+          warning.includes("Recovered finding") &&
+          warning.includes("dropped dangling rootCause.evidenceRefs"),
       ),
     ).toBe(true);
     expect(
       completed.warnings.some(
         (warning) =>
           warning.includes("Recovered finding") &&
-          warning.includes("dropped dangling rootCause.evidenceRefs"),
+          warning.includes("dropped dangling attackPath.evidenceRefs"),
+      ),
+    ).toBe(true);
+    expect(
+      completed.warnings.some(
+        (warning) =>
+          warning.includes("Recovered finding") &&
+          warning.includes("dropped dangling attackPath.dataflow.evidenceRefs"),
       ),
     ).toBe(true);
 
@@ -961,6 +1010,18 @@ describe("malformed scan artifact recovery", () => {
     expect(
       (malformedEvidenceRecovered as Record<string, unknown>)?.["rootCause"],
     ).toMatchObject({ evidenceRefs: [] });
+
+    const duplicateEvidenceRecovered = recovered.find(
+      (finding) => finding?.identity.anchor === "duplicate-evidence",
+    );
+    expect(duplicateEvidenceRecovered).toBeDefined();
+    expect(duplicateEvidenceRecovered).not.toHaveProperty("codeEvidence");
+    expect(
+      (duplicateEvidenceRecovered as Record<string, unknown>)?.["attackPath"],
+    ).toMatchObject({
+      evidenceRefs: [],
+      dataflow: { evidenceRefs: [] },
+    });
   });
 
   test("keeps verified coverage receipts and downgrades invalid coverage", async () => {

--- a/sdk/typescript/tests-ts/scan-recovery.test.ts
+++ b/sdk/typescript/tests-ts/scan-recovery.test.ts
@@ -886,23 +886,52 @@ describe("malformed scan artifact recovery", () => {
     }
   });
 
-  test("keeps findings while recovering missing taxonomy CWE and malformed code evidence", async () => {
+  test("backfills a missing taxonomy.cwe instead of discarding the finding", async () => {
     const fixture = await startDraftScan();
     const path = join(fixture.scanDir, "findings.json");
     const document = await readJson<FindingsDocument>(path);
-    const valid = document.findings[0]!;
 
-    const missingCwe = structuredClone(valid);
+    const missingCwe = structuredClone(document.findings[0]!);
     missingCwe.identity.anchor = "missing-cwe";
-    const missingCweTaxonomy = (missingCwe as Record<string, unknown>)[
+    const taxonomy = (missingCwe as Record<string, unknown>)[
       "taxonomy"
     ] as Partial<{ cwe: string[] }>;
-    delete missingCweTaxonomy.cwe;
+    delete taxonomy.cwe;
+    document.findings.push(missingCwe);
+    await writeJson(path, document);
 
-    const malformedEvidence = structuredClone(valid);
+    const completed = await completeScan(fixture);
+
+    expect(completed.progress.status).toBe("complete");
+    expect(completed.findingCount).toBe(2);
+    expect(completed.warnings).toHaveLength(1);
+    expect(
+      completed.warnings.some(
+        (warning) =>
+          warning.includes("Recovered finding") &&
+          warning.includes("backfilled missing taxonomy.cwe"),
+      ),
+    ).toBe(true);
+
+    const recovered = (await readJson<FindingsDocument>(path)).findings.find(
+      (finding) => finding?.identity.anchor === "missing-cwe",
+    );
+    expect(recovered).toBeDefined();
+    expect((recovered as Record<string, unknown>)?.["taxonomy"]).toMatchObject({
+      cwe: [],
+    });
+  });
+
+  test("drops schema-invalid codeEvidence and prunes the rootCause references it strands", async () => {
+    const fixture = await startDraftScan();
+    const path = join(fixture.scanDir, "findings.json");
+    const document = await readJson<FindingsDocument>(path);
+
+    const malformedEvidence = structuredClone(document.findings[0]!);
     malformedEvidence.identity.anchor = "malformed-evidence";
     (malformedEvidence as Record<string, unknown>)["codeEvidence"] = [
-      // Missing the required `explanation` field.
+      // Missing the required `explanation` field, so the JSON-schema pass
+      // rejects it while the hand-rolled validator would accept it.
       {
         id: "ev1",
         label: "sink",
@@ -915,11 +944,47 @@ describe("malformed scan artifact recovery", () => {
       summary: "Dangling reference regression check.",
       evidenceRefs: ["ev1"],
     };
+    document.findings.push(malformedEvidence);
+    await writeJson(path, document);
 
-    // A codeEvidence malformation caught by the hand-rolled validator itself
-    // (duplicate ids), not only by the JSON-schema pass, plus a dangling
-    // reference in the nested `attackPath.dataflow.evidenceRefs` location.
-    const duplicateEvidence = structuredClone(valid);
+    const completed = await completeScan(fixture);
+
+    expect(completed.progress.status).toBe("complete");
+    expect(completed.findingCount).toBe(2);
+    expect(completed.warnings).toHaveLength(2);
+    expect(
+      completed.warnings.filter((warning) =>
+        warning.startsWith("Skipped malformed codeEvidence for finding"),
+      ),
+    ).toHaveLength(1);
+    expect(
+      completed.warnings.some(
+        (warning) =>
+          warning.includes("Recovered finding") &&
+          warning.includes("dropped dangling rootCause.evidenceRefs"),
+      ),
+    ).toBe(true);
+
+    const recovered = (await readJson<FindingsDocument>(path)).findings.find(
+      (finding) => finding?.identity.anchor === "malformed-evidence",
+    );
+    expect(recovered).toBeDefined();
+    expect(recovered).not.toHaveProperty("codeEvidence");
+    expect((recovered as Record<string, unknown>)?.["rootCause"]).toMatchObject(
+      { evidenceRefs: [] },
+    );
+  });
+
+  test("drops duplicate codeEvidence ids and prunes nested attackPath references", async () => {
+    const fixture = await startDraftScan();
+    const path = join(fixture.scanDir, "findings.json");
+    const document = await readJson<FindingsDocument>(path);
+
+    // Duplicate ids are caught by the hand-rolled validator rather than the
+    // JSON-schema pass, so this exercises the other detection path. The
+    // stranded references also live in the nested
+    // `attackPath.dataflow.evidenceRefs` location, not just the top level.
+    const duplicateEvidence = structuredClone(document.findings[0]!);
     duplicateEvidence.identity.anchor = "duplicate-evidence";
     (duplicateEvidence as Record<string, unknown>)["codeEvidence"] = [
       {
@@ -950,34 +1015,19 @@ describe("malformed scan artifact recovery", () => {
       },
       evidenceRefs: ["ev1"],
     };
-
-    document.findings.push(missingCwe, malformedEvidence, duplicateEvidence);
+    document.findings.push(duplicateEvidence);
     await writeJson(path, document);
 
     const completed = await completeScan(fixture);
 
     expect(completed.progress.status).toBe("complete");
-    expect(completed.findingCount).toBe(4);
-    expect(completed.warnings).toHaveLength(6);
-    expect(
-      completed.warnings.some(
-        (warning) =>
-          warning.includes("Recovered finding") &&
-          warning.includes("backfilled missing taxonomy.cwe"),
-      ),
-    ).toBe(true);
+    expect(completed.findingCount).toBe(2);
+    expect(completed.warnings).toHaveLength(3);
     expect(
       completed.warnings.filter((warning) =>
         warning.startsWith("Skipped malformed codeEvidence for finding"),
       ),
-    ).toHaveLength(2);
-    expect(
-      completed.warnings.some(
-        (warning) =>
-          warning.includes("Recovered finding") &&
-          warning.includes("dropped dangling rootCause.evidenceRefs"),
-      ),
-    ).toBe(true);
+    ).toHaveLength(1);
     expect(
       completed.warnings.some(
         (warning) =>
@@ -993,31 +1043,13 @@ describe("malformed scan artifact recovery", () => {
       ),
     ).toBe(true);
 
-    const recovered = (await readJson<FindingsDocument>(path)).findings;
-    const missingCweRecovered = recovered.find(
-      (finding) => finding?.identity.anchor === "missing-cwe",
-    );
-    expect(missingCweRecovered).toBeDefined();
-    expect(
-      (missingCweRecovered as Record<string, unknown>)?.["taxonomy"],
-    ).toMatchObject({ cwe: [] });
-
-    const malformedEvidenceRecovered = recovered.find(
-      (finding) => finding?.identity.anchor === "malformed-evidence",
-    );
-    expect(malformedEvidenceRecovered).toBeDefined();
-    expect(malformedEvidenceRecovered).not.toHaveProperty("codeEvidence");
-    expect(
-      (malformedEvidenceRecovered as Record<string, unknown>)?.["rootCause"],
-    ).toMatchObject({ evidenceRefs: [] });
-
-    const duplicateEvidenceRecovered = recovered.find(
+    const recovered = (await readJson<FindingsDocument>(path)).findings.find(
       (finding) => finding?.identity.anchor === "duplicate-evidence",
     );
-    expect(duplicateEvidenceRecovered).toBeDefined();
-    expect(duplicateEvidenceRecovered).not.toHaveProperty("codeEvidence");
+    expect(recovered).toBeDefined();
+    expect(recovered).not.toHaveProperty("codeEvidence");
     expect(
-      (duplicateEvidenceRecovered as Record<string, unknown>)?.["attackPath"],
+      (recovered as Record<string, unknown>)?.["attackPath"],
     ).toMatchObject({
       evidenceRefs: [],
       dataflow: { evidenceRefs: [] },

--- a/sdk/typescript/tests-ts/scan-recovery.test.ts
+++ b/sdk/typescript/tests-ts/scan-recovery.test.ts
@@ -1024,6 +1024,63 @@ describe("malformed scan artifact recovery", () => {
     });
   });
 
+  test("prunes non-string evidenceRefs entries instead of crashing recovery", async () => {
+    const fixture = await startDraftScan();
+    const path = join(fixture.scanDir, "findings.json");
+    const document = await readJson<FindingsDocument>(path);
+    const valid = document.findings[0]!;
+
+    // codeEvidence is malformed so it gets stripped, and evidenceRefs mixes a
+    // valid string with unhashable (object/array) and non-string (number)
+    // garbage that a malfunctioning producer could emit. Recovery must prune
+    // these rather than crash when testing set membership.
+    const garbageRefs = structuredClone(valid);
+    garbageRefs.identity.anchor = "garbage-evidence-refs";
+    (garbageRefs as Record<string, unknown>)["codeEvidence"] = [
+      {
+        id: "ev1",
+        label: "sink",
+        path: "src/extract.py",
+        startLine: 1,
+        code: "x = 1",
+      },
+    ];
+    (garbageRefs as Record<string, unknown>)["rootCause"] = {
+      summary: "Non-string evidenceRefs regression check.",
+      evidenceRefs: ["ev1", { nested: "garbage" }, ["nested", "garbage"], 42],
+    };
+
+    document.findings.push(garbageRefs);
+    await writeJson(path, document);
+
+    const completed = await completeScan(fixture);
+
+    expect(completed.progress.status).toBe("complete");
+    expect(completed.findingCount).toBe(2);
+    expect(
+      completed.warnings.some((warning) =>
+        warning.startsWith("Skipped malformed codeEvidence for finding"),
+      ),
+    ).toBe(true);
+    expect(
+      completed.warnings.some(
+        (warning) =>
+          warning.includes("Recovered finding") &&
+          warning.includes("dropped dangling rootCause.evidenceRefs"),
+      ),
+    ).toBe(true);
+
+    const recovered = (await readJson<FindingsDocument>(path)).findings;
+    const garbageRefsRecovered = recovered.find(
+      (finding) => finding?.identity.anchor === "garbage-evidence-refs",
+    );
+    expect(garbageRefsRecovered).toBeDefined();
+    expect(garbageRefsRecovered).not.toHaveProperty("codeEvidence");
+    expect(
+      (garbageRefsRecovered as Record<string, unknown>)?.["rootCause"],
+    ).toMatchObject({ evidenceRefs: [] });
+  });
+
   test("keeps verified coverage receipts and downgrades invalid coverage", async () => {
     const fixture = await startDraftScan();
     const path = join(fixture.scanDir, "coverage.json");


### PR DESCRIPTION
## Summary

`finalize_scan_contract.py` already salvages a malformed `writeup`, `remediationTests`, or
`preventiveControls` field by dropping just that field and keeping the finding. Any other schema
mismatch falls through to the outer handler and discards the **entire finding** instead.

Two concrete cases hit this even though the finding's actual content is otherwise fine:

- `taxonomy.cwe` is optional in the hand-rolled validator (defaults to an empty list) but required
  as a key by the JSON schema, so a finding missing the key outright is silently dropped in full.
- `codeEvidence` is optional at the finding level, but a single malformed entry (missing
  `explanation`, wrong shape, missing `id`, duplicate `id`, etc.) currently fails the whole finding
  instead of just that auxiliary field, unlike its sibling optional fields.

A real, otherwise-valid finding can vanish from `report.md`, `findings.json`, SARIF, and CSV because
one optional field was malformed, with only a generic completion warning as a trace.

## Changes

- Backfill a missing `taxonomy.cwe` key to an empty list before final schema validation, matching
  the hand-rolled validator's own tolerant default.
- Extend the existing auxiliary-field salvage pattern to `codeEvidence`: a malformed entry drops
  just that field, keeping the finding.
- Move `codeEvidence` recovery ahead of `_validate_finding`. The hand-rolled validator independently
  rejects some `codeEvidence` malformations (non-array, non-object entries, missing `id`, duplicate
  `id`) before the schema-based recovery would otherwise run, so validating/stripping `codeEvidence`
  first ensures every malformation type is salvaged consistently, not only the ones a bare
  JSON-schema check would catch.
- Dropping `codeEvidence` can leave dangling `evidenceRefs` in `rootCause`, `validation`, and
  `attackPath` — including the documented nested `attackPath.dataflow.evidenceRefs` location. These
  are pruned in the same pass, with a recovery warning recorded, so the sealed contract never
  references removed evidence.

## Deliberately not changed

`identity` and `confidence.rationale` remain hard requirements in both validators. There is no safe
default for `identity`, and `confidence.rationale` is a genuine content requirement rather than a
validator mismatch, so a finding missing either is still (correctly) discarded.

## Verification

Reproduced directly against `finalize_scan_contract.py` and the bundled example finding before any
change: a missing `taxonomy.cwe` and five distinct malformed-`codeEvidence` shapes each discarded
the whole finding. After the fix, all seven cases are recovered — finding kept, offending
field/reference stripped, warning recorded — while `identity`/`confidence.rationale` cases are
unchanged.

Added a regression case to `tests-ts/scan-recovery.test.ts` covering all of the above, including the
nested `attackPath.dataflow.evidenceRefs` case. Confirmed the test fails against unpatched
`upstream/main` source (`findingCount` 4 → 1, all three malformed findings fully discarded) before
passing against the fix.

Full local gate: `pnpm run types`, `pnpm run test` (702 pass / 5 skip, 0 fail), `pnpm run format`,
`pnpm run build`, and the packaging check (`pnpm pack` + `check:package`) all pass.
