### PR TITLE
fix: remove CLI input, output, and configuration limits

### DIFF
--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -112,11 +112,6 @@ import {
 } from "./version.js";
 
 const PROGRESS_REFRESH_MILLISECONDS = 1_000;
-const MAX_CODEX_OVERRIDE_KEY_LENGTH = 1_024;
-const MAX_CODEX_OVERRIDE_VALUE_LENGTH = 64 * 1_024;
-const MAX_CODEX_OVERRIDE_DEPTH = 64;
-const MAX_SKILL_INPUT_BYTES = 1_024 * 1_024;
-const MAX_SKILL_INPUT_COUNT = 64;
 const MAX_SKILL_EVENT_BYTES = 1_024 * 1_024;
 const MAX_SKILL_RESPONSE_BYTES = 256 * 1_024;
 const SKILL_OUTPUT_LIMIT_MESSAGE =
@@ -2280,9 +2275,6 @@ async function runSkill(
   stderr: Writable,
   dependencies: CliDependencies,
 ): Promise<number> {
-  if (inputs.length > MAX_SKILL_INPUT_COUNT) {
-    throw new CodexSecurityError("Skill inputs exceed the 64-item limit.");
-  }
   const overrides = parseCodexOverrides(codexOverrides, undefined, effort);
   if (
     Object.keys(overrides).some(
@@ -2297,16 +2289,12 @@ async function runSkill(
     await mergedCodexConfig({ codexOverrides: overrides }),
   );
   const directory = dependencies.currentDirectory();
-  let totalBytes = 0;
   const contents: string[] = [];
   for (const input of inputs) {
     if (input.trim().length === 0) {
       throw new CodexSecurityError(
         "Finding or issue inputs must not be empty.",
       );
-    }
-    if (Buffer.byteLength(input, "utf8") > MAX_SKILL_INPUT_BYTES) {
-      throw new CodexSecurityError("Skill input exceeds the 1 MiB limit.");
     }
     let contentsOrLiteral = input;
     const windowsNamespace =
@@ -2349,9 +2337,6 @@ async function runSkill(
             "Finding and issue inputs must be files or literal text.",
           );
         }
-        if (metadata.size > MAX_SKILL_INPUT_BYTES) {
-          throw new CodexSecurityError("Skill input exceeds the 1 MiB limit.");
-        }
         try {
           contentsOrLiteral = await readFile(path, "utf8");
         } catch {
@@ -2365,10 +2350,6 @@ async function runSkill(
           );
         }
       }
-    }
-    totalBytes += Buffer.byteLength(contentsOrLiteral, "utf8");
-    if (totalBytes > MAX_SKILL_INPUT_BYTES) {
-      throw new CodexSecurityError("Skill input exceeds the 1 MiB limit.");
     }
     contents.push(contentsOrLiteral);
   }
