### PR TITLE
ci: enforce conventional pull request titles

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,0 +1,33 @@
+name: Validate PR Title
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate-pr-title:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            release
+            revert
+            style
+            test
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,33 +1,23 @@
 name: Validate PR Title
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [main]
     types: [opened, edited, reopened, synchronize]
 
-permissions:
-  pull-requests: read
+permissions: {}
 
 jobs:
   validate-pr-title:
     name: Validate PR Title
     runs-on: ubuntu-latest
-    timeout-minutes: 5
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
-        with:
-          types: |
-            build
-            chore
-            ci
-            docs
-            feat
-            fix
-            perf
-            refactor
-            release
-            revert
-            style
-            test
+      - name: Check conventional title
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|release|revert|style|test)(\([^()[:space:]]+\))?!?:[[:space:]][^[:space:]].*$'
+          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+            echo '::error::PR titles must use a supported Conventional Commit type.'
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- Validate Conventional Commit pull-request titles, including supported `release:` titles.
- Use the ordinary pull-request event with no token permissions, checkout, or third-party action.
- Pass the untrusted title through an environment variable before checking it with Bash.

## Verification

- Checked accepted and rejected titles against the actual workflow step.
- `prettier --check .github/workflows/validate-pr-title.yml`
