### PR TITLE
fix(deep-scan): avoid unspawnable Windows Codex paths

### DIFF
--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -63,6 +63,8 @@ const CREDENTIAL_LOGOUT_MARKER = ".codex-security-logged-out";
 const CREDENTIAL_LOCK_POLL_MILLISECONDS = 25;
 const INCOMPLETE_CREDENTIAL_LOCK_MILLISECONDS = 30_000;
 const MAX_WINDOWS_CREDENTIAL_ACL_STDERR = 64 * 1024;
+const WINDOWS_APPS_PATH = /(^|[\\/])windowsapps([\\/]|$)/iu;
+const WINDOWS_DIRECT_EXECUTABLE = /^\.(?:exe|com)$/iu;
 
 export interface PluginInstall {
   pluginRoot: string;
@@ -2289,13 +2291,44 @@ export async function resolvePluginPython(
 export function pluginExecutionEnvironment(
   python: string,
   environment: ProcessEnvironment = process.env,
+  platform: NodeJS.Platform = process.platform,
 ): ProcessEnvironment {
+  const configuredCodexPath = configuredCodexCliPath(environment, platform);
+  const codexPath =
+    configuredCodexPath !== undefined &&
+    (platform !== "win32" ||
+      (WINDOWS_DIRECT_EXECUTABLE.test(extname(configuredCodexPath)) &&
+        !WINDOWS_APPS_PATH.test(configuredCodexPath)))
+      ? configuredCodexPath
+      : resolveCodexCommand().command;
+  const normalizedEnvironment =
+    platform === "win32"
+      ? Object.fromEntries(
+          Object.entries(environment).filter(
+            ([name]) => name.toUpperCase() !== "CODEX_CLI_PATH",
+          ),
+        )
+      : environment;
   return {
-    ...environment,
+    ...normalizedEnvironment,
     PYTHON: python,
-    CODEX_CLI_PATH:
-      environment["CODEX_CLI_PATH"]?.trim() || resolveCodexCommand().command,
+    CODEX_CLI_PATH: codexPath,
   };
+}
+
+function configuredCodexCliPath(
+  environment: ProcessEnvironment,
+  platform: NodeJS.Platform,
+): string | undefined {
+  const exact = environment["CODEX_CLI_PATH"]?.trim();
+  if (exact) return exact;
+  if (platform !== "win32") return undefined;
+  return Object.entries(environment)
+    .find(
+      ([name, value]) =>
+        name.toUpperCase() === "CODEX_CLI_PATH" && value?.trim(),
+    )?.[1]
+    ?.trim();
 }
 
 export async function cleanupSdkDirectory(path: string): Promise<void> {

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -1715,6 +1715,36 @@ describe("plugin runtime preparation", () => {
     ).toBe(resolveCodexCommand().command);
   });
 
+  test("uses only directly spawnable Windows Codex overrides for nested workers", () => {
+    const configured = String.raw`C:\Users\example\AppData\Local\OpenAI\Codex\bin\0.146.0\codex.exe`;
+    const bundled = resolveCodexCommand().command;
+
+    expect(
+      pluginExecutionEnvironment(
+        String.raw`C:\Python\python.exe`,
+        { Codex_Cli_Path: ` ${configured} ` },
+        "win32",
+      ),
+    ).toEqual({
+      CODEX_CLI_PATH: configured,
+      PYTHON: String.raw`C:\Python\python.exe`,
+    });
+
+    for (const rejected of [
+      String.raw`C:\Users\example\AppData\Roaming\npm\codex`,
+      String.raw`C:\Users\example\AppData\Roaming\npm\codex.cmd`,
+      String.raw`C:\Program Files\WindowsApps\OpenAI.Codex_26.727.6591.0_x64__2p2nqsd0c76g0\app\resources\codex.exe`,
+    ]) {
+      expect(
+        pluginExecutionEnvironment(
+          String.raw`C:\Python\python.exe`,
+          { CODEX_CLI_PATH: rejected },
+          "win32",
+        )["CODEX_CLI_PATH"],
+      ).toBe(bundled);
+    }
+  });
+
   test("selects the native Windows Codex executable package", () => {
     expect(codexPlatformPackage("win32", "x64")).toEqual({
       packageName: "@openai/codex-win32-x64",


### PR DESCRIPTION
## What changed

- Keep an inherited `CODEX_CLI_PATH` for nested Deep Scan workers on Windows only when it names a directly spawnable `.exe` or `.com` launcher outside `WindowsApps`.
- Normalize case-variant `CODEX_CLI_PATH` keys before forwarding the MCP/worker environment.
- Fall back to the existing `resolveCodexCommand()` platform-package resolver for extensionless npm shims, batch launchers, blank values, and protected WindowsApps executables.
- Add focused regression coverage for a working per-user `codex.exe`, extensionless npm `codex`, `codex.cmd`, and a WindowsApps `codex.exe`.

## Why

The bundled Deep Scan executor passes `CODEX_CLI_PATH` to `@openai/codex-sdk` as `codexPathOverride`, and that SDK launches it directly with `child_process.spawn`. The public SDK already forwards the exact uppercase variable through the MCP manifest, but it previously trusted every nonblank inherited value. On Windows that can select either the extensionless npm shim or the desktop app's protected `C:\Program Files\WindowsApps\...\codex.exe`; both fail before discovery with `spawn EPERM`, even though the package's native platform executable is available.

This keeps explicit executable overrides working while using the existing bundled resolver for launchers Node cannot directly spawn. It does not change sandbox settings.

Links: [CLI-18410](https://linear.app/openai/issue/CLI-18410/codex-security-0114-deep-scan-fails-with-spawn-eperm-on-windows-when), [openai/codex#35872](https://github.com/openai/codex/issues/35872)

## Validation

- `/home/dev-user/.bun/bin/bun test tests-ts/runtime.test.ts --test-name-pattern 'uses only directly spawnable Windows Codex overrides for nested workers'`
- `pnpm run types`, `pnpm run format`, and `pnpm run build`
- `TMPDIR=/home/dev-user/.codex-security-cli18410-temp /home/dev-user/.bun/bin/bun test --timeout 30000 ./tests-ts` (1,039 pass, 10 expected skips, 0 fail)
- `pnpm pack --pack-destination ../../dist` and `pnpm run test:package` (installed-package nested worker smoke passed)
- `codex review --base origin/main` (no actionable findings)