### PR TITLE
release: bump Codex Security to 0.1.9

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-security",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "TypeScript SDK and CLI for Codex Security",
   "license": "Apache-2.0",
   "author": "OpenAI",


### PR DESCRIPTION
## Summary

- Bump `@openai/codex-security` from `0.1.8` to `0.1.9` with the same one-line release change used for 0.1.8.
- Release the fixes already merged since `npm-v0.1.8`, including large session-event handling and nonfatal optional tracking (#331), scan/report limit removal (#328, #329, #330, #332, #334, #335), and dependency security updates (#323, #314).
- Keep the dependency lockfile, bundled plugin version, and protected release workflows unchanged.

## Verification

- `git diff HEAD^ HEAD --check`
- `node sdk/typescript/scripts/release-automation.mjs version sdk/typescript/package.json` → `0.1.9`
- `node sdk/typescript/scripts/release-automation.mjs require-increase 0.1.9 0.1.8` → `0.1.9`
- `node sdk/typescript/scripts/release-automation.mjs release-tag tag refs/tags/npm-v0.1.9 npm-v0.1.9 sdk/typescript/package.json` → `0.1.9`
- Confirmed the manifest differs from current `main` only in its version.
- Full Node/Bun platform coverage remains the normal pull-request CI gate.

## Release sequencing

Merge separately approved prerequisite fixes into `main` before merging this release PR. The completed-worker shutdown deadlock identified in Deep Scans is not fixed on current `main` and needs its own independently reviewed change if it must be included in 0.1.9.

After review and merge, successful `node-ci` on the exact merged `main` commit triggers `node-release-cut`, which creates `npm-v0.1.9` and dispatches the protected `node-release` workflow. Opening or merging this PR is not npm publication; the protected `npm` deployment still requires its normal approval.
