### PR TITLE
fix: forward enterprise proxy and certificate settings

### DIFF
--- a/sdk/typescript/_bundled_plugin/.mcp.json
+++ b/sdk/typescript/_bundled_plugin/.mcp.json
@@ -12,7 +12,14 @@
         "PYTHON",
         "CODEX_SECURITY_KNOWLEDGE_BASE",
         "CODEX_SECURITY_SCAN_ROOT",
-        "CODEX_SECURITY_STATE_DIR"
+        "CODEX_SECURITY_STATE_DIR",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "NO_PROXY",
+        "SSL_CERT_FILE",
+        "REQUESTS_CA_BUNDLE",
+        "NODE_EXTRA_CA_CERTS"
       ],
       "tool_timeout_sec": 86400
     }


### PR DESCRIPTION
## Summary

- Forward HTTP_PROXY, HTTPS_PROXY, ALL_PROXY, NO_PROXY, SSL_CERT_FILE, REQUESTS_CA_BUNDLE, and NODE_EXTRA_CA_CERTS into the bundled MCP server.
- Allow enterprise proxy and custom-certificate configurations to reach both Node and Python scan components.

## Stack

- Independent PR targeting `main`.
- Prerequisite for the pending 0.1.6 release in #244; package version is unchanged.

## Verification

- Parsed every bundled workbench Python module.
- Verified all 94 declared plugin payload files exist.
- Initialized a fresh private workbench SQLite database successfully.
- Passed Prettier for all 1 changed formatted files.
- The complete reconstructed sync passed 775 tests (5 platform/integration skips) and the installed-package smoke test.
