### PR TITLE
[codex-security] cut npm releases only after public CI succeeds

### DIFF
--- a/.github/workflows/node-release-cut.yml
+++ b/.github/workflows/node-release-cut.yml
@@ -66,6 +66,18 @@ jobs:
 
           version="$(node sdk/typescript/scripts/release-automation.mjs version sdk/typescript/package.json)"
 
+          if ! published_versions="$(
+            npm view @openai/codex-security versions \
+              --json \
+              --registry=https://registry.npmjs.org/
+          )"; then
+            published_versions="$(
+              printf '%s\n' "$published_versions" |
+                node sdk/typescript/scripts/release-automation.mjs \
+                  initial-published-versions "$version"
+            )"
+          fi
+
           if [[ "$GITHUB_EVENT_NAME" == "workflow_run" ]] &&
              previous_sha="$(git rev-parse "$RELEASE_SHA^" 2>/dev/null)"; then
             if previous_manifest="$(git show "$previous_sha:sdk/typescript/package.json" 2>/dev/null)"; then
@@ -81,26 +93,23 @@ jobs:
                   '
               )"
               if [[ "$version" == "$previous_version" ]]; then
-                echo "Package version is unchanged; no release is needed."
-                echo "changed=false" >> "$GITHUB_OUTPUT"
-                exit 0
+                release_mode="$(
+                  printf '%s\n' "$published_versions" |
+                    node sdk/typescript/scripts/release-automation.mjs \
+                      release-mode "$version"
+                )"
+                if [[ "$release_mode" == "recover" ]]; then
+                  echo "Package version is unchanged and already published."
+                  echo "changed=false" >> "$GITHUB_OUTPUT"
+                  exit 0
+                fi
+              else
+                node sdk/typescript/scripts/release-automation.mjs \
+                  require-increase "$version" "$previous_version" >/dev/null
               fi
-              node sdk/typescript/scripts/release-automation.mjs \
-                require-increase "$version" "$previous_version" >/dev/null
             fi
           fi
 
-          if ! published_versions="$(
-            npm view @openai/codex-security versions \
-              --json \
-              --registry=https://registry.npmjs.org/
-          )"; then
-            published_versions="$(
-              printf '%s\n' "$published_versions" |
-                node sdk/typescript/scripts/release-automation.mjs \
-                  initial-published-versions "$version"
-            )"
-          fi
           printf '%s\n' "$published_versions" |
             node sdk/typescript/scripts/release-automation.mjs \
               require-published-increase "$version" >/dev/null

--- a/.github/workflows/node-release-cut.yml
+++ b/.github/workflows/node-release-cut.yml
@@ -1,10 +1,10 @@
 name: node-release-cut
 
 on:
-  push:
+  workflow_run:
+    workflows: ["node-ci"]
+    types: [completed]
     branches: [main]
-    paths:
-      - sdk/typescript/package.json
   workflow_dispatch:
 
 permissions:
@@ -16,12 +16,18 @@ concurrency:
 
 jobs:
   cut:
