### PR TITLE
perf: batch Windows credential ACL inspection

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -90,7 +90,7 @@ jobs:
           TMP: ${{ steps.windows-temp.outputs.path || runner.temp }}
           TMPDIR: ${{ steps.windows-temp.outputs.path || runner.temp }}
           CODEX_SECURITY_ALLOW_MACHINE_POLICY_TEST: ${{ runner.environment == 'github-hosted' && runner.os == 'Windows' && 'true' || 'false' }}
-        run: pnpm --dir sdk/typescript run test ${{ runner.os == 'Windows' && '--timeout 60000' || '' }}
+        run: pnpm --dir sdk/typescript run test
 
       - name: Check formatting
         run: pnpm --dir sdk/typescript run format

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -371,6 +371,12 @@ class RepairableWindowsCredentialAclError extends Error {
   }
 }
 
+class RepairableWindowsCredentialOwnerError extends Error {
+  public constructor(cause: UntrustedWindowsCredentialOwnerError) {
+    super(cause.message, { cause });
+  }
+}
+
 /** Inspect a Windows DACL without translating locale-specific account names. */
 export function inspectWindowsCredentialAcl(
   descriptor: string,
@@ -573,6 +579,7 @@ function windowsAceAllowsAncestorReplacement(
 export async function verifyStableWindowsCredentialDescendants(
   path: string,
   inspectDescriptors: () => Promise<number>,
+  options: { inspectEmpty?: boolean } = {},
 ): Promise<void> {
   for (let attempt = 0; attempt < 3; attempt += 1) {
     let descendants = 0;
@@ -603,7 +610,7 @@ export async function verifyStableWindowsCredentialDescendants(
       }
       throw error;
     }
-    if (descendants === 0) return;
+    if (descendants === 0 && options.inspectEmpty !== true) return;
 
     if ((await inspectDescriptors()) === descendants) return;
   }
@@ -670,6 +677,106 @@ export async function streamWindowsCredentialAclDescriptors(
   return descriptors;
 }
 
+export async function inspectWindowsCredentialAclSnapshot(
+  path: string,
+  currentUserSid: string,
+  options: {
+    command: string;
+    args: readonly string[];
+    environment?: NodeJS.ProcessEnv;
+    resolvedAliases?: Readonly<Record<string, string>>;
+    resolveDescriptorAliases?: (descriptor: string) => Promise<void>;
+  },
+): Promise<{
+  home: WindowsCredentialAcl;
+  descendantsArePrivate: boolean;
+}> {
+  let ancestors = 0;
+  for (let ancestor = dirname(path); ; ancestor = dirname(ancestor)) {
+    ancestors += 1;
+    if (ancestor === dirname(ancestor)) break;
+  }
+
+  let home: WindowsCredentialAcl | undefined;
+  let descendantsArePrivate = true;
+  await verifyStableWindowsCredentialDescendants(
+    path,
+    async () => {
+      home = undefined;
+      descendantsArePrivate = true;
+      let inspected = 0;
+      const descriptors = await streamWindowsCredentialAclDescriptors(
+        options.command,
+        options.args,
+        async (descriptor) => {
+          const index = inspected;
+          inspected += 1;
+          await options.resolveDescriptorAliases?.(descriptor);
+
+          if (index < ancestors) {
+            const ancestor = inspectWindowsCredentialAcl(
+              descriptor,
+              currentUserSid,
+              {
+                resolvedAliases: options.resolvedAliases,
+                scope: "ancestor",
+              },
+            );
+            if (ancestor.untrustedPrincipals.length !== 0) {
+              throw new Error(
+                "Windows credential-home ancestor allows another identity to replace the directory",
+              );
+            }
+            return;
+          }
+
+          if (index === ancestors) {
+            try {
+              home = inspectWindowsCredentialAcl(descriptor, currentUserSid, {
+                resolvedAliases: options.resolvedAliases,
+              });
+            } catch (error) {
+              if (error instanceof UntrustedWindowsCredentialOwnerError) {
+                throw new RepairableWindowsCredentialOwnerError(error);
+              }
+              throw new RepairableWindowsCredentialAclError(error);
+            }
+            return;
+          }
+
+          const descendant = inspectWindowsCredentialAcl(
+            descriptor,
+            currentUserSid,
+            {
+              resolvedAliases: options.resolvedAliases,
+              scope: "file",
+            },
+          );
+          if (
+            !descendant.grantsCurrentUserAccess ||
+            descendant.untrustedPrincipals.length !== 0
+          ) {
+            descendantsArePrivate = false;
+          }
+        },
+        { environment: options.environment },
+      );
+      if (descriptors <= ancestors) {
+        throw new Error(
+          "Windows credential-home ancestry could not be verified",
+        );
+      }
+      return descriptors - ancestors - 1;
+    },
+    { inspectEmpty: true },
+  );
+
+  if (home === undefined) {
+    throw new Error("Windows credential ACL could not be verified");
+  }
+  return { home, descendantsArePrivate };
+}
+
 async function secureWindowsCredentialHome(path: string): Promise<void> {
   const systemRoot = process.env["SystemRoot"] ?? "C:\\Windows";
   const systemDirectory = join(systemRoot, "System32");
@@ -715,7 +822,10 @@ async function secureWindowsCredentialHome(path: string): Promise<void> {
   // arbitrary .NET constructors, static methods, and SID translation do not.
   const script = [
     "$ErrorActionPreference = 'Stop'",
+    "$path = $env:CODEX_SECURITY_CREDENTIAL_ACL_PATH",
+    "while ($true) { $parent = Microsoft.PowerShell.Management\\Split-Path -Path $path -Parent; if (-not $parent -or $parent -eq $path) { break }; Microsoft.PowerShell.Security\\Get-Acl -LiteralPath $parent | Microsoft.PowerShell.Utility\\Select-Object -ExpandProperty Sddl; $path = $parent }",
     "Microsoft.PowerShell.Security\\Get-Acl -LiteralPath $env:CODEX_SECURITY_CREDENTIAL_ACL_PATH | Microsoft.PowerShell.Utility\\Select-Object -ExpandProperty Sddl",
+    "Microsoft.PowerShell.Management\\Get-ChildItem -LiteralPath $env:CODEX_SECURITY_CREDENTIAL_ACL_PATH -Recurse -Force | Microsoft.PowerShell.Security\\Get-Acl | Microsoft.PowerShell.Utility\\Select-Object -ExpandProperty Sddl",
   ].join("; ");
   const resolvePrincipalScript = [
     "$ErrorActionPreference = 'Stop'",
@@ -770,21 +880,17 @@ async function secureWindowsCredentialHome(path: string): Promise<void> {
       remaining = rest;
     }
   };
+  let descendantsArePrivate = true;
   const readAcl = async (): Promise<WindowsCredentialAcl> => {
-    const descriptor = await execFile(
-      powershell,
-      ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
-      processOptions,
-    );
-    try {
-      await resolveDescriptorAliases(descriptor.stdout);
-      return inspectWindowsCredentialAcl(descriptor.stdout, sid, {
-        resolvedAliases,
-      });
-    } catch (error) {
-      if (error instanceof UntrustedWindowsCredentialOwnerError) throw error;
-      throw new RepairableWindowsCredentialAclError(error);
-    }
+    const snapshot = await inspectWindowsCredentialAclSnapshot(path, sid, {
+      command: powershell,
+      args: ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
+      environment: processOptions.env,
+      resolvedAliases,
+      resolveDescriptorAliases,
+    });
+    descendantsArePrivate = snapshot.descendantsArePrivate;
+    return snapshot.home;
   };
 
   const icacls = join(systemDirectory, "icacls.exe");
@@ -802,81 +908,12 @@ async function secureWindowsCredentialHome(path: string): Promise<void> {
       processOptions,
     );
   };
-  const ancestorScript = [
-    "$ErrorActionPreference = 'Stop'",
-    "$path = $env:CODEX_SECURITY_CREDENTIAL_ACL_PATH",
-    "while ($true) { $parent = Microsoft.PowerShell.Management\\Split-Path -Path $path -Parent; if (-not $parent -or $parent -eq $path) { break }; Microsoft.PowerShell.Security\\Get-Acl -LiteralPath $parent | Microsoft.PowerShell.Utility\\Select-Object -ExpandProperty Sddl; $path = $parent }",
-  ].join("; ");
-  const ancestorPaths: string[] = [];
-  for (let ancestor = dirname(path); ; ancestor = dirname(ancestor)) {
-    ancestorPaths.push(ancestor);
-    if (ancestor === dirname(ancestor)) break;
-  }
-  const ancestry = await execFile(
-    powershell,
-    ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", ancestorScript],
-    processOptions,
-  );
-  const ancestorDescriptors = ancestry.stdout
-    .split(/\r?\n/u)
-    .filter((descriptor) => descriptor !== "");
-  if (ancestorDescriptors.length !== ancestorPaths.length) {
-    throw new Error("Windows credential-home ancestry could not be verified");
-  }
-  for (const descriptor of ancestorDescriptors) {
-    await resolveDescriptorAliases(descriptor);
-    const ancestor = inspectWindowsCredentialAcl(descriptor, sid, {
-      resolvedAliases,
-      scope: "ancestor",
-    });
-    if (ancestor.untrustedPrincipals.length === 0) continue;
-    throw new Error(
-      "Windows credential-home ancestor allows another identity to replace the directory",
-    );
-  }
-
-  const descendantsArePrivate = async (): Promise<boolean> => {
-    const descendantScript = [
-      "$ErrorActionPreference = 'Stop'",
-      "Microsoft.PowerShell.Management\\Get-ChildItem -LiteralPath $env:CODEX_SECURITY_CREDENTIAL_ACL_PATH -Recurse -Force | Microsoft.PowerShell.Security\\Get-Acl | Microsoft.PowerShell.Utility\\Select-Object -ExpandProperty Sddl",
-    ].join("; ");
-    let privateDescendants = true;
-    await verifyStableWindowsCredentialDescendants(path, async () => {
-      privateDescendants = true;
-      return streamWindowsCredentialAclDescriptors(
-        powershell,
-        [
-          "-NoLogo",
-          "-NoProfile",
-          "-NonInteractive",
-          "-Command",
-          descendantScript,
-        ],
-        async (descriptor) => {
-          await resolveDescriptorAliases(descriptor);
-          const descendant = inspectWindowsCredentialAcl(descriptor, sid, {
-            resolvedAliases,
-            scope: "file",
-          });
-          if (
-            !descendant.grantsCurrentUserAccess ||
-            descendant.untrustedPrincipals.length !== 0
-          ) {
-            privateDescendants = false;
-          }
-        },
-        { environment: processOptions.env },
-      );
-    });
-    return privateDescendants;
-  };
-
   let existing: WindowsCredentialAcl | undefined;
   for (let attempt = 0; existing === undefined && attempt < 3; attempt += 1) {
     try {
       existing = await readAcl();
     } catch (error) {
-      if (error instanceof UntrustedWindowsCredentialOwnerError) {
+      if (error instanceof RepairableWindowsCredentialOwnerError) {
         await execFile(icacls, [path, "/setowner", `*${sid}`], processOptions);
       } else if (error instanceof RepairableWindowsCredentialAclError) {
         await installTrustedAcl();
@@ -947,13 +984,14 @@ async function secureWindowsCredentialHome(path: string): Promise<void> {
   if (verified.untrustedPrincipals.length !== 0) {
     throw new Error("Windows credential ACL grants access to another identity");
   }
-  if (!(await descendantsArePrivate())) {
+  if (!descendantsArePrivate) {
     await execFile(
       icacls,
       [join(path, "*"), "/reset", "/t", "/q"],
       processOptions,
     );
-    if (!(await descendantsArePrivate())) {
+    await readAcl();
+    if (!descendantsArePrivate) {
       throw new Error("Windows credential descendants remain accessible");
     }
   }

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -58,6 +58,7 @@ import {
   codexSecurityStateDirectory,
   codexPlatformPackage,
   inspectWindowsCredentialAcl,
+  inspectWindowsCredentialAclSnapshot,
   isPythonPathCandidate,
   planOutputArchive,
   prepareCodexSecurityCredentialHome,
@@ -2040,6 +2041,132 @@ describe("runtime directories and plugin Python boundary", () => {
       }),
     ).rejects.toThrow("Windows credential descendants could not be verified");
     expect(attempts).toBe(3);
+  });
+
+  test("inspects Windows credential ancestry, home, and descendants in one subprocess", async () => {
+    const root = await temporaryDirectory();
+    const home = join(root, "home");
+    const inspectionCount = join(root, "inspection-count");
+    await mkdir(home);
+    await writeFile(join(home, "auth.json"), "credential\n");
+    const sid = "S-1-5-21-111-222-333-1001";
+    const directory = `O:${sid}G:SYD:P(A;OICI;FA;;;${sid})`;
+    const file = `O:${sid}G:SYD:P(A;;FA;;;${sid})`;
+    const ancestors: string[] = [];
+    for (let ancestor = dirname(home); ; ancestor = dirname(ancestor)) {
+      ancestors.push(directory);
+      if (ancestor === dirname(ancestor)) break;
+    }
+    const descriptors = [...ancestors, directory, file];
+    const script = [
+      `require("node:fs").appendFileSync(${JSON.stringify(inspectionCount)}, "inspection\\n")`,
+      `process.stdout.write(${JSON.stringify(`${descriptors.join("\n")}\n`)})`,
+    ].join("; ");
+
+    const snapshot = await inspectWindowsCredentialAclSnapshot(home, sid, {
+      command: process.execPath,
+      args: ["--eval", script],
+    });
+
+    expect(snapshot.home).toMatchObject({
+      owner: sid,
+      protected: true,
+      grantsCurrentUserAccess: true,
+      untrustedPrincipals: [],
+    });
+    expect(snapshot.descendantsArePrivate).toBe(true);
+    expect(await readFile(inspectionCount, "utf8")).toBe("inspection\n");
+  });
+
+  test("inspects Windows credential ancestry and the home even without descendants", async () => {
+    const root = await temporaryDirectory();
+    const home = join(root, "home");
+    await mkdir(home);
+    const sid = "S-1-5-21-111-222-333-1001";
+    const directory = `O:${sid}G:SYD:P(A;OICI;FA;;;${sid})`;
+    const ancestors: string[] = [];
+    for (let ancestor = dirname(home); ; ancestor = dirname(ancestor)) {
+      ancestors.push(directory);
+      if (ancestor === dirname(ancestor)) break;
+    }
+    const descriptors = [...ancestors, directory];
+
+    await expect(
+      inspectWindowsCredentialAclSnapshot(home, sid, {
+        command: process.execPath,
+        args: [
+          "--eval",
+          `process.stdout.write(${JSON.stringify(`${descriptors.join("\n")}\n`)})`,
+        ],
+      }),
+    ).resolves.toMatchObject({
+      home: { owner: sid, protected: true },
+      descendantsArePrivate: true,
+    });
+  });
+
+  test("rejects unsafe Windows credential ancestry during combined ACL inspection", async () => {
+    const root = await temporaryDirectory();
+    const home = join(root, "home");
+    await mkdir(home);
+    const sid = "S-1-5-21-111-222-333-1001";
+    const unsafe = `O:${sid}G:SYD:P(A;OICI;FA;;;${sid})(A;OICI;FA;;;WD)`;
+
+    await expect(
+      inspectWindowsCredentialAclSnapshot(home, sid, {
+        command: process.execPath,
+        args: [
+          "--eval",
+          `process.stdout.write(${JSON.stringify(`${unsafe}\n`)})`,
+        ],
+      }),
+    ).rejects.toThrow(
+      "Windows credential-home ancestor allows another identity to replace the directory",
+    );
+  });
+
+  test("rejects incomplete combined Windows credential ACL inspections", async () => {
+    const root = await temporaryDirectory();
+    const home = join(root, "home");
+    await mkdir(home);
+    const sid = "S-1-5-21-111-222-333-1001";
+    const directory = `O:${sid}G:SYD:P(A;OICI;FA;;;${sid})`;
+
+    await expect(
+      inspectWindowsCredentialAclSnapshot(home, sid, {
+        command: process.execPath,
+        args: [
+          "--eval",
+          `process.stdout.write(${JSON.stringify(`${directory}\n`)})`,
+        ],
+      }),
+    ).rejects.toThrow("Windows credential-home ancestry could not be verified");
+  });
+
+  test("detects unsafe descendants during combined Windows credential ACL inspections", async () => {
+    const root = await temporaryDirectory();
+    const home = join(root, "home");
+    await mkdir(home);
+    await writeFile(join(home, "auth.json"), "credential\n");
+    const sid = "S-1-5-21-111-222-333-1001";
+    const directory = `O:${sid}G:SYD:P(A;OICI;FA;;;${sid})`;
+    const unsafeFile = `O:${sid}G:SYD:P(A;;FA;;;${sid})(A;;FR;;;WD)`;
+    const ancestors: string[] = [];
+    for (let ancestor = dirname(home); ; ancestor = dirname(ancestor)) {
+      ancestors.push(directory);
+      if (ancestor === dirname(ancestor)) break;
+    }
+    const descriptors = [...ancestors, directory, unsafeFile];
+
+    await expect(
+      inspectWindowsCredentialAclSnapshot(home, sid, {
+        command: process.execPath,
+        args: [
+          "--eval",
+          `process.stdout.write(${JSON.stringify(`${descriptors.join("\n")}\n`)})`,
+        ],
+      }),
+    ).resolves.toMatchObject({ descendantsArePrivate: false });
   });
 
   test("streams Windows credential ACL output larger than the subprocess buffer", async () => {

--- a/sdk/typescript/tests-ts/skeleton.test.ts
+++ b/sdk/typescript/tests-ts/skeleton.test.ts
@@ -70,7 +70,7 @@ describe("TypeScript package skeleton", () => {
     }
   });
 
-  test("gives Windows credential integration tests a larger CI timeout", async () => {
+  test("uses the default test timeout consistently across CI platforms", async () => {
     const packageJson = JSON.parse(
       await readFile(new URL("../package.json", import.meta.url), "utf8"),
     );
@@ -82,9 +82,8 @@ describe("TypeScript package skeleton", () => {
     expect(packageJson.scripts.test).toBe(
       "bun test --timeout 30000 ./tests-ts",
     );
-    expect(ciWorkflow).toContain(
-      "run: pnpm --dir sdk/typescript run test ${{ runner.os == 'Windows' && '--timeout 60000' || '' }}",
-    );
+    expect(ciWorkflow).toContain("run: pnpm --dir sdk/typescript run test\n");
+    expect(ciWorkflow).not.toContain("--timeout 60000");
   });
 
   test("builds packages without a preinstalled package manager and provides a production audit", async () => {


### PR DESCRIPTION
## Summary

Stacked on #298; this pull request is intentionally based on `dev/kyleb/windows-ci-credential-acl-flakes` and does not modify that PR.

- Batch credential-home ancestry, home ACL, and descendant ACL inspection into a single streaming PowerShell process per validation instead of starting separate PowerShell processes for each stage.
- Preserve full ACL revalidation on every access, trusted-owner/SID checks, attacker-writable ancestry rejection, descendant stability checks, bounded retries, credential ACL repair, and constrained-language compatibility.
- Keep ancestor-owner failures non-repairable while allowing repair of an untrusted credential-home owner.
- Restore the ordinary 30-second test timeout on Windows instead of retaining the 60-second workaround from #298.
- Add cross-platform regression coverage for one-process inspection, empty homes, unsafe ancestors, unsafe descendants, and incomplete subprocess output.

## Why

Windows credential workflows repeatedly validate the managed credential home. Before this change, each validation starts separate PowerShell processes for ancestry, the home, and existing descendants; a scan can repeat that work seven or eight times.

On the same #298 commit, the parallel-scan test takes **25.0 seconds on Windows versus 298 milliseconds on Linux**, and the Windows suite takes **399.86 seconds versus 61.38 seconds on Linux**. Historical Windows logs show one representative scan test increasing from **5.2 seconds to 26.4 seconds** when managed ACL validation was introduced.

## Verification

- New combined-inspection regression fails before the implementation because the snapshot helper does not exist, then passes with the implementation.
- Focused runtime/package-skeleton suites: **119 passed, 7 platform-specific skips, 0 failed**.
- Full randomized SDK suite (`--randomize --seed 12345 --timeout 30000`): **950 passed, 10 platform-specific skips, 0 failed** across 960 tests.
- TypeScript typecheck and generated-model validation passed.
- Full Prettier check passed.
- Production build passed.
- `pnpm pack` and installed-package smoke validation passed, including the public import, CLI, 106 bundled plugin files, nested worker, and 198 archive entries.
- Real Windows Node 22 and Node 24 both passed all **958 tests** with the restored **30-second** timeout.
- Windows Node 24 parallel scans: **25.02s -> 14.03s**; delegated credential login: **30.87s -> 17.20s**; full suite: **399.86s -> 303.17s**.
- Windows Node 22 parallel scans completed in **14.16s**, delegated credential login in **16.70s**, and the full suite in **309.01s**.
- Both real Windows jobs passed attacker-writable ancestry rejection, nested credential ACL repair, and constrained-PowerShell regressions.
- All **8 Node CI matrix jobs** passed: Linux Node 22/24.0.0/24/26.0.0/26, macOS Node 22, and Windows Node 22/24.
- Full successful workflow: https://github.com/openai/codex-security/actions/runs/31146638449