### PR TITLE
fix(windows): decode git output as UTF-8, not the process locale

### DIFF
--- a/sdk/typescript/_bundled_plugin/scripts/generate_rank_input.py
+++ b/sdk/typescript/_bundled_plugin/scripts/generate_rank_input.py
@@ -502,6 +502,10 @@ def run_git_changed_paths(repo: Path, diff_args: list[str]) -> list[tuple[Path, 
         check=True,
         capture_output=True,
         text=True,
+        # Git emits path names as UTF-8; decoding them with the process locale
+        # leaves stdout None for the split below when one tracked file has a
+        # non-ASCII name and the host codepage cannot represent it.
+        encoding="utf-8",
     )
     fields = result.stdout.split("\0")
     if fields and not fields[-1]:

--- a/sdk/typescript/_bundled_plugin/scripts/workbench_target.py
+++ b/sdk/typescript/_bundled_plugin/scripts/workbench_target.py
@@ -59,18 +59,32 @@ def git_command(
         command.extend(["--git-dir", str(git_dir), "--work-tree", str(work_tree)])
     full_command = [*command, *args]
     try:
+        if text:
+            # Git reports paths as UTF-8; text=True alone would decode them with
+            # the process locale, which on Windows is the ANSI codepage. A
+            # multi-byte codepage raises in subprocess's reader thread and leaves
+            # stdout None, which git_output then calls .strip() on.
+            return subprocess.run(
+                full_command,
+                check=False,
+                capture_output=True,
+                env=environment,
+                text=True,
+                encoding="utf-8",
+            )
         return subprocess.run(
             full_command,
             check=False,
             capture_output=True,
             env=environment,
-            text=text,
+            text=False,
         )
     except FileNotFoundError:
         # Git is optional for Codebase scans. Treat an unavailable executable like
         # any other failed Git probe so the target falls back to a directory snapshot.
-        empty_output = "" if text else b""
-        return subprocess.CompletedProcess(full_command, 127, empty_output, empty_output)
+        if text:
+            return subprocess.CompletedProcess(full_command, 127, "", "")
+        return subprocess.CompletedProcess(full_command, 127, b"", b"")
 
 
 def update_digest_field(digest: Any, label: bytes, value: bytes) -> None:


### PR DESCRIPTION
Fixes #192.

Git reports paths as UTF-8 on every platform. `subprocess.run(..., text=True)` decodes with the process locale, which on Windows is the ANSI codepage, so a non-ASCII path is decoded with the wrong codec.

I hit this on a Traditional Chinese host (cp950) and the symptom did not match the filed report, which turned out to be informative rather than a separate bug.

## Two shapes, one cause

| codepage | behaviour | what the user sees |
|---|---|---|
| single-byte, e.g. cp1251 (as filed) | every byte decodes, nothing raises, string is wrong | `Path.relative_to` fails → *"Scan target must stay inside its Git working tree."* |
| multi-byte, cp932 / cp936 / cp950 | sequence rejected outright | `UnicodeDecodeError` on subprocess's **reader thread**, so `run` returns with `returncode 0` and `stdout` **None**, and `git_output` calls `.strip()` on it → `AttributeError: 'NoneType' object has no attribute 'strip'` |

The same bytes, decoded five ways:

```
git stdout : b'.../\xe6\xb8\xac\xe8\xa9\xa6\xe5\xb0\x88\xe6\xa1\x88-...'
     utf-8 : 測試專案-繁體中文          ← correct
    cp1251 : жё¬и©¦е°€жЎ€-...          ← silently wrong, never raises
    cp1252 : UnicodeDecodeError
     cp950 : UnicodeDecodeError
     cp936 : UnicodeDecodeError
     cp932 : UnicodeDecodeError
```

## A second call site, outside the issue's scope

Sweeping the plugin for the same pattern found three `text=True` calls with no `encoding=`, and no call anywhere that passes one. Two route through `git_command`; the third is separate:

`generate_rank_input.run_git_changed_paths` reads names out of `git diff --name-status -z`. **The repository path does not need to contain non-ASCII at all** — one tracked file with a non-ASCII name is enough:

```
repo path (ascii only): ...\ascii-only-repo
tracked file          : 測試檔案.py
git stdout raw        : b'A\x00\xe6\xb8\xac\xe8\xa9\xa6\xe6\xaa\x94\xe6\xa1\x88.py\x00'

as shipped   : stdout None → AttributeError: 'NoneType' object has no attribute 'split'
encoding=utf-8: ['A', '測試檔案.py']
```

That widens the population from "checkout is in a non-ASCII folder" to "any repository containing a non-ASCII file name, scanned from a non-UTF-8 Windows host".

File I/O in the plugin is already binary (`"rb"`/`"wb"`) throughout, so this is the whole exposure I could find.

## Verification

Windows 10, Python 3.11.6, ANSI codepage cp950, git 2.52.0.windows.1, exercising the patched modules directly rather than a copy of their logic:

```
                              before                    after
CJK repo directory            AttributeError 'strip'    ok
Cyrillic repo directory       AttributeError 'strip'    ok
CJK file in ASCII repo        AttributeError 'split'    ok
pure ASCII control            ok                        ok
git_bytes returns bytes       ok                        ok
```

The Cyrillic row is the reporter's own case, confirmed fixed on this host. The ASCII control and `git_bytes` rows are there to show the text-mode branch did not disturb the binary path.

## Notes on the change

- `encoding="utf-8"` is exactly what `PYTHONUTF8=1` achieves, which #192 confirms as a workaround, without depending on the environment being set.
- No `errors=` handler. On Windows the filesystem is UTF-16 and git converts to UTF-8, so strict decoding is correct here; adding `surrogateescape` would only move a failure into JSON serialisation later.
- The text branch is now written out explicitly instead of `text=text`, because `encoding=` implies text mode and the two modes should not be conflated. That also let the `FileNotFoundError` fallback drop its `str | bytes` union.

Happy to split the second file into its own PR if you would rather keep this scoped strictly to #192.
