### PR TITLE
fix: remove preflight configuration limits

### DIFF
--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -501,7 +501,7 @@ export class CodexSecurity {
       if (runtime.configPath !== undefined) {
         await writeCodexConfig(
           runtime.configPath,
-          scanPreflightCodexConfig(effectiveConfig, repo),
+          scanPreflightCodexConfig(effectiveConfig),
         );
       }
       const runtimeHome = await realpath(runtime.codexHome);
@@ -710,7 +710,6 @@ export class CodexSecurity {
       costTracker = tracker;
       const recipe = scanRecipe(
         repo,
-        protectedRoot,
         normalized,
         mode,
         expectation.repositoryRevision,
@@ -2095,7 +2094,6 @@ function targetInstruction(target: NormalizedTarget): string {
 
 function scanRecipe(
   repository: string,
-  activeProjectPath: string,
   target: NormalizedTarget,
   mode: ScanMode,
   repositoryRevision: string | null,
@@ -2119,7 +2117,7 @@ function scanRecipe(
     mode,
     ...(repositoryRevision === null ? {} : { repositoryRevision }),
     pluginVersion,
-    config: scanPreflightCodexConfig(effectiveConfig, activeProjectPath),
+    config: scanPreflightCodexConfig(effectiveConfig),
     ...(failOnSeverity === undefined ? {} : { failOnSeverity }),
     ...(knowledgeBasePaths === undefined ? {} : { knowledgeBasePaths }),
     ...(maxCostUsd === undefined ? {} : { maxCostUsd }),
@@ -2464,25 +2462,15 @@ export function scanRuntimeCodexConfig(
   };
 }
 
-export function scanPreflightCodexConfig(
-  config: JsonObject,
-  activeProjectPath?: string,
-): JsonObject {
-  const safeString = (value: unknown, maxLength: number): value is string =>
+export function scanPreflightCodexConfig(config: JsonObject): JsonObject {
+  const safeString = (value: unknown): value is string =>
     typeof value === "string" &&
     value.length > 0 &&
-    value.length <= maxLength &&
-    !/[\u0000-\u001f\u007f]/u.test(value) &&
-    !/(?:^|[^a-z0-9])(?:api[_-]?key|access[_-]?key(?:[_-]?id)?|key|secret|token|env|mcp|set|password|passwd|credential|authorization|bearer)(?:[^a-z0-9]|$)/iu.test(
-      value,
-    );
+    !/[\u0000-\u001f\u007f]/u.test(value);
   const safeProfileName = (value: unknown): value is string =>
-    safeString(value, 128) && /^[A-Za-z0-9_-]+$/u.test(value);
+    safeString(value) && /^[A-Za-z0-9_-]+$/u.test(value);
   const safeInteger = (value: unknown): value is number =>
-    typeof value === "number" &&
-    Number.isSafeInteger(value) &&
-    value >= 0 &&
-    value <= 1_000_000;
+    typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
   const capabilityFeatures = (value: unknown): JsonObject => {
     if (!isRecord(value)) return {};
     const result: JsonObject = {};
@@ -2516,7 +2504,7 @@ export function scanPreflightCodexConfig(
       "service_tier",
     ]) {
       const value = source[key];
-      if (safeString(value, 512)) result[key] = value;
+      if (safeString(value)) result[key] = value;
     }
     const features = capabilityFeatures(source["features"]);
     if (Object.keys(features).length > 0) result["features"] = features;
@@ -2537,20 +2525,6 @@ export function scanPreflightCodexConfig(
     }
     return result;
   };
-  const prioritizedEntries = (
-    value: Record<string, unknown>,
-    priority: string | undefined,
-  ): [string, unknown][] => {
-    const entries = Object.entries(value);
-    if (priority === undefined || !Object.hasOwn(value, priority)) {
-      return entries;
-    }
-    return [
-      [priority, value[priority]],
-      ...entries.filter(([key]) => key !== priority),
-    ];
-  };
-
   const result = executionConfig(config);
   const selectedProfile = safeProfileName(config["profile"])
     ? config["profile"]
@@ -2561,17 +2535,11 @@ export function scanPreflightCodexConfig(
   const profiles = config["profiles"];
   if (isRecord(profiles)) {
     const sanitized: JsonObject = {};
-    let accepted = 0;
-    for (const [name, profile] of prioritizedEntries(
-      profiles,
-      selectedProfile,
-    )) {
+    for (const [name, profile] of Object.entries(profiles)) {
       if (!safeProfileName(name) || !isRecord(profile)) continue;
       const projected = executionConfig(profile as JsonObject);
       if (Object.keys(projected).length === 0) continue;
       sanitized[name] = projected;
-      accepted += 1;
-      if (accepted === 256) break;
     }
     if (Object.keys(sanitized).length > 0) result["profiles"] = sanitized;
   }
@@ -2588,7 +2556,7 @@ export function scanPreflightCodexConfig(
       const sanitized: JsonObject = {};
       for (const key of ["region", "profile"]) {
         const value = aws[key];
-        if (safeString(value, 512)) sanitized[key] = value;
+        if (safeString(value)) sanitized[key] = value;
       }
       if (Object.keys(sanitized).length > 0) {
         result["model_providers"] = {
@@ -2599,48 +2567,20 @@ export function scanPreflightCodexConfig(
   }
   const rootMarkers = config["project_root_markers"];
   if (Array.isArray(rootMarkers)) {
-    result["project_root_markers"] = rootMarkers
-      .filter((value): value is string => safeString(value, 256))
-      .slice(0, 64);
+    result["project_root_markers"] = rootMarkers.filter(safeString);
   }
   const projects = config["projects"];
   if (isRecord(projects)) {
     const sanitized: JsonObject = {};
-    let accepted = 0;
-    const activeProjectRoot =
-      activeProjectPath === undefined
-        ? undefined
-        : Object.keys(projects)
-            .filter((path) => {
-              if (!safeString(path, 4096) || !isAbsolute(path)) return false;
-              const remaining = relative(path, activeProjectPath);
-              return (
-                remaining === "" ||
-                (remaining !== ".." &&
-                  !remaining.startsWith(`..${sep}`) &&
-                  !isAbsolute(remaining))
-              );
-            })
-            .sort((left, right) => right.length - left.length)[0];
-    for (const [path, project] of prioritizedEntries(
-      projects,
-      activeProjectRoot ?? activeProjectPath,
-    )) {
-      if (!safeString(path, 4096) || !isAbsolute(path) || !isRecord(project)) {
+    for (const [path, project] of Object.entries(projects)) {
+      if (!safeString(path) || !isAbsolute(path) || !isRecord(project)) {
         continue;
       }
       const trust = project["trust_level"];
       if (trust !== "trusted" && trust !== "untrusted") continue;
       sanitized[path] = { trust_level: trust };
-      accepted += 1;
-      if (accepted === 256) break;
     }
     if (Object.keys(sanitized).length > 0) result["projects"] = sanitized;
-  }
-  if (Buffer.byteLength(JSON.stringify(result), "utf8") > 256 * 1024) {
-    throw new CodexSecurityError(
-      "The sanitized Codex Security preflight config exceeds the size limit.",
-    );
   }
   return result;
 }

--- a/sdk/typescript/tests-ts/api-preflight-config.test.ts
+++ b/sdk/typescript/tests-ts/api-preflight-config.test.ts
@@ -135,6 +135,8 @@ describe("CodexSecurity preflight configuration", () => {
         },
         secret_profile: { features: { goals: false } },
         "credential-prod": { features: { goals: false } },
+        "mcp-server": { features: { goals: true } },
+        "token-review": { features: { goals: false } },
         development: { features: { goals: true } },
         ["a".repeat(129)]: { features: { goals: false } },
       },
@@ -150,6 +152,8 @@ describe("CodexSecurity preflight configuration", () => {
         [repository]: { trust_level: "trusted", token: "PROJECT_TOKEN" },
         [join(root, "secret-project")]: { trust_level: "trusted" },
         [join(root, "bearer-PRIVATE")]: { trust_level: "trusted" },
+        [join(root, "mcp-server")]: { trust_level: "trusted" },
+        [join(root, "token-review")]: { trust_level: "untrusted" },
         [ordinaryProject]: { trust_level: "untrusted" },
         relative: { trust_level: "trusted" },
         [join(root, "bad-trust")]: { trust_level: "PROJECT_SECRET" },
@@ -169,11 +173,27 @@ describe("CodexSecurity preflight configuration", () => {
           features: { goals: true },
           agents: { max_threads: 4 },
         },
+        secret_profile: { features: { goals: false } },
+        "credential-prod": { features: { goals: false } },
+        "mcp-server": { features: { goals: true } },
+        "token-review": { features: { goals: false } },
         development: { features: { goals: true } },
+        ["a".repeat(129)]: { features: { goals: false } },
       },
-      project_root_markers: [".git", ".workspace", "settings.gradle"],
+      project_root_markers: [
+        ".git",
+        ".workspace",
+        ".env",
+        "PASSWORD_VALUE",
+        "settings.gradle",
+        "a".repeat(257),
+      ],
       projects: {
         [repository]: { trust_level: "trusted" },
+        [join(root, "secret-project")]: { trust_level: "trusted" },
+        [join(root, "bearer-PRIVATE")]: { trust_level: "trusted" },
+        [join(root, "mcp-server")]: { trust_level: "trusted" },
+        [join(root, "token-review")]: { trust_level: "untrusted" },
         [ordinaryProject]: { trust_level: "untrusted" },
       },
     });
@@ -285,19 +305,18 @@ describe("CodexSecurity preflight configuration", () => {
       "multiagent_config.max_concurrency",
     );
     expect(JSON.stringify(bridgePreflight)).toContain("12");
-    expect(() =>
-      scanPreflightCodexConfig({
-        projects: Object.fromEntries(
-          Array.from({ length: 256 }, (_, index) => [
-            `/workspace/${index}/${"界".repeat(1300)}`,
-            { trust_level: "trusted" },
-          ]),
-        ),
-      }),
-    ).toThrow(
-      "sanitized Codex Security preflight config exceeds the size limit",
+    const largeConfig = scanPreflightCodexConfig({
+      projects: Object.fromEntries(
+        Array.from({ length: 256 }, (_, index) => [
+          `/workspace/${index}/${"界".repeat(1300)}`,
+          { trust_level: "trusted" },
+        ]),
+      ),
+    });
+    expect(Object.keys(largeConfig["projects"] as JsonObject)).toHaveLength(
+      256,
     );
-    const emptyV2 = scanPreflightCodexConfig({
+    const largeCapacity = scanPreflightCodexConfig({
       features: {
         multi_agent_v2: {
           unknown: true,
@@ -305,13 +324,17 @@ describe("CodexSecurity preflight configuration", () => {
         },
       },
     });
-    expect(emptyV2).toEqual({});
+    expect(largeCapacity).toEqual({
+      features: {
+        multi_agent_v2: { max_concurrent_threads_per_session: 1_000_001 },
+      },
+    });
     await expect(
-      writeCodexConfig(join(root, "empty-v2.toml"), emptyV2),
+      writeCodexConfig(join(root, "large-capacity.toml"), largeCapacity),
     ).resolves.toBeUndefined();
   });
 
-  test("prioritizes the selected profile and active project before projection limits", () => {
+  test("keeps every valid profile, project, and root marker", () => {
     const activeProject = "/workspace/active";
     const profiles = Object.fromEntries([
       ...Array.from({ length: 256 }, (_, index) => [
@@ -328,28 +351,30 @@ describe("CodexSecurity preflight configuration", () => {
       [activeProject, { trust_level: "trusted" }],
     ]);
 
-    const prioritized = scanPreflightCodexConfig(
-      {
-        profile: "selected",
-        profiles,
-        projects,
-      },
-      join(activeProject, "packages", "service"),
-    );
+    const prioritized = scanPreflightCodexConfig({
+      profile: "selected",
+      profiles,
+      projects,
+      project_root_markers: Array.from(
+        { length: 65 },
+        (_, index) => `.marker-${index}`,
+      ),
+    });
 
     expect(prioritized["profile"]).toBe("selected");
     expect(Object.keys(prioritized["profiles"] as JsonObject)).toHaveLength(
-      256,
+      257,
     );
     expect(prioritized["profiles"]).toMatchObject({
       selected: { agents: { max_threads: 17 } },
     });
     expect(Object.keys(prioritized["projects"] as JsonObject)).toHaveLength(
-      256,
+      257,
     );
     expect(prioritized["projects"]).toMatchObject({
       [activeProject]: { trust_level: "trusted" },
     });
+    expect(prioritized["project_root_markers"]).toHaveLength(65);
 
     const validProfiles = Object.fromEntries(
       Array.from({ length: 256 }, (_, index) => [


### PR DESCRIPTION
Remove keyword, size, count, and length limits from scan preflight configuration. Accept project names such as `mcp-server` and `token-review`.

Keep credentials out of files that scanning agents can read.

Tests: 105 API and preflight tests; TypeScript and formatting checks.
