### PR TITLE
fix(plugin): restore bundled plugin version 0.1.16

### DIFF
--- a/sdk/typescript/_bundled_plugin/.codex-plugin/plugin.json
+++ b/sdk/typescript/_bundled_plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-security",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Codex Security workflows for security scans, analysis, and investigation.",
   "author": {
     "name": "OpenAI"

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -9,7 +9,7 @@ const PACKAGE_VERSIONS = packageVersions(
 export const VERSION = PACKAGE_VERSIONS.package;
 export const CODEX_SDK_VERSION = PACKAGE_VERSIONS.sdk;
 export const CODEX_EXECUTABLE_VERSION = PACKAGE_VERSIONS.executable;
-export const BUNDLED_PLUGIN_VERSION = "0.1.15" as const;
+export const BUNDLED_PLUGIN_VERSION = "0.1.16" as const;
 
 const PACKAGE_NAME = "@openai/codex-security";
 const VERSION_PATTERN =


### PR DESCRIPTION
## Summary

- Restore bundled plugin version `0.1.16` in its manifest and SDK version constant.
- Leave the SDK package version and all other files unchanged.

## Verification

- Confirmed both version surfaces agree and the current PR checks pass.
