### PR TITLE
fix: remove Codex session-event size limit

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -463,9 +463,7 @@ including cached input and cache writes; fees and surcharges are not included.
 
 Use `--max-cost USD` to stop a scan, including its delegated workers, when its
 running cost exceeds the limit. Partial results are preserved. Requests
-already in progress can finish above the limit. Cost tracking accepts Codex
-session events up to 1 MiB; an oversized event stops the scan because its
-running cost can no longer be verified safely.
+already in progress can finish above the limit.
 
 Run `npx @openai/codex-security scan --help` or `npx @openai/codex-security bulk-scan --help`
 for the complete CLI references.

--- a/sdk/typescript/src/cost.ts
+++ b/sdk/typescript/src/cost.ts
@@ -88,7 +88,6 @@ const MODEL_PRICING_NANODOLLARS: Readonly<Record<string, ModelPricing>> = {
 
 const COST_POLL_INTERVAL_MS = 100;
 const SESSION_READ_SIZE = 64 * 1_024;
-const MAX_SESSION_EVENT_BYTES = 1 * 1_024 * 1_024;
 
 export class ScanCostTracker {
   readonly #options: ScanCostTrackerOptions;
@@ -379,9 +378,6 @@ function readSessionChunk(
     const lineEnd = newline === -1 ? contents.length : newline;
     const fragment = contents.subarray(lineStart, lineEnd);
     const lineBytes = session.pendingLineBytes + fragment.length;
-    if (lineBytes > MAX_SESSION_EVENT_BYTES) {
-      throw new Error("Codex session event exceeds the 1 MiB safety limit.");
-    }
 
     if (newline === -1) {
       if (fragment.length > 0) {

--- a/sdk/typescript/src/cost.ts
+++ b/sdk/typescript/src/cost.ts
@@ -45,7 +45,6 @@ interface SessionUsage {
   offset: number;
   pendingLine: Buffer[];
   pendingLineBytes: number;
-  discardingLine: boolean;
   unreadable: boolean;
   threadId: string | null;
   parentThreadId: string | null;
@@ -89,7 +88,6 @@ const MODEL_PRICING_NANODOLLARS: Readonly<Record<string, ModelPricing>> = {
 
 const COST_POLL_INTERVAL_MS = 100;
 const SESSION_READ_SIZE = 64 * 1_024;
-const MAX_BUFFERED_SESSION_EVENT_BYTES = 1_024 * 1_024;
 
 export class ScanCostTracker {
   readonly #options: ScanCostTrackerOptions;
@@ -184,7 +182,6 @@ export class ScanCostTracker {
           offset: 0,
           pendingLine: [],
           pendingLineBytes: 0,
-          discardingLine: false,
           unreadable: false,
           threadId: null,
           parentThreadId: null,
@@ -378,27 +375,9 @@ function readSessionChunk(
   let lineStart = 0;
   while (lineStart < contents.length) {
     const newline = contents.indexOf(0x0a, lineStart);
-    if (session.discardingLine) {
-      if (newline === -1) return;
-      session.discardingLine = false;
-      lineStart = newline + 1;
-      continue;
-    }
-
     const lineEnd = newline === -1 ? contents.length : newline;
     const fragment = contents.subarray(lineStart, lineEnd);
     const lineBytes = session.pendingLineBytes + fragment.length;
-    if (lineBytes > MAX_BUFFERED_SESSION_EVENT_BYTES) {
-      session.pendingLine = [];
-      session.pendingLineBytes = 0;
-      if (newline === -1) {
-        session.discardingLine = true;
-        return;
-      }
-      lineStart = newline + 1;
-      continue;
-    }
-
     if (newline === -1) {
       if (fragment.length > 0) {
         session.pendingLine.push(Buffer.from(fragment));

--- a/sdk/typescript/src/cost.ts
+++ b/sdk/typescript/src/cost.ts
@@ -45,6 +45,7 @@ interface SessionUsage {
   offset: number;
   pendingLine: Buffer[];
   pendingLineBytes: number;
+  discardingLine: boolean;
   unreadable: boolean;
   threadId: string | null;
   parentThreadId: string | null;
@@ -88,6 +89,7 @@ const MODEL_PRICING_NANODOLLARS: Readonly<Record<string, ModelPricing>> = {
 
 const COST_POLL_INTERVAL_MS = 100;
 const SESSION_READ_SIZE = 64 * 1_024;
+const MAX_BUFFERED_SESSION_EVENT_BYTES = 1_024 * 1_024;
 
 export class ScanCostTracker {
   readonly #options: ScanCostTrackerOptions;
@@ -182,6 +184,7 @@ export class ScanCostTracker {
           offset: 0,
           pendingLine: [],
           pendingLineBytes: 0,
+          discardingLine: false,
           unreadable: false,
           threadId: null,
           parentThreadId: null,
@@ -375,9 +378,26 @@ function readSessionChunk(
   let lineStart = 0;
   while (lineStart < contents.length) {
     const newline = contents.indexOf(0x0a, lineStart);
+    if (session.discardingLine) {
+      if (newline === -1) return;
+      session.discardingLine = false;
+      lineStart = newline + 1;
+      continue;
+    }
+
     const lineEnd = newline === -1 ? contents.length : newline;
     const fragment = contents.subarray(lineStart, lineEnd);
     const lineBytes = session.pendingLineBytes + fragment.length;
+    if (lineBytes > MAX_BUFFERED_SESSION_EVENT_BYTES) {
+      session.pendingLine = [];
+      session.pendingLineBytes = 0;
+      if (newline === -1) {
+        session.discardingLine = true;
+        return;
+      }
+      lineStart = newline + 1;
+      continue;
+    }
 
     if (newline === -1) {
       if (fragment.length > 0) {

--- a/sdk/typescript/tests-ts/cost.test.ts
+++ b/sdk/typescript/tests-ts/cost.test.ts
@@ -1412,81 +1412,43 @@ describe("live scan cost tracking", () => {
     expect((await tracker.stop()).cost?.inputTokens).toBe(250);
   });
 
-  test("rejects and quarantines a session event larger than 1 MiB", async () => {
+  test("reads session events larger than 1 MiB across polling cycles", async () => {
     const home = await codexHome();
     const path = await writeSession(home, "scan-thread", {
       input_tokens: 100,
       output_tokens: 10,
     });
-    await appendFile(path, "x".repeat(1 * 1_024 * 1_024 + 1));
+    const event = JSON.stringify({
+      type: "response_item",
+      payload: {
+        type: "function_call_output",
+        call_id: "large-tool-output",
+        output: "x".repeat(2 * 1_024 * 1_024),
+      },
+    });
+    const split = 1 * 1_024 * 1_024 + 1;
+    await appendFile(path, event.slice(0, split));
     const tracker = new ScanCostTracker({
       codexHome: home,
       model: "gpt-5.6-terra",
     });
     tracker.start("scan-thread");
+    expect((await tracker.refresh()).cost?.inputTokens).toBe(100);
 
-    await expect(tracker.refresh()).rejects.toThrow(
-      "Codex session event exceeds the 1 MiB safety limit.",
-    );
-    expect((await tracker.refresh()).cost).toEqual({
-      model: "gpt-5.6-terra",
-      inputTokens: 100,
-      cachedInputTokens: 0,
-      cacheWriteInputTokens: 0,
-      outputTokens: 10,
-      estimatedUsd: 0.00032,
+    const usage = JSON.stringify({
+      type: "event_msg",
+      payload: {
+        type: "token_count",
+        info: {
+          total_token_usage: { input_tokens: 250, output_tokens: 20 },
+        },
+      },
     });
-  });
-
-  test("ignores oversized events from unrelated prior credential sessions", async () => {
-    const home = await codexHome();
-    const unrelated = await writeSession(home, "unrelated-thread", {
-      input_tokens: 99,
-      output_tokens: 1,
-    });
-    await appendFile(unrelated, "x".repeat(1 * 1_024 * 1_024 + 1));
-    await writeSession(home, "scan-thread", {
-      input_tokens: 100,
-      output_tokens: 10,
-    });
-    const tracker = new ScanCostTracker({
-      codexHome: home,
-      model: "gpt-5.6-terra",
-    });
-    tracker.start("scan-thread");
+    await appendFile(path, `${event.slice(split)}\n${usage}\n`);
 
     expect((await tracker.stop()).cost).toMatchObject({
-      inputTokens: 100,
-      outputTokens: 10,
-    });
-  });
-
-  test("ignores oversized delegated sessions belonging to an unrelated scan", async () => {
-    const home = await codexHome();
-    await writeSession(home, "unrelated-parent", {
-      input_tokens: 1,
-      output_tokens: 1,
-    });
-    const unrelated = await writeSession(
-      home,
-      "unrelated-child",
-      { input_tokens: 1, output_tokens: 1 },
-      "unrelated-parent",
-    );
-    await appendFile(unrelated, "x".repeat(1 * 1_024 * 1_024 + 1));
-    await writeSession(home, "scan-thread", {
-      input_tokens: 100,
-      output_tokens: 10,
-    });
-    const tracker = new ScanCostTracker({
-      codexHome: home,
-      model: "gpt-5.6-terra",
-    });
-    tracker.start("scan-thread");
-
-    expect((await tracker.stop()).cost).toMatchObject({
-      inputTokens: 100,
-      outputTokens: 10,
+      inputTokens: 250,
+      outputTokens: 20,
     });
   });
 

--- a/sdk/typescript/tests-ts/cost.test.ts
+++ b/sdk/typescript/tests-ts/cost.test.ts
@@ -1412,11 +1412,25 @@ describe("live scan cost tracking", () => {
     expect((await tracker.stop()).cost?.inputTokens).toBe(250);
   });
 
-  test("reads session events larger than 1 MiB across polling cycles", async () => {
+  test("processes large delegated tool output across polling cycles", async () => {
     const home = await codexHome();
-    const path = await writeSession(home, "scan-thread", {
+    await writeSession(home, "scan-thread", {
       input_tokens: 100,
       output_tokens: 10,
+    });
+    const path = await writeSession(
+      home,
+      "worker-thread",
+      { input_tokens: 0, output_tokens: 0 },
+      "scan-thread",
+    );
+    await appendSessionItem(path, {
+      type: "function_call",
+      name: "exec_command",
+      call_id: "large-tool-output",
+      arguments: JSON.stringify({
+        cmd: 'rg "password" "$CODEX_SECURITY_REPOSITORY/routes/login.ts"',
+      }),
     });
     const event = JSON.stringify({
       type: "response_item",
@@ -1428,9 +1442,12 @@ describe("live scan cost tracking", () => {
     });
     const split = 1 * 1_024 * 1_024 + 1;
     await appendFile(path, event.slice(0, split));
+    const activities: ScanActivity[] = [];
     const tracker = new ScanCostTracker({
       codexHome: home,
       model: "gpt-5.6-terra",
+      repository: "/code/juice-shop",
+      onActivity: (activity) => activities.push(activity),
     });
     tracker.start("scan-thread");
     expect((await tracker.refresh()).cost?.inputTokens).toBe(100);
@@ -1440,7 +1457,7 @@ describe("live scan cost tracking", () => {
       payload: {
         type: "token_count",
         info: {
-          total_token_usage: { input_tokens: 250, output_tokens: 20 },
+          total_token_usage: { input_tokens: 150, output_tokens: 10 },
         },
       },
     });
@@ -1450,11 +1467,26 @@ describe("live scan cost tracking", () => {
       inputTokens: 250,
       outputTokens: 20,
     });
+    expect(activities).toEqual([
+      expect.objectContaining({
+        id: "worker-thread:large-tool-output",
+        status: "running",
+      }),
+      expect.objectContaining({
+        id: "worker-thread:large-tool-output",
+        status: "completed",
+      }),
+    ]);
   });
 
-  test("discards oversized malformed events without losing later usage", async () => {
+  test("ignores oversized events from unrelated prior credential sessions", async () => {
     const home = await codexHome();
-    const path = await writeSession(home, "scan-thread", {
+    const unrelated = await writeSession(home, "unrelated-thread", {
+      input_tokens: 99,
+      output_tokens: 1,
+    });
+    await appendFile(unrelated, "x".repeat(1 * 1_024 * 1_024 + 1));
+    await writeSession(home, "scan-thread", {
       input_tokens: 100,
       output_tokens: 10,
     });
@@ -1464,25 +1496,38 @@ describe("live scan cost tracking", () => {
     });
     tracker.start("scan-thread");
 
-    await appendFile(path, "x".repeat(2 * 1_024 * 1_024));
-    expect((await tracker.refresh()).cost?.inputTokens).toBe(100);
-    await appendFile(path, "x".repeat(2 * 1_024 * 1_024));
-    expect((await tracker.refresh()).cost?.inputTokens).toBe(100);
-
-    const usage = JSON.stringify({
-      type: "event_msg",
-      payload: {
-        type: "token_count",
-        info: {
-          total_token_usage: { input_tokens: 250, output_tokens: 20 },
-        },
-      },
+    expect((await tracker.stop()).cost).toMatchObject({
+      inputTokens: 100,
+      outputTokens: 10,
     });
-    await appendFile(path, `\n${usage}\n`);
+  });
+
+  test("ignores oversized delegated sessions belonging to an unrelated scan", async () => {
+    const home = await codexHome();
+    await writeSession(home, "unrelated-parent", {
+      input_tokens: 1,
+      output_tokens: 1,
+    });
+    const unrelated = await writeSession(
+      home,
+      "unrelated-child",
+      { input_tokens: 1, output_tokens: 1 },
+      "unrelated-parent",
+    );
+    await appendFile(unrelated, "x".repeat(1 * 1_024 * 1_024 + 1));
+    await writeSession(home, "scan-thread", {
+      input_tokens: 100,
+      output_tokens: 10,
+    });
+    const tracker = new ScanCostTracker({
+      codexHome: home,
+      model: "gpt-5.6-terra",
+    });
+    tracker.start("scan-thread");
 
     expect((await tracker.stop()).cost).toMatchObject({
-      inputTokens: 250,
-      outputTokens: 20,
+      inputTokens: 100,
+      outputTokens: 10,
     });
   });
 

--- a/sdk/typescript/tests-ts/cost.test.ts
+++ b/sdk/typescript/tests-ts/cost.test.ts
@@ -1452,6 +1452,40 @@ describe("live scan cost tracking", () => {
     });
   });
 
+  test("discards oversized malformed events without losing later usage", async () => {
+    const home = await codexHome();
+    const path = await writeSession(home, "scan-thread", {
+      input_tokens: 100,
+      output_tokens: 10,
+    });
+    const tracker = new ScanCostTracker({
+      codexHome: home,
+      model: "gpt-5.6-terra",
+    });
+    tracker.start("scan-thread");
+
+    await appendFile(path, "x".repeat(2 * 1_024 * 1_024));
+    expect((await tracker.refresh()).cost?.inputTokens).toBe(100);
+    await appendFile(path, "x".repeat(2 * 1_024 * 1_024));
+    expect((await tracker.refresh()).cost?.inputTokens).toBe(100);
+
+    const usage = JSON.stringify({
+      type: "event_msg",
+      payload: {
+        type: "token_count",
+        info: {
+          total_token_usage: { input_tokens: 250, output_tokens: 20 },
+        },
+      },
+    });
+    await appendFile(path, `\n${usage}\n`);
+
+    expect((await tracker.stop()).cost).toMatchObject({
+      inputTokens: 250,
+      outputTokens: 20,
+    });
+  });
+
   test("reports a changed running cost only once", async () => {
     const home = await codexHome();
     await writeSession(home, "scan-thread", {


### PR DESCRIPTION
Remove the arbitrary 1 MiB limit from the local Codex session-event reader. Codex owns tool execution and session logs; legitimate delegated tool responses should be processed instead of rejected or silently discarded.

A 2 MiB worker response split across polling cycles now completes its activity normally and preserves token accounting. Existing scan-cost limits and report finalization remain unchanged.

Fixes #291.

Validation:
- Complete SDK suite: 978 passed, 11 expected platform/integration skips.
- Focused session-cost suite: 32 passed, including large delegated completions and unrelated-session isolation.
- Build, TypeScript, and Prettier checks passed.
