### PR TITLE
fix(docx): preserve manual line breaks

### DIFF
--- a/sdk/typescript/src/knowledge-base.ts
+++ b/sdk/typescript/src/knowledge-base.ts
@@ -204,6 +204,7 @@ function extractDocx(path: string, bytes: Uint8Array): string {
     return decodeXml(
       xml
         .replace(/<\/(?:\w+:)?p\s*>/gu, "\n")
+        .replace(/<(?:\w+:)?(?:br|cr)\b[^>]*>/gu, "\n")
         .replace(/<(?:\w+:)?tab\b[^>]*\/>/gu, "\t")
         .replace(/<[^>]+>/gu, ""),
     );

--- a/sdk/typescript/tests-ts/knowledge-base.test.ts
+++ b/sdk/typescript/tests-ts/knowledge-base.test.ts
@@ -44,10 +44,14 @@ async function extractedDocuments(path: string): Promise<string[]> {
   );
 }
 
-function docx(text: string): Uint8Array {
+function docx(
+  text: string,
+  secondLine?: string,
+  breakElement = "<w:br/>",
+): Uint8Array {
   return zipSync({
     "word/document.xml": strToU8(
-      `<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>${text}</w:t></w:r></w:p></w:body></w:document>`,
+      `<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>${text}</w:t></w:r>${secondLine === undefined ? "" : `${breakElement}<w:r><w:t>${secondLine}</w:t></w:r>`}</w:p></w:body></w:document>`,
     ),
   });
 }
@@ -232,14 +236,27 @@ describe("scan knowledge bases", () => {
       join(root, "architecture.pdf"),
       pdf("Payment service boundary"),
     );
-    await writeFile(join(root, "threat-model.docx"), docx("SSRF &amp; IDOR"));
+    await writeFile(
+      join(root, "threat-model.docx"),
+      docx("SSRF &amp; IDOR", "Review authentication"),
+    );
+    await writeFile(
+      join(root, "paired-break.docx"),
+      docx("Authorization", "Review permissions", "<w:br></w:br>"),
+    );
+    await writeFile(
+      join(root, "carriage-return.docx"),
+      docx("Authentication", "Review sessions", "<w:cr/>"),
+    );
 
     const knowledgeBase = await prepareKnowledgeBase([root]);
     temporaryDirectories.push(knowledgeBase.path);
     const documents = await extractedDocuments(knowledgeBase.path);
 
     expect(documents).toContain("Payment service boundary");
-    expect(documents).toContain("SSRF & IDOR\n");
+    expect(documents).toContain("SSRF & IDOR\nReview authentication\n");
+    expect(documents).toContain("Authorization\nReview permissions\n");
+    expect(documents).toContain("Authentication\nReview sessions\n");
   });
 
   test("cleans up documents and rediscovers directory contents on later runs", async () => {


### PR DESCRIPTION
## Summary

DOCX manual line breaks are removed during knowledge-base extraction, joining words across lines. Translate WordprocessingML br and cr elements into newlines.

## Changes

- Preserve both break element forms, including paired elements.
- Cover manual breaks alongside existing PDF and DOCX extraction behavior.

## Testing

- Knowledge-base suite on Windows: 14 passed, 2 platform skips.
- TypeScript typecheck and changed-file Prettier checks passed.

## Risk and rollout

No public API changes. The output now preserves document line boundaries. Upstream Actions currently require maintainer approval.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
