### PR TITLE
ci: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/container-ci.yml
+++ b/.github/workflows/container-ci.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -240,7 +240,7 @@ jobs:
 
     steps:
       - name: Checkout release source
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -321,7 +321,7 @@ jobs:
 
     steps:
       - name: Checkout approved release source
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -417,7 +417,7 @@ jobs:
 
     steps:
       - name: Checkout approved customer configuration
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -564,7 +564,7 @@ jobs:
 
     steps:
       - name: Checkout approved immutable-version verifier
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -46,14 +46,14 @@ jobs:
           cache_dependency_path: sdk/typescript/pnpm-lock.yaml
 
       - name: Set up Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node }}
           cache: npm
           cache-dependency-path: sdk/typescript/pnpm-lock.yaml
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.14"
 

--- a/.github/workflows/node-github-release.yml
+++ b/.github/workflows/node-github-release.yml
@@ -38,14 +38,14 @@ jobs:
 
     steps:
       - name: Checkout release automation
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
           ref: refs/heads/main
 
       - name: Set up Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24.15.0"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/node-release-cut.yml
+++ b/.github/workflows/node-release-cut.yml
@@ -25,13 +25,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24.15.0"
           package-manager-cache: false

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -29,19 +29,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Socket Firewall
-        uses: SocketDev/action@937f824ec476dfd164d4a4d9995751427b0be143 # v1
+        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
           firewall-version: "1.15.0"
 
       - name: Set up Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.13.0"
           package-manager-cache: false
@@ -67,7 +67,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.14"
           no-cache: true
@@ -220,13 +220,13 @@ jobs:
 
     steps:
       - name: Checkout release verification source
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24.15.0"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
## Summary

Surveyed open and closed PRs in this repo: no existing PR updates the GitHub Actions to their latest released versions (the most recent CI work, #163, #91, #84, #10, touched workflow logic, not action versions).

Updates all SHA-pinned actions to their latest stable tags:

| Action | From | To |
| --- | --- | --- |
| `actions/checkout` | `de0fac2e…` # v6.0.2 | `3d3c42e5…` # v7.0.1 |
| `actions/setup-node` | `53b83947…` # v6 | `82076278…` # v7.0.0 |
| `SocketDev/action` | `937f824e…` # v1 | `ba6de6cc…` # v1.3.2 |
| `oven-sh/setup-bun` | comment only | # v2.2.0 (pinned commit already v2.2.0) |

Unchanged (already at latest): `docker/setup-buildx-action` v4.2.0, `docker/build-push-action` v7.3.0, `docker/login-action` v4.6.0, `pnpm/action-setup` v6.0.9, `actions/upload-artifact` v7.0.1, `actions/download-artifact` v8.0.1, `actions/attest-build-provenance` v4.1.1.

No breaking input changes: checkout v7 drops no inputs used here and adds fork-PR safety for `pull_request_target`/`workflow_run`; setup-node v7 migrates to ESM and keeps `node-version`/`cache`/`registry-url`/`package-manager-cache` support.

## Verification

- All 6 workflow YAML files parse cleanly.
- No stale pinned SHAs remain.
- Changes are limited to `uses:` pins and version comments.