### PR TITLE
fix(git): decode workbench text output as UTF-8

### DIFF
--- a/sdk/typescript/_bundled_plugin/scripts/workbench_target.py
+++ b/sdk/typescript/_bundled_plugin/scripts/workbench_target.py
@@ -144,6 +144,7 @@ def git_command(
             full_command,
             check=False,
             capture_output=True,
+            encoding="utf-8" if text and os.name == "nt" else None,
             env=environment,
             text=text,
             input=input_data,

--- a/sdk/typescript/tests-ts/workbench-canonical-paths.test.ts
+++ b/sdk/typescript/tests-ts/workbench-canonical-paths.test.ts
@@ -129,6 +129,60 @@ function runPythonProbe(
 }
 
 describe("bundled workbench canonical paths", () => {
+  testWindows("decodes non-ASCII Git worktree paths as UTF-8", async () => {
+    const root = await temporaryDirectory();
+    const repository = join(root, "репозиторий");
+    await mkdir(repository);
+    const initialized = Bun.spawnSync(["git", "init", repository], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(initialized.exitCode).toBe(0);
+
+    expect(
+      runPythonProbe(
+        [
+          "import json, sys",
+          "from pathlib import Path",
+          "sys.path.insert(0, sys.argv[1])",
+          "import workbench_target as target",
+          "original_run = target.subprocess.run",
+          "def legacy_run(*args, **kwargs):",
+          "    if kwargs.get('text') and kwargs.get('encoding') is None:",
+          "        kwargs['encoding'] = 'cp1252'",
+          "    return original_run(*args, **kwargs)",
+          "target.subprocess.run = legacy_run",
+          "repository, pathspec = target.git_worktree_context(Path(sys.argv[2]))",
+          "print(json.dumps({'repository': str(repository), 'pathspec': pathspec}))",
+        ].join("\n"),
+        repository,
+      ),
+    ).toEqual({
+      repository: await realpath(repository),
+      pathspec: ".",
+    });
+  });
+
+  testPosix("uses the native decoder for Git pathname output", () => {
+    expect(
+      runPythonProbe(
+        [
+          "import json, subprocess, sys",
+          "from pathlib import Path",
+          "sys.path.insert(0, sys.argv[1])",
+          "import workbench_target as target",
+          "observed = {}",
+          "def run(command, **kwargs):",
+          "    observed['encoding'] = kwargs.get('encoding')",
+          "    return subprocess.CompletedProcess(command, 1, '', '')",
+          "target.subprocess.run = run",
+          "target.git_command(Path('.'), 'rev-parse', text=True)",
+          "print(json.dumps(observed))",
+        ].join("\n"),
+      ),
+    ).toEqual({ encoding: null });
+  });
+
   testPosix(
     "rejects private scan directories under insecure shared parents",
     async () => {


### PR DESCRIPTION
Fixes #192

## Summary

- Decode text-mode Git subprocess output as UTF-8 in the bundled workbench.
- Leave binary Git output unchanged for snapshots and object data.
- Add a Windows regression using a real Cyrillic worktree while forcing Python's locale decoder to `cp1252`.

## Root cause

`subprocess.run(..., text=True)` used Python's locale encoding. On Windows systems with a non-UTF-8 code page, Git's UTF-8 worktree path was decoded into a different string, so `Path.relative_to()` incorrectly concluded that the scan target was outside its repository.

## Impact

Windows scans can inspect valid Git worktrees whose paths contain Cyrillic or other non-ASCII characters without requiring `PYTHONUTF8=1`. POSIX behavior and byte-oriented Git commands are unchanged.

## Validation

- `pnpm dlx bun test --timeout 30000 ./tests-ts/workbench-canonical-paths.test.ts` — 4 passed, 2 platform skips
- `pnpm dlx bun test --timeout 30000 ./tests-ts/scan-recovery.test.ts` — 16 passed
- `pnpm exec tsc --noEmit`
- `python -m py_compile sdk/typescript/_bundled_plugin/scripts/workbench_target.py`
- `pnpm exec prettier --check tests-ts/workbench-canonical-paths.test.ts`
- `git diff --check`
