### PR TITLE
fix: remove authentication output and instruction limits

### DIFF
--- a/sdk/typescript/src/auth.ts
+++ b/sdk/typescript/src/auth.ts
@@ -1,14 +1,10 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { isIP } from "node:net";
-import { PluginBootstrapError } from "./errors.js";
+import { PluginBootstrapError, redactedErrorMessage } from "./errors.js";
 import type { CodexCommand, ProcessEnvironment } from "./runtime.js";
 
 const LOGIN_CHILD_TERMINATION_GRACE_MS = 1_000;
 const MAX_CODEX_AUTH_OUTPUT_BYTES = 64 * 1024;
-const LOGIN_OUTPUT_LIMIT_MESSAGE =
-  "Codex login output exceeded the 64 KiB safety limit.";
-const COMMAND_OUTPUT_LIMIT_MESSAGE =
-  "Codex authentication command output exceeded the 64 KiB safety limit.";
 const INSTRUCTION_TAIL_BYTES = 4 * 1024;
 type TerminalEscapeState = "text" | "escape" | "csi" | "osc" | "osc-escape";
 
@@ -48,7 +44,6 @@ export class CodexLoginHandle {
   #stderrAuthUrl: string | null = null;
   #stdoutUserCode: string | null = null;
   #stderrUserCode: string | null = null;
-  #outputLimitExceeded = false;
 
   public constructor(
     command: CodexCommand,
@@ -90,22 +85,15 @@ export class CodexLoginHandle {
         this.#clearForcedTermination();
         this.#forceCompletion = null;
         this.#destroyPipes();
-        if (!this.#outputLimitExceeded && !this.#canceled) {
+        if (!this.#canceled) {
           this.#flushInstructionTails();
         }
-        const result = this.#outputLimitExceeded
-          ? {
-              success: false,
-              exitCode,
-              stdout: "",
-              stderr: LOGIN_OUTPUT_LIMIT_MESSAGE,
-            }
-          : {
-              success: exitCode === 0 && !this.#canceled,
-              exitCode,
-              stdout: this.#stdout,
-              stderr: this.#stderr,
-            };
+        const result = {
+          success: exitCode === 0 && !this.#canceled,
+          exitCode,
+          stdout: redactedErrorMessage(this.#stdout),
+          stderr: redactedErrorMessage(this.#stderr),
+        };
         this.#settleInstructionWaiters(result);
         if (result.success) onSuccess();
         resolve(result);
@@ -202,7 +190,6 @@ export class CodexLoginHandle {
   }
 
   #recordOutput(stream: "stdout" | "stderr", chunk: string): void {
-    if (this.#outputLimitExceeded) return;
     const current = stream === "stdout" ? this.#stdout : this.#stderr;
     const appended = appendUtf8Tail(
       current,
@@ -210,16 +197,9 @@ export class CodexLoginHandle {
       MAX_CODEX_AUTH_OUTPUT_BYTES,
     );
     if (stream === "stdout") {
-      this.#stdout = appended.value;
+      this.#stdout = appended;
     } else {
-      this.#stderr = appended.value;
-    }
-    if (appended.exceeded) {
-      this.#outputLimitExceeded = true;
-      this.#stdout = "";
-      this.#stderr = LOGIN_OUTPUT_LIMIT_MESSAGE;
-      this.#requestTermination();
-      return;
+      this.#stderr = appended;
     }
 
     const tail =
@@ -244,7 +224,7 @@ export class CodexLoginHandle {
       "",
       candidate.slice(lastDelimiter + 1),
       INSTRUCTION_TAIL_BYTES,
-    ).value;
+    );
     if (stream === "stdout") {
       this.#stdoutAuthUrl ??= url;
       this.#stdoutUserCode ??= userCode;
@@ -412,13 +392,8 @@ export async function runCodex(
       chunk,
       MAX_CODEX_AUTH_OUTPUT_BYTES,
     );
-    if (stream === "stdout") stdout = appended.value;
-    else stderr = appended.value;
-    if (!appended.exceeded) return;
-    stdout = "";
-    stderr = "";
-    processError = new PluginBootstrapError(COMMAND_OUTPUT_LIMIT_MESSAGE);
-    terminate();
+    if (stream === "stdout") stdout = appended;
+    else stderr = appended;
   };
   child.stdout.setEncoding("utf8");
   child.stderr.setEncoding("utf8");
@@ -451,7 +426,12 @@ export async function runCodex(
       if (processError !== null) {
         reject(processError);
       } else {
-        resolve({ success: exitCode === 0, exitCode, stdout, stderr });
+        resolve({
+          success: exitCode === 0,
+          exitCode,
+          stdout: redactedErrorMessage(stdout),
+          stderr: redactedErrorMessage(stderr),
+        });
       }
     });
   });
@@ -499,24 +479,19 @@ function appendUtf8Tail(
   current: string,
   chunk: string,
   maximumBytes: number,
-): { value: string; exceeded: boolean } {
+): string {
   const currentBytes = Buffer.from(current);
   const chunkBytes = Buffer.from(chunk);
-  const exceeded = currentBytes.length + chunkBytes.length > maximumBytes;
-  if (!exceeded) return { value: `${current}${chunk}`, exceeded: false };
+  if (currentBytes.length + chunkBytes.length <= maximumBytes) {
+    return `${current}${chunk}`;
+  }
   if (chunkBytes.length >= maximumBytes) {
-    return {
-      value: chunkBytes.subarray(chunkBytes.length - maximumBytes).toString(),
-      exceeded: true,
-    };
+    return chunkBytes.subarray(chunkBytes.length - maximumBytes).toString();
   }
   const retained = currentBytes.subarray(
     Math.max(0, currentBytes.length - (maximumBytes - chunkBytes.length)),
   );
-  return {
-    value: Buffer.concat([retained, chunkBytes]).toString(),
-    exceeded: true,
-  };
+  return Buffer.concat([retained, chunkBytes]).toString();
 }
 
 function plainTerminalText(value: string): string {

--- a/sdk/typescript/src/auth.ts
+++ b/sdk/typescript/src/auth.ts
@@ -4,7 +4,6 @@ import { PluginBootstrapError } from "./errors.js";
 import type { CodexCommand, ProcessEnvironment } from "./runtime.js";
 
 const LOGIN_CHILD_TERMINATION_GRACE_MS = 1_000;
-const INSTRUCTION_TAIL_BYTES = 4 * 1024;
 type TerminalEscapeState = "text" | "escape" | "csi" | "osc" | "osc-escape";
 
 export interface LoginResult {
@@ -213,9 +212,7 @@ export class CodexLoginHandle {
     const completed = candidate.slice(0, lastDelimiter + 1);
     const url = preferredAuthUrl(completed);
     const userCode = userCodeFromOutput(completed);
-    const nextTail = Buffer.from(candidate.slice(lastDelimiter + 1))
-      .subarray(-INSTRUCTION_TAIL_BYTES)
-      .toString();
+    const nextTail = candidate.slice(lastDelimiter + 1);
     if (stream === "stdout") {
       this.#stdoutAuthUrl ??= url;
       this.#stdoutUserCode ??= userCode;

--- a/sdk/typescript/src/auth.ts
+++ b/sdk/typescript/src/auth.ts
@@ -1,15 +1,11 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { isIP } from "node:net";
-import { PluginBootstrapError, redactedErrorMessage } from "./errors.js";
+import { PluginBootstrapError } from "./errors.js";
 import type { CodexCommand, ProcessEnvironment } from "./runtime.js";
 
 const LOGIN_CHILD_TERMINATION_GRACE_MS = 1_000;
-const MAX_CODEX_AUTH_OUTPUT_BYTES = 64 * 1024;
 const INSTRUCTION_TAIL_BYTES = 4 * 1024;
-const AUTH_OUTPUT_TRUNCATED_MESSAGE =
-  "Codex authentication output was truncated.";
 type TerminalEscapeState = "text" | "escape" | "csi" | "osc" | "osc-escape";
-type AuthenticationStatusMarkers = { signedOut: boolean; chatgpt: boolean };
 
 export interface LoginResult {
   success: boolean;
@@ -39,8 +35,6 @@ export class CodexLoginHandle {
   #forceCompletion: (() => void) | null = null;
   #stdout = "";
   #stderr = "";
-  #stdoutTruncated = false;
-  #stderrTruncated = false;
   #stdoutInstructionTail = "";
   #stderrInstructionTail = "";
   #stdoutTerminalState: TerminalEscapeState = "text";
@@ -96,14 +90,8 @@ export class CodexLoginHandle {
         const result = {
           success: exitCode === 0 && !this.#canceled,
           exitCode,
-          stdout: capturedAuthenticationOutput(
-            this.#stdout,
-            this.#stdoutTruncated,
-          ),
-          stderr: capturedAuthenticationOutput(
-            this.#stderr,
-            this.#stderrTruncated,
-          ),
+          stdout: this.#stdout,
+          stderr: this.#stderr,
         };
         this.#settleInstructionWaiters(result);
         if (result.success) onSuccess();
@@ -201,21 +189,10 @@ export class CodexLoginHandle {
   }
 
   #recordOutput(stream: "stdout" | "stderr", chunk: string): void {
-    const current = stream === "stdout" ? this.#stdout : this.#stderr;
-    const truncated =
-      Buffer.byteLength(current, "utf8") + Buffer.byteLength(chunk, "utf8") >
-      MAX_CODEX_AUTH_OUTPUT_BYTES;
-    const appended = appendUtf8Tail(
-      current,
-      chunk,
-      MAX_CODEX_AUTH_OUTPUT_BYTES,
-    );
     if (stream === "stdout") {
-      this.#stdout = appended;
-      this.#stdoutTruncated ||= truncated;
+      this.#stdout += chunk;
     } else {
-      this.#stderr = appended;
-      this.#stderrTruncated ||= truncated;
+      this.#stderr += chunk;
     }
 
     const tail =
@@ -236,11 +213,9 @@ export class CodexLoginHandle {
     const completed = candidate.slice(0, lastDelimiter + 1);
     const url = preferredAuthUrl(completed);
     const userCode = userCodeFromOutput(completed);
-    const nextTail = appendUtf8Tail(
-      "",
-      candidate.slice(lastDelimiter + 1),
-      INSTRUCTION_TAIL_BYTES,
-    );
+    const nextTail = Buffer.from(candidate.slice(lastDelimiter + 1))
+      .subarray(-INSTRUCTION_TAIL_BYTES)
+      .toString();
     if (stream === "stdout") {
       this.#stdoutAuthUrl ??= url;
       this.#stdoutUserCode ??= userCode;
@@ -380,16 +355,6 @@ export async function runCodex(
   });
   let stdout = "";
   let stderr = "";
-  let stdoutTruncated = false;
-  let stderrTruncated = false;
-  const stdoutMarkers: AuthenticationStatusMarkers = {
-    signedOut: false,
-    chatgpt: false,
-  };
-  const stderrMarkers: AuthenticationStatusMarkers = {
-    signedOut: false,
-    chatgpt: false,
-  };
   let processError: Error | null = null;
   let forcedTermination: ReturnType<typeof setTimeout> | undefined;
   const terminate = (): void => {
@@ -411,36 +376,13 @@ export async function runCodex(
       child.stderr.destroy();
     }, LOGIN_CHILD_TERMINATION_GRACE_MS);
   };
-  const recordOutput = (stream: "stdout" | "stderr", chunk: string): void => {
-    if (processError !== null) return;
-    const current = stream === "stdout" ? stdout : stderr;
-    const markers = stream === "stdout" ? stdoutMarkers : stderrMarkers;
-    const observed = `${current}${chunk}`;
-    markers.signedOut ||= /not logged in|unauthenticated/iu.test(observed);
-    markers.chatgpt ||= /\bchatgpt\b/iu.test(observed);
-    const truncated =
-      Buffer.byteLength(current, "utf8") + Buffer.byteLength(chunk, "utf8") >
-      MAX_CODEX_AUTH_OUTPUT_BYTES;
-    const appended = appendUtf8Tail(
-      current,
-      chunk,
-      MAX_CODEX_AUTH_OUTPUT_BYTES,
-    );
-    if (stream === "stdout") {
-      stdout = appended;
-      stdoutTruncated ||= truncated;
-    } else {
-      stderr = appended;
-      stderrTruncated ||= truncated;
-    }
-  };
   child.stdout.setEncoding("utf8");
   child.stderr.setEncoding("utf8");
   child.stdout.on("data", (chunk: string) => {
-    recordOutput("stdout", chunk);
+    stdout += chunk;
   });
   child.stderr.on("data", (chunk: string) => {
-    recordOutput("stderr", chunk);
+    stderr += chunk;
   });
   const completion = new Promise<LoginResult>((resolve, reject) => {
     child.once("error", (error) => {
@@ -465,20 +407,7 @@ export async function runCodex(
       if (processError !== null) {
         reject(processError);
       } else {
-        resolve({
-          success: exitCode === 0,
-          exitCode,
-          stdout: capturedAuthenticationOutput(
-            stdout,
-            stdoutTruncated,
-            stdoutMarkers,
-          ),
-          stderr: capturedAuthenticationOutput(
-            stderr,
-            stderrTruncated,
-            stderrMarkers,
-          ),
-        });
+        resolve({ success: exitCode === 0, exitCode, stdout, stderr });
       }
     });
   });
@@ -520,46 +449,6 @@ function userCodeFromOutput(value: string): string | null {
     output.match(/\b[A-Z0-9]{4,}(?:-[A-Z0-9]{4,})+\b/)?.[0] ??
     null
   );
-}
-
-function appendUtf8Tail(
-  current: string,
-  chunk: string,
-  maximumBytes: number,
-): string {
-  const currentBytes = Buffer.from(current);
-  const chunkBytes = Buffer.from(chunk);
-  if (currentBytes.length + chunkBytes.length <= maximumBytes) {
-    return `${current}${chunk}`;
-  }
-  const bytes = Buffer.concat([currentBytes, chunkBytes]);
-  let start = bytes.length - maximumBytes;
-  while (
-    start < bytes.length &&
-    (bytes[start]! & 0b1100_0000) === 0b1000_0000
-  ) {
-    start += 1;
-  }
-  return bytes.subarray(start).toString();
-}
-
-function capturedAuthenticationOutput(
-  value: string,
-  truncated: boolean,
-  markers?: AuthenticationStatusMarkers,
-): string {
-  if (!truncated) {
-    return appendUtf8Tail(
-      "",
-      redactedErrorMessage(value),
-      MAX_CODEX_AUTH_OUTPUT_BYTES,
-    );
-  }
-  return [
-    ...(markers?.signedOut === true ? ["Not logged in"] : []),
-    ...(markers?.chatgpt === true ? ["Logged in using ChatGPT"] : []),
-    AUTH_OUTPUT_TRUNCATED_MESSAGE,
-  ].join("\n");
 }
 
 function plainTerminalText(value: string): string {

--- a/sdk/typescript/src/auth.ts
+++ b/sdk/typescript/src/auth.ts
@@ -6,7 +6,10 @@ import type { CodexCommand, ProcessEnvironment } from "./runtime.js";
 const LOGIN_CHILD_TERMINATION_GRACE_MS = 1_000;
 const MAX_CODEX_AUTH_OUTPUT_BYTES = 64 * 1024;
 const INSTRUCTION_TAIL_BYTES = 4 * 1024;
+const AUTH_OUTPUT_TRUNCATED_MESSAGE =
+  "Codex authentication output was truncated.";
 type TerminalEscapeState = "text" | "escape" | "csi" | "osc" | "osc-escape";
+type AuthenticationStatusMarkers = { signedOut: boolean; chatgpt: boolean };
 
 export interface LoginResult {
   success: boolean;
@@ -36,6 +39,8 @@ export class CodexLoginHandle {
   #forceCompletion: (() => void) | null = null;
   #stdout = "";
   #stderr = "";
+  #stdoutTruncated = false;
+  #stderrTruncated = false;
   #stdoutInstructionTail = "";
   #stderrInstructionTail = "";
   #stdoutTerminalState: TerminalEscapeState = "text";
@@ -91,8 +96,14 @@ export class CodexLoginHandle {
         const result = {
           success: exitCode === 0 && !this.#canceled,
           exitCode,
-          stdout: redactedErrorMessage(this.#stdout),
-          stderr: redactedErrorMessage(this.#stderr),
+          stdout: capturedAuthenticationOutput(
+            this.#stdout,
+            this.#stdoutTruncated,
+          ),
+          stderr: capturedAuthenticationOutput(
+            this.#stderr,
+            this.#stderrTruncated,
+          ),
         };
         this.#settleInstructionWaiters(result);
         if (result.success) onSuccess();
@@ -191,6 +202,9 @@ export class CodexLoginHandle {
 
   #recordOutput(stream: "stdout" | "stderr", chunk: string): void {
     const current = stream === "stdout" ? this.#stdout : this.#stderr;
+    const truncated =
+      Buffer.byteLength(current, "utf8") + Buffer.byteLength(chunk, "utf8") >
+      MAX_CODEX_AUTH_OUTPUT_BYTES;
     const appended = appendUtf8Tail(
       current,
       chunk,
@@ -198,8 +212,10 @@ export class CodexLoginHandle {
     );
     if (stream === "stdout") {
       this.#stdout = appended;
+      this.#stdoutTruncated ||= truncated;
     } else {
       this.#stderr = appended;
+      this.#stderrTruncated ||= truncated;
     }
 
     const tail =
@@ -364,6 +380,16 @@ export async function runCodex(
   });
   let stdout = "";
   let stderr = "";
+  let stdoutTruncated = false;
+  let stderrTruncated = false;
+  const stdoutMarkers: AuthenticationStatusMarkers = {
+    signedOut: false,
+    chatgpt: false,
+  };
+  const stderrMarkers: AuthenticationStatusMarkers = {
+    signedOut: false,
+    chatgpt: false,
+  };
   let processError: Error | null = null;
   let forcedTermination: ReturnType<typeof setTimeout> | undefined;
   const terminate = (): void => {
@@ -387,13 +413,26 @@ export async function runCodex(
   };
   const recordOutput = (stream: "stdout" | "stderr", chunk: string): void => {
     if (processError !== null) return;
+    const current = stream === "stdout" ? stdout : stderr;
+    const markers = stream === "stdout" ? stdoutMarkers : stderrMarkers;
+    const observed = `${current}${chunk}`;
+    markers.signedOut ||= /not logged in|unauthenticated/iu.test(observed);
+    markers.chatgpt ||= /\bchatgpt\b/iu.test(observed);
+    const truncated =
+      Buffer.byteLength(current, "utf8") + Buffer.byteLength(chunk, "utf8") >
+      MAX_CODEX_AUTH_OUTPUT_BYTES;
     const appended = appendUtf8Tail(
-      stream === "stdout" ? stdout : stderr,
+      current,
       chunk,
       MAX_CODEX_AUTH_OUTPUT_BYTES,
     );
-    if (stream === "stdout") stdout = appended;
-    else stderr = appended;
+    if (stream === "stdout") {
+      stdout = appended;
+      stdoutTruncated ||= truncated;
+    } else {
+      stderr = appended;
+      stderrTruncated ||= truncated;
+    }
   };
   child.stdout.setEncoding("utf8");
   child.stderr.setEncoding("utf8");
@@ -429,8 +468,16 @@ export async function runCodex(
         resolve({
           success: exitCode === 0,
           exitCode,
-          stdout: redactedErrorMessage(stdout),
-          stderr: redactedErrorMessage(stderr),
+          stdout: capturedAuthenticationOutput(
+            stdout,
+            stdoutTruncated,
+            stdoutMarkers,
+          ),
+          stderr: capturedAuthenticationOutput(
+            stderr,
+            stderrTruncated,
+            stderrMarkers,
+          ),
         });
       }
     });
@@ -485,13 +532,39 @@ function appendUtf8Tail(
   if (currentBytes.length + chunkBytes.length <= maximumBytes) {
     return `${current}${chunk}`;
   }
-  if (chunkBytes.length >= maximumBytes) {
-    return chunkBytes.subarray(chunkBytes.length - maximumBytes).toString();
+  const bytes = Buffer.concat([currentBytes, chunkBytes]);
+  let start = bytes.length - maximumBytes;
+  while (
+    start < bytes.length &&
+    (bytes[start]! & 0b1100_0000) === 0b1000_0000
+  ) {
+    start += 1;
   }
-  const retained = currentBytes.subarray(
-    Math.max(0, currentBytes.length - (maximumBytes - chunkBytes.length)),
-  );
-  return Buffer.concat([retained, chunkBytes]).toString();
+  return bytes.subarray(start).toString();
+}
+
+function capturedAuthenticationOutput(
+  value: string,
+  truncated: boolean,
+  markers?: AuthenticationStatusMarkers,
+): string {
+  if (!truncated) return redactedErrorMessage(value);
+  const delimiter = /[\r\n]/u.exec(value)?.index;
+  const safeTail =
+    delimiter === undefined
+      ? ""
+      : redactedErrorMessage(value.slice(delimiter + 1));
+  const preserved = [
+    ...(markers?.signedOut === true ? ["Not logged in"] : []),
+    ...(markers?.chatgpt === true ? ["Logged in using ChatGPT"] : []),
+  ].join("\n");
+  const diagnostic = safeTail || AUTH_OUTPUT_TRUNCATED_MESSAGE;
+  if (preserved.length === 0) return diagnostic;
+  return `${preserved}\n${appendUtf8Tail(
+    "",
+    diagnostic,
+    MAX_CODEX_AUTH_OUTPUT_BYTES - Buffer.byteLength(preserved, "utf8") - 1,
+  )}`;
 }
 
 function plainTerminalText(value: string): string {

--- a/sdk/typescript/src/auth.ts
+++ b/sdk/typescript/src/auth.ts
@@ -204,15 +204,17 @@ export class CodexLoginHandle {
         ? this.#stdoutTerminalState
         : this.#stderrTerminalState,
     );
-    const candidate = `${tail}${visible.text}`;
-    const lastDelimiter = Math.max(
-      candidate.lastIndexOf("\n"),
-      candidate.lastIndexOf("\r"),
-    );
-    const completed = candidate.slice(0, lastDelimiter + 1);
+    const lastDelimiter = visible.text.lastIndexOf("\n");
+    const completed =
+      lastDelimiter === -1
+        ? ""
+        : `${tail}${visible.text.slice(0, lastDelimiter + 1)}`;
     const url = preferredAuthUrl(completed);
     const userCode = userCodeFromOutput(completed);
-    const nextTail = candidate.slice(lastDelimiter + 1);
+    const nextTail =
+      lastDelimiter === -1
+        ? `${tail}${visible.text}`
+        : visible.text.slice(lastDelimiter + 1);
     if (stream === "stdout") {
       this.#stdoutAuthUrl ??= url;
       this.#stdoutUserCode ??= userCode;

--- a/sdk/typescript/src/auth.ts
+++ b/sdk/typescript/src/auth.ts
@@ -548,23 +548,18 @@ function capturedAuthenticationOutput(
   truncated: boolean,
   markers?: AuthenticationStatusMarkers,
 ): string {
-  if (!truncated) return redactedErrorMessage(value);
-  const delimiter = /[\r\n]/u.exec(value)?.index;
-  const safeTail =
-    delimiter === undefined
-      ? ""
-      : redactedErrorMessage(value.slice(delimiter + 1));
-  const preserved = [
+  if (!truncated) {
+    return appendUtf8Tail(
+      "",
+      redactedErrorMessage(value),
+      MAX_CODEX_AUTH_OUTPUT_BYTES,
+    );
+  }
+  return [
     ...(markers?.signedOut === true ? ["Not logged in"] : []),
     ...(markers?.chatgpt === true ? ["Logged in using ChatGPT"] : []),
+    AUTH_OUTPUT_TRUNCATED_MESSAGE,
   ].join("\n");
-  const diagnostic = safeTail || AUTH_OUTPUT_TRUNCATED_MESSAGE;
-  if (preserved.length === 0) return diagnostic;
-  return `${preserved}\n${appendUtf8Tail(
-    "",
-    diagnostic,
-    MAX_CODEX_AUTH_OUTPUT_BYTES - Buffer.byteLength(preserved, "utf8") - 1,
-  )}`;
 }
 
 function plainTerminalText(value: string): string {

--- a/sdk/typescript/tests-ts/auth.test.ts
+++ b/sdk/typescript/tests-ts/auth.test.ts
@@ -140,8 +140,52 @@ describe("Codex authentication process boundary", () => {
       process.env,
     );
     expect(result.success).toBe(true);
-    expect(result.stdout).toContain("completed");
+    expect(result.stdout).toContain("authentication output was truncated");
     expect(JSON.stringify(result)).not.toContain(secretFragment);
+  });
+
+  test("does not expose a multiline private key cut by the output boundary", async () => {
+    const root = await mkdtemp(join(tmpdir(), "codex-security-auth-pem-"));
+    temporaryDirectories.push(root);
+    const script = join(root, "private-key.mjs");
+    await writeFile(
+      script,
+      'process.stdout.write("private_key=-----BEGIN PRIVATE KEY-----\\n" + "SENSITIVE_PRIVATE_KEY_BODY\\n".repeat(4_000) + "-----END PRIVATE KEY-----\\n", () => process.exit(0));\n',
+    );
+
+    const result = await runCodex(
+      { command: process.execPath, prefixArgs: [script] },
+      [],
+      process.env,
+    );
+    expect(result.success).toBe(true);
+    expect(result.stdout).toContain("authentication output was truncated");
+    expect(result.stdout).not.toContain("SENSITIVE_PRIVATE_KEY_BODY");
+    expect(result.stdout).not.toContain("END PRIVATE KEY");
+  });
+
+  test("bounds diagnostics after credential redaction expands their size", async () => {
+    const root = await mkdtemp(
+      join(tmpdir(), "codex-security-auth-expansion-"),
+    );
+    temporaryDirectories.push(root);
+    const script = join(root, "redaction.mjs");
+    await writeFile(
+      script,
+      'process.stdout.write("token=x\\n".repeat(6_000), () => process.exit(0));\n',
+    );
+
+    const result = await runCodex(
+      { command: process.execPath, prefixArgs: [script] },
+      [],
+      process.env,
+    );
+    expect(result.success).toBe(true);
+    expect(Buffer.byteLength(result.stdout, "utf8")).toBeLessThanOrEqual(
+      64 * 1024,
+    );
+    expect(result.stdout).toContain("[redacted]");
+    expect(result.stdout).not.toContain("token=x");
   });
 
   test("does not terminate a verbose authentication command", async () => {
@@ -208,7 +252,7 @@ process.stderr.write("x".repeat(128 * 1024), () => setTimeout(() => process.exit
     const script = join(root, "unicode.mjs");
     await writeFile(
       script,
-      'process.stdout.write("discard\\n" + "🔒".repeat(20_000) + "\\n" + "界".repeat(15_000), () => process.exit(0));\n',
+      'process.stdout.write("🔒".repeat(10_000) + "\\n" + "token=x\\n".repeat(3_000), () => process.exit(0));\n',
     );
 
     const result = await runCodex(
@@ -221,7 +265,7 @@ process.stderr.write("x".repeat(128 * 1024), () => setTimeout(() => process.exit
       64 * 1024,
     );
     expect(result.stdout).not.toContain("�");
-    expect(result.stdout).toEndWith("界");
+    expect(result.stdout).toEndWith("[redacted]\n");
   });
 
   test("captures quoted interactive login metadata and completion", async () => {

--- a/sdk/typescript/tests-ts/auth.test.ts
+++ b/sdk/typescript/tests-ts/auth.test.ts
@@ -100,15 +100,15 @@ describe("Codex authentication process boundary", () => {
     ).resolves.toMatchObject({ success: false, exitCode: 1 });
   });
 
-  test("keeps verbose authentication output bounded and redacted", async () => {
+  test("retains large noninteractive authentication output", async () => {
     const root = await mkdtemp(join(tmpdir(), "codex-security-auth-output-"));
     temporaryDirectories.push(root);
-    const secret = "sk-proj-SYNTHETIC_OVERSIZED_OUTPUT_SECRET";
+    const output = "verbose authentication output ".repeat(3_000);
     for (const stream of ["stdout", "stderr"] as const) {
       const script = join(root, `${stream}.mjs`);
       await writeFile(
         script,
-        `process.${stream}.write(${JSON.stringify(secret)}.repeat(3_000), () => process.exit(0));\n`,
+        `process.${stream}.write(${JSON.stringify(output)}, () => process.exit(0));\n`,
       );
       const result = await runCodex(
         { command: process.execPath, prefixArgs: [script] },
@@ -116,99 +116,8 @@ describe("Codex authentication process boundary", () => {
         process.env,
       );
       expect(result.success).toBe(true);
-      expect(Buffer.byteLength(result[stream], "utf8")).toBeLessThanOrEqual(
-        64 * 1024,
-      );
-      expect(result[stream]).toContain("authentication output was truncated");
-      expect(JSON.stringify(result)).not.toContain(secret);
+      expect(result[stream]).toBe(output);
     }
-  });
-
-  test("never exposes a credential value cut by the retained-output boundary", async () => {
-    const root = await mkdtemp(join(tmpdir(), "codex-security-auth-secret-"));
-    temporaryDirectories.push(root);
-    const script = join(root, "credential.mjs");
-    const secretFragment = "s".repeat(256);
-    await writeFile(
-      script,
-      'process.stdout.write("token=" + "s".repeat(128 * 1024) + "\\ncompleted\\n", () => process.exit(0));\n',
-    );
-
-    const result = await runCodex(
-      { command: process.execPath, prefixArgs: [script] },
-      [],
-      process.env,
-    );
-    expect(result.success).toBe(true);
-    expect(result.stdout).toContain("authentication output was truncated");
-    expect(JSON.stringify(result)).not.toContain(secretFragment);
-  });
-
-  test("does not expose a multiline private key cut by the output boundary", async () => {
-    const root = await mkdtemp(join(tmpdir(), "codex-security-auth-pem-"));
-    temporaryDirectories.push(root);
-    const script = join(root, "private-key.mjs");
-    await writeFile(
-      script,
-      'process.stdout.write("private_key=-----BEGIN PRIVATE KEY-----\\n" + "SENSITIVE_PRIVATE_KEY_BODY\\n".repeat(4_000) + "-----END PRIVATE KEY-----\\n", () => process.exit(0));\n',
-    );
-
-    const result = await runCodex(
-      { command: process.execPath, prefixArgs: [script] },
-      [],
-      process.env,
-    );
-    expect(result.success).toBe(true);
-    expect(result.stdout).toContain("authentication output was truncated");
-    expect(result.stdout).not.toContain("SENSITIVE_PRIVATE_KEY_BODY");
-    expect(result.stdout).not.toContain("END PRIVATE KEY");
-  });
-
-  test("bounds diagnostics after credential redaction expands their size", async () => {
-    const root = await mkdtemp(
-      join(tmpdir(), "codex-security-auth-expansion-"),
-    );
-    temporaryDirectories.push(root);
-    const script = join(root, "redaction.mjs");
-    await writeFile(
-      script,
-      'process.stdout.write("token=x\\n".repeat(6_000), () => process.exit(0));\n',
-    );
-
-    const result = await runCodex(
-      { command: process.execPath, prefixArgs: [script] },
-      [],
-      process.env,
-    );
-    expect(result.success).toBe(true);
-    expect(Buffer.byteLength(result.stdout, "utf8")).toBeLessThanOrEqual(
-      64 * 1024,
-    );
-    expect(result.stdout).toContain("[redacted]");
-    expect(result.stdout).not.toContain("token=x");
-  });
-
-  test("does not terminate a verbose authentication command", async () => {
-    const root = await mkdtemp(
-      join(tmpdir(), "codex-security-auth-command-kill-"),
-    );
-    temporaryDirectories.push(root);
-    const script = join(root, "command.mjs");
-    await writeFile(
-      script,
-      `
-process.on("SIGTERM", () => process.exit(9));
-process.stderr.write("x".repeat(128 * 1024), () => setTimeout(() => process.exit(0), 20));
-`,
-    );
-
-    await expect(
-      runCodex(
-        { command: process.execPath, prefixArgs: [script] },
-        [],
-        process.env,
-      ),
-    ).resolves.toMatchObject({ success: true, exitCode: 0 });
   });
 
   test("reports account state and performs logout", async () => {
@@ -218,54 +127,6 @@ process.stderr.write("x".repeat(128 * 1024), () => setTimeout(() => process.exit
       details: "Logged in using ChatGPT",
     });
     await expect(logout(command, process.env)).resolves.toBeUndefined();
-  });
-
-  test.each([
-    ["Logged in using ChatGPT", true],
-    ["not logged in", false],
-    ["unauthenticated", false],
-  ] as const)(
-    "preserves the %s account-status marker after output truncation",
-    async (marker, authenticated) => {
-      const root = await mkdtemp(join(tmpdir(), "codex-security-auth-status-"));
-      temporaryDirectories.push(root);
-      const script = join(root, "status.mjs");
-      await writeFile(
-        script,
-        `process.stdout.write(${JSON.stringify(`${marker}\n`)} + "x".repeat(128 * 1024), () => process.exit(0));\n`,
-      );
-
-      const status = await accountStatus(
-        { command: process.execPath, prefixArgs: [script] },
-        process.env,
-      );
-      expect(status.authenticated).toBe(authenticated);
-      expect(status.details).toContain(
-        authenticated ? "ChatGPT" : "Not logged in",
-      );
-    },
-  );
-
-  test("keeps truncated multilingual diagnostics on UTF-8 boundaries", async () => {
-    const root = await mkdtemp(join(tmpdir(), "codex-security-auth-unicode-"));
-    temporaryDirectories.push(root);
-    const script = join(root, "unicode.mjs");
-    await writeFile(
-      script,
-      'process.stdout.write("🔒".repeat(10_000) + "\\n" + "token=x\\n".repeat(3_000), () => process.exit(0));\n',
-    );
-
-    const result = await runCodex(
-      { command: process.execPath, prefixArgs: [script] },
-      [],
-      process.env,
-    );
-    expect(result.success).toBe(true);
-    expect(Buffer.byteLength(result.stdout, "utf8")).toBeLessThanOrEqual(
-      64 * 1024,
-    );
-    expect(result.stdout).not.toContain("�");
-    expect(result.stdout).toEndWith("[redacted]\n");
   });
 
   test("captures quoted interactive login metadata and completion", async () => {
@@ -286,18 +147,18 @@ process.stderr.write("x".repeat(128 * 1024), () => setTimeout(() => process.exit
     expect(succeeded).toBe(true);
   });
 
-  test("bounds interactive output while retaining discovered instructions", async () => {
+  test("retains large interactive output and login instructions", async () => {
     const root = await mkdtemp(join(tmpdir(), "codex-security-auth-output-"));
     temporaryDirectories.push(root);
     const script = join(root, "login.mjs");
-    const secret = "sk-proj-SYNTHETIC_INTERACTIVE_OUTPUT_SECRET";
+    const output = "verbose authentication output ".repeat(3_000);
     await writeFile(
       script,
       `
 console.error("Open https://auth.example.test/device");
 console.error("User code: ABCD-EFGH");
 setTimeout(() => {
-  process.stderr.write(${JSON.stringify(secret)}.repeat(3_000), () => process.exit(0));
+  process.stderr.write(${JSON.stringify(output)}, () => process.exit(0));
 }, 10);
 `,
     );
@@ -316,11 +177,7 @@ setTimeout(() => {
     expect(handle.userCode).toBe("ABCD-EFGH");
     const result = await handle.wait();
     expect(result).toMatchObject({ success: true, exitCode: 0, stdout: "" });
-    expect(Buffer.byteLength(result.stderr, "utf8")).toBeLessThanOrEqual(
-      64 * 1024,
-    );
-    expect(result.stderr).toContain("authentication output was truncated");
-    expect(JSON.stringify(result)).not.toContain(secret);
+    expect(result.stderr).toContain(output);
     expect(succeeded).toBe(true);
   });
 
@@ -401,43 +258,13 @@ setTimeout(() => {
     await expect(handle.wait()).resolves.toMatchObject({ success: true });
   });
 
-  test("finds login instructions after verbose output", async () => {
+  test("finds login instructions after large authentication output", async () => {
     const root = await mkdtemp(join(tmpdir(), "codex-security-auth-tail-"));
     temporaryDirectories.push(root);
     const script = join(root, "login.mjs");
     await writeFile(
       script,
-      'process.stderr.write("x".repeat(128 * 1024), () => process.stderr.write("\\nOpen https://auth.example.test/device\\nUser code: ABCD-EFGH\\n", () => process.exit(0)));\n',
-    );
-    const handle = new CodexLoginHandle(
-      { command: process.execPath, prefixArgs: [script] },
-      ["login"],
-      process.env,
-      () => {},
-    );
-
-    await handle.waitForInstructions({ deviceCode: true });
-    expect(handle.verificationUrl).toBe("https://auth.example.test/device");
-    expect(handle.userCode).toBe("ABCD-EFGH");
-    await expect(handle.wait()).resolves.toMatchObject({ success: true });
-  });
-
-  test("does not terminate a verbose interactive login", async () => {
-    const root = await mkdtemp(
-      join(tmpdir(), "codex-security-auth-output-kill-"),
-    );
-    temporaryDirectories.push(root);
-    const script = join(root, "login.mjs");
-    await writeFile(
-      script,
-      `
-console.error("Open https://auth.example.test/device");
-console.error("User code: ABCD-EFGH");
-process.on("SIGTERM", () => process.exit(9));
-setTimeout(() => {
-  process.stderr.write("x".repeat(128 * 1024), () => setTimeout(() => process.exit(0), 20));
-}, 10);
-`,
+      'process.stderr.write(("x".repeat(1024) + "\\n").repeat(128), () => process.stderr.write("Open https://auth.example.test/device\\nUser code: ABCD-EFGH\\n", () => process.exit(0)));\n',
     );
     const handle = new CodexLoginHandle(
       { command: process.execPath, prefixArgs: [script] },
@@ -446,17 +273,10 @@ setTimeout(() => {
       () => {},
     );
 
-    try {
-      await handle.waitForInstructions({ deviceCode: true });
-      const result = await handle.wait();
-      expect(result).toMatchObject({ success: true, exitCode: 0 });
-      expect(Buffer.byteLength(result.stderr, "utf8")).toBeLessThanOrEqual(
-        64 * 1024,
-      );
-    } finally {
-      handle.cancel();
-      await handle.wait();
-    }
+    await handle.waitForInstructions({ deviceCode: true });
+    expect(handle.verificationUrl).toBe("https://auth.example.test/device");
+    expect(handle.userCode).toBe("ABCD-EFGH");
+    await expect(handle.wait()).resolves.toMatchObject({ success: true });
   });
 
   test("drains native login stderr before resolving authentication", async () => {

--- a/sdk/typescript/tests-ts/auth.test.ts
+++ b/sdk/typescript/tests-ts/auth.test.ts
@@ -258,13 +258,13 @@ setTimeout(() => {
     await expect(handle.wait()).resolves.toMatchObject({ success: true });
   });
 
-  test("finds login instructions after large authentication output", async () => {
+  test("preserves login instructions on long output lines", async () => {
     const root = await mkdtemp(join(tmpdir(), "codex-security-auth-tail-"));
     temporaryDirectories.push(root);
     const script = join(root, "login.mjs");
     await writeFile(
       script,
-      'process.stderr.write(("x".repeat(1024) + "\\n").repeat(128), () => process.stderr.write("Open https://auth.example.test/device\\nUser code: ABCD-EFGH\\n", () => process.exit(0)));\n',
+      'process.stderr.write("Open https://auth.example.test/device " + "x".repeat(128 * 1024), () => process.stderr.write("\\nUser code: ABCD-EFGH\\n", () => process.exit(0)));\n',
     );
     const handle = new CodexLoginHandle(
       { command: process.execPath, prefixArgs: [script] },

--- a/sdk/typescript/tests-ts/auth.test.ts
+++ b/sdk/typescript/tests-ts/auth.test.ts
@@ -119,9 +119,29 @@ describe("Codex authentication process boundary", () => {
       expect(Buffer.byteLength(result[stream], "utf8")).toBeLessThanOrEqual(
         64 * 1024,
       );
-      expect(result[stream]).toContain("[redacted]");
+      expect(result[stream]).toContain("authentication output was truncated");
       expect(JSON.stringify(result)).not.toContain(secret);
     }
+  });
+
+  test("never exposes a credential value cut by the retained-output boundary", async () => {
+    const root = await mkdtemp(join(tmpdir(), "codex-security-auth-secret-"));
+    temporaryDirectories.push(root);
+    const script = join(root, "credential.mjs");
+    const secretFragment = "s".repeat(256);
+    await writeFile(
+      script,
+      'process.stdout.write("token=" + "s".repeat(128 * 1024) + "\\ncompleted\\n", () => process.exit(0));\n',
+    );
+
+    const result = await runCodex(
+      { command: process.execPath, prefixArgs: [script] },
+      [],
+      process.env,
+    );
+    expect(result.success).toBe(true);
+    expect(result.stdout).toContain("completed");
+    expect(JSON.stringify(result)).not.toContain(secretFragment);
   });
 
   test("does not terminate a verbose authentication command", async () => {
@@ -154,6 +174,54 @@ process.stderr.write("x".repeat(128 * 1024), () => setTimeout(() => process.exit
       details: "Logged in using ChatGPT",
     });
     await expect(logout(command, process.env)).resolves.toBeUndefined();
+  });
+
+  test.each([
+    ["Logged in using ChatGPT", true],
+    ["not logged in", false],
+    ["unauthenticated", false],
+  ] as const)(
+    "preserves the %s account-status marker after output truncation",
+    async (marker, authenticated) => {
+      const root = await mkdtemp(join(tmpdir(), "codex-security-auth-status-"));
+      temporaryDirectories.push(root);
+      const script = join(root, "status.mjs");
+      await writeFile(
+        script,
+        `process.stdout.write(${JSON.stringify(`${marker}\n`)} + "x".repeat(128 * 1024), () => process.exit(0));\n`,
+      );
+
+      const status = await accountStatus(
+        { command: process.execPath, prefixArgs: [script] },
+        process.env,
+      );
+      expect(status.authenticated).toBe(authenticated);
+      expect(status.details).toContain(
+        authenticated ? "ChatGPT" : "Not logged in",
+      );
+    },
+  );
+
+  test("keeps truncated multilingual diagnostics on UTF-8 boundaries", async () => {
+    const root = await mkdtemp(join(tmpdir(), "codex-security-auth-unicode-"));
+    temporaryDirectories.push(root);
+    const script = join(root, "unicode.mjs");
+    await writeFile(
+      script,
+      'process.stdout.write("discard\\n" + "🔒".repeat(20_000) + "\\n" + "界".repeat(15_000), () => process.exit(0));\n',
+    );
+
+    const result = await runCodex(
+      { command: process.execPath, prefixArgs: [script] },
+      [],
+      process.env,
+    );
+    expect(result.success).toBe(true);
+    expect(Buffer.byteLength(result.stdout, "utf8")).toBeLessThanOrEqual(
+      64 * 1024,
+    );
+    expect(result.stdout).not.toContain("�");
+    expect(result.stdout).toEndWith("界");
   });
 
   test("captures quoted interactive login metadata and completion", async () => {
@@ -207,7 +275,7 @@ setTimeout(() => {
     expect(Buffer.byteLength(result.stderr, "utf8")).toBeLessThanOrEqual(
       64 * 1024,
     );
-    expect(result.stderr).toContain("[redacted]");
+    expect(result.stderr).toContain("authentication output was truncated");
     expect(JSON.stringify(result)).not.toContain(secret);
     expect(succeeded).toBe(true);
   });

--- a/sdk/typescript/tests-ts/auth.test.ts
+++ b/sdk/typescript/tests-ts/auth.test.ts
@@ -100,7 +100,7 @@ describe("Codex authentication process boundary", () => {
     ).resolves.toMatchObject({ success: false, exitCode: 1 });
   });
 
-  test("rejects oversized noninteractive authentication output", async () => {
+  test("keeps verbose authentication output bounded and redacted", async () => {
     const root = await mkdtemp(join(tmpdir(), "codex-security-auth-output-"));
     temporaryDirectories.push(root);
     const secret = "sk-proj-SYNTHETIC_OVERSIZED_OUTPUT_SECRET";
@@ -110,21 +110,21 @@ describe("Codex authentication process boundary", () => {
         script,
         `process.${stream}.write(${JSON.stringify(secret)}.repeat(3_000), () => process.exit(0));\n`,
       );
-      const failure = await runCodex(
+      const result = await runCodex(
         { command: process.execPath, prefixArgs: [script] },
         [],
         process.env,
-      ).then(
-        () => null,
-        (error: unknown) => error,
       );
-      expect(failure).toBeInstanceOf(PluginBootstrapError);
-      expect(String(failure)).toContain("64 KiB safety limit");
-      expect(String(failure)).not.toContain(secret);
+      expect(result.success).toBe(true);
+      expect(Buffer.byteLength(result[stream], "utf8")).toBeLessThanOrEqual(
+        64 * 1024,
+      );
+      expect(result[stream]).toContain("[redacted]");
+      expect(JSON.stringify(result)).not.toContain(secret);
     }
   });
 
-  test("forces oversized noninteractive authentication to terminate", async () => {
+  test("does not terminate a verbose authentication command", async () => {
     const root = await mkdtemp(
       join(tmpdir(), "codex-security-auth-command-kill-"),
     );
@@ -133,29 +133,18 @@ describe("Codex authentication process boundary", () => {
     await writeFile(
       script,
       `
-process.on("SIGTERM", () => {});
-process.stderr.write("x".repeat(128 * 1024));
-setInterval(() => {}, 1000);
+process.on("SIGTERM", () => process.exit(9));
+process.stderr.write("x".repeat(128 * 1024), () => setTimeout(() => process.exit(0), 20));
 `,
     );
-    const timeout = AbortSignal.timeout(2_500);
 
     await expect(
-      Promise.race([
-        runCodex(
-          { command: process.execPath, prefixArgs: [script] },
-          [],
-          process.env,
-        ),
-        new Promise<never>((_, reject) => {
-          timeout.addEventListener(
-            "abort",
-            () => reject(new Error("Oversized authentication did not settle.")),
-            { once: true },
-          );
-        }),
-      ]),
-    ).rejects.toThrow("64 KiB safety limit");
+      runCodex(
+        { command: process.execPath, prefixArgs: [script] },
+        [],
+        process.env,
+      ),
+    ).resolves.toMatchObject({ success: true, exitCode: 0 });
   });
 
   test("reports account state and performs logout", async () => {
@@ -214,13 +203,13 @@ setTimeout(() => {
     expect(handle.verificationUrl).toBe("https://auth.example.test/device");
     expect(handle.userCode).toBe("ABCD-EFGH");
     const result = await handle.wait();
-    expect(result).toMatchObject({
-      success: false,
-      stdout: "",
-      stderr: "Codex login output exceeded the 64 KiB safety limit.",
-    });
+    expect(result).toMatchObject({ success: true, exitCode: 0, stdout: "" });
+    expect(Buffer.byteLength(result.stderr, "utf8")).toBeLessThanOrEqual(
+      64 * 1024,
+    );
+    expect(result.stderr).toContain("[redacted]");
     expect(JSON.stringify(result)).not.toContain(secret);
-    expect(succeeded).toBe(false);
+    expect(succeeded).toBe(true);
   });
 
   test("ignores authentication instructions hidden in a split terminal escape", async () => {
@@ -300,13 +289,13 @@ setTimeout(() => {
     await expect(handle.wait()).resolves.toMatchObject({ success: true });
   });
 
-  test("rejects instruction waiters when an unfinished login exceeds its output bound", async () => {
+  test("finds login instructions after verbose output", async () => {
     const root = await mkdtemp(join(tmpdir(), "codex-security-auth-tail-"));
     temporaryDirectories.push(root);
     const script = join(root, "login.mjs");
     await writeFile(
       script,
-      'process.stderr.write("Open https://auth.example.test/device"); setTimeout(() => process.stderr.write("x".repeat(128 * 1024)), 20);\n',
+      'process.stderr.write("x".repeat(128 * 1024), () => process.stderr.write("\\nOpen https://auth.example.test/device\\nUser code: ABCD-EFGH\\n", () => process.exit(0)));\n',
     );
     const handle = new CodexLoginHandle(
       { command: process.execPath, prefixArgs: [script] },
@@ -315,13 +304,13 @@ setTimeout(() => {
       () => {},
     );
 
-    await expect(handle.waitForInstructions()).rejects.toThrow(
-      "64 KiB safety limit",
-    );
-    await expect(handle.wait()).resolves.toMatchObject({ success: false });
+    await handle.waitForInstructions({ deviceCode: true });
+    expect(handle.verificationUrl).toBe("https://auth.example.test/device");
+    expect(handle.userCode).toBe("ABCD-EFGH");
+    await expect(handle.wait()).resolves.toMatchObject({ success: true });
   });
 
-  test("forces an oversized login to settle when it ignores termination", async () => {
+  test("does not terminate a verbose interactive login", async () => {
     const root = await mkdtemp(
       join(tmpdir(), "codex-security-auth-output-kill-"),
     );
@@ -332,10 +321,9 @@ setTimeout(() => {
       `
 console.error("Open https://auth.example.test/device");
 console.error("User code: ABCD-EFGH");
-process.on("SIGTERM", () => {});
+process.on("SIGTERM", () => process.exit(9));
 setTimeout(() => {
-  process.stderr.write("x".repeat(128 * 1024));
-  setInterval(() => {}, 1000);
+  process.stderr.write("x".repeat(128 * 1024), () => setTimeout(() => process.exit(0), 20));
 }, 10);
 `,
     );
@@ -348,21 +336,11 @@ setTimeout(() => {
 
     try {
       await handle.waitForInstructions({ deviceCode: true });
-      const timeout = AbortSignal.timeout(2_500);
-      const result = await Promise.race([
-        handle.wait(),
-        new Promise<never>((_, reject) => {
-          timeout.addEventListener(
-            "abort",
-            () => reject(new Error("Oversized login did not settle.")),
-            { once: true },
-          );
-        }),
-      ]);
-      expect(result).toMatchObject({
-        success: false,
-        stderr: "Codex login output exceeded the 64 KiB safety limit.",
-      });
+      const result = await handle.wait();
+      expect(result).toMatchObject({ success: true, exitCode: 0 });
+      expect(Buffer.byteLength(result.stderr, "utf8")).toBeLessThanOrEqual(
+        64 * 1024,
+      );
     } finally {
       handle.cancel();
       await handle.wait();


### PR DESCRIPTION
Remove the arbitrary 64 KiB authentication-output limit and 4 KiB login-instruction tail limit.

Keep complete subprocess output and parse login instructions incrementally while preserving login URLs, device codes, account status, cancellation, and existing error handling. No truncation, replacement limit, credential heuristics, or new configuration is introduced.

Validation:
- Complete SDK suite: 980 passed, 11 expected platform/integration skips.
- Focused authentication suite: 15 passed, including large interactive/noninteractive output, complete instructions on long lines, and real cancellation.
- Build, TypeScript, and Prettier checks passed.
