### PR TITLE
fix(deps): patch high-severity js-yaml advisory

### DIFF
--- a/sdk/typescript/pnpm-lock.yaml
+++ b/sdk/typescript/pnpm-lock.yaml
@@ -487,8 +487,8 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   json-schema-to-typescript@15.0.4:
@@ -596,7 +596,7 @@ snapshots:
     dependencies:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@cfworker/json-schema@4.1.1': {}
 
@@ -965,7 +965,7 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -975,7 +975,7 @@ snapshots:
       '@types/json-schema': 7.0.15
       '@types/lodash': 4.17.24
       is-glob: 4.0.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       minimist: 1.2.8
       prettier: 3.2.5


### PR DESCRIPTION
## Summary
- Upgrade the transitive `js-yaml` lockfile resolution from 4.3.0 to the patched 4.3.1 release.
- Address high-severity advisory GHSA-5p4m-2wfm-xmqj (CVE-2026-59870) without changing direct dependencies or unrelated lock entries.
- Keep the separate `pdfjs-dist` advisories in existing PR #314.

## Verification
- `pnpm install --frozen-lockfile --ignore-scripts --registry=https://openai.firewall.socket.dev/npm/`
- `pnpm run types`
- `bun test --timeout 30000 tests-ts/skeleton.test.ts tests-ts/package-provenance.test.ts` (13 passing)
- Verified the installed version, both transitive dependency references, and the registry SHA-512 integrity are exactly `js-yaml@4.3.1`.