### PR TITLE
fix: remove local plugin and workbench output limits

### DIFF
--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -1,5 +1,5 @@
 import { execFile as execFileCallback, spawn } from "node:child_process";
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { constants, existsSync, type Stats } from "node:fs";
 import {
   chmod,
@@ -57,10 +57,6 @@ const MAX_ZIP_ENTRIES = 4_096;
 const MAX_ZIP_CENTRAL_DIRECTORY = 16 * 1024 * 1024;
 const MAX_ZIP_ENTRY_SIZE = 128 * 1024 * 1024;
 const MAX_ZIP_EXPANDED_SIZE = 512 * 1024 * 1024;
-const MAX_PLUGIN_MANIFEST_SIZE = 1024 * 1024;
-const MAX_PLUGIN_COPY_ENTRIES = 4_096;
-const MAX_PLUGIN_COPY_FILE_SIZE = 128 * 1024 * 1024;
-const MAX_PLUGIN_COPY_SIZE = 512 * 1024 * 1024;
 const MODEL_UNSAFE_PATH = /[\u0000-\u001f\u007f-\u009f\u2028\u2029]/u;
 const CREDENTIAL_LOCK_NAME = ".codex-security-scan.lock";
 const CREDENTIAL_LOGOUT_MARKER = ".codex-security-logged-out";
@@ -1303,7 +1299,7 @@ export async function runWorkbench(
           ),
         ),
         encoding: "utf8",
-        maxBuffer: 4 * 1024 * 1024,
+        maxBuffer: Infinity,
         windowsHide: true,
         signal: options.signal,
       },
@@ -1979,137 +1975,6 @@ export async function createMarketplace(
   return marketplace;
 }
 
