### PR TITLE
fix: allow large validation and patch responses

### DIFF
--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -22,7 +22,8 @@ import {
   win32,
 } from "node:path";
 import { cwd } from "node:process";
-import { Writable as NodeWritable } from "node:stream";
+import { createInterface } from "node:readline";
+import { Readable, Writable as NodeWritable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import type { ModelReasoningEffort } from "@openai/codex-sdk";
@@ -117,10 +118,6 @@ const MAX_CODEX_OVERRIDE_VALUE_LENGTH = 64 * 1_024;
 const MAX_CODEX_OVERRIDE_DEPTH = 64;
 const MAX_SKILL_INPUT_BYTES = 1_024 * 1_024;
 const MAX_SKILL_INPUT_COUNT = 64;
-const MAX_SKILL_EVENT_BYTES = 1_024 * 1_024;
-const MAX_SKILL_RESPONSE_BYTES = 256 * 1_024;
-const SKILL_OUTPUT_LIMIT_MESSAGE =
-  "Codex skill output exceeded the 1 MiB event or 256 KiB response safety limit.";
 const WINDOWS_NETWORK_PATH = /^[\\/]{2}/u;
 const WINDOWS_LOCAL_DEVICE_ROOT =
   /^[\\/]{2}[?.][\\/](?:[A-Za-z]:|Volume\{[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}\}|GLOBALROOT[\\/]Device[\\/]HarddiskVolume[0-9]+)(?=[\\/]|$)/iu;
@@ -515,7 +512,6 @@ export async function runCodexSkillCommand(
     windowsHide: true,
   });
   let requestedSignal: SignalName | null = null;
-  let skillOutputLimitExceeded = false;
   let forcedTermination: ReturnType<typeof setTimeout> | undefined;
   let forceStatusCompletion: (() => void) | null = null;
   let forceCaptureCompletion: (() => void) | null = null;
