### PR TITLE
fix(deep-scan): require completion before sealing SDK scans

### DIFF
--- a/sdk/typescript/_bundled_plugin/scripts/workbench_db.py
+++ b/sdk/typescript/_bundled_plugin/scripts/workbench_db.py
@@ -1447,8 +1447,7 @@ def complete_scan_locked(
         claim_token,
         error_message="Scan completion is owned by another continuation.",
     )
-    if scan["recipe_json"] is None:
-        deep_scan.require_deep_scan_ready_for_parent_completion(connection, scan)
+    deep_scan.require_deep_scan_ready_for_parent_completion(connection, scan)
     warnings = json.loads(scan["completion_warnings_json"])
     target_warnings: list[str] = []
     warning = scan_target_warning(scan)
@@ -1541,8 +1540,7 @@ def complete_scan_locked(
             return scan_context(connection, scan["id"])
         if scan["status"] != "running":
             raise SystemExit("Only a running scan can be completed.")
-        if scan["recipe_json"] is None:
-            deep_scan.require_deep_scan_ready_for_parent_completion(connection, scan)
+        deep_scan.require_deep_scan_ready_for_parent_completion(connection, scan)
         handoff.require_current_continuation(
             scan,
             claim_token,

--- a/sdk/typescript/tests-ts/deep-scan-workbench.test.ts
+++ b/sdk/typescript/tests-ts/deep-scan-workbench.test.ts
@@ -93,6 +93,62 @@ function runOwnershipProbe(probe: OwnershipProbe): Record<string, unknown> {
 }
 
 describe("deep scan workbench ownership", () => {
+  test("rejects completion before an SDK-created Deep Scan finishes", async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), "codex-security-deep-completion-guard-")),
+    );
+    temporaryDirectories.push(root);
+    const repository = join(root, "repository");
+    const scanDir = join(root, "scan");
+    const stateDir = join(root, "state");
+    await mkdir(repository);
+    await mkdir(scanDir, { mode: 0o700 });
+    const python = Bun.which("python3") ?? Bun.which("python");
+    expect(python).not.toBeNull();
+    const command = (args: string[]) =>
+      Bun.spawnSync(
+        [
+          python!,
+          "-I",
+          "-B",
+          join(PLUGIN_ROOT, "scripts", "workbench_db.py"),
+          ...args,
+        ],
+        {
+          env: { ...process.env, CODEX_SECURITY_STATE_DIR: stateDir },
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      );
+    const registered = command([
+      "register-cli-scan",
+      "--repository",
+      repository,
+      "--scan-dir",
+      scanDir,
+      "--recipe-json",
+      JSON.stringify({
+        config: {},
+        mode: "deep",
+        repository,
+        target: { kind: "repository", paths: [] },
+      }),
+    ]);
+    expect(
+      registered.exitCode,
+      new TextDecoder().decode(registered.stderr),
+    ).toBe(0);
+    const { scanId } = JSON.parse(
+      new TextDecoder().decode(registered.stdout),
+    ) as { scanId: string };
+
+    const premature = command(["complete-scan", "--scan-id", scanId]);
+    expect(premature.exitCode).not.toBe(0);
+    expect(new TextDecoder().decode(premature.stderr)).toContain(
+      "orchestration must finish and persist its manifest",
+    );
+  });
+
   test.each([
     [undefined, 96],
     [0.5, 0.5],


### PR DESCRIPTION
## Changes

- Apply the existing Deep Scan completion guard to scans created by the SDK.
- Reject completion before the Deep Scan coordinator writes its manifest.
- Keep Standard and diff scan behavior unchanged.

## Checks

- Focused Deep Scan completion test passed.
- TypeScript checks passed.
- Formatting checks passed.