### PR TITLE
release: bump Codex Security to 0.1.8

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-security",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "TypeScript SDK and CLI for Codex Security",
   "license": "Apache-2.0",
   "author": "OpenAI",


### PR DESCRIPTION
## Summary

- Bump `@openai/codex-security` from `0.1.7` to `0.1.8` with a one-line change on the latest `main`.
- Release the fixes already merged since `npm-v0.1.7` while keeping the frozen dependency lockfile and protected release workflows unchanged.

## Validation

- Confirmed public `main` and npm `latest` are both `0.1.7`.
- Confirmed there is no open competing Codex Security release PR, no matching release branch, and no `npm-v0.1.8` tag.
- Not run locally: this is a version-only change created directly against the OSS repository; normal PR CI will validate it.

## Release

After review and merge, the existing `node-release-cut` workflow observes the higher version on `main`, creates `npm-v0.1.8` on the exact merged commit, and dispatches the protected, provenance-enabled `node-release` workflow.

Opening or merging this PR does not itself publish the package; publication still requires the protected `npm` deployment approval.