@@ -552,10 +548,7 @@ export async function runCodexSkillCommand(
       output === undefined || invocation.stdout === null
         ? Promise.resolve(undefined)
         : Promise.race([
-            readSkillCommandOutput(invocation.stdout, () => {
-              skillOutputLimitExceeded = true;
-              requestTermination("SIGTERM");
-            }),
+            readSkillCommandOutput(invocation.stdout),
             new Promise<undefined>((resolve) => {
               forceCaptureCompletion = () => resolve(undefined);
             }),
@@ -587,9 +580,6 @@ export async function runCodexSkillCommand(
       invocation.once(output === undefined ? "exit" : "close", complete);
     });
     const [status, events] = await Promise.all([invocationStatus, captured]);
-    if (skillOutputLimitExceeded) {
-      throw new CodexSecurityError(SKILL_OUTPUT_LIMIT_MESSAGE);
-    }
     if (output === undefined || status === 130 || status === 143) return status;
     if (status !== 0) {
       await writeCliOutput(
@@ -2411,33 +2401,23 @@ async function runSkill(
 
 export async function readSkillCommandOutput(
   stream: AsyncIterable<Buffer | string>,
-  onLimitExceeded?: () => void,
 ): Promise<{ message?: string; error?: string; malformed: boolean }> {
   let message: string | undefined;
   let error: string | undefined;
   let malformed = false;
-  let exceeded = false;
-  const markExceeded = (): void => {
-    if (exceeded) return;
-    exceeded = true;
-    onLimitExceeded?.();
-  };
 
-  const readLine = (bytes: Buffer): void => {
-    const content =
-      bytes.at(-1) === 0x0d ? bytes.subarray(0, bytes.length - 1) : bytes;
-    const line = content.toString("utf8");
-    if (line.trim().length === 0) return;
+  for await (const line of createInterface({ input: Readable.from(stream) })) {
+    if (line.trim().length === 0) continue;
     let event: unknown;
     try {
       event = JSON.parse(line);
     } catch {
       malformed = true;
-      return;
+      continue;
     }
     if (typeof event !== "object" || event === null) {
       malformed = true;
-      return;
+      continue;
     }
     const value = event as Record<string, unknown>;
     if (value["type"] === "item.completed") {
@@ -2450,11 +2430,7 @@ export async function readSkillCommandOutput(
         "text" in item &&
         typeof item.text === "string"
       ) {
-        if (Buffer.byteLength(item.text, "utf8") > MAX_SKILL_RESPONSE_BYTES) {
-          markExceeded();
-        } else {
-          message = item.text;
-        }
+        message = item.text;
       }
     } else if (value["type"] === "turn.failed") {
       const detail = value["error"];
@@ -2464,63 +2440,15 @@ export async function readSkillCommandOutput(
         "message" in detail &&
         typeof detail.message === "string"
       ) {
-        if (
-          Buffer.byteLength(detail.message, "utf8") > MAX_SKILL_RESPONSE_BYTES
-        ) {
-          markExceeded();
-        } else {
-          error = detail.message;
-        }
+        error = detail.message;
       }
     } else if (
       value["type"] === "error" &&
       typeof value["message"] === "string"
     ) {
-      if (
-        Buffer.byteLength(value["message"], "utf8") > MAX_SKILL_RESPONSE_BYTES
-      ) {
-        markExceeded();
-      } else {
-        error = value["message"];
-      }
-    }
-  };
-
-  const pending = Buffer.alloc(MAX_SKILL_EVENT_BYTES);
-  let pendingBytes = 0;
-  let discardingOversizedLine = false;
-  for await (const rawChunk of stream) {
-    const chunk = Buffer.isBuffer(rawChunk)
-      ? rawChunk
-      : Buffer.from(rawChunk, "utf8");
-    let start = 0;
-    while (start < chunk.length) {
-      const newline = chunk.indexOf(0x0a, start);
-      const end = newline === -1 ? chunk.length : newline;
-      const segment = chunk.subarray(start, end);
-      if (!discardingOversizedLine) {
-        if (pendingBytes + segment.length > MAX_SKILL_EVENT_BYTES) {
-          markExceeded();
-          discardingOversizedLine = true;
-          pendingBytes = 0;
-        } else if (segment.length > 0) {
-          segment.copy(pending, pendingBytes);
-          pendingBytes += segment.length;
-        }
-      }
-      if (newline === -1) break;
-      if (!discardingOversizedLine) {
-        readLine(pending.subarray(0, pendingBytes));
-      }
-      pendingBytes = 0;
-      discardingOversizedLine = false;
-      start = newline + 1;
+      error = value["message"];
     }
   }
-  if (!discardingOversizedLine && pendingBytes > 0) {
-    readLine(pending.subarray(0, pendingBytes));
-  }
-  if (exceeded) throw new CodexSecurityError(SKILL_OUTPUT_LIMIT_MESSAGE);
   return {
     ...(message === undefined ? {} : { message }),
     ...(error === undefined ? {} : { error }),

--- a/sdk/typescript/tests-ts/cli-skills.test.ts
+++ b/sdk/typescript/tests-ts/cli-skills.test.ts
@@ -457,7 +457,7 @@ describe("CLI skill commands", () => {
     });
   });
 
-  test("drains and rejects oversized skill events and responses", async () => {
+  test("continues past large events and preserves large skill responses", async () => {
     let drained = false;
     async function* oversizedLine(): AsyncGenerator<Buffer> {
       for (let remaining = 1_024 * 1_024 + 1; remaining > 0; ) {
@@ -470,9 +470,10 @@ describe("CLI skill commands", () => {
       );
       drained = true;
     }
-    await expect(readSkillCommandOutput(oversizedLine())).rejects.toThrow(
-      "Codex skill output exceeded the 1 MiB event",
-    );
+    await expect(readSkillCommandOutput(oversizedLine())).resolves.toEqual({
+      message: "must still drain",
+      malformed: true,
+    });
     expect(drained).toBe(true);
 
     async function* oversizedResponse(): AsyncGenerator<Buffer> {
@@ -481,14 +482,14 @@ describe("CLI skill commands", () => {
           type: "item.completed",
           item: {
             type: "agent_message",
-            text: "x".repeat(256 * 1_024 + 1),
+            text: "x".repeat(2 * 1_024 * 1_024 + 1),
           },
         })}\n`,
       );
     }
-    await expect(readSkillCommandOutput(oversizedResponse())).rejects.toThrow(
-      "Codex skill output exceeded the 1 MiB event",
-    );
+    const response = await readSkillCommandOutput(oversizedResponse());
+    expect(response.message).toHaveLength(2 * 1_024 * 1_024 + 1);
+    expect(response.malformed).toBe(false);
 
     const stdout = capture();
     const stderr = capture();
@@ -500,19 +501,18 @@ describe("CLI skill commands", () => {
           command: process.execPath,
           prefixArgs: [
             "-e",
-            'process.stdout.write(JSON.stringify({type:"item.completed",item:{type:"agent_message",text:"x".repeat(256*1024+1)}})+"\\n")',
+            'process.stdout.write(JSON.stringify({type:"item.completed",item:{type:"agent_message",text:"x".repeat(2*1024*1024+1)}})+"\\n")',
           ],
         },
       ),
-    ).rejects.toThrow("Codex skill output exceeded the 1 MiB event");
-    expect(stdout.text()).toBe("");
+    ).resolves.toBe(0);
+    expect(stdout.text()).toHaveLength(2 * 1024 * 1024 + 2);
     expect(stderr.text()).toBe("");
   });
 
-  test("terminates an oversized skill child that keeps its output open", async () => {
+  test("does not terminate a child that emits a large skill response", async () => {
     const stdout = capture();
     const stderr = capture();
-    const timeout = AbortSignal.timeout(2_500);
     const invocation = runCodexSkillCommand(
       [],
       { command: "validate", stdout: stdout.stream, stderr: stderr.stream },
@@ -520,31 +520,19 @@ describe("CLI skill commands", () => {
         command: process.execPath,
         prefixArgs: [
           "-e",
-          'process.on("SIGTERM",()=>{});process.stdout.write(JSON.stringify({type:"item.completed",item:{type:"agent_message",text:"x".repeat(256*1024+1)}})+"\\n");setInterval(()=>{},1000)',
+          'process.on("SIGTERM",()=>process.exit(9));process.stdout.write(JSON.stringify({type:"item.completed",item:{type:"agent_message",text:"x".repeat(1024*1024+1)}})+"\\n",()=>setTimeout(()=>process.exit(0),20))',
         ],
       },
     );
 
-    await expect(
-      Promise.race([
-        invocation,
-        new Promise<never>((_, reject) => {
-          timeout.addEventListener(
-            "abort",
-            () => reject(new Error("Oversized skill process did not settle.")),
-            { once: true },
-          );
-        }),
-      ]),
-    ).rejects.toThrow("Codex skill output exceeded the 1 MiB event");
-    expect(stdout.text()).toBe("");
+    await expect(invocation).resolves.toBe(0);
+    expect(stdout.text()).toHaveLength(1024 * 1024 + 2);
     expect(stderr.text()).toBe("");
   });
 
-  test("terminates an oversized skill child after it closes its stdout", async () => {
+  test("preserves a large response when the child closes stdout before exit", async () => {
     const stdout = capture();
     const stderr = capture();
-    const timeout = AbortSignal.timeout(2_500);
     const invocation = runCodexSkillCommand(
       [],
       { command: "validate", stdout: stdout.stream, stderr: stderr.stream },
@@ -552,24 +540,13 @@ describe("CLI skill commands", () => {
         command: process.execPath,
         prefixArgs: [
           "-e",
-          'process.on("SIGTERM",()=>{});process.stdout.write(JSON.stringify({type:"item.completed",item:{type:"agent_message",text:"x".repeat(256*1024+1)}})+"\\n");process.stdout.end();setInterval(()=>{},1000)',
+          'process.on("SIGTERM",()=>process.exit(9));process.stdout.end(JSON.stringify({type:"item.completed",item:{type:"agent_message",text:"x".repeat(1024*1024+1)}})+"\\n",()=>setTimeout(()=>process.exit(0),20))',
         ],
       },
     );
 
-    await expect(
-      Promise.race([
-        invocation,
-        new Promise<never>((_, reject) => {
-          timeout.addEventListener(
-            "abort",
-            () => reject(new Error("Oversized skill process did not settle.")),
-            { once: true },
-          );
-        }),
-      ]),
-    ).rejects.toThrow("Codex skill output exceeded the 1 MiB event");
-    expect(stdout.text()).toBe("");
+    await expect(invocation).resolves.toBe(0);
+    expect(stdout.text()).toHaveLength(1024 * 1024 + 2);
     expect(stderr.text()).toBe("");
   });
 


### PR DESCRIPTION
Accept Codex skill events and completed responses without the previous 1 MiB event or 256 KiB response limits. Validation and patching now process the normal JSONL stream directly instead of terminating an otherwise successful Codex process.

Keep final-response selection, credential-safe failure summaries, and interruption handling unchanged.

Validation:
- Full SDK suite: 978 passed, 11 expected skips.
- Focused skill-command suite: 12 passed, including malformed events above 1 MiB, completed responses above 2 MiB, and child-process completion after stdout closes.
- TypeScript and focused Prettier checks passed.
