### PR TITLE
Normalize configured GitHub host names

### DIFF
--- a/sdk/typescript/src/bulk-scan-discovery.ts
+++ b/sdk/typescript/src/bulk-scan-discovery.ts
@@ -139,7 +139,7 @@ export async function runBulkScanWizard(
   }
   signal?.throwIfAborted();
 
-  const githubHost = dependencies.githubHost ?? "github.com";
+  const githubHost = (dependencies.githubHost ?? "github.com").toLowerCase();
   const github = await dependencies.createGitHub(githubHost, signal);
   const owner = await selectGitHubOwner(github, prompt, signal);
   prompt.write("\nFinding active repositories...\n");

--- a/sdk/typescript/tests-ts/bulk-scan-discovery.test.ts
+++ b/sdk/typescript/tests-ts/bulk-scan-discovery.test.ts
@@ -321,6 +321,22 @@ describe("bulk scan repository discovery", () => {
     );
   });
 
+  test("normalizes configured GitHub host names", async () => {
+    const root = await temporaryDirectory();
+    const { dependencies, prompt, hosts } = discoveryDependencies(root, {
+      host: "GitHub.COM",
+    });
+    prompt.confirms = [true];
+
+    const result = await runBulkScanWizard(dependencies);
+
+    expect(result?.githubHost).toBe("github.com");
+    expect(hosts).toEqual(["github.com"]);
+    expect(await readFile(result!.inputPath, "utf8")).toContain(
+      "https://github.com/acme/payments-api.git",
+    );
+  });
+
   test("requires an existing GitHub sign-in", async () => {
     const root = await temporaryDirectory();
     const { dependencies, requests } = discoveryDependencies(root, {


### PR DESCRIPTION
## Summary

- canonicalize the configured GitHub host before authentication and repository discovery
- ensure case variants of `github.com` use the public GitHub API instead of the Enterprise `/api/v3` base
- use the canonical host consistently in generated repository URLs and downstream credential configuration
- add full wizard regression coverage for `GitHub.COM`

## Root cause

GitHub hostnames are case-insensitive, but the discovery path compared the configured value to lowercase `github.com` with a case-sensitive string check. A valid value such as `GH_HOST=GitHub.com` was therefore treated as GitHub Enterprise and produced the wrong API base URL.

## Impact

Case variants of public and Enterprise GitHub hostnames now resolve consistently. Existing lowercase configurations are unchanged.

## Overlap check

Repository-wide issue and pull-request searches were run for `GH_HOST`, GitHub host casing, and the incorrect `api/v3` public API path. No active or closed issue or pull request overlaps this fix.

## Validation

- `pnpm dlx bun test --timeout 30000 ./tests-ts/bulk-scan-discovery.test.ts` — 11 passed
- `pnpm exec tsc --noEmit`
- `pnpm exec prettier --check src/bulk-scan-discovery.ts tests-ts/bulk-scan-discovery.test.ts`
- `git diff --check`