### PR TITLE
release: bump Codex Security to 0.1.5

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-security",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "TypeScript SDK and CLI for Codex Security",
   "license": "Apache-2.0",
   "author": "OpenAI",


### PR DESCRIPTION
## Summary

- Bump `@openai/codex-security` from `0.1.4` to `0.1.5` with a one-line manifest change on the current `main`; preserve the frozen dependency lockfile and protected, provenance-enabled release workflows.
- Ship the 16 commits merged since `npm-v0.1.4`, including:
  - Private scan output and contributor/runtime security hardening ([#118](https://github.com/openai/codex-security/pull/118), [#152](https://github.com/openai/codex-security/pull/152)).
  - Resilient finding recovery and actionable missing-artifact/first-scan errors ([#83](https://github.com/openai/codex-security/pull/83), [#159](https://github.com/openai/codex-security/pull/159), [#167](https://github.com/openai/codex-security/pull/167)).
  - Nested Git snapshot support, scan comparison matching, clearer scan errors, and polished completion summaries ([#113](https://github.com/openai/codex-security/pull/113), [#114](https://github.com/openai/codex-security/pull/114), [#115](https://github.com/openai/codex-security/pull/115), [#116](https://github.com/openai/codex-security/pull/116)).
  - Verified automated npm/GitHub releases and safe historical release backfills ([#91](https://github.com/openai/codex-security/pull/91), [#165](https://github.com/openai/codex-security/pull/165), [#166](https://github.com/openai/codex-security/pull/166)).
  - Protected multi-architecture container publication, manifest verification, and registry-attestation hardening ([#17](https://github.com/openai/codex-security/pull/17), [#161](https://github.com/openai/codex-security/pull/161), [#162](https://github.com/openai/codex-security/pull/162), [#163](https://github.com/openai/codex-security/pull/163)).

## Validation

- Confirmed `main` and the latest public GitHub release are `0.1.4`, with no competing `0.1.5` release PR or `npm-v0.1.5` tag.
- `pnpm install --frozen-lockfile --offline`: passed; all 95 locked dependencies restored without changing the lockfile.
- `pnpm run types`: passed.
- `pnpm run format`: passed.
- `bun test --timeout 30000 ./tests-ts`: **706 passed, 5 expected platform/integration skips, 0 failures** across 32 files.
- `pnpm run build`: passed.
- Release automation accepts the stable package version, the `0.1.4 → 0.1.5` increase, and the exact `npm-v0.1.5` tag.
- Packed `openai-codex-security-0.1.5.tgz` using the protected release workflow's exact `gitHead` stamping procedure for commit `3187364e5aa0d43fc25d47e111e87c1e8d472acc`; the temporary stamp is not included in this PR.
- Exact-commit `check:package`: **179 validated archive entries**, matching release provenance, all **95 bundled plugin files**, and a fresh-install SDK/CLI smoke.
- Independent `pnpm run test:package -- /private/tmp/codex-security-release-0.1.5/openai-codex-security-0.1.5.tgz`: passed, including the public SDK import and installed CLI.
- Validated artifact SHA-256: `e74ea6b9155e7eec3afe798f17c7e6e92d6da30746dae1f2d6cec3db9130295f`.

## Release

After review and merge, the existing `node-release-cut` workflow observes the version change on `main`, creates `npm-v0.1.5` on the exact merged commit, and dispatches the protected, provenance-enabled `node-release` workflow. Publication still depends on the protected npm release environment and its verification gates; opening this PR does not publish the package.
