### PR TITLE
fix: remove session event limits and keep scans running

### DIFF
--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -675,37 +675,59 @@ export class CodexSecurity {
           { ...progress, filesTotal: scopeFileCount },
         );
       };
+      const reportTrackingError = (error: unknown): void => {
+        if (options.maxCostUsd !== undefined) {
+          costAbortController.abort(error);
+          return;
+        }
+        notifyObserver(
+          "onWarning",
+          options.onWarning,
+          options.onObserverError,
+          `Could not track scan activity: ${redactedErrorMessage(error)}`,
+        );
+      };
       const tracker = new ScanCostTracker({
         codexHome: runtime.codexHome,
         model,
         repository: repo,
         maxCostUsd: options.maxCostUsd,
-        onActivity: (activity) => {
-          notifyObserver(
-            "onActivity",
-            options.onActivity,
-            options.onObserverError,
-            activity,
-          );
-        },
-        onProgress: reportProgress,
-        onCost: (cost) => {
-          notifyObserver(
-            "onCost",
-            options.onCost,
-            options.onObserverError,
-            cost,
-          );
-          if (
-            options.maxCostUsd !== undefined &&
-            cost.estimatedUsd > options.maxCostUsd
-          ) {
-            costAbortController.abort(
-              new ScanCostLimitExceededError(options.maxCostUsd, cost, scanDir),
-            );
-          }
-        },
-        onError: (error) => costAbortController.abort(error),
+        onActivity:
+          options.onActivity === undefined
+            ? undefined
+            : (activity) =>
+                notifyObserver(
+                  "onActivity",
+                  options.onActivity,
+                  options.onObserverError,
+                  activity,
+                ),
+        onProgress:
+          options.onProgress === undefined ? undefined : reportProgress,
+        onCost:
+          options.onCost === undefined && options.maxCostUsd === undefined
+            ? undefined
+            : (cost) => {
+                notifyObserver(
+                  "onCost",
+                  options.onCost,
+                  options.onObserverError,
+                  cost,
+                );
+                if (
+                  options.maxCostUsd !== undefined &&
+                  cost.estimatedUsd > options.maxCostUsd
+                ) {
+                  costAbortController.abort(
+                    new ScanCostLimitExceededError(
+                      options.maxCostUsd,
+                      cost,
+                      scanDir,
+                    ),
+                  );
+                }
+              },
+        onError: reportTrackingError,
       });
       costTracker = tracker;
       const recipe = scanRecipe(
@@ -973,7 +995,11 @@ export class CodexSecurity {
         model,
         onThreadStarted: (threadId) => tracker.start(threadId),
         onFinalize: async (usage) => {
-          const snapshot = await tracker.stop(usage);
+          const snapshot = await tracker.stop(usage).catch((error: unknown) => {
+            if (options.maxCostUsd !== undefined) throw error;
+            reportTrackingError(error);
+            return { usage, cost: estimateScanCost(model, usage) };
+          });
           throwIfAborted(signal, scanDir);
           if (options.maxCostUsd !== undefined && snapshot.cost === null) {
             notifyObserver(

--- a/sdk/typescript/src/cost.ts
+++ b/sdk/typescript/src/cost.ts
@@ -88,7 +88,6 @@ const MODEL_PRICING_NANODOLLARS: Readonly<Record<string, ModelPricing>> = {
 
 const COST_POLL_INTERVAL_MS = 100;
 const SESSION_READ_SIZE = 64 * 1_024;
-const MAX_SESSION_EVENT_BYTES = 1 * 1_024 * 1_024;
 
 export class ScanCostTracker {
   readonly #options: ScanCostTrackerOptions;
@@ -379,9 +378,6 @@ function readSessionChunk(
     const lineEnd = newline === -1 ? contents.length : newline;
     const fragment = contents.subarray(lineStart, lineEnd);
     const lineBytes = session.pendingLineBytes + fragment.length;
-    if (lineBytes > MAX_SESSION_EVENT_BYTES) {
-      throw new Error("Codex session event exceeds the 1 MiB safety limit.");
-    }
 
     if (newline === -1) {
       if (fragment.length > 0) {

--- a/sdk/typescript/src/worker-progress.ts
+++ b/sdk/typescript/src/worker-progress.ts
@@ -1,5 +1,3 @@
-const MAX_WORKER_STATUS_BYTES = 64 * 1024;
-const MAX_WORKER_COUNT = 1024;
 const WORKER_STATUS_PREFIX = "CODEX_SECURITY_WORKER_STATUS ";
 const SCAN_PROGRESS_PREFIX = "CODEX_SECURITY_SCAN_PROGRESS ";
 const PREFLIGHT_COMMAND = /(?:^|[\\/])config_preflight\.py(?=$|["'\s])/u;
@@ -68,12 +66,7 @@ export function scanProgressUpdatesFromEvent(
       : item["type"] === "command_execution"
         ? item["aggregated_output"]
         : null;
-  if (
-    typeof output !== "string" ||
-    Buffer.byteLength(output, "utf8") > MAX_WORKER_STATUS_BYTES
-  ) {
-    return [];
-  }
+  if (typeof output !== "string") return [];
   const updates: ScanProgress[] = [];
   let codeFence = false;
   for (const line of output.split(/\r?\n/u)) {
@@ -82,15 +75,8 @@ export function scanProgressUpdatesFromEvent(
       continue;
     }
     if (codeFence || !line.startsWith(SCAN_PROGRESS_PREFIX)) continue;
-    if (
-      updates.length === MAX_WORKER_COUNT ||
-      (item["type"] === "agent_message" && updates.length > 0)
-    ) {
-      return [];
-    }
     const progress = scanProgressFromMarker(line);
-    if (progress === null) return [];
-    updates.push(progress);
+    if (progress !== null) updates.push(progress);
   }
   return updates;
 }
@@ -104,7 +90,6 @@ function scanProgressFromMarker(marker: string): ScanProgress | null {
   }
   if (
     !isRecord(payload) ||
-    Object.keys(payload).length !== 3 ||
     !isScanPhase(payload["phase"]) ||
     !isProgressCount(payload["filesCompleted"]) ||
     !isProgressCount(payload["filesTotal"]) ||
@@ -125,9 +110,7 @@ function preflightStatus(
   if (
     typeof item["command"] !== "string" ||
     !PREFLIGHT_COMMAND.test(item["command"]) ||
-    typeof item["aggregated_output"] !== "string" ||
-    Buffer.byteLength(item["aggregated_output"], "utf8") >
-      MAX_WORKER_STATUS_BYTES
+    typeof item["aggregated_output"] !== "string"
   ) {
     return null;
   }
@@ -172,7 +155,7 @@ function preflightStatus(
   const configuredSlots =
     capacity.length === 1 &&
     capacityResult !== undefined &&
-    isWorkerCount(capacityResult["actual"])
+    isProgressCount(capacityResult["actual"])
       ? capacityResult["actual"]
       : null;
   return { kind: "preflight", delegation, configuredSlots };
@@ -181,12 +164,7 @@ function preflightStatus(
 function dispatchStatus(
   item: Readonly<Record<string, unknown>>,
 ): ScanWorkerStatus | null {
-  if (
-    typeof item["text"] !== "string" ||
-    Buffer.byteLength(item["text"], "utf8") > MAX_WORKER_STATUS_BYTES
-  ) {
-    return null;
-  }
+  if (typeof item["text"] !== "string") return null;
   const markers = item["text"]
     .split(/\r?\n/u)
     .filter((line) => line.startsWith(WORKER_STATUS_PREFIX));
@@ -200,11 +178,10 @@ function dispatchStatus(
   }
   if (
     !isRecord(payload) ||
-    Object.keys(payload).length !== 3 ||
     typeof payload["phase"] !== "string" ||
     !WORKER_PHASES.has(payload["phase"]) ||
-    !isWorkerCount(payload["planned"]) ||
-    !isWorkerCount(payload["started"]) ||
+    !isProgressCount(payload["planned"]) ||
+    !isProgressCount(payload["started"]) ||
     payload["started"] > payload["planned"]
   ) {
     return null;
@@ -215,15 +192,6 @@ function dispatchStatus(
     planned: payload["planned"],
     started: payload["started"],
   };
-}
-
-function isWorkerCount(value: unknown): value is number {
-  return (
-    typeof value === "number" &&
-    Number.isSafeInteger(value) &&
-    value >= 0 &&
-    value <= MAX_WORKER_COUNT
-  );
 }
 
 function isProgressCount(value: unknown): value is number {

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -2314,6 +2314,65 @@ describe("CodexSecurity orchestration", () => {
     await client.close();
   });
 
+  test.each([
+    ["without", false],
+    ["with", true],
+  ] as const)(
+    "handles a session-tracking failure %s an explicit cost limit",
+    async (_description, enforceCostLimit) => {
+      const root = await temporaryDirectory();
+      const repository = join(root, "repository");
+      const codexHome = join(root, "codex-home");
+      const scanDir = join(root, "scan");
+      await mkdir(repository);
+      await mkdir(codexHome);
+      await mkdir(scanDir, { mode: 0o700 });
+      await writeFile(join(codexHome, "sessions"), "not a directory");
+      const commands: string[] = [];
+      const warnings: string[] = [];
+      const client = new TestClient(
+        {},
+        {
+          environment: {},
+          prepareRuntime: async () => preparedRuntime(codexHome),
+          resolvePluginPython: async () => "/managed/python",
+          prepareOutputDir: async () => scanDir,
+          repositoryRevision: async () => "deadbeef",
+          runWorkbench: async (_options: unknown, args: readonly string[]) => {
+            commands.push(args[0]!);
+            return mockWorkbench(args);
+          },
+          createCodex: () => ({
+            startThread: () => ({
+              id: null,
+              async runStreamed() {
+                await copyCompletedScan(root);
+                return { events: completedEvents() };
+              },
+            }),
+          }),
+        },
+      );
+
+      const scan = client.run(repository, {
+        ...(enforceCostLimit ? { maxCostUsd: 1 } : {}),
+        onActivity: () => {},
+        onWarning: (warning) => warnings.push(warning),
+      });
+      if (enforceCostLimit) {
+        await expect(scan).rejects.toThrow("interrupted");
+        expect(commands).toContain("fail-scan");
+      } else {
+        await expect(scan).resolves.toMatchObject({ threadId: "thread-1" });
+        expect(warnings).toContainEqual(
+          expect.stringContaining("Could not track scan activity:"),
+        );
+        expect(commands).toContain("complete-scan");
+      }
+      await client.close();
+    },
+  );
+
   test("uses the actual scanner inventory instead of a stale workbench estimate", async () => {
     const root = await temporaryDirectory();
     const repository = join(root, "repository");

--- a/sdk/typescript/tests-ts/cost.test.ts
+++ b/sdk/typescript/tests-ts/cost.test.ts
@@ -1382,7 +1382,7 @@ describe("live scan cost tracking", () => {
     });
   });
 
-  test("retains a bounded partial event across incremental reads", async () => {
+  test("retains a partial event across incremental reads", async () => {
     const home = await codexHome();
     const path = await writeSession(home, "scan-thread", {
       input_tokens: 100,
@@ -1412,82 +1412,33 @@ describe("live scan cost tracking", () => {
     expect((await tracker.stop()).cost?.inputTokens).toBe(250);
   });
 
-  test("rejects and quarantines a session event larger than 1 MiB", async () => {
+  test("reads session events larger than 16 MiB", async () => {
     const home = await codexHome();
     const path = await writeSession(home, "scan-thread", {
       input_tokens: 100,
       output_tokens: 10,
     });
-    await appendFile(path, "x".repeat(1 * 1_024 * 1_024 + 1));
     const tracker = new ScanCostTracker({
       codexHome: home,
       model: "gpt-5.6-terra",
     });
     tracker.start("scan-thread");
 
-    await expect(tracker.refresh()).rejects.toThrow(
-      "Codex session event exceeds the 1 MiB safety limit.",
-    );
-    expect((await tracker.refresh()).cost).toEqual({
-      model: "gpt-5.6-terra",
-      inputTokens: 100,
-      cachedInputTokens: 0,
-      cacheWriteInputTokens: 0,
-      outputTokens: 10,
-      estimatedUsd: 0.00032,
+    const event = JSON.stringify({
+      type: "event_msg",
+      payload: {
+        type: "token_count",
+        info: {
+          total_token_usage: { input_tokens: 250, output_tokens: 20 },
+        },
+        details: "x".repeat(16 * 1_024 * 1_024 + 1),
+      },
     });
-  });
+    await appendFile(path, event.slice(0, -10));
+    expect((await tracker.refresh()).cost?.inputTokens).toBe(100);
 
-  test("ignores oversized events from unrelated prior credential sessions", async () => {
-    const home = await codexHome();
-    const unrelated = await writeSession(home, "unrelated-thread", {
-      input_tokens: 99,
-      output_tokens: 1,
-    });
-    await appendFile(unrelated, "x".repeat(1 * 1_024 * 1_024 + 1));
-    await writeSession(home, "scan-thread", {
-      input_tokens: 100,
-      output_tokens: 10,
-    });
-    const tracker = new ScanCostTracker({
-      codexHome: home,
-      model: "gpt-5.6-terra",
-    });
-    tracker.start("scan-thread");
-
-    expect((await tracker.stop()).cost).toMatchObject({
-      inputTokens: 100,
-      outputTokens: 10,
-    });
-  });
-
-  test("ignores oversized delegated sessions belonging to an unrelated scan", async () => {
-    const home = await codexHome();
-    await writeSession(home, "unrelated-parent", {
-      input_tokens: 1,
-      output_tokens: 1,
-    });
-    const unrelated = await writeSession(
-      home,
-      "unrelated-child",
-      { input_tokens: 1, output_tokens: 1 },
-      "unrelated-parent",
-    );
-    await appendFile(unrelated, "x".repeat(1 * 1_024 * 1_024 + 1));
-    await writeSession(home, "scan-thread", {
-      input_tokens: 100,
-      output_tokens: 10,
-    });
-    const tracker = new ScanCostTracker({
-      codexHome: home,
-      model: "gpt-5.6-terra",
-    });
-    tracker.start("scan-thread");
-
-    expect((await tracker.stop()).cost).toMatchObject({
-      inputTokens: 100,
-      outputTokens: 10,
-    });
+    await appendFile(path, `${event.slice(-10)}\n`);
+    expect((await tracker.stop()).cost?.inputTokens).toBe(250);
   });
 
   test("reports a changed running cost only once", async () => {

--- a/sdk/typescript/tests-ts/worker-progress.test.ts
+++ b/sdk/typescript/tests-ts/worker-progress.test.ts
@@ -99,7 +99,7 @@ describe("worker progress events", () => {
     });
   });
 
-  test("reads a bounded dispatch marker from the agent message", () => {
+  test("reads a dispatch marker from the agent message", () => {
     expect(
       workerStatusFromEvent(
         messageEvent(
@@ -159,7 +159,7 @@ describe("worker progress events", () => {
     ]);
   });
 
-  test("ignores a command when any file-progress update is invalid", () => {
+  test("keeps valid progress when another update is invalid", () => {
     expect(
       scanProgressUpdatesFromEvent(
         commandEvent(
@@ -167,10 +167,69 @@ describe("worker progress events", () => {
           [
             'CODEX_SECURITY_SCAN_PROGRESS {"phase":"discovery","filesCompleted":0,"filesTotal":2}',
             'CODEX_SECURITY_SCAN_PROGRESS {"phase":"discovery","filesCompleted":3,"filesTotal":2}',
+            'CODEX_SECURITY_SCAN_PROGRESS {"phase":"discovery","filesCompleted":2,"filesTotal":2}',
           ].join("\n"),
         ),
       ),
-    ).toEqual([]);
+    ).toEqual([
+      { phase: "discovery", filesCompleted: 0, filesTotal: 2 },
+      { phase: "discovery", filesCompleted: 2, filesTotal: 2 },
+    ]);
+  });
+
+  test("accepts additional progress fields, multiple markers, and verbose output", () => {
+    expect(
+      scanProgressUpdatesFromEvent(
+        messageEvent(
+          [
+            "x".repeat(65 * 1024),
+            'CODEX_SECURITY_SCAN_PROGRESS {"phase":"discovery","filesCompleted":3,"filesTotal":8,"path":"/repository"}',
+            'CODEX_SECURITY_SCAN_PROGRESS {"phase":"discovery","filesCompleted":4,"filesTotal":8}',
+          ].join("\n"),
+        ),
+      ),
+    ).toEqual([
+      { phase: "discovery", filesCompleted: 3, filesTotal: 8 },
+      { phase: "discovery", filesCompleted: 4, filesTotal: 8 },
+    ]);
+  });
+
+  test("accepts verbose worker status and more than 1,024 workers", () => {
+    expect(
+      workerStatusFromEvent(
+        commandEvent(
+          "python3 /plugin/scripts/config_preflight.py",
+          JSON.stringify({
+            profile: "security_scan",
+            details: "x".repeat(65 * 1024),
+            results: [
+              { capability: "delegated_workers", status: "pass" },
+              {
+                capability: "usable_worker_slots_2048",
+                status: "pass",
+                actual: 2048,
+              },
+            ],
+          }),
+        ),
+      ),
+    ).toEqual({
+      kind: "preflight",
+      delegation: "available",
+      configuredSlots: 2048,
+    });
+    expect(
+      workerStatusFromEvent(
+        messageEvent(
+          `${"x".repeat(65 * 1024)}\nCODEX_SECURITY_WORKER_STATUS {"phase":"ranking","planned":2048,"started":1025,"timestamp":1}`,
+        ),
+      ),
+    ).toEqual({
+      kind: "dispatch",
+      phase: "ranking",
+      planned: 2048,
+      started: 1025,
+    });
   });
 
   test("does not mistake documented examples for real scan progress", () => {
@@ -195,9 +254,6 @@ describe("worker progress events", () => {
       'CODEX_SECURITY_SCAN_PROGRESS {"phase":"discovery","filesCompleted":-1,"filesTotal":8}',
       'CODEX_SECURITY_SCAN_PROGRESS {"phase":"discovery","filesCompleted":1.5,"filesTotal":8}',
       'CODEX_SECURITY_SCAN_PROGRESS {"phase":"unknown","filesCompleted":3,"filesTotal":8}',
-      'CODEX_SECURITY_SCAN_PROGRESS {"phase":"discovery","filesCompleted":3,"filesTotal":8,"path":"/repository"}',
-      'CODEX_SECURITY_SCAN_PROGRESS {"phase":"discovery","filesCompleted":3,"filesTotal":8}\nCODEX_SECURITY_SCAN_PROGRESS {"phase":"discovery","filesCompleted":4,"filesTotal":8}',
-      `CODEX_SECURITY_SCAN_PROGRESS {"phase":"discovery","filesCompleted":3,"filesTotal":8}${" ".repeat(65 * 1024)}`,
     ]) {
       expect(scanProgressUpdatesFromEvent(messageEvent(text))).toEqual([]);
     }
@@ -206,7 +262,7 @@ describe("worker progress events", () => {
     ).toEqual([]);
   });
 
-  test("ignores unrelated, malformed, conflicting, or oversized events", () => {
+  test("ignores unrelated, malformed, or conflicting events", () => {
     const preflight = JSON.stringify({
       profile: "security_scan",
       results: [{ capability: "delegated_workers", status: "pass" }],
@@ -238,10 +294,6 @@ describe("worker progress events", () => {
           ],
         }),
       ),
-      commandEvent(
-        "python3 /plugin/scripts/config_preflight.py",
-        `${preflight}${" ".repeat(65 * 1024)}`,
-      ),
       messageEvent(
         'CODEX_SECURITY_WORKER_STATUS {"phase":"ranking","planned":2,"started":3}',
       ),
@@ -250,9 +302,6 @@ describe("worker progress events", () => {
       ),
       messageEvent(
         'CODEX_SECURITY_WORKER_STATUS {"phase":"discovery","planned":2,"started":1}',
-      ),
-      messageEvent(
-        'CODEX_SECURITY_WORKER_STATUS {"phase":"ranking","planned":2,"started":1,"path":"/repository"}',
       ),
       messageEvent(
         'CODEX_SECURITY_WORKER_STATUS {"phase":"ranking","planned":2,"started":1}\nCODEX_SECURITY_WORKER_STATUS {"phase":"ranking","planned":2,"started":0}',


### PR DESCRIPTION
Remove the session-event size limit and accept events larger than 16 MiB.

Keep scans running if optional cost or progress tracking fails. Stop only when an explicitly requested cost limit cannot be enforced.

Accept large worker output, extra marker fields, multiple progress updates, and valid worker counts.

Tests: 140 cost, API, and worker-progress tests; TypeScript and formatting checks.
