### PR TITLE
Handle quoted authentication URLs

### DIFF
--- a/sdk/typescript/src/auth.ts
+++ b/sdk/typescript/src/auth.ts
@@ -461,7 +461,7 @@ export async function runCodex(
 
 function preferredAuthUrl(value: string): string | null {
   for (const match of plainTerminalText(value).matchAll(
-    /https?:\/\/[^\s<>]+/g,
+    /https?:\/\/[^\s<>"']+/g,
   )) {
     const url = match[0].replace(/[.,;:!?)\]}]+$/, "");
     try {

--- a/sdk/typescript/tests-ts/auth.test.ts
+++ b/sdk/typescript/tests-ts/auth.test.ts
@@ -58,7 +58,7 @@ if (args.join(" ") === "login --with-api-key") {
   console.error("Listening on http://[::ffff:127.0.0.1]:1455.");
   console.error("Listening on http://[::ffff:0.0.0.0]:1455.");
   console.error("Listening on http://[::127.0.0.1]:1455.");
-  console.error("Open \\u001b[32mhttps://127.auth.example.test/device\\u001b[0m");
+  console.error('Open "\\u001b[32mhttps://127.auth.example.test/device\\u001b[0m"');
   console.error("Enter this one-time code");
   console.error("\\u001b[36m8356-V2EGR\\u001b[0m");
   process.exit(0);
@@ -167,7 +167,7 @@ setInterval(() => {}, 1000);
     await expect(logout(command, process.env)).resolves.toBeUndefined();
   });
 
-  test("captures interactive login metadata and completion", async () => {
+  test("captures quoted interactive login metadata and completion", async () => {
     const command = await fakeCodex();
     let succeeded = false;
     const handle = new CodexLoginHandle(


### PR DESCRIPTION
## Summary

- stop authentication URL discovery at single- and double-quote delimiters
- cover quoted, ANSI-decorated device-login output with a regression test

## Root cause

The terminal URL matcher allowed quote characters inside a matched token. When Codex printed a verification URL in quotes, the closing quote was retained and became part of the returned URL path.

## Impact

Interactive login callers now receive the exact verification URL when terminal output wraps it in quotes.

## Overlap check

Searched open issues and pull requests for quoted authentication URLs, device-auth URL quoting, and the affected helper name; no overlapping work was found.

## Validation

- `pnpm dlx bun test --timeout 30000 ./tests-ts/auth.test.ts` (16 passed, 1 platform skip)
- `pnpm exec tsc --noEmit`
- `pnpm exec prettier --check src/auth.ts tests-ts/auth.test.ts`
- `git diff --cached --check`