### PR TITLE
feat(cli): inspect saved scan and worker logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,8 @@ npx @openai/codex-security scan . --verbose
 `LOG_LEVEL=debug` is its fallback. JSON results remain on stdout, and
 credentials and provider identifiers remain redacted.
 
-Use `npx @openai/codex-security scans logs SCAN_ID` to inspect saved activity
-from a scan and its workers. Add `--raw` only when complete, unredacted session
-events are required.
+Use `npx @openai/codex-security scans logs SCAN_ID` to inspect saved session
+events from a scan and its workers.
 
 ## TypeScript SDK
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ npx @openai/codex-security scan . --verbose
 `LOG_LEVEL=debug` is its fallback. JSON results remain on stdout, and
 credentials and provider identifiers remain redacted.
 
+Use `npx @openai/codex-security scans logs SCAN_ID` to inspect saved activity
+from a scan and its workers. Add `--raw` only when complete, unredacted session
+events are required.
+
 ## TypeScript SDK
 
 ```ts

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -219,7 +219,6 @@ npx @openai/codex-security scans list /path/to/repository
 npx @openai/codex-security scans list --scan-root /path/outside/repository/results
 npx @openai/codex-security scans show SCAN_ID
 npx @openai/codex-security scans logs SCAN_ID
-npx @openai/codex-security scans logs SCAN_ID --raw --json
 npx @openai/codex-security scans rerun SCAN_ID
 npx @openai/codex-security scans match PREVIOUS_SCAN_ID CURRENT_SCAN_ID
 npx @openai/codex-security scans match --all
@@ -510,9 +509,8 @@ whose artifacts are under a particular root. `scans show SCAN_ID` includes the
 scan configuration, results, coverage, and artifact locations. Add
 `--show-linked-findings` to include finding links from previous scans.
 
-`scans logs SCAN_ID` shows saved commands, tool calls, reasoning, and messages
-from the scan and its workers. Credentials are redacted. Add `--raw` only when
-you need complete session events; raw logs can contain source code and secrets.
+`scans logs SCAN_ID` shows complete session events from the scan and its
+workers, which can include source code and credentials.
 
 Every scan history command accepts a full scan ID or a unique prefix of at
 least eight characters.

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -218,6 +218,8 @@ npx @openai/codex-security bulk-scan repositories.csv --output-dir /path/outside
 npx @openai/codex-security scans list /path/to/repository
 npx @openai/codex-security scans list --scan-root /path/outside/repository/results
 npx @openai/codex-security scans show SCAN_ID
+npx @openai/codex-security scans logs SCAN_ID
+npx @openai/codex-security scans logs SCAN_ID --raw --json
 npx @openai/codex-security scans rerun SCAN_ID
 npx @openai/codex-security scans match PREVIOUS_SCAN_ID CURRENT_SCAN_ID
 npx @openai/codex-security scans match --all
@@ -507,6 +509,10 @@ repository path to inspect another checkout, `--scan-root DIR` to list scans
 whose artifacts are under a particular root. `scans show SCAN_ID` includes the
 scan configuration, results, coverage, and artifact locations. Add
 `--show-linked-findings` to include finding links from previous scans.
+
+`scans logs SCAN_ID` shows saved commands, tool calls, reasoning, and messages
+from the scan and its workers. Credentials are redacted. Add `--raw` only when
+you need complete session events; raw logs can contain source code and secrets.
 
 Every scan history command accepts a full scan ID or a unique prefix of at
 least eight characters.

--- a/sdk/typescript/_bundled_plugin/scripts/workbench_cli.py
+++ b/sdk/typescript/_bundled_plugin/scripts/workbench_cli.py
@@ -147,6 +147,10 @@ def parse_args(description: str) -> argparse.Namespace:
     register_cli_scan.add_argument("--archive-existing", action="store_true")
     register_cli_scan.add_argument("--archived-scan-dir")
 
+    set_scan_thread = subparsers.add_parser("set-scan-thread")
+    set_scan_thread.add_argument("--scan-id", required=True)
+    set_scan_thread.add_argument("--thread-id", required=True)
+
     get_scan_recipe = subparsers.add_parser("get-scan-recipe")
     get_scan_recipe.add_argument("--scan-id", required=True)
 

--- a/sdk/typescript/_bundled_plugin/scripts/workbench_db.py
+++ b/sdk/typescript/_bundled_plugin/scripts/workbench_db.py
@@ -1432,6 +1432,25 @@ def register_cli_scan(connection: sqlite3.Connection, args: argparse.Namespace) 
     }
 
 
+def set_scan_thread(connection: sqlite3.Connection, args: argparse.Namespace) -> dict[str, Any]:
+    scan = require_scan(connection, args.scan_id)
+    thread_id = optional_text(args.thread_id, maximum=512)
+    if thread_id is None:
+        raise SystemExit("thread-id is required.")
+    if scan["status"] != "running":
+        raise SystemExit("Only a running scan can save its session.")
+    current = scan["continuation_thread_id"]
+    if current is not None and current != thread_id:
+        raise SystemExit("This scan already belongs to another session.")
+    if current is None:
+        with connection:
+            connection.execute(
+                "UPDATE scans SET continuation_thread_id = ?, updated_at = ? WHERE id = ?",
+                (thread_id, now(), scan["id"]),
+            )
+    return {"scanId": scan["id"], "threadId": thread_id}
+
+
 def parse_scan_recipe(value: str, repository: Path) -> dict[str, Any]:
     if len(value.encode("utf-8")) > SCAN_RECIPE_MAX_BYTES:
         raise SystemExit("Scan launch recipe must be no larger than 256 KiB.")
@@ -3354,6 +3373,8 @@ def main() -> None:
             )
         elif args.command == "register-cli-scan":
             result = register_cli_scan(connection, args)
+        elif args.command == "set-scan-thread":
+            result = set_scan_thread(connection, args)
         elif args.command == "get-scan-recipe":
             result = get_scan_recipe(connection, args)
         elif args.command == "compare-scans":

--- a/sdk/typescript/_bundled_plugin/scripts/workbench_db.py
+++ b/sdk/typescript/_bundled_plugin/scripts/workbench_db.py
@@ -1434,21 +1434,12 @@ def register_cli_scan(connection: sqlite3.Connection, args: argparse.Namespace) 
 
 def set_scan_thread(connection: sqlite3.Connection, args: argparse.Namespace) -> dict[str, Any]:
     scan = require_scan(connection, args.scan_id)
-    thread_id = optional_text(args.thread_id, maximum=512)
-    if thread_id is None:
-        raise SystemExit("thread-id is required.")
-    if scan["status"] != "running":
-        raise SystemExit("Only a running scan can save its session.")
-    current = scan["continuation_thread_id"]
-    if current is not None and current != thread_id:
-        raise SystemExit("This scan already belongs to another session.")
-    if current is None:
-        with connection:
-            connection.execute(
-                "UPDATE scans SET continuation_thread_id = ?, updated_at = ? WHERE id = ?",
-                (thread_id, now(), scan["id"]),
-            )
-    return {"scanId": scan["id"], "threadId": thread_id}
+    with connection:
+        connection.execute(
+            "UPDATE scans SET continuation_thread_id = ?, updated_at = ? WHERE id = ?",
+            (args.thread_id, now(), scan["id"]),
+        )
+    return {"scanId": scan["id"], "threadId": args.thread_id}
 
 
 def parse_scan_recipe(value: str, repository: Path) -> dict[str, Any]:

--- a/sdk/typescript/scripts/check-package.mjs
+++ b/sdk/typescript/scripts/check-package.mjs
@@ -158,6 +158,7 @@ const distFiles = new Set(
     "scan-comparison",
     "scan-dashboard",
     "scan-history-renderer",
+    "scan-logs",
     "targets",
     "trusted-executable",
     "version",

--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -992,7 +992,25 @@ export class CodexSecurity {
         authentication,
         workbenchValidated: true,
         model,
-        onThreadStarted: (threadId) => tracker.start(threadId),
+        onThreadStarted: async (threadId) => {
+          tracker.start(threadId);
+          try {
+            await workbench(workbenchOptions, [
+              "set-scan-thread",
+              "--scan-id",
+              scanId,
+              "--thread-id",
+              threadId,
+            ]);
+          } catch (error) {
+            notifyObserver(
+              "onWarning",
+              options.onWarning,
+              options.onObserverError,
+              `Could not save scan session: ${redactedErrorMessage(error)}`,
+            );
+          }
+        },
         onFinalize: async (usage) => {
           const snapshot = await tracker.stop(usage).catch((error: unknown) => {
             if (options.maxCostUsd !== undefined) throw error;
@@ -1748,7 +1766,7 @@ interface ScanEventRunOptions {
   model?: string;
   expectedFilesTotal?: number;
   onFinalize?: (usage: unknown) => Promise<unknown>;
-  onThreadStarted?: (threadId: string) => void;
+  onThreadStarted?: (threadId: string) => Promise<void> | void;
   onScanStarted?: () => void;
   onTrustedAccessStatus?: (status: ScanTrustedAccessStatus) => void;
   onReconnect?: (
@@ -1833,7 +1851,7 @@ export async function runScanEvents(
         const startedThreadId = event["thread_id"];
         if (typeof startedThreadId === "string") {
           threadId = startedThreadId;
-          options.onThreadStarted?.(startedThreadId);
+          await options.onThreadStarted?.(startedThreadId);
         }
         if (!scanStarted) {
           scanStarted = true;

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -906,39 +906,25 @@ export async function main(
           .min(1)
           .describe("Saved scan identifier or unique prefix."),
       }),
-      options: z.object({
-        raw: z
-          .boolean()
-          .default(false)
-          .describe("Include complete unredacted session events."),
-      }),
       output: z.record(z.string(), z.unknown()).optional(),
-      async run({ args, options }) {
+      async run({ args }) {
         return await history(
           ["get-scan", "--scan-id", args.scanId],
           async (value) => {
-            const scan = value["scan"];
-            if (
-              typeof scan !== "object" ||
-              scan === null ||
-              Array.isArray(scan) ||
-              typeof scan["scanId"] !== "string" ||
-              typeof scan["targetPath"] !== "string"
-            ) {
-              throw new CodexSecurityError("The saved scan could not be read.");
-            }
-            const threadId = scan["continuationThreadId"];
-            if (typeof threadId !== "string" || threadId.length === 0) {
+            const scan = value["scan"] as {
+              scanId: string;
+              continuationThreadId?: string;
+            };
+            const threadId = scan.continuationThreadId;
+            if (!threadId) {
               throw new CodexSecurityError(
-                `No session is associated with scan ${scan["scanId"]}.`,
+                `No session is associated with scan ${scan.scanId}.`,
               );
             }
             return (await readScanLogs({
-              scanId: scan["scanId"],
+              scanId: scan.scanId,
               threadId,
-              repository: scan["targetPath"],
               codexHome: codexSecurityCredentialHome(dependencies.environment),
-              raw: options.raw,
             })) as unknown as JsonObject;
           },
         );

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -89,6 +89,7 @@ import {
   matchScanFindings,
   type ScanComparisonInput,
 } from "./scan-comparison.js";
+import { readScanLogs } from "./scan-logs.js";
 import {
   renderScanHistory,
   type HistoryCommand,
@@ -893,6 +894,53 @@ export async function main(
           "show",
           format,
           { showLinkedFindings: options.showLinkedFindings },
+        );
+      },
+    })
+    .command("logs", {
+      description: "Show saved activity for a scan and its workers.",
+      mcp: false,
+      args: z.object({
+        scanId: z
+          .string()
+          .min(1)
+          .describe("Saved scan identifier or unique prefix."),
+      }),
+      options: z.object({
+        raw: z
+          .boolean()
+          .default(false)
+          .describe("Include complete unredacted session events."),
+      }),
+      output: z.record(z.string(), z.unknown()).optional(),
+      async run({ args, options }) {
+        return await history(
+          ["get-scan", "--scan-id", args.scanId],
+          async (value) => {
+            const scan = value["scan"];
+            if (
+              typeof scan !== "object" ||
+              scan === null ||
+              Array.isArray(scan) ||
+              typeof scan["scanId"] !== "string" ||
+              typeof scan["targetPath"] !== "string"
+            ) {
+              throw new CodexSecurityError("The saved scan could not be read.");
+            }
+            const threadId = scan["continuationThreadId"];
+            if (typeof threadId !== "string" || threadId.length === 0) {
+              throw new CodexSecurityError(
+                `No session is associated with scan ${scan["scanId"]}.`,
+              );
+            }
+            return (await readScanLogs({
+              scanId: scan["scanId"],
+              threadId,
+              repository: scan["targetPath"],
+              codexHome: codexSecurityCredentialHome(dependencies.environment),
+              raw: options.raw,
+            })) as unknown as JsonObject;
+          },
         );
       },
     })

--- a/sdk/typescript/src/cost.ts
+++ b/sdk/typescript/src/cost.ts
@@ -311,7 +311,7 @@ export class ScanCostTracker {
   }
 }
 
-async function* sessionFiles(directory: string): AsyncGenerator<string> {
+export async function* sessionFiles(directory: string): AsyncGenerator<string> {
   let entries;
   try {
     entries = await readdir(directory, { withFileTypes: true });

--- a/sdk/typescript/src/scan-logs.ts
+++ b/sdk/typescript/src/scan-logs.ts
@@ -1,17 +1,12 @@
-import { readdir, readFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { CodexSecurityError, redactedErrorMessage } from "./errors.js";
-import {
-  scanActivityFromSessionEvent,
-  type ScanActivity,
-} from "./scan-activity.js";
+import { sessionFiles } from "./cost.js";
+import { CodexSecurityError } from "./errors.js";
 
 interface ScanLogOptions {
   scanId: string;
   threadId: string;
-  repository: string;
   codexHome: string;
-  raw?: boolean;
 }
 
 interface SessionLog {
@@ -22,20 +17,9 @@ interface SessionLog {
   events: Record<string, unknown>[];
 }
 
-export interface ScanLogs {
-  scanId: string;
-  threadId: string;
-  sessions: Array<{
-    threadId: string;
-    parentThreadId: string | null;
-    path: string;
-  }>;
-  events: Record<string, unknown>[];
-}
-
-export async function readScanLogs(options: ScanLogOptions): Promise<ScanLogs> {
+export async function readScanLogs(options: ScanLogOptions) {
   const logs = new Map<string, SessionLog>();
-  for (const path of await sessionPaths(join(options.codexHome, "sessions"))) {
+  for await (const path of sessionFiles(join(options.codexHome, "sessions"))) {
     const events = (await readFile(path, "utf8"))
       .split("\n")
       .filter((line) => line.trim() !== "")
@@ -79,90 +63,34 @@ export async function readScanLogs(options: ScanLogOptions): Promise<ScanLogs> {
     );
   }
 
-  const included = new Set([root.threadId]);
-  let changed = true;
-  while (changed) {
-    changed = false;
+  const sessions = [root];
+  for (const parent of sessions) {
     for (const session of logs.values()) {
-      if (
-        session.parentThreadId !== null &&
-        included.has(session.parentThreadId) &&
-        !included.has(session.threadId)
-      ) {
-        included.add(session.threadId);
-        changed = true;
-      }
+      if (session.parentThreadId === parent.threadId) sessions.push(session);
     }
   }
-
-  const sessions = [
-    root,
-    ...[...logs.values()].filter(
-      (session) =>
-        session.threadId !== root.threadId && included.has(session.threadId),
-    ),
-  ];
   const events: Record<string, unknown>[] = [];
   for (const session of sessions) {
-    const calls = new Map<string, ScanActivity>();
     let replaying = false;
     for (const event of session.events) {
       const payload = event["payload"];
       if (event["type"] === "session_meta" && isRecord(payload)) {
         replaying = payload["id"] !== session.threadId;
-      } else if (replaying) {
+      }
+      if (replaying) {
         if (
-          event["type"] === "event_msg" &&
-          isRecord(payload) &&
-          payload["type"] === "task_started" &&
-          typeof payload["started_at"] === "number" &&
-          session.startedAt !== null &&
-          payload["started_at"] >= session.startedAt
+          event["type"] !== "event_msg" ||
+          !isRecord(payload) ||
+          payload["type"] !== "task_started" ||
+          typeof payload["started_at"] !== "number" ||
+          session.startedAt === null ||
+          payload["started_at"] < session.startedAt
         ) {
-          replaying = false;
-        } else {
           continue;
         }
+        replaying = false;
       }
-      if (replaying) continue;
-      if (options.raw) {
-        events.push({ threadId: session.threadId, event });
-        continue;
-      }
-      let activity = scanActivityFromSessionEvent(event, options.repository);
-      if (
-        activity === null &&
-        event["type"] === "response_item" &&
-        isRecord(payload) &&
-        (payload["type"] === "function_call_output" ||
-          payload["type"] === "custom_tool_call_output") &&
-        typeof payload["call_id"] === "string"
-      ) {
-        const call = calls.get(payload["call_id"]);
-        if (call !== undefined) {
-          activity = {
-            ...call,
-            status: payload["status"] === "failed" ? "failed" : "completed",
-          };
-          calls.delete(call.id);
-        }
-      }
-      if (activity === null) continue;
-      if (activity.status === "running") calls.set(activity.id, activity);
-      events.push({
-        threadId: session.threadId,
-        ...(typeof event["timestamp"] === "string"
-          ? { timestamp: event["timestamp"] }
-          : {}),
-        kind: activity.kind,
-        status: activity.status,
-        description: redactedErrorMessage(activity.description),
-        ...(activity.paths.length === 0
-          ? {}
-          : {
-              paths: activity.paths.map((path) => redactedErrorMessage(path)),
-            }),
-      });
+      events.push({ threadId: session.threadId, event });
     }
   }
 
@@ -176,24 +104,6 @@ export async function readScanLogs(options: ScanLogOptions): Promise<ScanLogs> {
     })),
     events,
   };
-}
-
-async function sessionPaths(directory: string): Promise<string[]> {
-  let entries;
-  try {
-    entries = await readdir(directory, { withFileTypes: true });
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
-    throw error;
-  }
-  const paths = await Promise.all(
-    entries.map(async (entry) => {
-      const path = join(directory, entry.name);
-      if (entry.isDirectory()) return await sessionPaths(path);
-      return entry.isFile() && entry.name.endsWith(".jsonl") ? [path] : [];
-    }),
-  );
-  return paths.flat();
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/sdk/typescript/src/scan-logs.ts
+++ b/sdk/typescript/src/scan-logs.ts
@@ -1,0 +1,201 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { CodexSecurityError, redactedErrorMessage } from "./errors.js";
+import {
+  scanActivityFromSessionEvent,
+  type ScanActivity,
+} from "./scan-activity.js";
+
+interface ScanLogOptions {
+  scanId: string;
+  threadId: string;
+  repository: string;
+  codexHome: string;
+  raw?: boolean;
+}
+
+interface SessionLog {
+  threadId: string;
+  parentThreadId: string | null;
+  startedAt: number | null;
+  path: string;
+  events: Record<string, unknown>[];
+}
+
+export interface ScanLogs {
+  scanId: string;
+  threadId: string;
+  sessions: Array<{
+    threadId: string;
+    parentThreadId: string | null;
+    path: string;
+  }>;
+  events: Record<string, unknown>[];
+}
+
+export async function readScanLogs(options: ScanLogOptions): Promise<ScanLogs> {
+  const logs = new Map<string, SessionLog>();
+  for (const path of await sessionPaths(join(options.codexHome, "sessions"))) {
+    const events = (await readFile(path, "utf8"))
+      .split("\n")
+      .filter((line) => line.trim() !== "")
+      .flatMap((line) => {
+        try {
+          const event: unknown = JSON.parse(line);
+          return isRecord(event) ? [event] : [];
+        } catch {
+          return [];
+        }
+      });
+    const first = events[0];
+    if (first?.["type"] !== "session_meta" || !isRecord(first["payload"])) {
+      continue;
+    }
+    const metadata = first["payload"];
+    const threadId = metadata["id"];
+    if (typeof threadId !== "string") continue;
+    const source = metadata["source"];
+    const subagent = isRecord(source) ? source["subagent"] : undefined;
+    const spawn = isRecord(subagent) ? subagent["thread_spawn"] : undefined;
+    const parent =
+      metadata["parent_thread_id"] ??
+      (isRecord(spawn) ? spawn["parent_thread_id"] : undefined);
+    logs.set(threadId, {
+      threadId,
+      parentThreadId: typeof parent === "string" ? parent : null,
+      startedAt:
+        typeof metadata["timestamp"] === "string"
+          ? Math.floor(Date.parse(metadata["timestamp"]) / 1_000)
+          : null,
+      path,
+      events,
+    });
+  }
+
+  const root = logs.get(options.threadId);
+  if (root === undefined) {
+    throw new CodexSecurityError(
+      `No saved session logs are available for scan ${options.scanId}.`,
+    );
+  }
+
+  const included = new Set([root.threadId]);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const session of logs.values()) {
+      if (
+        session.parentThreadId !== null &&
+        included.has(session.parentThreadId) &&
+        !included.has(session.threadId)
+      ) {
+        included.add(session.threadId);
+        changed = true;
+      }
+    }
+  }
+
+  const sessions = [
+    root,
+    ...[...logs.values()].filter(
+      (session) =>
+        session.threadId !== root.threadId && included.has(session.threadId),
+    ),
+  ];
+  const events: Record<string, unknown>[] = [];
+  for (const session of sessions) {
+    const calls = new Map<string, ScanActivity>();
+    let replaying = false;
+    for (const event of session.events) {
+      const payload = event["payload"];
+      if (event["type"] === "session_meta" && isRecord(payload)) {
+        replaying = payload["id"] !== session.threadId;
+      } else if (replaying) {
+        if (
+          event["type"] === "event_msg" &&
+          isRecord(payload) &&
+          payload["type"] === "task_started" &&
+          typeof payload["started_at"] === "number" &&
+          session.startedAt !== null &&
+          payload["started_at"] >= session.startedAt
+        ) {
+          replaying = false;
+        } else {
+          continue;
+        }
+      }
+      if (replaying) continue;
+      if (options.raw) {
+        events.push({ threadId: session.threadId, event });
+        continue;
+      }
+      let activity = scanActivityFromSessionEvent(event, options.repository);
+      if (
+        activity === null &&
+        event["type"] === "response_item" &&
+        isRecord(payload) &&
+        (payload["type"] === "function_call_output" ||
+          payload["type"] === "custom_tool_call_output") &&
+        typeof payload["call_id"] === "string"
+      ) {
+        const call = calls.get(payload["call_id"]);
+        if (call !== undefined) {
+          activity = {
+            ...call,
+            status: payload["status"] === "failed" ? "failed" : "completed",
+          };
+          calls.delete(call.id);
+        }
+      }
+      if (activity === null) continue;
+      if (activity.status === "running") calls.set(activity.id, activity);
+      events.push({
+        threadId: session.threadId,
+        ...(typeof event["timestamp"] === "string"
+          ? { timestamp: event["timestamp"] }
+          : {}),
+        kind: activity.kind,
+        status: activity.status,
+        description: redactedErrorMessage(activity.description),
+        ...(activity.paths.length === 0
+          ? {}
+          : {
+              paths: activity.paths.map((path) => redactedErrorMessage(path)),
+            }),
+      });
+    }
+  }
+
+  return {
+    scanId: options.scanId,
+    threadId: root.threadId,
+    sessions: sessions.map(({ threadId, parentThreadId, path }) => ({
+      threadId,
+      parentThreadId,
+      path,
+    })),
+    events,
+  };
+}
+
+async function sessionPaths(directory: string): Promise<string[]> {
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+  const paths = await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) return await sessionPaths(path);
+      return entry.isFile() && entry.name.endsWith(".jsonl") ? [path] : [];
+    }),
+  );
+  return paths.flat();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -3320,65 +3320,6 @@ describe("CodexSecurity orchestration", () => {
     await client.close();
   });
 
-  test("keeps the session ID when a started scan fails", async () => {
-    const root = await temporaryDirectory();
-    const repository = join(root, "repository");
-    const codexHome = join(root, "codex-home");
-    const stateDirectory = join(root, "state");
-    const scanDir = join(root, "scan");
-    await mkdir(repository);
-    await mkdir(codexHome);
-    await mkdir(scanDir, { mode: 0o700 });
-    const python = Bun.which("python3") ?? Bun.which("python");
-    expect(python).not.toBeNull();
-    const environment = {
-      PATH: process.env["PATH"],
-      CODEX_SECURITY_STATE_DIR: stateDirectory,
-    };
-    const client = new TestClient(
-      {},
-      {
-        environment,
-        prepareRuntime: async () => ({
-          ...preparedRuntime(codexHome),
-          environment,
-        }),
-        resolvePluginPython: async () => python!,
-        prepareOutputDir: async () => scanDir,
-        repositoryRevision: async () => "deadbeef",
-        runWorkbench,
-        createCodex: () => ({
-          startThread: () => ({
-            id: null,
-            async runStreamed() {
-              async function* events(): AsyncGenerator<ThreadEvent> {
-                yield { type: "thread.started", thread_id: "failed-thread" };
-                yield {
-                  type: "turn.failed",
-                  error: { message: "validation failed" },
-                };
-              }
-              return { events: events() };
-            },
-          }),
-        }),
-      },
-    );
-
-    await expect(client.run(repository)).rejects.toThrow("validation failed");
-    const history = await runWorkbench(
-      { python: python!, pluginRoot: PLUGIN_ROOT, environment },
-      ["list-scans", "--repository", repository],
-    );
-    expect(history["scans"]).toMatchObject([
-      {
-        continuationThreadId: "failed-thread",
-        progress: { status: "failed" },
-      },
-    ]);
-    await client.close();
-  });
-
   test("redacts credentials from the stored scan failure message", async () => {
     const root = await temporaryDirectory();
     const repository = join(root, "repository");
@@ -3422,6 +3363,7 @@ describe("CodexSecurity orchestration", () => {
             id: null,
             async runStreamed() {
               async function* failingEvents(): AsyncGenerator<ThreadEvent> {
+                yield { type: "thread.started", thread_id: "failed-thread" };
                 yield {
                   type: "error",
                   message: `${SYNTHETIC_CREDENTIALS} ${quotedCredential}`,
@@ -3449,6 +3391,7 @@ describe("CodexSecurity orchestration", () => {
       ["get-scan", "--scan-id", scanId],
     );
     expect(context["scan"]).toMatchObject({
+      continuationThreadId: "failed-thread",
       progress: { status: "failed" },
       failureMessage: redactedFailure,
     });

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -1940,11 +1940,18 @@ describe("CodexSecurity orchestration", () => {
       "scan_example_001",
     ]);
     expect(commands[2]).toEqual([
+      "set-scan-thread",
+      "--scan-id",
+      "scan_example_001",
+      "--thread-id",
+      "thread-1",
+    ]);
+    expect(commands[3]).toEqual([
       "prepare-scan-completion",
       "--scan-id",
       "scan_example_001",
     ]);
-    expect(commands[3]).toEqual([
+    expect(commands[4]).toEqual([
       "complete-scan",
       "--scan-id",
       "scan_example_001",
@@ -2308,6 +2315,7 @@ describe("CodexSecurity orchestration", () => {
     expect(commands).toEqual([
       "register-cli-scan",
       "get-scan-feedback",
+      "set-scan-thread",
       "prepare-scan-completion",
       "fail-scan",
     ]);
@@ -2820,6 +2828,7 @@ describe("CodexSecurity orchestration", () => {
     expect(commands.map((command) => command[0])).toEqual([
       "register-cli-scan",
       "get-scan-feedback",
+      "set-scan-thread",
       "prepare-scan-completion",
       "complete-scan",
     ]);
@@ -3033,6 +3042,13 @@ describe("CodexSecurity orchestration", () => {
       "scan_example_001",
     ]);
     expect(commands[2]).toEqual([
+      "set-scan-thread",
+      "--scan-id",
+      "scan_example_001",
+      "--thread-id",
+      "scan-thread",
+    ]);
+    expect(commands[3]).toEqual([
       "fail-scan",
       "--scan-id",
       "scan_example_001",
@@ -3108,6 +3124,7 @@ describe("CodexSecurity orchestration", () => {
     expect(commands.map(([command]) => command)).toEqual([
       "register-cli-scan",
       "get-scan-feedback",
+      "set-scan-thread",
       "prepare-scan-completion",
       "complete-scan",
     ]);
@@ -3299,6 +3316,65 @@ describe("CodexSecurity orchestration", () => {
     );
     expect(history["scans"]).toMatchObject([
       { progress: { status: "failed" } },
+    ]);
+    await client.close();
+  });
+
+  test("keeps the session ID when a started scan fails", async () => {
+    const root = await temporaryDirectory();
+    const repository = join(root, "repository");
+    const codexHome = join(root, "codex-home");
+    const stateDirectory = join(root, "state");
+    const scanDir = join(root, "scan");
+    await mkdir(repository);
+    await mkdir(codexHome);
+    await mkdir(scanDir, { mode: 0o700 });
+    const python = Bun.which("python3") ?? Bun.which("python");
+    expect(python).not.toBeNull();
+    const environment = {
+      PATH: process.env["PATH"],
+      CODEX_SECURITY_STATE_DIR: stateDirectory,
+    };
+    const client = new TestClient(
+      {},
+      {
+        environment,
+        prepareRuntime: async () => ({
+          ...preparedRuntime(codexHome),
+          environment,
+        }),
+        resolvePluginPython: async () => python!,
+        prepareOutputDir: async () => scanDir,
+        repositoryRevision: async () => "deadbeef",
+        runWorkbench,
+        createCodex: () => ({
+          startThread: () => ({
+            id: null,
+            async runStreamed() {
+              async function* events(): AsyncGenerator<ThreadEvent> {
+                yield { type: "thread.started", thread_id: "failed-thread" };
+                yield {
+                  type: "turn.failed",
+                  error: { message: "validation failed" },
+                };
+              }
+              return { events: events() };
+            },
+          }),
+        }),
+      },
+    );
+
+    await expect(client.run(repository)).rejects.toThrow("validation failed");
+    const history = await runWorkbench(
+      { python: python!, pluginRoot: PLUGIN_ROOT, environment },
+      ["list-scans", "--repository", repository],
+    );
+    expect(history["scans"]).toMatchObject([
+      {
+        continuationThreadId: "failed-thread",
+        progress: { status: "failed" },
+      },
     ]);
     await client.close();
   });

--- a/sdk/typescript/tests-ts/cli-workbench.test.ts
+++ b/sdk/typescript/tests-ts/cli-workbench.test.ts
@@ -203,36 +203,33 @@ describe("CLI workbench", () => {
           .join("\n"),
       );
 
-      for (const raw of [false, true]) {
-        const calls: Array<readonly string[]> = [];
-        const stdout = capture();
-        const deps = dependencies({
-          environment: { CODEX_SECURITY_STATE_DIR: state },
-          onWorkbench: (args) => {
-            calls.push(args);
-            return {
-              scan: {
-                scanId: "scan-1",
-                targetPath: "/repo",
-                continuationThreadId: "thread-1",
-              },
-            };
-          },
-        });
-        deps.createSecurity = () => {
-          throw new Error("logs must not initialize Codex");
-        };
-        expect(
-          await main(
-            ["scans", "logs", "scan-1", ...(raw ? ["--raw"] : []), "--json"],
-            stdout.stream,
-            capture().stream,
-            deps,
-          ),
-        ).toBe(0);
-        expect(calls).toEqual([["get-scan", "--scan-id", "scan-1"]]);
-        expect(stdout.text().includes("SYNTHETIC_KEY")).toBe(raw);
-      }
+      const calls: Array<readonly string[]> = [];
+      const stdout = capture();
+      const deps = dependencies({
+        environment: { CODEX_SECURITY_STATE_DIR: state },
+        onWorkbench: (args) => {
+          calls.push(args);
+          return {
+            scan: {
+              scanId: "scan-1",
+              continuationThreadId: "thread-1",
+            },
+          };
+        },
+      });
+      deps.createSecurity = () => {
+        throw new Error("logs must not initialize Codex");
+      };
+      expect(
+        await main(
+          ["scans", "logs", "scan-1", "--json"],
+          stdout.stream,
+          capture().stream,
+          deps,
+        ),
+      ).toBe(0);
+      expect(calls).toEqual([["get-scan", "--scan-id", "scan-1"]]);
+      expect(stdout.text()).toContain("SYNTHETIC_KEY");
     } finally {
       await rm(state, { recursive: true, force: true });
     }

--- a/sdk/typescript/tests-ts/cli-workbench.test.ts
+++ b/sdk/typescript/tests-ts/cli-workbench.test.ts
@@ -1,4 +1,6 @@
-import { resolve } from "node:path";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { describe, expect, test } from "bun:test";
 import type { CodexSecurityConfig, JsonObject } from "../src/index.js";
 import { DiffTarget } from "../src/index.js";
@@ -169,6 +171,90 @@ describe("CLI workbench", () => {
       expect(calls).toEqual([expected]);
       expect(JSON.parse(stdout.text())).toEqual(output);
     }
+  });
+
+  test("shows saved scan activity without starting Codex", async () => {
+    const state = await realpath(
+      await mkdtemp(join(tmpdir(), "codex-security-cli-logs-")),
+    );
+    try {
+      const sessions = join(state, "codex-home", "sessions", "2026", "08");
+      await mkdir(sessions, { recursive: true });
+      await writeFile(
+        join(sessions, "rollout-thread-1.jsonl"),
+        [
+          {
+            type: "session_meta",
+            payload: { id: "thread-1" },
+          },
+          {
+            type: "response_item",
+            payload: {
+              type: "function_call",
+              call_id: "call-1",
+              name: "exec_command",
+              arguments: JSON.stringify({
+                cmd: "OPENAI_API_KEY=sk-proj-SYNTHETIC_KEY_123 pytest",
+              }),
+            },
+          },
+        ]
+          .map((event) => JSON.stringify(event))
+          .join("\n"),
+      );
+
+      for (const raw of [false, true]) {
+        const calls: Array<readonly string[]> = [];
+        const stdout = capture();
+        const deps = dependencies({
+          environment: { CODEX_SECURITY_STATE_DIR: state },
+          onWorkbench: (args) => {
+            calls.push(args);
+            return {
+              scan: {
+                scanId: "scan-1",
+                targetPath: "/repo",
+                continuationThreadId: "thread-1",
+              },
+            };
+          },
+        });
+        deps.createSecurity = () => {
+          throw new Error("logs must not initialize Codex");
+        };
+        expect(
+          await main(
+            ["scans", "logs", "scan-1", ...(raw ? ["--raw"] : []), "--json"],
+            stdout.stream,
+            capture().stream,
+            deps,
+          ),
+        ).toBe(0);
+        expect(calls).toEqual([["get-scan", "--scan-id", "scan-1"]]);
+        expect(stdout.text().includes("SYNTHETIC_KEY")).toBe(raw);
+      }
+    } finally {
+      await rm(state, { recursive: true, force: true });
+    }
+  });
+
+  test("explains when a saved scan has no associated session", async () => {
+    const stderr = capture();
+    expect(
+      await main(
+        ["scans", "logs", "scan-1"],
+        capture().stream,
+        stderr.stream,
+        dependencies({
+          onWorkbench: () => ({
+            scan: { scanId: "scan-1", targetPath: "/repo" },
+          }),
+        }),
+      ),
+    ).toBe(2);
+    expect(stderr.text()).toContain(
+      "No session is associated with scan scan-1.",
+    );
   });
 
   test("matches findings before matching or comparing scans", async () => {

--- a/sdk/typescript/tests-ts/scan-logs.test.ts
+++ b/sdk/typescript/tests-ts/scan-logs.test.ts
@@ -57,35 +57,45 @@ async function temporaryHome(): Promise<string> {
   return directory;
 }
 
+function commandEvent(command: string, id: string, timestamp?: string) {
+  return {
+    type: "response_item",
+    ...(timestamp === undefined ? {} : { timestamp }),
+    payload: {
+      type: "function_call",
+      call_id: id,
+      name: "exec_command",
+      arguments: JSON.stringify({ cmd: command }),
+    },
+  };
+}
+
 describe("saved scan logs", () => {
-  test("includes parent and worker activity but excludes unrelated sessions", async () => {
+  test("returns complete parent and worker events without unrelated sessions", async () => {
     const home = await temporaryHome();
     await writeSession(home, "parent", [
-      {
-        type: "response_item",
-        timestamp: "2026-08-11T12:00:00.000Z",
-        payload: {
-          type: "function_call",
-          call_id: "call-parent",
-          name: "exec_command",
-          arguments: JSON.stringify({
-            cmd: "rg authorization /repo/src/auth.ts",
-          }),
-        },
-      },
+      commandEvent(
+        "OPENAI_API_KEY=sk-proj-SYNTHETIC_KEY_123 rg authorization /repo/src/auth.ts",
+        "call-parent",
+        "2026-08-11T12:00:00.000Z",
+      ),
     ]);
     await writeSession(
       home,
       "worker",
       [
+        commandEvent(
+          "python3 -m pytest /repo/tests",
+          "call-worker",
+          "2026-08-11T12:00:01.000Z",
+        ),
         {
           type: "response_item",
-          timestamp: "2026-08-11T12:00:01.000Z",
           payload: {
-            type: "function_call",
+            type: "function_call_output",
             call_id: "call-worker",
-            name: "exec_command",
-            arguments: JSON.stringify({ cmd: "python3 -m pytest /repo/tests" }),
+            status: "failed",
+            output: "private command output",
           },
         },
       ],
@@ -101,7 +111,6 @@ describe("saved scan logs", () => {
     const result = await readScanLogs({
       scanId: "scan-1",
       threadId: "parent",
-      repository: "/repo",
       codexHome: home,
     });
 
@@ -109,61 +118,23 @@ describe("saved scan logs", () => {
       "parent",
       "worker",
     ]);
-    expect(result.events).toEqual([
-      {
-        threadId: "parent",
-        timestamp: "2026-08-11T12:00:00.000Z",
-        kind: "command",
-        status: "running",
-        description: "rg authorization /repo/src/auth.ts",
-        paths: ["src/auth.ts"],
-      },
-      {
-        threadId: "worker",
-        timestamp: "2026-08-11T12:00:01.000Z",
-        kind: "command",
-        status: "running",
-        description: "python3 -m pytest /repo/tests",
-        paths: ["tests"],
-      },
+    expect(result.events.map(({ threadId }) => threadId)).toEqual([
+      "parent",
+      "parent",
+      "worker",
+      "worker",
+      "worker",
     ]);
-    expect(JSON.stringify(result)).not.toContain("private unrelated scan");
-  });
-
-  test("redacts credentials unless raw events are explicitly requested", async () => {
-    const home = await temporaryHome();
-    await writeSession(home, "parent", [
-      {
+    expect(result.events.at(-1)).toMatchObject({
+      threadId: "worker",
+      event: {
         type: "response_item",
-        payload: {
-          type: "function_call",
-          call_id: "call-1",
-          name: "exec_command",
-          arguments: JSON.stringify({
-            cmd: "OPENAI_API_KEY=sk-proj-SYNTHETIC_KEY_123 cat /repo/config/AWS_SECRET_ACCESS_KEY=SYNTHETIC_VALUE",
-          }),
-        },
+        payload: { status: "failed", output: "private command output" },
       },
-    ]);
-
-    const options = {
-      scanId: "scan-1",
-      threadId: "parent",
-      repository: "/repo",
-      codexHome: home,
-    };
-    const redacted = await readScanLogs(options);
-    expect(redacted.events[0]?.["description"]).toBe(
-      "OPENAI_API_KEY=[redacted] cat /repo/config/AWS_SECRET_ACCESS_KEY=[redacted]",
-    );
-    expect(redacted.events[0]?.["paths"]).toEqual([
-      "config/AWS_SECRET_ACCESS_KEY=[redacted]",
-    ]);
-    expect(JSON.stringify(redacted)).not.toContain("SYNTHETIC_KEY");
-    expect(JSON.stringify(redacted)).not.toContain("SYNTHETIC_VALUE");
-
-    const raw = await readScanLogs({ ...options, raw: true });
-    expect(JSON.stringify(raw)).toContain("sk-proj-SYNTHETIC_KEY_123");
+    });
+    expect(JSON.stringify(result)).toContain("SYNTHETIC_KEY");
+    expect(JSON.stringify(result)).toContain("private command output");
+    expect(JSON.stringify(result)).not.toContain("private unrelated scan");
   });
 
   test("excludes inherited parent history from worker logs", async () => {
@@ -211,53 +182,13 @@ describe("saved scan logs", () => {
       startedAt,
     );
 
-    for (const raw of [false, true]) {
-      const result = await readScanLogs({
-        scanId: "scan-1",
-        threadId: "parent",
-        repository: "/repo",
-        codexHome: home,
-        raw,
-      });
-      expect(JSON.stringify(result)).toContain("Reviewing authorization");
-      expect(JSON.stringify(result)).not.toContain("PRIVATE PRE-SCAN");
-    }
-  });
-
-  test("records completed and failed tool calls", async () => {
-    const home = await temporaryHome();
-    await writeSession(home, "parent", [
-      {
-        type: "response_item",
-        payload: {
-          type: "function_call",
-          call_id: "call-1",
-          name: "exec_command",
-          arguments: JSON.stringify({ cmd: "pytest /repo/tests" }),
-        },
-      },
-      {
-        type: "response_item",
-        payload: {
-          type: "function_call_output",
-          call_id: "call-1",
-          status: "failed",
-          output: "private command output",
-        },
-      },
-    ]);
-
     const result = await readScanLogs({
       scanId: "scan-1",
       threadId: "parent",
-      repository: "/repo",
       codexHome: home,
     });
-    expect(result.events.map((event) => event["status"])).toEqual([
-      "running",
-      "failed",
-    ]);
-    expect(JSON.stringify(result)).not.toContain("private command output");
+    expect(JSON.stringify(result)).toContain("Reviewing authorization");
+    expect(JSON.stringify(result)).not.toContain("PRIVATE PRE-SCAN");
   });
 
   test("reports when the saved scan session is missing", async () => {
@@ -266,7 +197,6 @@ describe("saved scan logs", () => {
       readScanLogs({
         scanId: "scan-1",
         threadId: "missing",
-        repository: "/repo",
         codexHome: home,
       }),
     ).rejects.toThrow("No saved session logs are available for scan scan-1.");

--- a/sdk/typescript/tests-ts/scan-logs.test.ts
+++ b/sdk/typescript/tests-ts/scan-logs.test.ts
@@ -1,0 +1,274 @@
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import { readScanLogs } from "../src/scan-logs.js";
+
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    directories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+async function writeSession(
+  home: string,
+  threadId: string,
+  events: Record<string, unknown>[],
+  parentThreadId?: string,
+  startedAt?: string,
+): Promise<void> {
+  const directory = join(home, "sessions", "2026", "08", "11");
+  await mkdir(directory, { recursive: true });
+  await writeFile(
+    join(directory, `rollout-${threadId}.jsonl`),
+    [
+      {
+        type: "session_meta",
+        payload: {
+          id: threadId,
+          ...(startedAt === undefined ? {} : { timestamp: startedAt }),
+          ...(parentThreadId === undefined
+            ? {}
+            : {
+                source: {
+                  subagent: {
+                    thread_spawn: { parent_thread_id: parentThreadId },
+                  },
+                },
+              }),
+        },
+      },
+      ...events,
+    ]
+      .map((event) => JSON.stringify(event))
+      .join("\n"),
+  );
+}
+
+async function temporaryHome(): Promise<string> {
+  const directory = await realpath(
+    await mkdtemp(join(tmpdir(), "codex-security-scan-logs-")),
+  );
+  directories.push(directory);
+  return directory;
+}
+
+describe("saved scan logs", () => {
+  test("includes parent and worker activity but excludes unrelated sessions", async () => {
+    const home = await temporaryHome();
+    await writeSession(home, "parent", [
+      {
+        type: "response_item",
+        timestamp: "2026-08-11T12:00:00.000Z",
+        payload: {
+          type: "function_call",
+          call_id: "call-parent",
+          name: "exec_command",
+          arguments: JSON.stringify({
+            cmd: "rg authorization /repo/src/auth.ts",
+          }),
+        },
+      },
+    ]);
+    await writeSession(
+      home,
+      "worker",
+      [
+        {
+          type: "response_item",
+          timestamp: "2026-08-11T12:00:01.000Z",
+          payload: {
+            type: "function_call",
+            call_id: "call-worker",
+            name: "exec_command",
+            arguments: JSON.stringify({ cmd: "python3 -m pytest /repo/tests" }),
+          },
+        },
+      ],
+      "parent",
+    );
+    await writeSession(home, "unrelated", [
+      {
+        type: "event_msg",
+        payload: { type: "agent_message", message: "private unrelated scan" },
+      },
+    ]);
+
+    const result = await readScanLogs({
+      scanId: "scan-1",
+      threadId: "parent",
+      repository: "/repo",
+      codexHome: home,
+    });
+
+    expect(result.sessions.map(({ threadId }) => threadId).sort()).toEqual([
+      "parent",
+      "worker",
+    ]);
+    expect(result.events).toEqual([
+      {
+        threadId: "parent",
+        timestamp: "2026-08-11T12:00:00.000Z",
+        kind: "command",
+        status: "running",
+        description: "rg authorization /repo/src/auth.ts",
+        paths: ["src/auth.ts"],
+      },
+      {
+        threadId: "worker",
+        timestamp: "2026-08-11T12:00:01.000Z",
+        kind: "command",
+        status: "running",
+        description: "python3 -m pytest /repo/tests",
+        paths: ["tests"],
+      },
+    ]);
+    expect(JSON.stringify(result)).not.toContain("private unrelated scan");
+  });
+
+  test("redacts credentials unless raw events are explicitly requested", async () => {
+    const home = await temporaryHome();
+    await writeSession(home, "parent", [
+      {
+        type: "response_item",
+        payload: {
+          type: "function_call",
+          call_id: "call-1",
+          name: "exec_command",
+          arguments: JSON.stringify({
+            cmd: "OPENAI_API_KEY=sk-proj-SYNTHETIC_KEY_123 cat /repo/config/AWS_SECRET_ACCESS_KEY=SYNTHETIC_VALUE",
+          }),
+        },
+      },
+    ]);
+
+    const options = {
+      scanId: "scan-1",
+      threadId: "parent",
+      repository: "/repo",
+      codexHome: home,
+    };
+    const redacted = await readScanLogs(options);
+    expect(redacted.events[0]?.["description"]).toBe(
+      "OPENAI_API_KEY=[redacted] cat /repo/config/AWS_SECRET_ACCESS_KEY=[redacted]",
+    );
+    expect(redacted.events[0]?.["paths"]).toEqual([
+      "config/AWS_SECRET_ACCESS_KEY=[redacted]",
+    ]);
+    expect(JSON.stringify(redacted)).not.toContain("SYNTHETIC_KEY");
+    expect(JSON.stringify(redacted)).not.toContain("SYNTHETIC_VALUE");
+
+    const raw = await readScanLogs({ ...options, raw: true });
+    expect(JSON.stringify(raw)).toContain("sk-proj-SYNTHETIC_KEY_123");
+  });
+
+  test("excludes inherited parent history from worker logs", async () => {
+    const home = await temporaryHome();
+    await writeSession(home, "parent", []);
+    const startedAt = "2026-08-11T12:02:00.000Z";
+    await writeSession(
+      home,
+      "worker",
+      [
+        {
+          type: "session_meta",
+          payload: { id: "parent", timestamp: "2026-08-11T12:00:00.000Z" },
+        },
+        {
+          type: "event_msg",
+          payload: {
+            type: "task_started",
+            started_at: Date.parse("2026-08-11T12:00:00.000Z") / 1_000,
+          },
+        },
+        {
+          type: "event_msg",
+          payload: {
+            type: "agent_message",
+            message: "PRIVATE PRE-SCAN CONVERSATION",
+          },
+        },
+        {
+          type: "event_msg",
+          payload: {
+            type: "task_started",
+            started_at: Date.parse(startedAt) / 1_000,
+          },
+        },
+        {
+          type: "event_msg",
+          payload: {
+            type: "agent_message",
+            message: "Reviewing authorization",
+          },
+        },
+      ],
+      "parent",
+      startedAt,
+    );
+
+    for (const raw of [false, true]) {
+      const result = await readScanLogs({
+        scanId: "scan-1",
+        threadId: "parent",
+        repository: "/repo",
+        codexHome: home,
+        raw,
+      });
+      expect(JSON.stringify(result)).toContain("Reviewing authorization");
+      expect(JSON.stringify(result)).not.toContain("PRIVATE PRE-SCAN");
+    }
+  });
+
+  test("records completed and failed tool calls", async () => {
+    const home = await temporaryHome();
+    await writeSession(home, "parent", [
+      {
+        type: "response_item",
+        payload: {
+          type: "function_call",
+          call_id: "call-1",
+          name: "exec_command",
+          arguments: JSON.stringify({ cmd: "pytest /repo/tests" }),
+        },
+      },
+      {
+        type: "response_item",
+        payload: {
+          type: "function_call_output",
+          call_id: "call-1",
+          status: "failed",
+          output: "private command output",
+        },
+      },
+    ]);
+
+    const result = await readScanLogs({
+      scanId: "scan-1",
+      threadId: "parent",
+      repository: "/repo",
+      codexHome: home,
+    });
+    expect(result.events.map((event) => event["status"])).toEqual([
+      "running",
+      "failed",
+    ]);
+    expect(JSON.stringify(result)).not.toContain("private command output");
+  });
+
+  test("reports when the saved scan session is missing", async () => {
+    const home = await temporaryHome();
+    await expect(
+      readScanLogs({
+        scanId: "scan-1",
+        threadId: "missing",
+        repository: "/repo",
+        codexHome: home,
+      }),
+    ).rejects.toThrow("No saved session logs are available for scan scan-1.");
+  });
+});


### PR DESCRIPTION
## Summary
- Save the scan session ID when work starts, even if the scan fails.
- Add `scans logs SCAN_ID` to return saved scan and worker events directly.
- Exclude unrelated scans and inherited worker history.
- Keep event contents unchanged; logs can contain source code and credentials.
- API-key scans also need #348 to keep their session logs.

## Tests
- 272 scan, CLI, session, and API tests passed.
- Types, formatting, build, and package checks passed.