### PR TITLE
fix(windows): avoid unspawnable Deep Scan launchers

### DIFF
--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -80,6 +80,20 @@ export interface CodexCommand {
 
 export type ProcessEnvironment = Record<string, string | undefined>;
 
+function environmentValue(
+  environment: ProcessEnvironment,
+  requested: string,
+): string | undefined {
+  const exact = environment[requested]?.trim();
+  if (exact) return exact;
+  return Object.entries(environment)
+    .find(
+      ([name, value]) =>
+        name.toUpperCase() === requested.toUpperCase() && value?.trim(),
+    )?.[1]
+    ?.trim();
+}
+
 export interface PluginPythonOptions {
   configuredPath?: string;
   environment?: ProcessEnvironment;
@@ -100,18 +114,10 @@ export interface WorkbenchCommandOptions {
 export function codexSecurityStateDirectory(
   environment: ProcessEnvironment = process.env,
 ): string {
-  const environmentValue = (requested: string): string | undefined => {
-    const exact = environment[requested]?.trim();
-    if (exact) return exact;
-    return Object.entries(environment)
-      .find(
-        ([name, value]) => name.toUpperCase() === requested && value?.trim(),
-      )?.[1]
-      ?.trim();
-  };
-  const configured = environmentValue("CODEX_SECURITY_STATE_DIR");
+  const configured = environmentValue(environment, "CODEX_SECURITY_STATE_DIR");
   if (configured !== undefined) return resolve(expandHome(configured));
-  const codexHome = environmentValue("CODEX_HOME") ?? join(homedir(), ".codex");
+  const codexHome =
+    environmentValue(environment, "CODEX_HOME") ?? join(homedir(), ".codex");
   return resolve(expandHome(codexHome), "state", "plugins", "codex-security");
 }
 
@@ -2293,9 +2299,32 @@ export function pluginExecutionEnvironment(
   return {
     ...environment,
     PYTHON: python,
-    CODEX_CLI_PATH:
-      environment["CODEX_CLI_PATH"]?.trim() || resolveCodexCommand().command,
+    CODEX_CLI_PATH: resolveNestedCodexPath(environment),
   };
+}
+
+export function resolveNestedCodexPath(
+  environment: ProcessEnvironment = process.env,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const configured = environmentValue(environment, "CODEX_CLI_PATH");
+  if (configured !== undefined && isSpawnableCodexPath(configured, platform)) {
+    return configured;
+  }
+  return resolveCodexCommand().command;
+}
+
+function isSpawnableCodexPath(
+  value: string,
+  platform: NodeJS.Platform,
+): boolean {
+  if (platform !== "win32") return true;
+  // CodexExec passes this path directly to spawn() without a shell. Windows
+  // cannot execute npm's extensionless/.cmd shims there, and MSIX package
+  // executables under WindowsApps can be denied to spawned MCP processes.
+  const windowsPath = value.replaceAll("/", "\\");
+  if (/(?:^|\\)windowsapps(?:\\|$)/iu.test(windowsPath)) return false;
+  return [".exe", ".com"].includes(extname(value).toLowerCase());
 }
 
 export async function cleanupSdkDirectory(path: string): Promise<void> {

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -68,6 +68,7 @@ import {
   requireSecureCredentialHome,
   requireSecureOutputAncestry,
   requireTrustedOutputAncestor,
+  resolveNestedCodexPath,
   runWorkbench,
   setCodexSecurityCredentialLogout,
   streamWindowsCredentialAclDescriptors,
@@ -1696,7 +1697,11 @@ describe("plugin runtime preparation", () => {
   });
 
   test("preserves an explicit Codex executable override for nested workers", () => {
-    const configured = join(tmpdir(), "custom codex", "codex");
+    const configured = join(
+      tmpdir(),
+      "custom codex",
+      process.platform === "win32" ? "codex.exe" : "codex",
+    );
 
     expect(
       pluginExecutionEnvironment("/managed/python", {
@@ -1713,6 +1718,27 @@ describe("plugin runtime preparation", () => {
         CODEX_CLI_PATH: "   ",
       })["CODEX_CLI_PATH"],
     ).toBe(resolveCodexCommand().command);
+  });
+
+  test("keeps only spawnable Windows Codex overrides for nested workers", () => {
+    const fallback = resolveCodexCommand().command;
+    const executable =
+      "C:\\Users\\alice\\AppData\\Local\\OpenAI\\Codex\\bin\\0.146.0\\codex.exe";
+
+    expect(
+      resolveNestedCodexPath({ Codex_Cli_Path: ` ${executable} ` }, "win32"),
+    ).toBe(executable);
+
+    for (const unusable of [
+      "C:\\Users\\alice\\AppData\\Roaming\\npm\\codex",
+      "C:\\Users\\alice\\AppData\\Roaming\\npm\\codex.cmd",
+      "C:\\Program Files\\WindowsApps\\OpenAI.Codex_1\\app\\resources\\codex.exe",
+      "   ",
+    ]) {
+      expect(
+        resolveNestedCodexPath({ CODEX_CLI_PATH: unusable }, "win32"),
+      ).toBe(fallback);
+    }
   });
 
   test("selects the native Windows Codex executable package", () => {


### PR DESCRIPTION
## Summary

- Normalize `CODEX_CLI_PATH` at the nested Deep Scan MCP environment boundary.
- On Windows, preserve explicit direct executables while rejecting extensionless npm shims, `.cmd` shims that require a shell, and protected `WindowsApps` binaries.
- Fall back to the existing `resolveCodexCommand()` platform-binary resolver instead of adding another launcher resolver.

## Root cause

Deep Scan workers inherit `CODEX_CLI_PATH` through the plugin MCP environment. Before this change, any non-empty value bypassed the canonical npm platform-binary resolver. On Windows that value can be the extensionless npm shim or a protected MSIX `WindowsApps` executable; `CodexExec` passes it directly to `child_process.spawn` without a shell, which can fail with `spawn EPERM` even when the installed `@openai/codex` platform package contains a valid executable.

This keeps case-insensitive Windows environment propagation intact, preserves explicit spawnable `.exe` / `.com` launchers, and uses the existing bundled platform executable when the inherited value cannot be launched.

Related: [CLI-18410](https://linear.app/openai/issue/CLI-18410/codex-security-0114-deep-scan-fails-with-spawn-eperm-on-windows-when), [codex#35872](https://github.com/openai/codex/issues/35872).

## Validation

- `bun test tests-ts/runtime.test.ts --test-name-pattern 'bundled Codex through|explicit Codex executable override|spawnable Windows'` — 3 passed
- `pnpm run types`
- `pnpm run build`
- `pnpm run format`
- `pnpm pack --pack-destination ../../dist`
- `pnpm run test:package` — validated the installed package and a nested worker without global `codex`
- Native prepublish review gate: 3 independent passes plus verifier; 0 findings

The full `runtime.test.ts` module was also attempted, but this host reports `/` and `/home` as UID 65534, so 24 unrelated trusted-owner tests fail closed. The launcher-focused tests and package smoke pass without weakening those checks.