### PR TITLE
test: stabilize Windows CI subprocess timing

### DIFF
--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -139,7 +139,7 @@ const {
 const releaseCommit = "1e03c89ad22d2df5ae65b146be1483b3608572a9";
 const releaseRun = "30481596229";
 const releaseRepository = "openai/codex-security";
-const releaseTagTimeout = process.platform === "win32" ? 30_000 : 10_000;
+const releaseTagTimeout = process.platform === "win32" ? 20_000 : 10_000;
 const releaseSigningCertificate =
   "MIIHOjCCBr+gAwIBAgIUDDD6xE6tccKRAzn6GcB6Ajvw2+swCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3Rv" +
   "cmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjYwNzI5MTg1MTA1WhcNMjYwNzI5MTkw" +

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -139,6 +139,7 @@ const {
 const releaseCommit = "1e03c89ad22d2df5ae65b146be1483b3608572a9";
 const releaseRun = "30481596229";
 const releaseRepository = "openai/codex-security";
+const releaseTagTimeout = process.platform === "win32" ? 30_000 : 10_000;
 const releaseSigningCertificate =
   "MIIHOjCCBr+gAwIBAgIUDDD6xE6tccKRAzn6GcB6Ajvw2+swCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3Rv" +
   "cmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjYwNzI5MTg1MTA1WhcNMjYwNzI5MTkw" +
@@ -1700,7 +1701,7 @@ describe("GitHub release workflow safeguards", () => {
         RELEASE_SHA: releaseCommit,
         RELEASE_TAG: "npm-v0.1.2",
       },
-      timeout: 10_000,
+      timeout: releaseTagTimeout,
     });
 
     expect(result.status).toBe(0);
@@ -1769,7 +1770,7 @@ describe("GitHub release workflow safeguards", () => {
           MOCK_LOOKUP_RESPONSE: lookupResponse,
           RELEASE_TAG: "npm-v0.1.2",
         },
-        timeout: 10_000,
+        timeout: releaseTagTimeout,
       });
 
       expect(result.status).toBe(status);
@@ -1846,7 +1847,7 @@ describe("GitHub release workflow safeguards", () => {
           MOCK_TAG_TYPE: tagType,
           RELEASE_TAG: "npm-v0.1.2",
         },
-        timeout: 10_000,
+        timeout: releaseTagTimeout,
       });
 
       expect(result.status).toBe(status);

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -2801,7 +2801,7 @@ describe("runtime directories and plugin Python boundary", () => {
         {
           encoding: "utf8",
           env: { ...process.env, CODEX_SECURITY_TEST_ACL_PATH: home },
-          timeout: 30_000,
+          timeout: 20_000,
           windowsHide: true,
         },
       );

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -2801,7 +2801,7 @@ describe("runtime directories and plugin Python boundary", () => {
         {
           encoding: "utf8",
           env: { ...process.env, CODEX_SECURITY_TEST_ACL_PATH: home },
-          timeout: 15_000,
+          timeout: 30_000,
           windowsHide: true,
         },
       );

--- a/sdk/typescript/tests-ts/scan-recovery.test.ts
+++ b/sdk/typescript/tests-ts/scan-recovery.test.ts
@@ -615,59 +615,58 @@ describe("malformed scan artifact recovery", () => {
     expect(coverage.deferred).toHaveLength(4);
   });
 
-  test("retains the strongest duplicate finding regardless of input order", async () => {
-    const cases = [
-      {
-        name: "severity ascending",
-        candidates: [
-          ["informational", "high", 1],
-          ["critical", "high", 1],
-        ],
-        expected: ["critical", "high", 1],
-      },
-      {
-        name: "severity descending",
-        candidates: [
-          ["critical", "high", 1],
-          ["informational", "high", 1],
-        ],
-        expected: ["critical", "high", 1],
-      },
-      {
-        name: "confidence ascending",
-        candidates: [
-          ["critical", "low", 1],
-          ["critical", "high", 1],
-        ],
-        expected: ["critical", "high", 1],
-      },
-      {
-        name: "confidence descending",
-        candidates: [
-          ["critical", "high", 1],
-          ["critical", "low", 1],
-        ],
-        expected: ["critical", "high", 1],
-      },
-      {
-        name: "evidence ascending",
-        candidates: [
-          ["critical", "high", 1],
-          ["critical", "high", 2],
-        ],
-        expected: ["critical", "high", 2],
-      },
-      {
-        name: "evidence descending",
-        candidates: [
-          ["critical", "high", 2],
-          ["critical", "high", 1],
-        ],
-        expected: ["critical", "high", 2],
-      },
-    ] as const;
-
-    for (const { name, candidates, expected } of cases) {
+  test.each([
+    {
+      name: "severity ascending",
+      candidates: [
+        ["informational", "high", 1],
+        ["critical", "high", 1],
+      ],
+      expected: ["critical", "high", 1],
+    },
+    {
+      name: "severity descending",
+      candidates: [
+        ["critical", "high", 1],
+        ["informational", "high", 1],
+      ],
+      expected: ["critical", "high", 1],
+    },
+    {
+      name: "confidence ascending",
+      candidates: [
+        ["critical", "low", 1],
+        ["critical", "high", 1],
+      ],
+      expected: ["critical", "high", 1],
+    },
+    {
+      name: "confidence descending",
+      candidates: [
+        ["critical", "high", 1],
+        ["critical", "low", 1],
+      ],
+      expected: ["critical", "high", 1],
+    },
+    {
+      name: "evidence ascending",
+      candidates: [
+        ["critical", "high", 1],
+        ["critical", "high", 2],
+      ],
+      expected: ["critical", "high", 2],
+    },
+    {
+      name: "evidence descending",
+      candidates: [
+        ["critical", "high", 2],
+        ["critical", "high", 1],
+      ],
+      expected: ["critical", "high", 2],
+    },
+  ] as const)(
+    "retains the strongest duplicate finding with $name input order",
+    async ({ name, candidates, expected }) => {
       const fixture = await startDraftScan();
       const path = join(fixture.scanDir, "findings.json");
       const document = await readJson<FindingsDocument>(path);
@@ -719,8 +718,8 @@ describe("malformed scan artifact recovery", () => {
       expect(sarif.runs[0]?.results[0]?.properties.severity, name).toBe(
         "critical",
       );
-    }
-  });
+    },
+  );
 
   test("completes scans when every draft finding is malformed", async () => {
     const fixture = await startDraftScan();


### PR DESCRIPTION
## Summary
- Give Windows release-tag subprocesses a 20-second budget, preserving 10 seconds of headroom under the existing 30-second test deadline and retaining the original Linux and macOS timeout.
- Allow managed Windows credential ACL verification to complete on slower runners.
- Run all six duplicate-finding recovery scenarios as individual tests so each receives the existing test timeout and independent cleanup.

## Why
The latest main node-ci run failed its Windows/Node 24 job because two release-tag subprocesses hit a 10-second timeout. The preceding main run failed the same job when Windows ACL verification exceeded 15 seconds and six recovery scenarios exhausted one shared 30-second test timeout.

## Verification
- Complete SDK suite: 997 passed, 11 skipped, 0 failed across 1,008 tests.
- Focused affected regressions: 11 passed; the Windows-only ACL integration is correctly skipped on macOS.
- TypeScript checks: `pnpm --dir sdk/typescript run types`.
- Formatting: `pnpm --dir sdk/typescript run format`.
- `git diff --check`.