### PR TITLE
fix: coalesce cost polling without changing tracker API

### DIFF
--- a/sdk/typescript/src/cost.ts
+++ b/sdk/typescript/src/cost.ts
@@ -49,6 +49,8 @@ interface ScanCostSnapshot {
   cost: ScanCost | null;
 }
 
+type ScanCostRefreshTask = () => Promise<void>;
+
 const MODEL_PRICING_NANODOLLARS: Readonly<Record<string, ModelPricing>> = {
   "gpt-5.6": [5_000, 500, 6_250, 30_000],
   "gpt-5.6-sol": [5_000, 500, 6_250, 30_000],
@@ -62,15 +64,21 @@ const MAX_SESSION_EVENT_BYTES = 1 * 1_024 * 1_024;
 
 export class ScanCostTracker {
   readonly #options: ScanCostTrackerOptions;
+  readonly #refreshTask: ScanCostRefreshTask;
   readonly #sessions = new Map<string, SessionUsage>();
   #threadId: string | null = null;
   #timer: NodeJS.Timeout | null = null;
-  #pending: Promise<void> = Promise.resolve();
+  #activeRefresh: Promise<void> | null = null;
+  #queuedRefresh: Promise<void> | null = null;
   #snapshot: ScanCostSnapshot = { usage: null, cost: null };
   #lastCost: number | null = null;
 
-  public constructor(options: ScanCostTrackerOptions) {
+  public constructor(
+    options: ScanCostTrackerOptions,
+    refreshTask?: ScanCostRefreshTask,
+  ) {
     this.#options = options;
+    this.#refreshTask = refreshTask ?? (() => this.#readSessions());
   }
 
   public start(threadId: string): void {
@@ -88,10 +96,12 @@ export class ScanCostTracker {
   }
 
   public async refresh(): Promise<ScanCostSnapshot> {
-    const update = this.#pending.then(async () => {
-      await this.#readSessions();
-    });
-    this.#pending = update.catch(() => {});
+    const update =
+      this.#activeRefresh === null
+        ? this.#startRefresh()
+        : (this.#queuedRefresh ??= this.#activeRefresh
+            .catch(() => {})
+            .then(this.#refreshTask));
     await update;
     return this.#snapshot;
   }
@@ -107,6 +117,31 @@ export class ScanCostTracker {
     this.#snapshot = { usage: fallbackUsage ?? null, cost };
     this.#reportCost(cost);
     return this.#snapshot;
+  }
+
+  #startRefresh(): Promise<void> {
+    const update = Promise.resolve().then(this.#refreshTask);
+    this.#activeRefresh = update;
+    void update.then(
+      () => this.#finishRefresh(update),
+      () => this.#finishRefresh(update),
+    );
+    return update;
+  }
+
+  #finishRefresh(finished: Promise<void>): void {
+    if (this.#activeRefresh !== finished) return;
+    const queued = this.#queuedRefresh;
+    if (queued === null) {
+      this.#activeRefresh = null;
+      return;
+    }
+    this.#activeRefresh = queued;
+    this.#queuedRefresh = null;
+    void queued.then(
+      () => this.#finishRefresh(queued),
+      () => this.#finishRefresh(queued),
+    );
   }
 
   async #readSessions(): Promise<void> {

--- a/sdk/typescript/src/cost.ts
+++ b/sdk/typescript/src/cost.ts
@@ -49,8 +49,6 @@ interface ScanCostSnapshot {
   cost: ScanCost | null;
 }
 
-type ScanCostRefreshTask = () => Promise<void>;
-
 const MODEL_PRICING_NANODOLLARS: Readonly<Record<string, ModelPricing>> = {
   "gpt-5.6": [5_000, 500, 6_250, 30_000],
   "gpt-5.6-sol": [5_000, 500, 6_250, 30_000],
@@ -64,31 +62,40 @@ const MAX_SESSION_EVENT_BYTES = 1 * 1_024 * 1_024;
 
 export class ScanCostTracker {
   readonly #options: ScanCostTrackerOptions;
-  readonly #refreshTask: ScanCostRefreshTask;
   readonly #sessions = new Map<string, SessionUsage>();
   #threadId: string | null = null;
   #timer: NodeJS.Timeout | null = null;
-  #activeRefresh: Promise<void> | null = null;
-  #queuedRefresh: Promise<void> | null = null;
+  #pending: Promise<void> = Promise.resolve();
   #snapshot: ScanCostSnapshot = { usage: null, cost: null };
   #lastCost: number | null = null;
 
-  public constructor(
-    options: ScanCostTrackerOptions,
-    refreshTask?: ScanCostRefreshTask,
-  ) {
+  public constructor(options: ScanCostTrackerOptions) {
     this.#options = options;
-    this.#refreshTask = refreshTask ?? (() => this.#readSessions());
   }
 
   public start(threadId: string): void {
     if (this.#threadId !== null) return;
     this.#threadId = threadId;
     if (this.#options.maxCostUsd === undefined) return;
+    let polling = false;
+    let rerun = false;
     const poll = () => {
-      void this.refresh().catch((error: unknown) => {
-        this.#options.onError?.(error);
-      });
+      if (polling) {
+        rerun = true;
+        return;
+      }
+      polling = true;
+      void this.refresh()
+        .catch((error: unknown) => {
+          this.#options.onError?.(error);
+        })
+        .finally(() => {
+          polling = false;
+          if (rerun && this.#timer !== null) {
+            rerun = false;
+            poll();
+          }
+        });
     };
     this.#timer = setInterval(poll, COST_POLL_INTERVAL_MS);
     this.#timer.unref();
@@ -96,12 +103,10 @@ export class ScanCostTracker {
   }
 
   public async refresh(): Promise<ScanCostSnapshot> {
-    const update =
-      this.#activeRefresh === null
-        ? this.#startRefresh()
-        : (this.#queuedRefresh ??= this.#activeRefresh
-            .catch(() => {})
-            .then(this.#refreshTask));
+    const update = this.#pending.then(async () => {
+      await this.#readSessions();
+    });
+    this.#pending = update.catch(() => {});
     await update;
     return this.#snapshot;
   }
@@ -117,31 +122,6 @@ export class ScanCostTracker {
     this.#snapshot = { usage: fallbackUsage ?? null, cost };
     this.#reportCost(cost);
     return this.#snapshot;
-  }
-
-  #startRefresh(): Promise<void> {
-    const update = Promise.resolve().then(this.#refreshTask);
-    this.#activeRefresh = update;
-    void update.then(
-      () => this.#finishRefresh(update),
-      () => this.#finishRefresh(update),
-    );
-    return update;
-  }
-
-  #finishRefresh(finished: Promise<void>): void {
-    if (this.#activeRefresh !== finished) return;
-    const queued = this.#queuedRefresh;
-    if (queued === null) {
-      this.#activeRefresh = null;
-      return;
-    }
-    this.#activeRefresh = queued;
-    this.#queuedRefresh = null;
-    void queued.then(
-      () => this.#finishRefresh(queued),
-      () => this.#finishRefresh(queued),
-    );
   }
 
   async #readSessions(): Promise<void> {

--- a/sdk/typescript/tests-ts/cost.test.ts
+++ b/sdk/typescript/tests-ts/cost.test.ts
@@ -13,6 +13,14 @@ import { estimateScanCost, ScanCostTracker } from "../src/cost.js";
 
 const temporaryDirectories: string[] = [];
 
+async function waitFor(check: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (check()) return;
+    await Promise.resolve();
+  }
+  throw new Error("Timed out waiting for the cost tracker.");
+}
+
 afterEach(async () => {
   await Promise.all(
     temporaryDirectories
@@ -142,6 +150,70 @@ describe("scan cost", () => {
 });
 
 describe("live scan cost tracking", () => {
+  test("coalesces overlapping refreshes and bounds final work", async () => {
+    const releases: Array<() => void> = [];
+    const tracker = new ScanCostTracker(
+      {
+        codexHome: await codexHome(),
+        model: "gpt-5.6-sol",
+      },
+      () => {
+        return new Promise<void>((resolve) => {
+          releases.push(() => resolve());
+        });
+      },
+    );
+    tracker.start("scan-thread");
+
+    const first = tracker.refresh();
+    await waitFor(() => releases.length === 1);
+    const overlapping = [
+      tracker.refresh(),
+      tracker.refresh(),
+      tracker.refresh(),
+    ];
+    const stopped = tracker.stop({
+      input_tokens: 100,
+      output_tokens: 10,
+    });
+    await Promise.resolve();
+    expect(releases).toHaveLength(1);
+
+    releases[0]!();
+    await waitFor(() => releases.length >= 2);
+    releases[1]!();
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      await Promise.resolve();
+    }
+    expect(releases).toHaveLength(2);
+
+    const snapshots = await Promise.all([first, ...overlapping]);
+    expect(snapshots.every((snapshot) => snapshot === snapshots[0])).toBe(true);
+    expect((await stopped).cost?.inputTokens).toBe(100);
+  });
+
+  test("recovers after a failed refresh", async () => {
+    let traversals = 0;
+    const tracker = new ScanCostTracker(
+      {
+        codexHome: await codexHome(),
+        model: "gpt-5.6-sol",
+      },
+      async () => {
+        traversals += 1;
+        if (traversals === 1) throw new Error("session read failed");
+      },
+    );
+    tracker.start("scan-thread");
+
+    await expect(tracker.refresh()).rejects.toThrow("session read failed");
+    await expect(tracker.refresh()).resolves.toEqual({
+      usage: null,
+      cost: null,
+    });
+    expect(traversals).toBe(2);
+  });
+
   test("counts the scan and delegated workers without including other scans", async () => {
     const home = await codexHome();
     await writeSession(home, "scan-thread", {

--- a/sdk/typescript/tests-ts/cost.test.ts
+++ b/sdk/typescript/tests-ts/cost.test.ts
@@ -16,7 +16,7 @@ const temporaryDirectories: string[] = [];
 async function waitFor(check: () => boolean): Promise<void> {
   for (let attempt = 0; attempt < 100; attempt += 1) {
     if (check()) return;
-    await Promise.resolve();
+    await new Promise<void>((resolve) => setTimeout(resolve, 5));
   }
   throw new Error("Timed out waiting for the cost tracker.");
 }
@@ -150,68 +150,76 @@ describe("scan cost", () => {
 });
 
 describe("live scan cost tracking", () => {
-  test("coalesces overlapping refreshes and bounds final work", async () => {
-    const releases: Array<() => void> = [];
-    const tracker = new ScanCostTracker(
-      {
-        codexHome: await codexHome(),
-        model: "gpt-5.6-sol",
-      },
-      () => {
-        return new Promise<void>((resolve) => {
-          releases.push(() => resolve());
-        });
-      },
-    );
-    tracker.start("scan-thread");
-
-    const first = tracker.refresh();
-    await waitFor(() => releases.length === 1);
-    const overlapping = [
-      tracker.refresh(),
-      tracker.refresh(),
-      tracker.refresh(),
-    ];
-    const stopped = tracker.stop({
+  test("coalesces overlapping polling ticks and bounds final work", async () => {
+    const home = await codexHome();
+    await writeSession(home, "scan-thread", {
       input_tokens: 100,
       output_tokens: 10,
     });
-    await Promise.resolve();
-    expect(releases).toHaveLength(1);
-
-    releases[0]!();
-    await waitFor(() => releases.length >= 2);
-    releases[1]!();
-    for (let attempt = 0; attempt < 10; attempt += 1) {
-      await Promise.resolve();
-    }
-    expect(releases).toHaveLength(2);
-
-    const snapshots = await Promise.all([first, ...overlapping]);
-    expect(snapshots.every((snapshot) => snapshot === snapshots[0])).toBe(true);
-    expect((await stopped).cost?.inputTokens).toBe(100);
-  });
-
-  test("recovers after a failed refresh", async () => {
-    let traversals = 0;
-    const tracker = new ScanCostTracker(
-      {
-        codexHome: await codexHome(),
-        model: "gpt-5.6-sol",
-      },
-      async () => {
-        traversals += 1;
-        if (traversals === 1) throw new Error("session read failed");
-      },
-    );
+    const releases: Array<() => void> = [];
+    const tracker = new ScanCostTracker({
+      codexHome: home,
+      model: "gpt-5.6-sol",
+      maxCostUsd: 1,
+    });
+    const refresh = tracker.refresh.bind(tracker);
+    tracker.refresh = async () => {
+      await new Promise<void>((resolve) => releases.push(resolve));
+      return refresh();
+    };
     tracker.start("scan-thread");
 
-    await expect(tracker.refresh()).rejects.toThrow("session read failed");
-    await expect(tracker.refresh()).resolves.toEqual({
-      usage: null,
-      cost: null,
+    await new Promise<void>((resolve) => setTimeout(resolve, 350));
+    expect(releases).toHaveLength(1);
+
+    const stopped = tracker.stop();
+    expect(releases).toHaveLength(2);
+    releases[0]!();
+    releases[1]!();
+
+    expect((await stopped).cost?.inputTokens).toBe(100);
+    expect(releases).toHaveLength(2);
+  });
+
+  test("retries one coalesced poll after a failed refresh", async () => {
+    const home = await codexHome();
+    await writeSession(home, "scan-thread", {
+      input_tokens: 100,
+      output_tokens: 10,
     });
+    const errors: string[] = [];
+    let traversals = 0;
+    let release: (() => void) | undefined;
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tracker = new ScanCostTracker({
+      codexHome: home,
+      model: "gpt-5.6-sol",
+      maxCostUsd: 1,
+      onError: (error) => {
+        if (error instanceof Error) errors.push(error.message);
+      },
+    });
+    const refresh = tracker.refresh.bind(tracker);
+    tracker.refresh = async () => {
+      traversals += 1;
+      if (traversals === 1) {
+        await blocked;
+        throw new Error("session read failed");
+      }
+      return refresh();
+    };
+    tracker.start("scan-thread");
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 250));
+    expect(traversals).toBe(1);
+    release!();
+    await waitFor(() => traversals === 2);
+
+    expect(errors).toEqual(["session read failed"]);
     expect(traversals).toBe(2);
+    expect((await tracker.stop()).cost?.inputTokens).toBe(100);
   });
 
   test("counts the scan and delegated workers without including other scans", async () => {


### PR DESCRIPTION
## Summary

Fixes #31. Builds directly on #177 and preserves @SiavashShams's original contributor-authored commit.

- Coalesce overlapping cost-polling interval ticks inside `ScanCostTracker.start()` instead of replacing the existing refresh serializer.
- Preserve the existing one-argument tracker constructor and remove the test-only refresh-task injection added by #177.
- Run at most one polling traversal at a time, remember whether any interval ticks arrived during that traversal, and immediately perform one follow-up while tracking remains active.
- Keep `stop()` authoritative: stopping clears the timer, suppresses any stale follow-up, and serializes exactly one final session refresh behind the in-flight poll.
- Deliver a failed poll to `onError` exactly once and allow the coalesced follow-up to recover normally.
- Exercise actual 100 ms timer ticks, real session JSONL files, bounded shutdown, failed traversal recovery, and deduplicated error reporting without widening production APIs for tests.

## Why

Each budgeted scan polls the Codex session tree every 100 ms. On `main`, every tick appends another full traversal to the refresh promise chain when filesystem work takes longer than the interval. The result is an unbounded backlog and unnecessarily long scan shutdown.

The existing refresh serializer already provides the ordering required by explicit refreshes and `stop()`. Coalescing only the interval producer fixes the actual source of the backlog while retaining those established semantics and avoiding a second scheduler.

With 3,000 real session files and no injected filesystem latency, a representative local run produced:

| Implementation | Session traversals | Session files opened | Shutdown wait |
| --- | ---: | ---: | ---: |
| Current `main` | 5 | 15,000 | 1,577 ms |
| This PR | 3 | 9,000 | 363 ms |

The new polling regression fails against unmodified `main`: four overlapping polling requests are observed where the fixed implementation permits one.

## Validation

- Full pinned Bun 1.3.14 suite: **717 passed, 5 expected platform/integration skips, 0 failed** across 32 files.
- Focused cost-tracker suite: **15 passed**.
- Focused cost-tracker compatibility checks on Node.js **22, 24, and 26**.
- `pnpm run types`.
- `pnpm run format`.
- `pnpm run build`.
- `pnpm pack` and complete package-contract validation: **179 verified entries**.
- Built SDK import/cost-estimation smoke and CLI version smoke.
- `git diff --check`.

This change addresses refresh backlog and shutdown latency. It does not claim to eliminate the separate cost of recursively discovering historical session files.