-    if: github.repository == 'openai/codex-security'
+    if: >-
+      github.repository == 'openai/codex-security' &&
+      (github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main'))
     name: cut release tag
     runs-on: ubuntu-latest
     permissions:
       actions: write
       contents: write
+    env:
+      RELEASE_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
 
     steps:
       - name: Checkout repository
@@ -29,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
@@ -39,10 +46,9 @@ jobs:
       - name: Resolve the stable package version
         id: release
         shell: bash
-        env:
-          BEFORE_SHA: ${{ github.event.before }}
         run: |
           set -euo pipefail
+          RELEASE_SHA="${RELEASE_SHA:-$GITHUB_SHA}"
 
           if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
             echo "Release tags can only be cut from main." >&2
@@ -53,11 +59,16 @@ jobs:
             echo "Release tags can only be cut from commits on main." >&2
             exit 1
           fi
+          if ! git merge-base --is-ancestor "$RELEASE_SHA" origin/main; then
+            echo "Release tags can only be cut from commits on main." >&2
+            exit 1
+          fi
 
           version="$(node sdk/typescript/scripts/release-automation.mjs version sdk/typescript/package.json)"
 
-          if [[ "$GITHUB_EVENT_NAME" == "push" && "$BEFORE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-            if previous_manifest="$(git show "$BEFORE_SHA:sdk/typescript/package.json" 2>/dev/null)"; then
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_run" ]] &&
+             previous_sha="$(git rev-parse "$RELEASE_SHA^" 2>/dev/null)"; then
+            if previous_manifest="$(git show "$previous_sha:sdk/typescript/package.json" 2>/dev/null)"; then
               previous_version="$(
                 printf '%s\n' "$previous_manifest" |
                   node --input-type=module --eval '
@@ -108,6 +119,7 @@ jobs:
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
         run: |
           set -euo pipefail
+          RELEASE_SHA="${RELEASE_SHA:-$GITHUB_SHA}"
 
           query_status=0
           tag_response="$(
@@ -169,17 +181,17 @@ jobs:
               echo "Release tag $RELEASE_TAG does not identify a valid commit." >&2
               exit 1
             fi
-            if [[ "$existing_sha" != "$GITHUB_SHA" ]]; then
+            if [[ "$existing_sha" != "$RELEASE_SHA" ]]; then
               echo "Release tag $RELEASE_TAG already points to a different commit." >&2
               exit 1
             fi
-            echo "Release tag $RELEASE_TAG already points to $GITHUB_SHA."
+            echo "Release tag $RELEASE_TAG already points to $RELEASE_SHA."
             exit 0
           fi
 
           gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
             -f "ref=refs/tags/$RELEASE_TAG" \
-            -f "sha=$GITHUB_SHA" \
+            -f "sha=$RELEASE_SHA" \
             --silent
 
       - name: Dispatch the protected npm release

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -1476,6 +1476,109 @@ describe("GitHub release workflow safeguards", () => {
 
   test.each([
     {
+      scenario: "a successful version-increase commit",
+      event: "workflow_run",
+      previousVersion: "0.1.5",
+      currentVersion: "0.1.6",
+      publishedVersions: ["0.1.5"],
+      changed: true,
+    },
+    {
+      scenario: "a successful fix after the version-increase commit failed CI",
+      event: "workflow_run",
+      previousVersion: "0.1.6",
+      currentVersion: "0.1.6",
+      publishedVersions: ["0.1.5"],
+      changed: true,
+    },
+    {
+      scenario: "an unchanged version that has already been published",
+      event: "workflow_run",
+      previousVersion: "0.1.5",
+      currentVersion: "0.1.5",
+      publishedVersions: ["0.1.5"],
+      changed: false,
+    },
+    {
+      scenario: "a manually dispatched unpublished version",
+      event: "workflow_dispatch",
+      previousVersion: "0.1.5",
+      currentVersion: "0.1.6",
+      publishedVersions: ["0.1.5"],
+      changed: true,
+    },
+  ])(
+    "resolves $scenario against its published npm history",
+    ({
+      event,
+      previousVersion,
+      currentVersion,
+      publishedVersions,
+      changed,
+    }) => {
+      const script = workflowStepShell(
+        releaseCutWorkflow,
+        "Resolve the stable package version",
+      );
+      const mocks = [
+        "git() {",
+        '  case "$1" in',
+        "    fetch|merge-base) return 0 ;;",
+        "    rev-parse) printf '%s\\n' \"$MOCK_PREVIOUS_SHA\" ;;",
+        '    show) printf \'{"version":"%s"}\\n\' "$MOCK_PREVIOUS_VERSION" ;;',
+        "    *) return 64 ;;",
+        "  esac",
+        "}",
+        "node() {",
+        '  if [[ "${2:-}" == "version" ]]; then',
+        "    printf '%s\\n' \"$MOCK_RELEASE_VERSION\"",
+        "    return 0",
+        "  fi",
+        '  command node "$@"',
+        "}",
+        "npm() { printf '%s\\n' \"$MOCK_PUBLISHED_VERSIONS\"; }",
+      ].join("\n");
+      const workspace = mkdtempSync(
+        join(tmpdir(), "codex-security-release-cut-"),
+      );
+
+      try {
+        const outputPath = join(workspace, "outputs");
+        const result = spawnSync("bash", ["-c", `${mocks}\n${script}`], {
+          cwd: fileURLToPath(new URL("../../../", import.meta.url)),
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            GITHUB_EVENT_NAME: event,
+            GITHUB_OUTPUT: outputPath,
+            GITHUB_REF: "refs/heads/main",
+            GITHUB_SHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            MOCK_PREVIOUS_SHA: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            MOCK_PREVIOUS_VERSION: previousVersion,
+            MOCK_PUBLISHED_VERSIONS: JSON.stringify(publishedVersions),
+            MOCK_RELEASE_VERSION: currentVersion,
+            RELEASE_SHA: releaseCommit,
+          },
+          timeout: 10_000,
+        });
+
+        expect(result.stderr).toBe("");
+        expect(result.status).toBe(0);
+
+        const outputs = readFileSync(outputPath, "utf8");
+        expect(outputs).toContain(`changed=${changed}`);
+        if (changed) {
+          expect(outputs).toContain(`version=${currentVersion}`);
+          expect(outputs).toContain(`tag=npm-v${currentVersion}`);
+        }
+      } finally {
+        rmSync(workspace, { recursive: true, force: true });
+      }
+    },
+  );
+
+  test.each([
+    {
       workflow: "release cut",
       version: "0.1.0",
       errorCode: "E404",
@@ -1565,6 +1668,44 @@ describe("GitHub release workflow safeguards", () => {
       }
     },
   );
+
+  test("creates the release tag at the successful CI commit", () => {
+    const script = workflowStepShell(
+      releaseCutWorkflow,
+      "Create the exact merged release tag",
+    );
+    const mock = [
+      "gh() {",
+      '  if [[ "$1" != "api" ]]; then return 64; fi',
+      "  shift",
+      '  if [[ "$1" == "--include" ]]; then',
+      "    printf 'HTTP/2.0 404 Mock\\nContent-Type: application/json\\n\\n'",
+      '    printf \'%s\\n\' \'{"message":"Not Found","status":"404"}\'',
+      "    return 1",
+      "  fi",
+      '  if [[ "$1" != "--method" || "$2" != "POST" ||',
+      '        "$3" != "repos/test/codex-security/git/refs" ||',
+      '        "$4" != "-f" || "$5" != "ref=refs/tags/npm-v0.1.2" ||',
+      '        "$6" != "-f" || "$7" != "sha=$RELEASE_SHA" ||',
+      '        "$8" != "--silent" ]]; then return 65; fi',
+      "  printf 'created tag at %s\\n' \"$RELEASE_SHA\"",
+      "}",
+    ].join("\n");
+    const result = spawnSync("bash", ["-c", `${mock}\n${script}`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GITHUB_REPOSITORY: "test/codex-security",
+        GITHUB_SHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        RELEASE_SHA: releaseCommit,
+        RELEASE_TAG: "npm-v0.1.2",
+      },
+      timeout: 10_000,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(`created tag at ${releaseCommit}`);
+  });
 
   test.each([
     {

--- a/sdk/typescript/tests-ts/release-cut-workflow.test.ts
+++ b/sdk/typescript/tests-ts/release-cut-workflow.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { expect, test } from "bun:test";
+
+const releaseCutWorkflow = readFileSync(
+  new URL("../../../.github/workflows/node-release-cut.yml", import.meta.url),
+  "utf8",
+);
+
+test("starts npm publication only after node-ci succeeds on main", () => {
+  expect(releaseCutWorkflow).toContain("workflow_run:");
+  expect(releaseCutWorkflow).toContain('workflows: ["node-ci"]');
+  expect(releaseCutWorkflow).toContain("types: [completed]");
+  expect(releaseCutWorkflow).toContain(
+    "github.event.workflow_run.conclusion == 'success'",
+  );
+  expect(releaseCutWorkflow).toContain(
+    "github.event.workflow_run.head_branch == 'main'",
+  );
+  expect(releaseCutWorkflow).not.toContain("  push:\n");
+});
+
+test("cuts the protected release tag from the exact successful CI commit", () => {
+  expect(releaseCutWorkflow).toContain(
+    "RELEASE_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}",
+  );
+  expect(releaseCutWorkflow).toContain(
+    "ref: ${{ github.event.workflow_run.head_sha || github.sha }}",
+  );
+  expect(releaseCutWorkflow).toContain(
+    'git merge-base --is-ancestor "$RELEASE_SHA" origin/main',
+  );
+  expect(releaseCutWorkflow).toContain('git rev-parse "$RELEASE_SHA^"');
+  expect(releaseCutWorkflow).toContain('-f "sha=$RELEASE_SHA"');
+});


### PR DESCRIPTION
## Summary
- Keep npm release orchestration in the public repository.
- Start the release cut only after node-ci succeeds on main, while preserving manual dispatch.
- Check out and tag the exact successful CI commit and preserve existing release safety checks.
- Add public Bun regressions for the workflow trigger and exact release commit.

## Testing
- bun test sdk/typescript/tests-ts/release-cut-workflow.test.ts
- YAML parsing and workflow trigger assertions