### PR TITLE
fix(scan): emit POSIX separators in Windows inventory

### DIFF
--- a/sdk/typescript/_bundled_plugin/scripts/generate_in_scope_files.py
+++ b/sdk/typescript/_bundled_plugin/scripts/generate_in_scope_files.py
@@ -68,7 +68,18 @@ def resolve_output(value: str) -> Path:
 
 def generate_in_scope_files(repository: Path, scope: str, output: Path) -> int:
     """Atomically write the exact ripgrep inventory sorted as ``LC_ALL=C``."""
-    command = ["rg", "--files", "--hidden", "--no-ignore", "--glob", "!.git/**", "--", scope]
+    command = [
+        "rg",
+        "--files",
+        "--hidden",
+        "--no-ignore",
+        "--path-separator",
+        "/",
+        "--glob",
+        "!.git/**",
+        "--",
+        scope,
+    ]
     with tempfile.TemporaryFile(mode="w+b") as inventory:
         try:
             result = subprocess.run(

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -221,24 +221,31 @@ describe("plugin runtime preparation", () => {
     ]);
   });
 
-  test("includes ignored tracked files in the scoped security inventory", async () => {
+  test("generates canonical scoped security inventory paths", async () => {
     if (Bun.which("rg") === null) {
       const generator = await readFile(
         join(PLUGIN_ROOT, "scripts", "generate_in_scope_files.py"),
         "utf8",
       );
       expect(generator).toContain('"--no-ignore"');
+      expect(generator).toContain('"--path-separator"');
       return;
     }
 
     const root = await temporaryDirectory("codex-security-scan-inventory-");
     const repository = join(root, "repository");
-    await mkdir(repository);
-    await writeFile(join(repository, ".gitignore"), "tracked-secret.py\n");
-    await writeFile(join(repository, "tracked-secret.py"), "secret = True\n");
+    await mkdir(join(repository, "nested"), { recursive: true });
+    await writeFile(
+      join(repository, ".gitignore"),
+      "nested/tracked-secret.py\n",
+    );
+    await writeFile(
+      join(repository, "nested", "tracked-secret.py"),
+      "secret = True\n",
+    );
     for (const args of [
       ["init", "--quiet", repository],
-      ["-C", repository, "add", "--force", "--", "tracked-secret.py"],
+      ["-C", repository, "add", "--force", "--", "nested/tracked-secret.py"],
     ]) {
       const initialized = spawnSync("git", args, { encoding: "utf8" });
       expect(initialized.status, initialized.stderr).toBe(0);
@@ -247,8 +254,8 @@ describe("plugin runtime preparation", () => {
     const python = Bun.which("python3") ?? Bun.which("python");
     expect(python).not.toBeNull();
     const output = join(root, "inventory.txt");
-    const inventory = spawnSync(
-      python!,
+    const repeatedOutput = join(root, "inventory-repeated.txt");
+    const generatorArguments = (destination: string) =>
       [
         "-I",
         "-B",
@@ -258,12 +265,68 @@ describe("plugin runtime preparation", () => {
         "--scope",
         ".",
         "--out",
-        output,
-      ],
-      { encoding: "utf8" },
+        destination,
+      ] as const;
+    for (const destination of [output, repeatedOutput]) {
+      const inventory = spawnSync(python!, generatorArguments(destination), {
+        encoding: "utf8",
+      });
+      expect(inventory.status, inventory.stderr).toBe(0);
+    }
+
+    const contents = await readFile(output);
+    expect(await readFile(repeatedOutput)).toEqual(contents);
+    const parts = await Promise.all(
+      ["000", "001"].map((part) =>
+        readFile(join(PLUGIN_ROOT, "mcp", `server.mjs.br.part-${part}`)),
+      ),
     );
-    expect(inventory.status, inventory.stderr).toBe(0);
-    expect(await readFile(output, "utf8")).toContain("tracked-secret.py");
+    const runtime = brotliDecompressSync(Buffer.concat(parts)).toString("utf8");
+    const validateSource =
+      /function validateRepositoryPath\(value, field\) \{[\s\S]*?\n\}/u.exec(
+        runtime,
+      )?.[0];
+    const parseSource =
+      /function parseInScopePaths\(content, path3\) \{[\s\S]*?\n\}/u.exec(
+        runtime,
+      )?.[0];
+    expect(validateSource).toBeDefined();
+    expect(parseSource).toBeDefined();
+    const parseInventory = new Function(
+      "import_node_util5",
+      `${validateSource}\n${parseSource}\nreturn parseInScopePaths;`,
+    )({ TextDecoder }) as (content: Uint8Array, path: string) => Set<string>;
+    expect(() => parseInventory(contents, "in_scope_files.txt")).not.toThrow();
+
+    const rows = contents.toString("utf8").trimEnd().split(/\r?\n/u);
+    expect(rows).toContain("./nested/tracked-secret.py");
+    for (const row of rows) {
+      const normalized = row.replace(/^(?:\.\/)+/u, "");
+      expect(row).toBe(row.trim());
+      expect(isAbsolute(row)).toBe(false);
+      expect(normalized).not.toMatch(/^[A-Za-z]:/u);
+      expect(normalized.split("/")).not.toContain("..");
+      if (process.platform === "win32") {
+        expect(row).not.toContain("\\");
+      }
+    }
+    if (process.platform !== "win32") {
+      await writeFile(
+        join(repository, String.raw`literal\backslash.txt`),
+        "backslash\n",
+      );
+      await writeFile(join(repository, "literal:colon.txt"), "colon\n");
+      const posixOutput = join(root, "inventory-posix-filenames.txt");
+      const inventory = spawnSync(python!, generatorArguments(posixOutput), {
+        encoding: "utf8",
+      });
+      expect(inventory.status, inventory.stderr).toBe(0);
+      const posixRows = (await readFile(posixOutput, "utf8"))
+        .trimEnd()
+        .split(/\r?\n/u);
+      expect(posixRows).toContain(String.raw`./literal\backslash.txt`);
+      expect(posixRows).toContain("./literal:colon.txt");
+    }
   });
 
   test("allows the workbench to derive missing deferred scan identifiers", async () => {


### PR DESCRIPTION
Fixes #302.

## Summary

- Pass `--path-separator /` to ripgrep when generating the shared in-scope inventory.
- Extend the inventory regression to exercise the shipped helper and bundled parser validation logic with a nested ignored tracked file.
- Verify repeated generation is byte-identical, with a POSIX-only producer control for literal backslash and colon filename characters.

## Root cause

On Windows, ripgrep prints paths with the platform-native `\` separator by default. The inventory helper preserved that output, while the existing parser rejects backslashes and expects repository-relative paths separated with `/`, causing setup validation to fail before discovery.

Selecting `/` at the producer aligns the generated representation with the existing parser without changing its validation rules.

## Impact

The reproduced repository-wide Deep Scan inventory can pass bundled path validation on native Windows instead of being rejected for its separator representation before discovery.

## Regression coverage

The focused regression invokes the shipped Python helper against a temporary repository, checks complete inventory rows, verifies the ignored nested file remains included, and passes the portable inventory through the bundled parser validation logic. It verifies repeated output is byte-identical and uses a separate POSIX producer control to confirm that literal backslash and colon filename characters are not rewritten.

The regression failed against the unmodified implementation, passed with the fix, failed again when only the production option was temporarily removed, and passed after restoration.

## Verification

- `bun test --timeout 30000 ./tests-ts/runtime.test.ts -t "generates canonical scoped security inventory paths"` on native Windows — 1 passed, 109 filtered, 0 failed
- The same focused test in a Linux container — 1 passed, 109 filtered, 0 failed
- `bun test --timeout 30000 ./tests-ts/runtime.test.ts` on native Windows — 86 passed, 24 skipped, 0 failed
- `corepack pnpm run types` — passed
- `corepack pnpm run format` — passed
- `corepack pnpm run build` — passed
- `python -m py_compile _bundled_plugin/scripts/generate_in_scope_files.py` — passed
- `corepack pnpm run check:package ../../dist/*.tgz` under Git Bash — 198 entries and the installed package validated
- `corepack pnpm run test:package` — installed-package smoke test passed
- `git diff --check` — passed

## Scope

This change does not modify repository-path validation, traversal or drive-prefix checks, Deep Scan orchestration, dependencies, lockfiles, or release configuration.

## Remaining limitations

The local complete SDK run finished with 888 passed, 54 skipped, and 10 environment-only failures that reproduce on the untouched base: Windows symlink creation is unavailable, `jq` is absent from the local Git Bash environment, and one control-character filename fixture fails with the local Python/Windows combination. This PR is initially a draft pending the repository's cross-platform CI results.
