### PR TITLE
fix(auth): preserve IPv6 verification URL brackets

### DIFF
--- a/sdk/typescript/src/auth.ts
+++ b/sdk/typescript/src/auth.ts
@@ -241,9 +241,27 @@ function preferredAuthUrl(value: string): string | null {
   for (const match of plainTerminalText(value).matchAll(
     /https?:\/\/[^\s<>"']+/g,
   )) {
-    const url = match[0].replace(/[.,;:!?)\]}]+$/, "");
-    try {
-      const hostname = new URL(url).hostname.toLowerCase().replace(/\.$/, "");
+    let url = match[0].replace(/[.,;:!?)}]+$/, "");
+    while (true) {
+      let parsed: URL;
+      try {
+        parsed = new URL(url);
+      } catch {
+        if (!url.endsWith("]")) break;
+        url = url.slice(0, -1);
+        continue;
+      }
+      if (
+        url.endsWith("]") &&
+        (!parsed.hostname.startsWith("[") ||
+          parsed.pathname !== "/" ||
+          parsed.search !== "" ||
+          parsed.hash !== "")
+      ) {
+        url = url.slice(0, -1);
+        continue;
+      }
+      const hostname = parsed.hostname.toLowerCase().replace(/\.$/, "");
       if (
         hostname !== "localhost" &&
         !hostname.endsWith(".localhost") &&
@@ -257,8 +275,7 @@ function preferredAuthUrl(value: string): string | null {
       ) {
         return url;
       }
-    } catch {
-      continue;
+      break;
     }
   }
   return null;

--- a/sdk/typescript/tests-ts/auth.test.ts
+++ b/sdk/typescript/tests-ts/auth.test.ts
@@ -164,7 +164,38 @@ describe("Codex authentication process boundary", () => {
     expect(succeeded).toBe(true);
   });
 
-  test("retains large interactive output and login instructions", async () => {
+  test("distinguishes IPv6 host brackets from surrounding punctuation", async () => {
+    const root = await mkdtemp(join(tmpdir(), "codex-security-auth-ipv6-"));
+    temporaryDirectories.push(root);
+    for (const [index, output, expected] of [
+      [0, "Open https://[2001:db8::1].", "https://[2001:db8::1]"],
+      [
+        1,
+        "Open [https://auth.example.test/device]",
+        "https://auth.example.test/device",
+      ],
+      [2, "Open [https://[2001:db8::2]]", "https://[2001:db8::2]"],
+    ] as const) {
+      const script = join(root, `login-${index}.mjs`);
+      await writeFile(
+        script,
+        `console.error(${JSON.stringify(output)}); console.error("User code: ABCD-EFGH");\n`,
+      );
+      const handle = new CodexLoginHandle(
+        { command: process.execPath },
+        [script, "login", "--device-auth"],
+        process.env,
+        () => {},
+      );
+
+      await handle.waitForInstructions({ deviceCode: true });
+      expect(handle.verificationUrl).toBe(expected);
+      expect(handle.userCode).toBe("ABCD-EFGH");
+      await expect(handle.wait()).resolves.toMatchObject({ success: true });
+    }
+  });
+
+  test("bounds interactive output while retaining discovered instructions", async () => {
     const root = await mkdtemp(join(tmpdir(), "codex-security-auth-output-"));
     temporaryDirectories.push(root);
     const script = join(root, "login.mjs");


### PR DESCRIPTION
## Summary

IPv6 verification URLs lose their closing host bracket when login output is parsed. Preserve that structural bracket while removing brackets and punctuation surrounding the URL.

## Changes

- Distinguish IPv6 host syntax from surrounding prose.
- Continue trimming punctuation after removing an enclosing bracket.
- Cover plain, enclosed, path-bearing, and query-bearing IPv6 URLs with real login subprocesses.

## Testing

- Authentication suite on Windows: 10 passed, 1 platform skip.
- TypeScript typecheck and changed-file Prettier checks passed.
- `git diff --check` passed.

## Risk and rollout

No CLI or authentication-setting changes. Existing local-address exclusions remain in place. Upstream Actions currently require maintainer approval.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
