### PR TITLE
fix(deep-scan): forward external provider credentials

### DIFF
--- a/sdk/typescript/_bundled_plugin/.mcp.json
+++ b/sdk/typescript/_bundled_plugin/.mcp.json
@@ -9,6 +9,8 @@
         "CODEX_SQLITE_HOME",
         "CODEX_API_KEY",
         "CODEX_CLI_PATH",
+        "OPENROUTER_API_KEY",
+        "FIREWORKS_API_KEY",
         "AWS_BEARER_TOKEN_BEDROCK",
         "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY",

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -125,8 +125,10 @@ describe("plugin runtime preparation", () => {
     ).toBe(true);
   });
 
-  test("forwards bundled Bedrock credentials through the MCP worker environment", async () => {
-    const awsKeys = [
+  test("forwards configured provider credentials through the MCP worker environment", async () => {
+    const providerKeys = [
+      "OPENROUTER_API_KEY",
+      "FIREWORKS_API_KEY",
       "AWS_BEARER_TOKEN_BEDROCK",
       "AWS_ACCESS_KEY_ID",
       "AWS_SECRET_ACCESS_KEY",
@@ -150,7 +152,7 @@ describe("plugin runtime preparation", () => {
       mcpServers: Record<string, { env_vars: string[] }>;
     };
     const parentEnvironment = Object.fromEntries(
-      awsKeys.map((name) => [name, `synthetic-${name.toLowerCase()}`]),
+      providerKeys.map((name) => [name, `synthetic-${name.toLowerCase()}`]),
     );
     const allowed = new Set(
       configuration.mcpServers["codex-security"]!.env_vars,


### PR DESCRIPTION
## Changes

- Forward OpenRouter and Fireworks API keys to Deep Scan workers.
- Keep existing Bedrock credentials and enterprise network settings.
- Extend the existing worker environment test to cover all supported providers.

## Checks

- Focused worker credential test passed.
- TypeScript checks passed.
- Formatting checks passed.