### PR TITLE
fix(ci): make production dependency audits advisory

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -62,6 +62,7 @@ jobs:
 
       - name: Audit production dependencies
         if: matrix.os == 'ubuntu-latest' && matrix.node == '22.13.0'
+        continue-on-error: true
         run: pnpm --dir sdk/typescript run audit:prod
 
       - name: Typecheck

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -119,6 +119,7 @@ jobs:
         run: sfw pnpm --dir sdk/typescript install --frozen-lockfile
 
       - name: Audit production dependencies
+        continue-on-error: true
         run: sfw pnpm --dir sdk/typescript run audit:prod
 
       - name: Verify

--- a/sdk/typescript/tests-ts/skeleton.test.ts
+++ b/sdk/typescript/tests-ts/skeleton.test.ts
@@ -84,6 +84,19 @@ describe("TypeScript package skeleton", () => {
     );
   });
 
+  test("keeps production dependency audits non-blocking in CI and releases", async () => {
+    for (const workflowName of ["node-ci.yml", "node-release.yml"]) {
+      const workflow = await readFile(
+        new URL(`../../../.github/workflows/${workflowName}`, import.meta.url),
+        "utf8",
+      );
+
+      expect(workflow).toMatch(
+        /- name: Audit production dependencies\n(?:\s+if: [^\n]+\n)?\s+continue-on-error: true\n\s+run: (?:sfw )?pnpm --dir sdk\/typescript run audit:prod/u,
+      );
+    }
+  });
+
   test("exposes canonical finding and hardening fields with public types", () => {
     const finding = {} as Finding;
     const scan = {} as ScanRecord;


### PR DESCRIPTION
## Summary
- Keep production dependency audits visible in Node CI and npm releases without letting unavailable remediation block the repository.
- Preserve the existing manual `audit:prod` command and all other build, test, package, and release gates.
- Add a regression test covering both workflow audit steps.

## Verification
- `env XDG_CACHE_HOME=/private/tmp/codex-security-bun-cache pnpm dlx bun@1.3.14 test --timeout 30000 ./tests-ts/skeleton.test.ts ./tests-ts/release-automation.test.ts` (187 passing)
- `pnpm run types`
- `pnpm run format`

Dependency findings remain visible in Actions logs, but are advisory until a patched package is available through the approved registry.