### PR TITLE
release: bump Codex Security to 0.1.11

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-security",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "TypeScript SDK and CLI for Codex Security",
   "license": "Apache-2.0",
   "author": "OpenAI",


### PR DESCRIPTION
## Summary

- Bump `@openai/codex-security` from `0.1.10` to `0.1.11`.
- Release the 11 changes already merged since `npm-v0.1.10`, including configurable Deep Scan time limits, scan reliability fixes, credential-only authentication, and simpler plugin installation.
- Keep the release scoped to the package version; the bundled plugin manifest and matching SDK constant already agree at `0.1.19`.

## Validation

- Confirmed `main` currently declares `0.1.10` and the latest GitHub release is `npm-v0.1.10`.
- Confirmed there is no competing release PR or existing `npm-v0.1.11` tag.
- Verified the branch diff contains exactly one changed line in `sdk/typescript/package.json`.
- Local tests were not run for this version-only change; the normal pull-request checks will validate it.

## Release

After merge, successful `node-ci` on `main` triggers `node-release-cut`, which creates `npm-v0.1.11` on the exact merged commit and dispatches the protected `node-release` workflow. Publication still requires the normal protected npm deployment approval.