@@ -3628,15 +3609,8 @@ export function parseCodexOverrides(
     if (key.length === 0 || literal.length === 0) {
       throw new CodexSecurityError("--codex expects KEY=VALUE");
     }
-    if (
-      Buffer.byteLength(key, "utf8") > MAX_CODEX_OVERRIDE_KEY_LENGTH ||
-      Buffer.byteLength(literal, "utf8") > MAX_CODEX_OVERRIDE_VALUE_LENGTH
-    ) {
-      throw new CodexSecurityError("--codex key or value exceeds the limit");
-    }
     const parts = key.split(".");
     if (
-      parts.length > MAX_CODEX_OVERRIDE_DEPTH ||
       parts.some(
         (part) =>
           part.length === 0 ||

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -22,7 +22,8 @@ import {
   win32,
 } from "node:path";
 import { cwd } from "node:process";
-import { Writable as NodeWritable } from "node:stream";
+import { createInterface } from "node:readline";
+import { Readable, Writable as NodeWritable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import type { ModelReasoningEffort } from "@openai/codex-sdk";
@@ -112,10 +113,6 @@ import {
 } from "./version.js";
 
 const PROGRESS_REFRESH_MILLISECONDS = 1_000;
-const MAX_SKILL_EVENT_BYTES = 1_024 * 1_024;
-const MAX_SKILL_RESPONSE_BYTES = 256 * 1_024;
-const SKILL_OUTPUT_LIMIT_MESSAGE =
-  "Codex skill output exceeded the 1 MiB event or 256 KiB response safety limit.";
 const WINDOWS_NETWORK_PATH = /^[\\/]{2}/u;
 const WINDOWS_LOCAL_DEVICE_ROOT =
   /^[\\/]{2}[?.][\\/](?:[A-Za-z]:|Volume\{[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}\}|GLOBALROOT[\\/]Device[\\/]HarddiskVolume[0-9]+)(?=[\\/]|$)/iu;
@@ -510,7 +507,6 @@ export async function runCodexSkillCommand(
     windowsHide: true,
   });
   let requestedSignal: SignalName | null = null;
-  let skillOutputLimitExceeded = false;
   let forcedTermination: ReturnType<typeof setTimeout> | undefined;
   let forceStatusCompletion: (() => void) | null = null;
   let forceCaptureCompletion: (() => void) | null = null;
@@ -547,10 +543,7 @@ export async function runCodexSkillCommand(
       output === undefined || invocation.stdout === null
         ? Promise.resolve(undefined)
         : Promise.race([
-            readSkillCommandOutput(invocation.stdout, () => {
-              skillOutputLimitExceeded = true;
-              requestTermination("SIGTERM");
-            }),
+            readSkillCommandOutput(invocation.stdout),
             new Promise<undefined>((resolve) => {
               forceCaptureCompletion = () => resolve(undefined);
             }),
@@ -582,9 +575,6 @@ export async function runCodexSkillCommand(
       invocation.once(output === undefined ? "exit" : "close", complete);
     });
     const [status, events] = await Promise.all([invocationStatus, captured]);
-    if (skillOutputLimitExceeded) {
-      throw new CodexSecurityError(SKILL_OUTPUT_LIMIT_MESSAGE);
-    }
     if (output === undefined || status === 130 || status === 143) return status;
     if (status !== 0) {
       await writeCliOutput(
@@ -2392,33 +2382,23 @@ async function runSkill(
 
 export async function readSkillCommandOutput(
   stream: AsyncIterable<Buffer | string>,
-  onLimitExceeded?: () => void,
 ): Promise<{ message?: string; error?: string; malformed: boolean }> {
   let message: string | undefined;
   let error: string | undefined;
   let malformed = false;
-  let exceeded = false;
-  const markExceeded = (): void => {
-    if (exceeded) return;
-    exceeded = true;
-    onLimitExceeded?.();
-  };
 
-  const readLine = (bytes: Buffer): void => {
-    const content =
-      bytes.at(-1) === 0x0d ? bytes.subarray(0, bytes.length - 1) : bytes;
-    const line = content.toString("utf8");
-    if (line.trim().length === 0) return;
+  for await (const line of createInterface({ input: Readable.from(stream) })) {
+    if (line.trim().length === 0) continue;
     let event: unknown;
     try {
       event = JSON.parse(line);
     } catch {
       malformed = true;
-      return;
+      continue;
     }
     if (typeof event !== "object" || event === null) {
       malformed = true;
-      return;
+      continue;
     }
     const value = event as Record<string, unknown>;
     if (value["type"] === "item.completed") {
@@ -2431,11 +2411,7 @@ export async function readSkillCommandOutput(
         "text" in item &&
         typeof item.text === "string"
       ) {
-        if (Buffer.byteLength(item.text, "utf8") > MAX_SKILL_RESPONSE_BYTES) {
-          markExceeded();
-        } else {
-          message = item.text;
-        }
+        message = item.text;
       }
     } else if (value["type"] === "turn.failed") {
       const detail = value["error"];
@@ -2445,63 +2421,15 @@ export async function readSkillCommandOutput(
         "message" in detail &&
         typeof detail.message === "string"
       ) {
-        if (
-          Buffer.byteLength(detail.message, "utf8") > MAX_SKILL_RESPONSE_BYTES
-        ) {
-          markExceeded();
-        } else {
-          error = detail.message;
-        }
+        error = detail.message;
       }
     } else if (
       value["type"] === "error" &&
       typeof value["message"] === "string"
     ) {
-      if (
-        Buffer.byteLength(value["message"], "utf8") > MAX_SKILL_RESPONSE_BYTES
-      ) {
-        markExceeded();
-      } else {
-        error = value["message"];
-      }
-    }
-  };
-
-  const pending = Buffer.alloc(MAX_SKILL_EVENT_BYTES);
-  let pendingBytes = 0;
-  let discardingOversizedLine = false;
-  for await (const rawChunk of stream) {
-    const chunk = Buffer.isBuffer(rawChunk)
-      ? rawChunk
-      : Buffer.from(rawChunk, "utf8");
-    let start = 0;
-    while (start < chunk.length) {
-      const newline = chunk.indexOf(0x0a, start);
-      const end = newline === -1 ? chunk.length : newline;
-      const segment = chunk.subarray(start, end);
-      if (!discardingOversizedLine) {
-        if (pendingBytes + segment.length > MAX_SKILL_EVENT_BYTES) {
-          markExceeded();
-          discardingOversizedLine = true;
-          pendingBytes = 0;
-        } else if (segment.length > 0) {
-          segment.copy(pending, pendingBytes);
-          pendingBytes += segment.length;
-        }
-      }
-      if (newline === -1) break;
-      if (!discardingOversizedLine) {
-        readLine(pending.subarray(0, pendingBytes));
-      }
-      pendingBytes = 0;
-      discardingOversizedLine = false;
-      start = newline + 1;
+      error = value["message"];
     }
   }
-  if (!discardingOversizedLine && pendingBytes > 0) {
-    readLine(pending.subarray(0, pendingBytes));
-  }
-  if (exceeded) throw new CodexSecurityError(SKILL_OUTPUT_LIMIT_MESSAGE);
   return {
     ...(message === undefined ? {} : { message }),
     ...(error === undefined ? {} : { error }),

--- a/sdk/typescript/tests-ts/cli-skills.test.ts
+++ b/sdk/typescript/tests-ts/cli-skills.test.ts
@@ -347,23 +347,17 @@ describe("CLI skill commands", () => {
     }
   });
 
-  test("rejects empty, non-file, and oversized skill inputs before launching Codex", async () => {
+  test("rejects empty and non-file skill inputs before launching Codex", async () => {
     const directory = await mkdtemp(
       join(tmpdir(), "codex-security-skill-inputs-"),
     );
     try {
       await mkdir(join(directory, "nested"));
-      await writeFile(
-        join(directory, "oversized.txt"),
-        Buffer.alloc(1024 * 1024 + 1),
-      );
       await writeFile(join(directory, "empty.txt"), " \n\t");
       const invalidInputs = [
         ["   ", "must not be empty"],
         ["nested", "must be files or literal text"],
         ["empty.txt", "must not be empty"],
-        ["oversized.txt", "exceeds the 1 MiB limit"],
-        ["x".repeat(1024 * 1024 + 1), "exceeds the 1 MiB limit"],
       ];
       for (const [input, expected] of invalidInputs) {
         let started = false;
@@ -385,25 +379,43 @@ describe("CLI skill commands", () => {
         expect(stderr.text()).toContain(expected!);
         expect(started).toBe(false);
       }
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
 
-      let started = false;
-      const tooMany = capture();
-      expect(
-        await main(
-          ["patch", ...Array.from({ length: 65 }, () => "issue")],
-          capture().stream,
-          tooMany.stream,
-          dependencies({
-            currentDirectory: directory,
-            onCodex: () => {
-              started = true;
-              return 0;
-            },
-          }),
-        ),
-      ).toBe(2);
-      expect(tooMany.text()).toContain("64-item limit");
-      expect(started).toBe(false);
+  test("accepts large skill inputs and more than 64 findings", async () => {
+    const directory = await mkdtemp(
+      join(tmpdir(), "codex-security-skill-large-inputs-"),
+    );
+    try {
+      const largeInput = "x".repeat(1024 * 1024 + 1);
+      await writeFile(join(directory, "large.txt"), largeInput);
+
+      for (const inputs of [
+        ["large.txt"],
+        [largeInput],
+        Array.from({ length: 65 }, () => "issue"),
+      ]) {
+        let received: string[] = [];
+        expect(
+          await main(
+            ["validate", ...inputs],
+            capture().stream,
+            capture().stream,
+            dependencies({
+              currentDirectory: directory,
+              onCodex: (args) => {
+                received = JSON.parse(args.at(-1)!.split("\n").at(-1)!);
+                return 0;
+              },
+            }),
+          ),
+        ).toBe(0);
+        expect(received).toEqual(
+          inputs[0] === "large.txt" ? [largeInput] : inputs,
+        );
+      }
     } finally {
       await rm(directory, { recursive: true, force: true });
     }

--- a/sdk/typescript/tests-ts/cli-skills.test.ts
+++ b/sdk/typescript/tests-ts/cli-skills.test.ts
@@ -469,7 +469,7 @@ describe("CLI skill commands", () => {
     });
   });
 
-  test("drains and rejects oversized skill events and responses", async () => {
+  test("accepts skill events and responses larger than 16 MiB", async () => {
     let drained = false;
     async function* oversizedLine(): AsyncGenerator<Buffer> {
       for (let remaining = 1_024 * 1_024 + 1; remaining > 0; ) {
@@ -482,25 +482,28 @@ describe("CLI skill commands", () => {
       );
       drained = true;
     }
-    await expect(readSkillCommandOutput(oversizedLine())).rejects.toThrow(
-      "Codex skill output exceeded the 1 MiB event",
-    );
+    await expect(readSkillCommandOutput(oversizedLine())).resolves.toEqual({
+      message: "must still drain",
+      malformed: true,
+    });
     expect(drained).toBe(true);
 
+    const largeResponse = "x".repeat(16 * 1_024 * 1_024 + 1);
     async function* oversizedResponse(): AsyncGenerator<Buffer> {
       yield Buffer.from(
         `${JSON.stringify({
           type: "item.completed",
           item: {
             type: "agent_message",
-            text: "x".repeat(256 * 1_024 + 1),
+            text: largeResponse,
           },
         })}\n`,
       );
     }
-    await expect(readSkillCommandOutput(oversizedResponse())).rejects.toThrow(
-      "Codex skill output exceeded the 1 MiB event",
-    );
+    await expect(readSkillCommandOutput(oversizedResponse())).resolves.toEqual({
+      message: largeResponse,
+      malformed: false,
+    });
 
     const stdout = capture();
     const stderr = capture();
@@ -512,76 +515,12 @@ describe("CLI skill commands", () => {
           command: process.execPath,
           prefixArgs: [
             "-e",
-            'process.stdout.write(JSON.stringify({type:"item.completed",item:{type:"agent_message",text:"x".repeat(256*1024+1)}})+"\\n")',
+            'process.stdout.write(JSON.stringify({type:"item.completed",item:{type:"agent_message",text:"x".repeat(1024*1024+1)}})+"\\n")',
           ],
         },
       ),
-    ).rejects.toThrow("Codex skill output exceeded the 1 MiB event");
-    expect(stdout.text()).toBe("");
-    expect(stderr.text()).toBe("");
-  });
-
-  test("terminates an oversized skill child that keeps its output open", async () => {
-    const stdout = capture();
-    const stderr = capture();
-    const timeout = AbortSignal.timeout(2_500);
-    const invocation = runCodexSkillCommand(
-      [],
-      { command: "validate", stdout: stdout.stream, stderr: stderr.stream },
-      {
-        command: process.execPath,
-        prefixArgs: [
-          "-e",
-          'process.on("SIGTERM",()=>{});process.stdout.write(JSON.stringify({type:"item.completed",item:{type:"agent_message",text:"x".repeat(256*1024+1)}})+"\\n");setInterval(()=>{},1000)',
-        ],
-      },
-    );
-
-    await expect(
-      Promise.race([
-        invocation,
-        new Promise<never>((_, reject) => {
-          timeout.addEventListener(
-            "abort",
-            () => reject(new Error("Oversized skill process did not settle.")),
-            { once: true },
-          );
-        }),
-      ]),
-    ).rejects.toThrow("Codex skill output exceeded the 1 MiB event");
-    expect(stdout.text()).toBe("");
-    expect(stderr.text()).toBe("");
-  });
-
-  test("terminates an oversized skill child after it closes its stdout", async () => {
-    const stdout = capture();
-    const stderr = capture();
-    const timeout = AbortSignal.timeout(2_500);
-    const invocation = runCodexSkillCommand(
-      [],
-      { command: "validate", stdout: stdout.stream, stderr: stderr.stream },
-      {
-        command: process.execPath,
-        prefixArgs: [
-          "-e",
-          'process.on("SIGTERM",()=>{});process.stdout.write(JSON.stringify({type:"item.completed",item:{type:"agent_message",text:"x".repeat(256*1024+1)}})+"\\n");process.stdout.end();setInterval(()=>{},1000)',
-        ],
-      },
-    );
-
-    await expect(
-      Promise.race([
-        invocation,
-        new Promise<never>((_, reject) => {
-          timeout.addEventListener(
-            "abort",
-            () => reject(new Error("Oversized skill process did not settle.")),
-            { once: true },
-          );
-        }),
-      ]),
-    ).rejects.toThrow("Codex skill output exceeded the 1 MiB event");
-    expect(stdout.text()).toBe("");
+    ).resolves.toBe(0);
+    expect(stdout.text()).toBe(`${"x".repeat(1024 * 1024 + 1)}\n`);
     expect(stderr.text()).toBe("");
   });
 

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -2227,7 +2227,7 @@ describe("CLI", () => {
     }
   });
 
-  test("redacts malformed and bounded --codex overrides", () => {
+  test("redacts malformed --codex overrides and accepts large values", () => {
     const secret = "SYNTHETIC_TOML_SECRET_MUST_NOT_ECHO";
     let malformed: unknown;
     try {
@@ -2241,19 +2241,18 @@ describe("CLI", () => {
     expect((malformed as Error).cause).toBeUndefined();
 
     const deep = `${Array.from({ length: 3_072 }, () => "a").join(".")}=1`;
-    expect(() => parseCodexOverrides([deep])).toThrow("--codex key");
-    expect(() => parseCodexOverrides([`${"a".repeat(1_025)}=1`])).toThrow(
-      "--codex key",
-    );
-    expect(() =>
-      parseCodexOverrides([`model=\"${"x".repeat(64 * 1_024)}\"`]),
-    ).toThrow("--codex key or value exceeds the limit");
-    expect(() => parseCodexOverrides([`${"ࠀ".repeat(342)}=1`])).toThrow(
-      "--codex key or value exceeds the limit",
-    );
-    expect(() =>
-      parseCodexOverrides([`model=\"${"ࠀ".repeat(65_534)}\"`]),
-    ).toThrow("--codex key or value exceeds the limit");
+    let nested: unknown = parseCodexOverrides([deep]);
+    for (let index = 0; index < 3_072; index++) {
+      nested = (nested as Record<string, unknown>)["a"];
+    }
+    expect(nested).toBe(1);
+
+    for (const key of ["a".repeat(1_025), "ࠀ".repeat(342)]) {
+      expect(parseCodexOverrides([`${key}=1`])[key]).toBe(1);
+    }
+    for (const value of ["x".repeat(64 * 1_024), "ࠀ".repeat(65_534)]) {
+      expect(parseCodexOverrides([`model=\"${value}\"`])["model"]).toBe(value);
+    }
   });
 
   test("rejects prototype-bearing override paths", () => {


### PR DESCRIPTION
Remove limits on validation and patch inputs, skill events, skill responses, and `--codex` values. Accept more than 64 inputs and deeply nested configuration.

Read Codex output with Node's standard line reader. Keep cancellation, input validation, credential redaction, and unsafe configuration-key checks.

Tests: 138 CLI and skill-command tests, including a response larger than 16 MiB; TypeScript, formatting, and generated-model checks.