-async function pluginProjectionFingerprint(
-  root: string,
-  signal?: AbortSignal,
-): Promise<string> {
-  throwIfSignalAborted(signal);
-  const canonical = await realpath(root);
-  const contractPath = join(
-    canonical,
-    ".internal",
-    "external-promotion",
-    "external-projection-contract.json",
-  );
-  let paths: string[];
-
-  if (
-    canonical === (await bundledPluginRoot()) &&
-    (await isRegularFile(contractPath))
-  ) {
-    let contract: unknown;
-    try {
-      contract = JSON.parse(await readFile(contractPath, "utf8"));
-    } catch (error) {
-      throw new PluginBootstrapError(
-        `Invalid plugin projection contract: ${contractPath}`,
-        { cause: error },
-      );
-    }
-    const shipped = isRecord(contract) ? contract["shippedExact"] : undefined;
-    if (
-      !Array.isArray(shipped) ||
-      !shipped.every((path) => typeof path === "string")
-    ) {
-      throw new PluginBootstrapError(
-        "Plugin projection contract must contain shippedExact paths.",
-      );
-    }
-    paths = [
-      ...new Set(
-        [".codex-plugin/plugin.json", ...shipped]
-          .filter((path) => !path.startsWith("sdk/"))
-          .map((path) => safeArchivePath(path)),
-      ),
-    ];
-  } else {
-    paths = [];
-    const pending = [canonical];
-    let entries = 1;
-    while (pending.length > 0) {
-      throwIfSignalAborted(signal);
-      const path = pending.pop()!;
-      const metadata = await lstat(path);
-      if (metadata.isSymbolicLink()) {
-        throw new PluginBootstrapError(
-          `Plugin contains an unsafe source path: ${path}`,
-        );
-      }
-      if (metadata.isDirectory()) {
-        for await (const entry of pluginDirectoryEntries(path, signal)) {
-          const child = join(path, entry);
-          if (++entries > MAX_PLUGIN_COPY_ENTRIES) {
-            throw new PluginBootstrapError(
-              `Plugin source exceeds the copy entry limit: ${child}`,
-            );
-          }
-          pending.push(child);
-        }
-      } else if (metadata.isFile()) {
-        paths.push(relative(canonical, path).split(sep).join("/"));
-      } else {
-        throw new PluginBootstrapError(
-          `Plugin contains a non-regular file: ${path}`,
-        );
-      }
-    }
-  }
-
-  paths.sort();
-  const fingerprint = createHash("sha256");
-  let totalSize = 0;
-  for (const relativePath of paths) {
-    throwIfSignalAborted(signal);
-    const path = join(canonical, ...relativePath.split("/"));
-    const metadata = await lstat(path);
-    if (!metadata.isFile() || metadata.isSymbolicLink()) {
-      throw new PluginBootstrapError(
-        `Plugin projection contains an unsafe source path: ${path}`,
-      );
-    }
-    if (metadata.size > MAX_PLUGIN_COPY_FILE_SIZE) {
-      throw new PluginBootstrapError(
-        `Plugin source exceeds the per-file safety limit: ${path}`,
-      );
-    }
-    totalSize += metadata.size;
-    if (totalSize > MAX_PLUGIN_COPY_SIZE) {
-      throw new PluginBootstrapError(
-        "Plugin source exceeds the copy safety limit.",
-      );
-    }
-    const handle = await open(
-      path,
-      constants.O_RDONLY |
-        (process.platform === "win32"
-          ? 0
-          : constants.O_NOFOLLOW | constants.O_NONBLOCK),
-    );
-    try {
-      if (!samePluginFile(metadata, await handle.stat())) {
-        throw new PluginBootstrapError(
-          `Plugin source changed before its integrity could be verified: ${path}`,
-        );
-      }
-      const contents = await readExactly(handle, metadata.size, 0, signal);
-      if (!samePluginFile(metadata, await handle.stat())) {
-        throw new PluginBootstrapError(
-          `Plugin source changed while its integrity was being verified: ${path}`,
-        );
-      }
-      fingerprint.update(relativePath);
-      fingerprint.update("\0");
-      fingerprint.update(String(metadata.size));
-      fingerprint.update("\0");
-      fingerprint.update(contents);
-      fingerprint.update("\0");
-    } finally {
-      await handle.close();
-    }
-  }
-  return fingerprint.digest("hex");
-}
-
 async function codexSecurityPluginRegistration(
   codexHome: string,
 ): Promise<{ marketplace: boolean; plugin: boolean }> {
@@ -2246,23 +2111,14 @@ export async function bootstrapPlugin(
   if (installedRoot !== null) {
     const installed = await pluginMetadata(installedRoot);
     if (installed.name === name && installed.version === version) {
-      const [selectedFingerprint, marketplaceFingerprint] = await Promise.all([
-        pluginProjectionFingerprint(root, options.signal),
-        pluginProjectionFingerprint(
-          join(existingMarketplace, "plugins", PLUGIN_NAME),
-          options.signal,
-        ),
-      ]);
-      if (selectedFingerprint === marketplaceFingerprint) {
-        return {
-          pluginRoot: root,
-          marketplaceRoot: existingMarketplace,
-          installedRoot,
-          marketplaceName: MARKETPLACE_NAME,
-          name,
-          version,
-        };
-      }
+      return {
+        pluginRoot: root,
+        marketplaceRoot: existingMarketplace,
+        installedRoot,
+        marketplaceName: MARKETPLACE_NAME,
+        name,
+        version,
+      };
     }
     upgradeExistingPlugin = true;
   }
@@ -2336,36 +2192,11 @@ export async function pluginMetadata(
   const manifestPath = join(root, ".codex-plugin", "plugin.json");
   let manifest: unknown;
   try {
-    const expected = await lstat(manifestPath);
-    if (
-      !expected.isFile() ||
-      expected.isSymbolicLink() ||
-      expected.size > MAX_PLUGIN_MANIFEST_SIZE
-    ) {
-      throw new Error("plugin manifest is not a bounded regular file");
+    const metadata = await lstat(manifestPath);
+    if (!metadata.isFile() || metadata.isSymbolicLink()) {
+      throw new Error("plugin manifest is not a regular file");
     }
-    const input = await open(
-      manifestPath,
-      constants.O_RDONLY |
-        (process.platform === "win32"
-          ? 0
-          : constants.O_NOFOLLOW | constants.O_NONBLOCK),
-    );
-    try {
-      const opened = await input.stat();
-      if (!samePluginFile(expected, opened)) {
-        throw new Error("plugin manifest changed before reading");
-      }
-      const bytes = await readExactly(input, expected.size, 0);
-      if (!samePluginFile(expected, await input.stat())) {
-        throw new Error("plugin manifest changed while reading");
-      }
-      manifest = JSON.parse(
-        new TextDecoder("utf-8", { fatal: true }).decode(bytes),
-      );
-    } finally {
-      await input.close();
-    }
+    manifest = JSON.parse(await readFile(manifestPath, "utf8"));
   } catch (error) {
     throw new PluginBootstrapError(`Invalid Codex plugin directory: ${root}`, {
       cause: error,
@@ -2592,8 +2423,6 @@ async function copyPluginTree(
     { source, destination },
   ];
   const directories = new Map<string, Stats>();
-  let entries = 1;
-  let size = 0;
   await mkdir(dirname(destination), { recursive: true, mode: 0o700 });
   try {
     while (pending.length > 0) {
@@ -2612,11 +2441,6 @@ async function copyPluginTree(
           signal,
         )) {
           const childSource = join(current.source, entry);
-          if (++entries > MAX_PLUGIN_COPY_ENTRIES) {
-            throw new PluginBootstrapError(
-              `Plugin source exceeds the copy entry limit: ${childSource}`,
-            );
-          }
           pending.push({
             source: childSource,
             destination: join(current.destination, entry),
@@ -2635,17 +2459,6 @@ async function copyPluginTree(
       if (!metadata.isFile()) {
         throw new PluginBootstrapError(
           `Plugin contains a non-regular file: ${current.source}`,
-        );
-      }
-      if (metadata.size > MAX_PLUGIN_COPY_FILE_SIZE) {
-        throw new PluginBootstrapError(
-          `Plugin source exceeds the per-file safety limit: ${current.source}`,
-        );
-      }
-      size += metadata.size;
-      if (size > MAX_PLUGIN_COPY_SIZE) {
-        throw new PluginBootstrapError(
-          "Plugin source exceeds the copy safety limit.",
         );
       }
       const input = await open(

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -14,7 +14,6 @@ import {
   rm,
   stat,
   symlink,
-  truncate,
   writeFile,
 } from "node:fs/promises";
 import * as fsPromises from "node:fs/promises";
@@ -751,32 +750,26 @@ describe("plugin runtime preparation", () => {
     ).toBeDefined();
   });
 
-  test("bounds configured plugin directory discovery", async () => {
-    const overflowRoot = await temporaryDirectory();
-    const overflowSource = await plugin(overflowRoot);
-    const overflowDirectory = join(overflowSource, "many-files");
-    await mkdir(overflowDirectory);
+  test("copies configured plugins with more than 4,096 entries", async () => {
+    const root = await temporaryDirectory();
+    const source = await plugin(root);
+    const directory = join(source, "many-files");
+    await mkdir(directory);
     for (let offset = 0; offset < 4_096; offset += 128) {
       await Promise.all(
         Array.from({ length: 128 }, (_value, index) =>
-          writeFile(join(overflowDirectory, String(offset + index)), ""),
+          writeFile(join(directory, String(offset + index)), ""),
         ),
       );
     }
-    const overflowDestination = join(overflowRoot, "overflow-home");
-    await expect(
-      createMarketplace(overflowDestination, overflowSource),
-    ).rejects.toThrow("copy entry limit");
+
+    const marketplace = await createMarketplace(join(root, "home"), source);
+
     expect(
       existsSync(
-        join(
-          overflowDestination,
-          "sdk-marketplace",
-          "plugins",
-          "codex-security",
-        ),
+        join(marketplace, "plugins", "codex-security", "many-files", "4095"),
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   test("cancels configured plugin directory discovery", async () => {
@@ -949,7 +942,7 @@ describe("plugin runtime preparation", () => {
   testPosix(
     "rejects unsafe configured plugin manifests without hanging",
     async () => {
-      for (const kind of ["fifo", "symlink", "sparse"] as const) {
+      for (const kind of ["fifo", "symlink"] as const) {
         const root = await temporaryDirectory();
         const workspace = join(root, "workspace");
         const source = join(root, "plugin");
@@ -963,11 +956,8 @@ describe("plugin runtime preparation", () => {
         );
         if (kind === "fifo") {
           expect(Bun.spawnSync(["mkfifo", manifest]).exitCode).toBe(0);
-        } else if (kind === "symlink") {
-          await symlink(outside, manifest);
         } else {
-          await writeFile(manifest, "{}");
-          await truncate(manifest, 2 * 1024 * 1024);
+          await symlink(outside, manifest);
         }
 
         await expect(resolvePluginPath(source, workspace)).rejects.toThrow(
@@ -976,6 +966,23 @@ describe("plugin runtime preparation", () => {
       }
     },
   );
+
+  test("accepts configured plugin manifests larger than 1 MiB", async () => {
+    const root = await temporaryDirectory();
+    const workspace = join(root, "workspace");
+    const source = await plugin(root);
+    await mkdir(workspace);
+    await writeFile(
+      join(source, ".codex-plugin", "plugin.json"),
+      JSON.stringify({
+        name: "codex-security",
+        version: "1.2.3",
+        description: "x".repeat(1024 * 1024),
+      }),
+    );
+
+    expect(await resolvePluginPath(source, workspace)).toBe(source);
+  });
 
   test("cancels marketplace projection before registering the plugin", async () => {
     const root = await temporaryDirectory();
@@ -1335,6 +1342,10 @@ describe("plugin runtime preparation", () => {
     expect(install.installedRoot).toBe(installed);
     expect(install.version).toBe("1.2.3");
 
+    await writeFile(
+      join(selected, "scripts", "helper.py"),
+      "print('updated')\n",
+    );
     const reused = await bootstrapPlugin(home, selected, {
       codexCommand: { command: "/codex", prefixArgs: [] },
       runCodex: async () => {
@@ -1401,89 +1412,6 @@ describe("plugin runtime preparation", () => {
       '{"token":"preserved"}\n',
     );
     expect(calls).toEqual([
-      ["plugin", "marketplace", "add", marketplace],
-      ["plugin", "add", "codex-security@codex-security-sdk"],
-    ]);
-  });
-
-  test("reinstalls changed plugin contents even when the version is unchanged", async () => {
-    const root = await temporaryDirectory();
-    const previous = await plugin(join(root, "previous"), "1.2.3");
-    const next = await plugin(join(root, "next"), "1.2.3");
-    await writeFile(join(next, "scripts", "helper.py"), "print('updated')\n");
-    const home = join(root, "home");
-    const marketplace = join(home, "sdk-marketplace");
-    const cache = join(
-      home,
-      "plugins",
-      "cache",
-      "codex-security-sdk",
-      "codex-security",
-    );
-    await mkdir(home);
-    let marketplaceRegistered = false;
-    let pluginRegistered = false;
-    const updateConfig = async () => {
-      const sections = ["[features]\nplugins = true\n"];
-      if (marketplaceRegistered) {
-        sections.push(
-          `[marketplaces.codex-security-sdk]\nsource_type = "local"\nsource = ${JSON.stringify(marketplace)}\n`,
-        );
-      }
-      if (pluginRegistered) {
-        sections.push(
-          '[plugins."codex-security@codex-security-sdk"]\nenabled = true\n',
-        );
-      }
-      await writeFile(join(home, "config.toml"), sections.join("\n"));
-    };
-    await updateConfig();
-    const calls: string[][] = [];
-    const options = {
-      codexCommand: { command: "/codex", prefixArgs: [] },
-      runCodex: async (
-        _command: { command: string; prefixArgs: readonly string[] },
-        args: readonly string[],
-      ) => {
-        calls.push([...args]);
-        if (args[1] === "marketplace" && args[2] === "add") {
-          marketplaceRegistered = true;
-        } else if (args[1] === "marketplace" && args[2] === "remove") {
-          marketplaceRegistered = false;
-        } else if (args[1] === "remove") {
-          pluginRegistered = false;
-          await rm(cache, { recursive: true, force: true });
-        } else if (args[1] === "add") {
-          const installed = join(cache, "1.2.3");
-          await mkdir(join(installed, ".codex-plugin"), { recursive: true });
-          await writeFile(
-            join(installed, ".codex-plugin", "plugin.json"),
-            JSON.stringify({ name: "codex-security", version: "1.2.3" }),
-          );
-          pluginRegistered = true;
-        } else {
-          throw new Error(`Unexpected plugin command: ${args.join(" ")}`);
-        }
-        await updateConfig();
-        return "";
-      },
-    };
-
-    await bootstrapPlugin(home, previous, options);
-    const result = await bootstrapPlugin(home, next, options);
-
-    expect(result.pluginRoot).toBe(next);
-    expect(
-      await readFile(
-        join(marketplace, "plugins", "codex-security", "scripts", "helper.py"),
-        "utf8",
-      ),
-    ).toBe("print('updated')\n");
-    expect(calls).toEqual([
-      ["plugin", "marketplace", "add", marketplace],
-      ["plugin", "add", "codex-security@codex-security-sdk"],
-      ["plugin", "remove", "codex-security@codex-security-sdk"],
-      ["plugin", "marketplace", "remove", "codex-security-sdk"],
       ["plugin", "marketplace", "add", marketplace],
       ["plugin", "add", "codex-security@codex-security-sdk"],
     ]);
@@ -3476,7 +3404,7 @@ describe("runtime directories and plugin Python boundary", () => {
     ).toMatchObject({ actual: 8, source: configPath });
   });
 
-  test("runs workbench commands without credentials or generated bytecode", async () => {
+  test("runs workbench commands without output limits, credentials, or generated bytecode", async () => {
     const root = await temporaryDirectory();
     const pluginRoot = join(root, "plugin");
     await mkdir(join(pluginRoot, "scripts"), { recursive: true });
@@ -3491,7 +3419,7 @@ describe("runtime directories and plugin Python boundary", () => {
         "assert os.environ.get('CODEX_API_KEY') is None",
         "assert os.environ.get('OPENROUTER_API_KEY') is None",
         "assert os.environ.get('FIREWORKS_API_KEY') is None",
-        "print(json.dumps({'ok': True}))",
+        "print(json.dumps({'ok': True, 'details': 'x' * (5 * 1024 * 1024)}))",
       ].join("\n"),
     );
     const python = Bun.which("python3") ?? Bun.which("python");
@@ -3510,7 +3438,8 @@ describe("runtime directories and plugin Python boundary", () => {
       },
       ["test-command"],
     );
-    expect(result).toEqual({ ok: true });
+    expect(result["ok"]).toBe(true);
+    expect(result["details"]).toHaveLength(5 * 1024 * 1024);
   });
 
   test("upgrades colliding legacy execution-profile and public CLI migrations", async () => {


### PR DESCRIPTION
Remove file-count, file-size, and manifest-size limits for local plugins. Reuse installed plugins when the name and version match. Accept workbench output larger than 4 MiB.

Validation: 115 runtime tests passed; TypeScript, generated-model, formatting, and build checks passed.