### PR TITLE
Accept RFC 3339 leap seconds

### DIFF
--- a/sdk/typescript/src/contract.ts
+++ b/sdk/typescript/src/contract.ts
@@ -1192,7 +1192,7 @@ function validRfc3339DateTime(value: string): boolean {
     day < 1 ||
     hour > 23 ||
     minute > 59 ||
-    second > 59 ||
+    second > 60 ||
     offsetHour > 23 ||
     offsetMinute > 59
   ) {

--- a/sdk/typescript/tests-ts/contract.test.ts
+++ b/sdk/typescript/tests-ts/contract.test.ts
@@ -373,6 +373,18 @@ describe("canonical scan contract", () => {
     ).resolves.toBeDefined();
   });
 
+  test("accepts RFC 3339 leap-second timestamps", async () => {
+    const scanDir = await copyExample();
+    const manifestPath = join(scanDir, "scan-manifest.json");
+    const manifest = await readJson(manifestPath);
+    manifest["scan"]["completedAt"] = "2016-12-31T23:59:60Z";
+    manifest["scan"]["sealedAt"] = "2016-12-31T23:59:60Z";
+    await writeJson(manifestPath, manifest);
+    await expect(
+      loadContract(scanDir, { pluginRoot: PLUGIN_ROOT }),
+    ).resolves.toBeDefined();
+  });
+
   test("requires completed and sealed timestamps to match exactly", async () => {
     const scanDir = await copyExample();
     const manifestPath = join(scanDir, "scan-manifest.json");


### PR DESCRIPTION
## Summary

- accept RFC 3339 leap-second timestamps with a seconds value of `60`
- add contract coverage using the 2016-12-31 leap second

## Root cause

The custom RFC 3339 validator capped seconds at `59`, even though RFC 3339 permits `60` for an inserted leap second.

## Impact

Canonical scan contracts containing a standards-compliant leap-second timestamp are no longer rejected as malformed.

## Overlap check

Searched open issues and pull requests for leap seconds, RFC 3339 second `60`, and the affected validator name. The newest open pull requests are unrelated.

## Validation

- `pnpm dlx bun test --timeout 30000 ./tests-ts/contract.test.ts` (26 passed, 4 platform skips)
- `pnpm exec tsc --noEmit`
- `pnpm exec prettier --check src/contract.ts tests-ts/contract.test.ts`
- `git diff --check`