### PR TITLE
fix: stabilize and speed up Windows credential ACL verification

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -90,7 +90,7 @@ jobs:
           TMP: ${{ steps.windows-temp.outputs.path || runner.temp }}
           TMPDIR: ${{ steps.windows-temp.outputs.path || runner.temp }}
           CODEX_SECURITY_ALLOW_MACHINE_POLICY_TEST: ${{ runner.environment == 'github-hosted' && runner.os == 'Windows' && 'true' || 'false' }}
-        run: pnpm --dir sdk/typescript run test ${{ runner.os == 'Windows' && '--timeout 60000' || '' }}
+        run: pnpm --dir sdk/typescript run test
 
       - name: Check formatting
         run: pnpm --dir sdk/typescript run format

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -90,7 +90,7 @@ jobs:
           TMP: ${{ steps.windows-temp.outputs.path || runner.temp }}
           TMPDIR: ${{ steps.windows-temp.outputs.path || runner.temp }}
           CODEX_SECURITY_ALLOW_MACHINE_POLICY_TEST: ${{ runner.environment == 'github-hosted' && runner.os == 'Windows' && 'true' || 'false' }}
-        run: pnpm --dir sdk/typescript run test
+        run: pnpm --dir sdk/typescript run test ${{ runner.os == 'Windows' && '--timeout 60000' || '' }}
 
       - name: Check formatting
         run: pnpm --dir sdk/typescript run format

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -371,6 +371,12 @@ class RepairableWindowsCredentialAclError extends Error {
   }
 }
 
