### PR TITLE
fix(cli): render nested scan configuration values as JSON

### DIFF
--- a/sdk/typescript/src/scan-history-renderer.ts
+++ b/sdk/typescript/src/scan-history-renderer.ts
@@ -246,7 +246,13 @@ export function renderScanHistory(
     if (config && Object.keys(config).length > 0) {
       lines.push(
         `  ${strong("CONFIGURATION")}  ${Object.entries(config)
-          .map(([key, value]) => `${clean(key)}=${clean(value)}`)
+          .map(([key, value]) => {
+            const rendered =
+              value !== null && typeof value === "object"
+                ? JSON.stringify(value)
+                : value;
+            return `${clean(key)}=${clean(rendered)}`;
+          })
           .join(`  ${accent("·")}  `)}`,
       );
     }

--- a/sdk/typescript/src/scan-history-renderer.ts
+++ b/sdk/typescript/src/scan-history-renderer.ts
@@ -248,9 +248,7 @@ export function renderScanHistory(
         `  ${strong("CONFIGURATION")}  ${Object.entries(config)
           .map(([key, value]) => {
             const rendered =
-              value !== null && typeof value === "object"
-                ? JSON.stringify(value)
-                : value;
+              typeof value === "object" ? JSON.stringify(value) : value;
             return `${clean(key)}=${clean(rendered)}`;
           })
           .join(`  ${accent("·")}  `)}`,

--- a/sdk/typescript/tests-ts/scan-history-renderer.test.ts
+++ b/sdk/typescript/tests-ts/scan-history-renderer.test.ts
@@ -207,10 +207,7 @@ describe("scan history renderer", () => {
         config: {
           model: "gpt-5.6-sol",
           model_reasoning_effort: "high",
-          features: {
-            goals: true,
-            multi_agent_v2: { enabled: true },
-          },
+          features: { goals: true, multi_agent_v2: { enabled: true } },
           trusted_paths: ["src", "packages/core"],
         },
       },

--- a/sdk/typescript/tests-ts/scan-history-renderer.test.ts
+++ b/sdk/typescript/tests-ts/scan-history-renderer.test.ts
@@ -204,7 +204,15 @@ describe("scan history renderer", () => {
       findingsTruncated: true,
       artifacts: { markdownReport: "/demo/results/report.md" },
       recipe: {
-        config: { model: "gpt-5.6-sol", model_reasoning_effort: "high" },
+        config: {
+          model: "gpt-5.6-sol",
+          model_reasoning_effort: "high",
+          features: {
+            goals: true,
+            multi_agent_v2: { enabled: true },
+          },
+          trusted_paths: ["src", "packages/core"],
+        },
       },
       findings: Array.from({ length: 20 }, (_, index) => ({
         severity: { level: "high" },
@@ -218,6 +226,8 @@ describe("scan history renderer", () => {
       "PARENT SCAN  87654321",
       "CONFIGURATION",
       "model=gpt-5.6-sol",
+      'features={"goals":true,"multi_agent_v2":{"enabled":true}}',
+      'trusted_paths=["src","packages/core"]',
       "COVERAGE",
       "12 of 15 reviewed",
       "9 files",


### PR DESCRIPTION
## Summary

- Render nested saved scan configuration objects and arrays as compact JSON instead of `[object Object]` or flattened comma-separated values.
- Preserve existing scalar formatting and terminal-control sanitization.
- Add regression coverage for nested feature flags and configured path arrays.

## Verification

- `bun test --timeout 30000 ./tests-ts` — 773 passed, 5 skipped
- `bun test --timeout 30000 ./tests-ts/scan-history-renderer.test.ts` — 6 passed
- `tsc --noEmit`
- `prettier --check src/scan-history-renderer.ts tests-ts/scan-history-renderer.test.ts`
