### PR TITLE
fix(python): preserve explicit virtualenv launchers

### DIFF
--- a/sdk/typescript/src/trusted-executable.ts
+++ b/sdk/typescript/src/trusted-executable.ts
@@ -1,7 +1,9 @@
 import { constants } from "node:fs";
 import { access, realpath, stat } from "node:fs/promises";
 import {
+  basename,
   delimiter,
+  dirname,
   extname,
   isAbsolute,
   join,
@@ -90,7 +92,18 @@ export async function resolveTrustedExecutable(
         process.platform === "win32" ? constants.F_OK : constants.X_OK,
       );
       if (!(await stat(canonical)).isFile()) continue;
-      executable ??= pathLike ? canonical : current.path;
+      const canonicalParent = await realpath(dirname(current.path)).catch(
+        () => null,
+      );
+      const invocationPath =
+        canonicalParent === null
+          ? current.path
+          : join(canonicalParent, basename(current.path));
+      // Explicit launchers outside the protected root retain invocation semantics
+      // such as Python virtualenv selection. Repository-local links still execute
+      // only the canonical target that passed the trust check.
+      executable ??=
+        pathLike && isWithin(root, invocationPath) ? canonical : current.path;
     } catch {
       continue;
     }

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -4794,6 +4794,34 @@ describe("runtime directories and plugin Python boundary", () => {
     ).rejects.toThrow(PluginPythonUnavailableError);
   });
 
+  testPosix("preserves an explicit virtualenv Python launcher", async () => {
+    const root = await temporaryDirectory();
+    const repository = join(root, "repository");
+    const systemBin = join(root, "system", "bin");
+    const virtualenvBin = join(root, "venv", "bin");
+    const systemPython = join(systemBin, "python3");
+    const virtualenvPython = join(virtualenvBin, "python");
+    await Promise.all([
+      mkdir(repository),
+      mkdir(systemBin, { recursive: true }),
+      mkdir(virtualenvBin, { recursive: true }),
+    ]);
+    await writeFile(
+      systemPython,
+      '#!/bin/sh\ncase "$0" in */venv/bin/python) ;; *) exit 1 ;; esac\nprintf "codex-security-python-ok\\n"\n',
+    );
+    await chmod(systemPython, 0o700);
+    await symlink(systemPython, virtualenvPython);
+
+    await expect(
+      resolvePluginPython({
+        configuredPath: virtualenvPython,
+        environment: { PATH: "" },
+        protectedRoot: repository,
+      }),
+    ).resolves.toBe(virtualenvPython);
+  });
+
   test.skipIf(process.platform !== "win32")(
     "uses a configured Windows Python path without the executable suffix",
     async () => {
@@ -4894,7 +4922,7 @@ describe("runtime directories and plugin Python boundary", () => {
           environment,
           protectedRoot: repository,
         }),
-      ).toBe(await realpath(interpreter));
+      ).toBe(interpreter);
       expect(existsSync(marker)).toBe(false);
     },
   );

--- a/sdk/typescript/tests-ts/trusted-executable.test.ts
+++ b/sdk/typescript/tests-ts/trusted-executable.test.ts
@@ -146,6 +146,35 @@ describe("trusted executable resolution", () => {
     },
   );
 
+  test.skipIf(process.platform === "win32")(
+    "canonicalizes aliased parents before preserving explicit launchers",
+    async () => {
+      const root = await temporaryDirectory();
+      const repository = join(root, "repository");
+      const repositoryBin = join(repository, "bin");
+      const aliasedBin = join(root, "repository-bin-alias");
+      const trusted = join(root, "trusted");
+      const wrapper = join(trusted, "python3");
+      const launcher = join(repositoryBin, "python");
+      await Promise.all([
+        mkdir(repositoryBin, { recursive: true }),
+        mkdir(trusted),
+      ]);
+      await writeFile(wrapper, "#!/bin/sh\nexit 0\n");
+      await chmod(wrapper, 0o700);
+      await symlink(wrapper, launcher);
+      await symlink(repositoryBin, aliasedBin, "dir");
+
+      await expect(
+        resolveTrustedExecutable(
+          join(aliasedBin, "python"),
+          { PATH: "" },
+          repository,
+        ),
+      ).resolves.toEqual({ executable: wrapper, environment: { PATH: "" } });
+    },
+  );
+
   test("selects runnable Windows executables ahead of extensionless and batch files", async () => {
     const root = await temporaryDirectory();
     const repository = join(root, "repository");


### PR DESCRIPTION
## Summary

Resolving an explicitly configured virtualenv Python symlink to its system interpreter loses virtualenv selection. Preserve the trusted invocation path outside the protected repository.

## Changes

- Canonicalize the launcher parent before deciding whether its invocation path is repository-controlled.
- Preserve virtualenv launcher semantics while retaining canonical targets for repository-local aliases.
- Cover the executable resolver and plugin Python subprocess boundary.

## Testing

- Trusted-executable suite: Windows 8 passed / 3 platform skips; Linux 9 passed / 2 platform skips.
- Linux explicit-virtualenv runtime regression passed.
- TypeScript typecheck and changed-file Prettier checks passed.

## Risk and rollout

No new setting or flag. Repository executable exclusions and sanitized PATH behavior remain in place. Upstream Actions currently require maintainer approval.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