+class RepairableWindowsCredentialOwnerError extends Error {
+  public constructor(cause: UntrustedWindowsCredentialOwnerError) {
+    super(cause.message, { cause });
+  }
+}
+
 /** Inspect a Windows DACL without translating locale-specific account names. */
 export function inspectWindowsCredentialAcl(
   descriptor: string,
@@ -573,6 +579,7 @@ function windowsAceAllowsAncestorReplacement(
 export async function verifyStableWindowsCredentialDescendants(
   path: string,
   inspectDescriptors: () => Promise<number>,
+  options: { inspectEmpty?: boolean } = {},
 ): Promise<void> {
   for (let attempt = 0; attempt < 3; attempt += 1) {
     let descendants = 0;
@@ -603,7 +610,7 @@ export async function verifyStableWindowsCredentialDescendants(
       }
       throw error;
     }
-    if (descendants === 0) return;
+    if (descendants === 0 && options.inspectEmpty !== true) return;
 
     if ((await inspectDescriptors()) === descendants) return;
   }
@@ -670,6 +677,106 @@ export async function streamWindowsCredentialAclDescriptors(
   return descriptors;
 }
 
+export async function inspectWindowsCredentialAclSnapshot(
+  path: string,
+  currentUserSid: string,
+  options: {
+    command: string;
+    args: readonly string[];
+    environment?: NodeJS.ProcessEnv;
+    resolvedAliases?: Readonly<Record<string, string>>;
+    resolveDescriptorAliases?: (descriptor: string) => Promise<void>;
+  },
+): Promise<{
+  home: WindowsCredentialAcl;
+  descendantsArePrivate: boolean;
+}> {
+  let ancestors = 0;
+  for (let ancestor = dirname(path); ; ancestor = dirname(ancestor)) {
+    ancestors += 1;
+    if (ancestor === dirname(ancestor)) break;
+  }
+
+  let home: WindowsCredentialAcl | undefined;
+  let descendantsArePrivate = true;
+  await verifyStableWindowsCredentialDescendants(
+    path,
+    async () => {
+      home = undefined;
+      descendantsArePrivate = true;
+      let inspected = 0;
+      const descriptors = await streamWindowsCredentialAclDescriptors(
+        options.command,
+        options.args,
+        async (descriptor) => {
+          const index = inspected;
+          inspected += 1;
+          await options.resolveDescriptorAliases?.(descriptor);
+
+          if (index < ancestors) {
+            const ancestor = inspectWindowsCredentialAcl(
+              descriptor,
+              currentUserSid,
+              {
+                resolvedAliases: options.resolvedAliases,
+                scope: "ancestor",
+              },
+            );
+            if (ancestor.untrustedPrincipals.length !== 0) {
+              throw new Error(
+                "Windows credential-home ancestor allows another identity to replace the directory",
+              );
+            }
+            return;
+          }
+
+          if (index === ancestors) {
+            try {
+              home = inspectWindowsCredentialAcl(descriptor, currentUserSid, {
+                resolvedAliases: options.resolvedAliases,
+              });
+            } catch (error) {
+              if (error instanceof UntrustedWindowsCredentialOwnerError) {
+                throw new RepairableWindowsCredentialOwnerError(error);
+              }
+              throw new RepairableWindowsCredentialAclError(error);
+            }
+            return;
+          }
+
+          const descendant = inspectWindowsCredentialAcl(
+            descriptor,
+            currentUserSid,
+            {
+              resolvedAliases: options.resolvedAliases,
+              scope: "file",
+            },
+          );
+          if (
+            !descendant.grantsCurrentUserAccess ||
+            descendant.untrustedPrincipals.length !== 0
+          ) {
+            descendantsArePrivate = false;
+          }
+        },
+        { environment: options.environment },
+      );
+      if (descriptors <= ancestors) {
+        throw new Error(
+          "Windows credential-home ancestry could not be verified",
+        );
+      }
+      return descriptors - ancestors - 1;
+    },
+    { inspectEmpty: true },
+  );
+
+  if (home === undefined) {
+    throw new Error("Windows credential ACL could not be verified");
+  }
+  return { home, descendantsArePrivate };
+}
+
 async function secureWindowsCredentialHome(path: string): Promise<void> {
   const systemRoot = process.env["SystemRoot"] ?? "C:\\Windows";
   const systemDirectory = join(systemRoot, "System32");
@@ -715,7 +822,10 @@ async function secureWindowsCredentialHome(path: string): Promise<void> {
   // arbitrary .NET constructors, static methods, and SID translation do not.
   const script = [
     "$ErrorActionPreference = 'Stop'",
+    "$path = $env:CODEX_SECURITY_CREDENTIAL_ACL_PATH",
+    "while ($true) { $parent = Microsoft.PowerShell.Management\\Split-Path -Path $path -Parent; if (-not $parent -or $parent -eq $path) { break }; Microsoft.PowerShell.Security\\Get-Acl -LiteralPath $parent | Microsoft.PowerShell.Utility\\Select-Object -ExpandProperty Sddl; $path = $parent }",
     "Microsoft.PowerShell.Security\\Get-Acl -LiteralPath $env:CODEX_SECURITY_CREDENTIAL_ACL_PATH | Microsoft.PowerShell.Utility\\Select-Object -ExpandProperty Sddl",
+    "Microsoft.PowerShell.Management\\Get-ChildItem -LiteralPath $env:CODEX_SECURITY_CREDENTIAL_ACL_PATH -Recurse -Force | Microsoft.PowerShell.Security\\Get-Acl | Microsoft.PowerShell.Utility\\Select-Object -ExpandProperty Sddl",
   ].join("; ");
   const resolvePrincipalScript = [
     "$ErrorActionPreference = 'Stop'",
@@ -770,21 +880,17 @@ async function secureWindowsCredentialHome(path: string): Promise<void> {
       remaining = rest;
     }
   };
+  let descendantsArePrivate = true;
   const readAcl = async (): Promise<WindowsCredentialAcl> => {
-    const descriptor = await execFile(
-      powershell,
-      ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
-      processOptions,
-    );
-    try {
-      await resolveDescriptorAliases(descriptor.stdout);
-      return inspectWindowsCredentialAcl(descriptor.stdout, sid, {
-        resolvedAliases,
-      });
-    } catch (error) {
-      if (error instanceof UntrustedWindowsCredentialOwnerError) throw error;
-      throw new RepairableWindowsCredentialAclError(error);
-    }
+    const snapshot = await inspectWindowsCredentialAclSnapshot(path, sid, {
+      command: powershell,
+      args: ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
+      environment: processOptions.env,
+      resolvedAliases,
+      resolveDescriptorAliases,
+    });
+    descendantsArePrivate = snapshot.descendantsArePrivate;
+    return snapshot.home;
   };
 
   const icacls = join(systemDirectory, "icacls.exe");
@@ -802,81 +908,12 @@ async function secureWindowsCredentialHome(path: string): Promise<void> {
       processOptions,
     );
   };
-  const ancestorScript = [
-    "$ErrorActionPreference = 'Stop'",
-    "$path = $env:CODEX_SECURITY_CREDENTIAL_ACL_PATH",
-    "while ($true) { $parent = Microsoft.PowerShell.Management\\Split-Path -Path $path -Parent; if (-not $parent -or $parent -eq $path) { break }; Microsoft.PowerShell.Security\\Get-Acl -LiteralPath $parent | Microsoft.PowerShell.Utility\\Select-Object -ExpandProperty Sddl; $path = $parent }",
-  ].join("; ");
-  const ancestorPaths: string[] = [];
-  for (let ancestor = dirname(path); ; ancestor = dirname(ancestor)) {
-    ancestorPaths.push(ancestor);
-    if (ancestor === dirname(ancestor)) break;
-  }
-  const ancestry = await execFile(
-    powershell,
-    ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", ancestorScript],
-    processOptions,
-  );
-  const ancestorDescriptors = ancestry.stdout
-    .split(/\r?\n/u)
-    .filter((descriptor) => descriptor !== "");
-  if (ancestorDescriptors.length !== ancestorPaths.length) {
-    throw new Error("Windows credential-home ancestry could not be verified");
-  }
-  for (const descriptor of ancestorDescriptors) {
-    await resolveDescriptorAliases(descriptor);
-    const ancestor = inspectWindowsCredentialAcl(descriptor, sid, {
-      resolvedAliases,
-      scope: "ancestor",
-    });
-    if (ancestor.untrustedPrincipals.length === 0) continue;
-    throw new Error(
-      "Windows credential-home ancestor allows another identity to replace the directory",
-    );
-  }
-
-  const descendantsArePrivate = async (): Promise<boolean> => {
-    const descendantScript = [
-      "$ErrorActionPreference = 'Stop'",
-      "Microsoft.PowerShell.Management\\Get-ChildItem -LiteralPath $env:CODEX_SECURITY_CREDENTIAL_ACL_PATH -Recurse -Force | Microsoft.PowerShell.Security\\Get-Acl | Microsoft.PowerShell.Utility\\Select-Object -ExpandProperty Sddl",
-    ].join("; ");
-    let privateDescendants = true;
-    await verifyStableWindowsCredentialDescendants(path, async () => {
-      privateDescendants = true;
-      return streamWindowsCredentialAclDescriptors(
-        powershell,
-        [
-          "-NoLogo",
-          "-NoProfile",
-          "-NonInteractive",
-          "-Command",
-          descendantScript,
-        ],
-        async (descriptor) => {
-          await resolveDescriptorAliases(descriptor);
-          const descendant = inspectWindowsCredentialAcl(descriptor, sid, {
-            resolvedAliases,
-            scope: "file",
-          });
-          if (
-            !descendant.grantsCurrentUserAccess ||
-            descendant.untrustedPrincipals.length !== 0
-          ) {
-            privateDescendants = false;
-          }
-        },
-        { environment: processOptions.env },
-      );
-    });
-    return privateDescendants;
-  };
-
   let existing: WindowsCredentialAcl | undefined;
   for (let attempt = 0; existing === undefined && attempt < 3; attempt += 1) {
     try {
       existing = await readAcl();
     } catch (error) {
-      if (error instanceof UntrustedWindowsCredentialOwnerError) {
+      if (error instanceof RepairableWindowsCredentialOwnerError) {
         await execFile(icacls, [path, "/setowner", `*${sid}`], processOptions);
       } else if (error instanceof RepairableWindowsCredentialAclError) {
         await installTrustedAcl();
@@ -947,13 +984,14 @@ async function secureWindowsCredentialHome(path: string): Promise<void> {
   if (verified.untrustedPrincipals.length !== 0) {
     throw new Error("Windows credential ACL grants access to another identity");
   }
-  if (!(await descendantsArePrivate())) {
+  if (!descendantsArePrivate) {
     await execFile(
       icacls,
       [join(path, "*"), "/reset", "/t", "/q"],
       processOptions,
     );
-    if (!(await descendantsArePrivate())) {
+    await readAcl();
+    if (!descendantsArePrivate) {
       throw new Error("Windows credential descendants remain accessible");
     }
   }

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -577,23 +577,31 @@ export async function verifyStableWindowsCredentialDescendants(
   for (let attempt = 0; attempt < 3; attempt += 1) {
     let descendants = 0;
     const pending = [path];
-    while (pending.length !== 0) {
-      const current = pending.pop()!;
-      const directory = await opendir(current);
-      for await (const entry of directory) {
-        const child = join(current, entry.name);
-        const metadata = await lstat(child);
-        if (metadata.isSymbolicLink()) {
-          throw new Error(
-            "Windows credential home contains a symbolic link or junction",
-          );
+    try {
+      while (pending.length !== 0) {
+        const current = pending.pop()!;
+        const directory = await opendir(current);
+        for await (const entry of directory) {
+          const child = join(current, entry.name);
+          const metadata = await lstat(child);
+          if (metadata.isSymbolicLink()) {
+            throw new Error(
+              "Windows credential home contains a symbolic link or junction",
+            );
+          }
+          if (!metadata.isDirectory() && !metadata.isFile()) {
+            throw new Error("Windows credential home contains an unsafe entry");
+          }
+          descendants += 1;
+          if (metadata.isDirectory()) pending.push(child);
         }
-        if (!metadata.isDirectory() && !metadata.isFile()) {
-          throw new Error("Windows credential home contains an unsafe entry");
-        }
-        descendants += 1;
-        if (metadata.isDirectory()) pending.push(child);
       }
+    } catch (error) {
+      const failure = error as NodeJS.ErrnoException;
+      if (failure.code === "ENOENT" && failure.path !== path) {
+        continue;
+      }
+      throw error;
     }
     if (descendants === 0) return;
 

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -58,6 +58,7 @@ import {
   codexSecurityStateDirectory,
   codexPlatformPackage,
   inspectWindowsCredentialAcl,
+  inspectWindowsCredentialAclSnapshot,
   isPythonPathCandidate,
   planOutputArchive,
   prepareCodexSecurityCredentialHome,
@@ -2040,6 +2041,132 @@ describe("runtime directories and plugin Python boundary", () => {
       }),
     ).rejects.toThrow("Windows credential descendants could not be verified");
     expect(attempts).toBe(3);
+  });
+
+  test("inspects Windows credential ancestry, home, and descendants in one subprocess", async () => {
+    const root = await temporaryDirectory();
+    const home = join(root, "home");
+    const inspectionCount = join(root, "inspection-count");
+    await mkdir(home);
+    await writeFile(join(home, "auth.json"), "credential\n");
+    const sid = "S-1-5-21-111-222-333-1001";
+    const directory = `O:${sid}G:SYD:P(A;OICI;FA;;;${sid})`;
+    const file = `O:${sid}G:SYD:P(A;;FA;;;${sid})`;
+    const ancestors: string[] = [];
+    for (let ancestor = dirname(home); ; ancestor = dirname(ancestor)) {
+      ancestors.push(directory);
+      if (ancestor === dirname(ancestor)) break;
+    }
+    const descriptors = [...ancestors, directory, file];
+    const script = [
+      `require("node:fs").appendFileSync(${JSON.stringify(inspectionCount)}, "inspection\\n")`,
+      `process.stdout.write(${JSON.stringify(`${descriptors.join("\n")}\n`)})`,
+    ].join("; ");
+
+    const snapshot = await inspectWindowsCredentialAclSnapshot(home, sid, {
+      command: process.execPath,
+      args: ["--eval", script],
+    });
+
+    expect(snapshot.home).toMatchObject({
+      owner: sid,
+      protected: true,
+      grantsCurrentUserAccess: true,
+      untrustedPrincipals: [],
+    });
+    expect(snapshot.descendantsArePrivate).toBe(true);
+    expect(await readFile(inspectionCount, "utf8")).toBe("inspection\n");
+  });
+
+  test("inspects Windows credential ancestry and the home even without descendants", async () => {
+    const root = await temporaryDirectory();
+    const home = join(root, "home");
+    await mkdir(home);
+    const sid = "S-1-5-21-111-222-333-1001";
+    const directory = `O:${sid}G:SYD:P(A;OICI;FA;;;${sid})`;
+    const ancestors: string[] = [];
+    for (let ancestor = dirname(home); ; ancestor = dirname(ancestor)) {
+      ancestors.push(directory);
+      if (ancestor === dirname(ancestor)) break;
+    }
+    const descriptors = [...ancestors, directory];
+
+    await expect(
+      inspectWindowsCredentialAclSnapshot(home, sid, {
+        command: process.execPath,
+        args: [
+          "--eval",
+          `process.stdout.write(${JSON.stringify(`${descriptors.join("\n")}\n`)})`,
+        ],
+      }),
+    ).resolves.toMatchObject({
+      home: { owner: sid, protected: true },
+      descendantsArePrivate: true,
+    });
+  });
+
+  test("rejects unsafe Windows credential ancestry during combined ACL inspection", async () => {
+    const root = await temporaryDirectory();
+    const home = join(root, "home");
+    await mkdir(home);
+    const sid = "S-1-5-21-111-222-333-1001";
+    const unsafe = `O:${sid}G:SYD:P(A;OICI;FA;;;${sid})(A;OICI;FA;;;WD)`;
+
+    await expect(
+      inspectWindowsCredentialAclSnapshot(home, sid, {
+        command: process.execPath,
+        args: [
+          "--eval",
+          `process.stdout.write(${JSON.stringify(`${unsafe}\n`)})`,
+        ],
+      }),
+    ).rejects.toThrow(
+      "Windows credential-home ancestor allows another identity to replace the directory",
+    );
+  });
+
+  test("rejects incomplete combined Windows credential ACL inspections", async () => {
+    const root = await temporaryDirectory();
+    const home = join(root, "home");
+    await mkdir(home);
+    const sid = "S-1-5-21-111-222-333-1001";
+    const directory = `O:${sid}G:SYD:P(A;OICI;FA;;;${sid})`;
+
+    await expect(
+      inspectWindowsCredentialAclSnapshot(home, sid, {
+        command: process.execPath,
+        args: [
+          "--eval",
+          `process.stdout.write(${JSON.stringify(`${directory}\n`)})`,
+        ],
+      }),
+    ).rejects.toThrow("Windows credential-home ancestry could not be verified");
+  });
+
+  test("detects unsafe descendants during combined Windows credential ACL inspections", async () => {
+    const root = await temporaryDirectory();
+    const home = join(root, "home");
+    await mkdir(home);
+    await writeFile(join(home, "auth.json"), "credential\n");
+    const sid = "S-1-5-21-111-222-333-1001";
+    const directory = `O:${sid}G:SYD:P(A;OICI;FA;;;${sid})`;
+    const unsafeFile = `O:${sid}G:SYD:P(A;;FA;;;${sid})(A;;FR;;;WD)`;
+    const ancestors: string[] = [];
+    for (let ancestor = dirname(home); ; ancestor = dirname(ancestor)) {
+      ancestors.push(directory);
+      if (ancestor === dirname(ancestor)) break;
+    }
+    const descriptors = [...ancestors, directory, unsafeFile];
+
+    await expect(
+      inspectWindowsCredentialAclSnapshot(home, sid, {
+        command: process.execPath,
+        args: [
+          "--eval",
+          `process.stdout.write(${JSON.stringify(`${descriptors.join("\n")}\n`)})`,
+        ],
+      }),
+    ).resolves.toMatchObject({ descendantsArePrivate: false });
   });
 
   test("streams Windows credential ACL output larger than the subprocess buffer", async () => {

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { execFile, spawnSync } from "node:child_process";
 import { existsSync, renameSync, symlinkSync } from "node:fs";
 import {
   chmod,
@@ -29,6 +29,7 @@ import {
   sep,
 } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { promisify } from "node:util";
 import { brotliDecompressSync } from "node:zlib";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { strToU8, zipSync } from "fflate";
@@ -1937,6 +1938,94 @@ describe("runtime directories and plugin Python boundary", () => {
     expect(attempts).toBe(2);
   });
 
+  test("retries Windows credential verification when a descendant disappears", async () => {
+    const root = await temporaryDirectory();
+    const home = join(root, "home");
+    const temporary = join(home, ".auth-temporary");
+    await mkdir(home);
+    await writeFile(join(home, "auth.json"), "credential\n");
+    await writeFile(temporary, "temporary credential\n");
+    const originalLstat = fsPromises.lstat;
+    let removed = false;
+    let inspections = 0;
+    mock.module("node:fs/promises", () => ({
+      ...fsPromises,
+      lstat: async (path: Parameters<typeof lstat>[0]) => {
+        if (path === temporary && !removed) {
+          removed = true;
+          await rm(temporary);
+        }
+        return originalLstat(path);
+      },
+    }));
+
+    try {
+      await verifyStableWindowsCredentialDescendants(home, async () => {
+        inspections += 1;
+        return 1;
+      });
+    } finally {
+      mock.module("node:fs/promises", () => ({
+        ...fsPromises,
+        lstat: originalLstat,
+      }));
+    }
+
+    expect(removed).toBe(true);
+    expect(inspections).toBe(1);
+  });
+
+  test("rejects Windows credential descendants that repeatedly disappear", async () => {
+    const root = await temporaryDirectory();
+    const home = join(root, "home");
+    const credential = join(home, "auth.json");
+    await mkdir(home);
+    await writeFile(credential, "credential\n");
+    const originalLstat = fsPromises.lstat;
+    let attempts = 0;
+    mock.module("node:fs/promises", () => ({
+      ...fsPromises,
+      lstat: async (path: Parameters<typeof lstat>[0]) => {
+        if (path === credential) {
+          attempts += 1;
+          throw Object.assign(new Error("credential disappeared"), {
+            code: "ENOENT",
+            path,
+          });
+        }
+        return originalLstat(path);
+      },
+    }));
+
+    try {
+      await expect(
+        verifyStableWindowsCredentialDescendants(home, async () => 1),
+      ).rejects.toThrow("Windows credential descendants could not be verified");
+    } finally {
+      mock.module("node:fs/promises", () => ({
+        ...fsPromises,
+        lstat: originalLstat,
+      }));
+    }
+
+    expect(attempts).toBe(3);
+  });
+
+  test("does not retry a missing Windows credential home", async () => {
+    const root = await temporaryDirectory();
+    const home = join(root, "missing-home");
+    let inspections = 0;
+
+    await expect(
+      verifyStableWindowsCredentialDescendants(home, async () => {
+        inspections += 1;
+        return 0;
+      }),
+    ).rejects.toMatchObject({ code: "ENOENT", path: home });
+
+    expect(inspections).toBe(0);
+  });
+
   test("rejects Windows credential descendants that never stabilize", async () => {
     const root = await temporaryDirectory();
     const home = join(root, "home");
@@ -2477,7 +2566,7 @@ describe("runtime directories and plugin Python boundary", () => {
         "$unexpected = @($acl.Access | Where-Object { $_.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and $trusted -notcontains $_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]).Value })",
         "[pscustomobject]@{ unexpected = $unexpected.Count } | ConvertTo-Json -Compress",
       ].join("; ");
-      const result = spawnSync(
+      const result = await promisify(execFile)(
         powershell,
         ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command],
         {
@@ -2488,7 +2577,6 @@ describe("runtime directories and plugin Python boundary", () => {
         },
       );
 
-      expect(result.status).toBe(0);
       expect(JSON.parse(result.stdout)).toEqual({ unexpected: 0 });
     },
   );

--- a/sdk/typescript/tests-ts/skeleton.test.ts
+++ b/sdk/typescript/tests-ts/skeleton.test.ts
@@ -70,7 +70,7 @@ describe("TypeScript package skeleton", () => {
     }
   });
 
-  test("gives Windows credential integration tests a larger CI timeout", async () => {
+  test("uses the default test timeout consistently across CI platforms", async () => {
     const packageJson = JSON.parse(
       await readFile(new URL("../package.json", import.meta.url), "utf8"),
     );
@@ -82,9 +82,8 @@ describe("TypeScript package skeleton", () => {
     expect(packageJson.scripts.test).toBe(
       "bun test --timeout 30000 ./tests-ts",
     );
-    expect(ciWorkflow).toContain(
-      "run: pnpm --dir sdk/typescript run test ${{ runner.os == 'Windows' && '--timeout 60000' || '' }}",
-    );
+    expect(ciWorkflow).toContain("run: pnpm --dir sdk/typescript run test\n");
+    expect(ciWorkflow).not.toContain("--timeout 60000");
   });
 
   test("builds packages without a preinstalled package manager and provides a production audit", async () => {

--- a/sdk/typescript/tests-ts/skeleton.test.ts
+++ b/sdk/typescript/tests-ts/skeleton.test.ts
@@ -70,6 +70,23 @@ describe("TypeScript package skeleton", () => {
     }
   });
 
+  test("gives Windows credential integration tests a larger CI timeout", async () => {
+    const packageJson = JSON.parse(
+      await readFile(new URL("../package.json", import.meta.url), "utf8"),
+    );
+    const ciWorkflow = await readFile(
+      new URL("../../../.github/workflows/node-ci.yml", import.meta.url),
+      "utf8",
+    );
+
+    expect(packageJson.scripts.test).toBe(
+      "bun test --timeout 30000 ./tests-ts",
+    );
+    expect(ciWorkflow).toContain(
+      "run: pnpm --dir sdk/typescript run test ${{ runner.os == 'Windows' && '--timeout 60000' || '' }}",
+    );
+  });
+
   test("builds packages without a preinstalled package manager and provides a production audit", async () => {
     const packageJson = JSON.parse(
       await readFile(new URL("../package.json", import.meta.url), "utf8"),


### PR DESCRIPTION
## Summary

- Retry bounded Windows credential descendant enumeration when a concurrent ambient-auth import removes a temporary file between directory traversal and `lstat`. A missing credential-home root, persistent instability, symbolic links, junctions, and other filesystem failures still fail closed.
- Run the Windows-only ACL integration check through asynchronous `execFile`, preserving the actual subprocess error instead of surfacing only an unexplained synchronous `status: null`.
- Batch credential-home ancestry, home ACL, and descendant ACL inspection into one streaming PowerShell process per validation. The same owner, trusted-SID, inheritance, attacker-writable-ancestor, descendant-privacy, alias-resolution, repair, and constrained-language checks still run on every access.
- Keep the standard `bun test --timeout 30000` timeout on every platform; the earlier Windows-only 60-second workaround is not part of the final diff.
- Add deterministic regression coverage for disappearing descendants, repeated instability, missing roots, one-process ACL snapshots, empty homes, unsafe ancestors, unsafe descendants, incomplete subprocess output, and the default CI timeout.

## Root cause

The flaky failure came from two Windows-only races: a descendant could disappear between filesystem enumeration and `lstat`, and the synchronous PowerShell test could occasionally return only `status: null`. Separately, managed credential workflows repeatedly validated the same credential home, and each validation started separate PowerShell processes for ancestry, the home ACL, and descendants. That subprocess startup cost pushed legitimate tests close to the 30-second limit.

The batching change removes the repeated PowerShell startup cost without caching or skipping ACL validation. A populated credential-home validation now uses one streaming PowerShell process for all ACL descriptors instead of separate ancestry, home, and descendant PowerShell processes; repair paths still re-inspect after mutation.

## Failure evidence

- Original Windows/Node 24 failure on `main`: https://github.com/openai/codex-security/actions/runs/31132067211/job/92723068033
- Windows/Node 22 concurrent credential import failure: https://github.com/openai/codex-security/actions/runs/31127158645/job/92702598234
- Earlier PR run showing the original PowerShell failure fixed but a different credential test reaching 30 seconds: https://github.com/openai/codex-security/actions/runs/31135518651/job/92733857846

## Verification

- The new disappearing-descendant and persistent-instability regressions failed against the original implementation, then passed with the bounded retry.
- The combined-inspection regression failed before the batching implementation, then passed with the single-process snapshot path.
- Randomized local SDK suite after batching (`--randomize --seed 12345 --timeout 30000`): 950 passed, 10 platform-specific skips, 0 failed.
- TypeScript typecheck, generated-model validation, full Prettier check, production build, `pnpm pack`, and installed-package smoke validation passed.
- Current GitHub Actions run: https://github.com/openai/codex-security/actions/runs/31205123609
- All 11 applicable checks passed, including Windows Node 22 and Node 24; 5 publication checks were intentionally skipped.
- Windows Node 24 passed 972 tests with the default 30-second timeout. The formerly slow parallel-scan test improved from 25.02s to 14.46s, delegated credential login from 30.87s to 17.70s, and the full Windows suite from 399.86s to 328.22s despite the combined PR running more tests.
- Windows Node 22 passed 972 tests with the default 30-second timeout; hostile ancestor rejection, nested credential ACL repair, and constrained PowerShell regressions passed on both Windows jobs.