### PR TITLE
docs: add simple guidance for coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Keep it simple
+
+- Trust local files, tools, and processes running as the current user.
+- Do not add arbitrary limits or extra checks without a real problem to solve.
+- Do not let optional logging or progress updates stop the main task.
+- Keep protections for credentials, unsafe paths, and settings the user explicitly requests.
+- Prefer straightforward code and tests for real behavior.


### PR DESCRIPTION
Add short guidance to keep agent-written code simple, avoid arbitrary limits, and preserve useful protections.

Validation: Prettier and git diff --check.