### PR TITLE
fix(sdk): use safe scan session warning

### DIFF
--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -1030,7 +1030,7 @@ export class CodexSecurity {
               "onWarning",
               options.onWarning,
               options.onObserverError,
-              `Could not save scan session: ${redactedErrorMessage(error)}`,
+              `Could not save scan session: ${safeErrorMessage(error)}`,
             );
           }
         },


### PR DESCRIPTION
## Summary

- replace the dangling `redactedErrorMessage` call in the scan-session warning with the already-imported `safeErrorMessage`
- restore the TypeScript and customer-container build gates on `main`

## Root cause

`redactedErrorMessage` was removed in favor of `safeErrorMessage`, but a call added while the branch was stale remained in `api.ts` after merge. That left `main` failing `tsc --noEmit` with `TS2552`.

## Validation

- `CI=true XDG_DATA_HOME=/tmp/codex-security-fix-xdg pnpm run types`
