### PR TITLE
fix: preserve remediation after filesystem remount

### DIFF
--- a/sdk/typescript/_bundled_plugin/scripts/workbench_target.py
+++ b/sdk/typescript/_bundled_plugin/scripts/workbench_target.py
@@ -495,9 +495,8 @@ def require_remediation_target(value: str) -> Path:
 
 def require_scan_target_identity(scan: sqlite3.Row) -> Path:
     target = require_remediation_target(scan["target_path"])
-    expected_device = scan["target_device"]
     expected_inode = scan["target_inode"]
-    if expected_device is None or expected_inode is None:
+    if expected_inode is None:
         raise SystemExit(
             "Remediation is unavailable because this scan does not record checkout identity. "
             "Start a new scan."
@@ -508,10 +507,7 @@ def require_scan_target_identity(scan: sqlite3.Row) -> Path:
         raise SystemExit(
             "Remediation is unavailable because the selected checkout is no longer accessible."
         ) from exc
-    if not (
-        stored_filesystem_identity_matches(expected_device, metadata.st_dev)
-        and stored_filesystem_identity_matches(expected_inode, metadata.st_ino)
-    ):
+    if not stored_filesystem_identity_matches(expected_inode, metadata.st_ino):
         raise SystemExit(
             "Remediation is unavailable because the selected checkout path was replaced. "
             "Start a new scan."

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -266,6 +266,41 @@ describe("plugin runtime preparation", () => {
     expect(await readFile(output, "utf8")).toContain("tracked-secret.py");
   });
 
+  test("preserves remediation when the filesystem device changes", async () => {
+    const python = Bun.which("python3") ?? Bun.which("python");
+    expect(python).not.toBeNull();
+    const target = await temporaryDirectory("codex-security-remounted-target-");
+    const verification = spawnSync(
+      python!,
+      [
+        "-I",
+        "-B",
+        "-c",
+        [
+          "import runpy, sys",
+          "from pathlib import Path",
+          "target = Path(sys.argv[2])",
+          "metadata = target.stat()",
+          "scan = {'target_path': str(target), 'target_device': metadata.st_dev + 1, 'target_inode': metadata.st_ino}",
+          "require_identity = runpy.run_path(sys.argv[1])['require_scan_target_identity']",
+          "assert require_identity(scan) == target",
+          "scan['target_inode'] += 1",
+          "try:",
+          "    require_identity(scan)",
+          "except SystemExit:",
+          "    pass",
+          "else:",
+          "    raise AssertionError('A replaced checkout must remain unavailable')",
+        ].join("\n"),
+        join(PLUGIN_ROOT, "scripts", "workbench_target.py"),
+        target,
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(verification.status, verification.stderr).toBe(0);
+  });
+
   test("allows the workbench to derive missing deferred scan identifiers", async () => {
     const schema = JSON.parse(
       await readFile(


### PR DESCRIPTION
## Change

- Keep remediation available when a remount changes the filesystem device number.
- Continue to reject replaced checkout paths and changed inode numbers.
- Test both cases against the bundled workbench.

## Checks

- `bun test --timeout 30000 ./tests-ts/runtime.test.ts` (104 passed, 7 skipped)
- `tsc --noEmit`
- `prettier --check tests-ts/runtime.test.ts`
