### PR TITLE
fix: validate knowledge-base inputs during dry-run scans

### DIFF
--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -322,6 +322,13 @@ export class CodexSecurity {
       await realpath(tmpdir()),
       "temporary",
     );
+    if (options.knowledgeBasePaths?.length) {
+      const knowledgeBase = await prepareKnowledgeBase(
+        options.knowledgeBasePaths,
+        options.signal,
+      );
+      await knowledgeBase.cleanup();
+    }
     const configuration = await mergedCodexConfig(this.config);
     const model = scanModelConfiguration(configuration);
     validateScanCostLimit(options.maxCostUsd, model.model);

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -847,9 +847,13 @@ describe("CodexSecurity orchestration", () => {
     const repository = join(root, "repository");
     const knowledgeBase = join(root, "threat-model.md");
     const invalidDocument = join(root, "broken.pdf");
+    const unsupportedDocument = join(root, "unsupported.exe");
+    const emptyDirectory = join(root, "empty");
     await mkdir(repository);
+    await mkdir(emptyDirectory);
     await writeFile(knowledgeBase, "# Threat model\nPublic API is in scope.\n");
     await writeFile(invalidDocument, "not a PDF");
+    await writeFile(unsupportedDocument, "not a supported document");
     let runtimeStarted = false;
     const client = new TestClient(
       {},
@@ -865,6 +869,28 @@ describe("CodexSecurity orchestration", () => {
     await expect(
       client.preflight(repository, { knowledgeBasePaths: [knowledgeBase] }),
     ).resolves.toMatchObject({ knowledgeBasePaths: [knowledgeBase] });
+    const invalidDocuments: Array<[string, string]> = [
+      [join(root, "missing.md"), "ENOENT"],
+      [unsupportedDocument, "Unsupported knowledge base document"],
+      [invalidDocument, "Cannot extract text from knowledge base PDF"],
+      [
+        emptyDirectory,
+        "Knowledge base directory contains no supported documents",
+      ],
+    ];
+    if (process.platform !== "win32") {
+      const linkedDocument = join(root, "linked.md");
+      await symlink(knowledgeBase, linkedDocument);
+      invalidDocuments.push([
+        linkedDocument,
+        "Knowledge base paths cannot be symbolic links",
+      ]);
+    }
+    for (const [path, message] of invalidDocuments) {
+      await expect(
+        client.preflight(repository, { knowledgeBasePaths: [path] }),
+      ).rejects.toThrow(message);
+    }
     await expect(
       client.run(repository, {
         knowledgeBasePaths: [join(root, "missing.md")],


### PR DESCRIPTION
## Summary

- Validate knowledge-base inputs during SDK preflight so `codex-security scan --dry-run` rejects the same invalid documents as an actual scan.
- Reuse existing document parsing and clean up temporary staging immediately without initializing the Codex runtime.
- Add regression coverage for valid Markdown, missing files, unsupported formats, malformed PDFs, empty directories, and symlinks.

## Validation

- Full SDK test suite: 908 passed, 10 expected platform/integration skips.
- TypeScript typecheck, generated-model verification, and formatting checks.
- Built the CLI and executed all five invalid knowledge-base cases plus a valid Markdown case.
- Packed and installed the npm artifact; package validation passed with 198 archive entries and all 106 bundled plugin files.
