### PR TITLE
fix: increase the Windows CI test timeout

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -90,7 +90,7 @@ jobs:
           TMP: ${{ steps.windows-temp.outputs.path || runner.temp }}
           TMPDIR: ${{ steps.windows-temp.outputs.path || runner.temp }}
           CODEX_SECURITY_ALLOW_MACHINE_POLICY_TEST: ${{ runner.environment == 'github-hosted' && runner.os == 'Windows' && 'true' || 'false' }}
-        run: pnpm --dir sdk/typescript run test
+        run: pnpm --dir sdk/typescript run test ${{ runner.os == 'Windows' && '--timeout 60000' || '' }}
 
       - name: Check formatting
         run: pnpm --dir sdk/typescript run format

--- a/sdk/typescript/tests-ts/skeleton.test.ts
+++ b/sdk/typescript/tests-ts/skeleton.test.ts
@@ -70,6 +70,23 @@ describe("TypeScript package skeleton", () => {
     }
   });
 
+  test("limits the longer CI test timeout to Windows", async () => {
+    const packageJson = JSON.parse(
+      await readFile(new URL("../package.json", import.meta.url), "utf8"),
+    );
+    const ciWorkflow = await readFile(
+      new URL("../../../.github/workflows/node-ci.yml", import.meta.url),
+      "utf8",
+    );
+
+    expect(packageJson.scripts.test).toBe(
+      "bun test --timeout 30000 ./tests-ts",
+    );
+    expect(ciWorkflow).toContain(
+      "run: pnpm --dir sdk/typescript run test ${{ runner.os == 'Windows' && '--timeout 60000' || '' }}",
+    );
+  });
+
   test("builds packages without a preinstalled package manager and provides a production audit", async () => {
     const packageJson = JSON.parse(
       await readFile(new URL("../package.json", import.meta.url), "utf8"),


### PR DESCRIPTION
## Change
- Set the Windows test timeout to 60 seconds.
- Keep the 30-second timeout on other platforms.
- Add a regression test for both limits.

## Tests
- Scan recovery and package tests: 30 passed.
- Type checks and formatting checks passed.