### PR TITLE
fix(deep-scan): count independent workers in scan cost limits

### DIFF
--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -740,6 +740,7 @@ export class CodexSecurity {
         codexHome: runtime.codexHome,
         model,
         repository: repo,
+        scanDirectory: scanDir,
         maxCostUsd: options.maxCostUsd,
         onActivity:
           options.onActivity === undefined

--- a/sdk/typescript/src/cost.ts
+++ b/sdk/typescript/src/cost.ts
@@ -1,5 +1,5 @@
 import { open, readdir } from "node:fs/promises";
-import { join } from "node:path";
+import { join, relative, sep } from "node:path";
 import {
   scanActivityFromSessionEvent,
   type ScanActivity,
@@ -48,6 +48,7 @@ interface SessionUsage {
   unreadable: boolean;
   threadId: string | null;
   parentThreadId: string | null;
+  workingDirectory: string | null;
   startedAt: number | null;
   inheritedUsage: ScanTokenUsage | null;
   replaying: boolean;
@@ -66,6 +67,7 @@ interface ScanCostTrackerOptions {
   codexHome: string;
   model: string;
   repository?: string;
+  scanDirectory?: string;
   maxCostUsd?: number;
   expectedFilesTotal?: number;
   onCost?: (cost: Readonly<ScanCost>) => void;
@@ -185,6 +187,7 @@ export class ScanCostTracker {
           unreadable: false,
           threadId: null,
           parentThreadId: null,
+          workingDirectory: null,
           startedAt: null,
           inheritedUsage: null,
           replaying: false,
@@ -209,6 +212,37 @@ export class ScanCostTracker {
     }
 
     const included = new Set([this.#threadId]);
+    if (this.#options.scanDirectory !== undefined) {
+      const scanStartedAt =
+        [...this.#sessions.values()].find(
+          (session) => session.threadId === this.#threadId,
+        )?.startedAt ?? null;
+      for (const session of this.#sessions.values()) {
+        if (
+          session.threadId === null ||
+          session.workingDirectory === null ||
+          scanStartedAt === null ||
+          session.startedAt === null ||
+          session.startedAt < scanStartedAt
+        ) {
+          continue;
+        }
+        const artifactsDirectory = join(
+          this.#options.scanDirectory,
+          "artifacts",
+        );
+        const workerDirectory = relative(
+          join(artifactsDirectory, "deep_discovery", "workers"),
+          session.workingDirectory,
+        ).split(sep);
+        if (
+          session.workingDirectory === artifactsDirectory ||
+          (workerDirectory.length === 2 && workerDirectory[1] === "output")
+        ) {
+          included.add(session.threadId);
+        }
+      }
+    }
     let changed = true;
     while (changed) {
       changed = false;
@@ -424,6 +458,9 @@ function readSessionEvent(
     }
     if (typeof payload["id"] === "string") {
       session.threadId = payload["id"];
+    }
+    if (typeof payload["cwd"] === "string") {
+      session.workingDirectory = payload["cwd"];
     }
     if (typeof payload["timestamp"] === "string") {
       session.startedAt = Math.floor(Date.parse(payload["timestamp"]) / 1_000);

--- a/sdk/typescript/tests-ts/cost.test.ts
+++ b/sdk/typescript/tests-ts/cost.test.ts
@@ -45,6 +45,8 @@ async function writeSession(
   threadId: string,
   usage: Record<string, number>,
   parentThreadId?: string,
+  workingDirectory?: string,
+  timestamp?: string,
 ): Promise<string> {
   const directory = join(home, "sessions", "2026", "07", "26");
   await mkdir(directory, { recursive: true });
@@ -56,6 +58,8 @@ async function writeSession(
         type: "session_meta",
         payload: {
           id: threadId,
+          ...(workingDirectory === undefined ? {} : { cwd: workingDirectory }),
+          ...(timestamp === undefined ? {} : { timestamp }),
           ...(parentThreadId === undefined
             ? {}
             : {
@@ -429,6 +433,96 @@ describe("live scan cost tracking", () => {
         outputTokens: 15,
         estimatedUsd: 0.006275,
       },
+    });
+  });
+
+  test("counts independent Deep workers inside the scan directory only", async () => {
+    const home = await codexHome();
+    const scanDirectory = join(home, "scans", "current");
+    await writeSession(
+      home,
+      "scan-thread",
+      { input_tokens: 1_000, output_tokens: 10 },
+      undefined,
+      scanDirectory,
+      "2026-07-26T12:00:00Z",
+    );
+    await writeSession(
+      home,
+      "deep-worker",
+      { input_tokens: 250, output_tokens: 2 },
+      undefined,
+      join(
+        scanDirectory,
+        "artifacts",
+        "deep_discovery",
+        "workers",
+        "worker",
+        "output",
+      ),
+      "2026-07-26T12:01:00Z",
+    );
+    await writeSession(
+      home,
+      "deep-reducer",
+      { input_tokens: 125, output_tokens: 1 },
+      undefined,
+      join(scanDirectory, "artifacts"),
+      "2026-07-26T12:02:00Z",
+    );
+    await writeSession(
+      home,
+      "deep-worker-child",
+      { input_tokens: 50, output_tokens: 1 },
+      "deep-worker",
+    );
+    await writeSession(
+      home,
+      "unrelated-thread",
+      { input_tokens: 1_000_000, output_tokens: 1_000_000 },
+      undefined,
+      `${scanDirectory}-other`,
+    );
+    await writeSession(
+      home,
+      "previous-scan",
+      { input_tokens: 1_000_000, output_tokens: 1_000_000 },
+      undefined,
+      join(scanDirectory, "artifacts", "deep_discovery", "previous-worker"),
+      "2026-07-26T11:59:00Z",
+    );
+    await writeSession(
+      home,
+      "unknown-start",
+      { input_tokens: 1_000_000, output_tokens: 1_000_000 },
+      undefined,
+      join(
+        scanDirectory,
+        "artifacts",
+        "deep_discovery",
+        "workers",
+        "stale",
+        "output",
+      ),
+    );
+    await writeSession(
+      home,
+      "nested-scan",
+      { input_tokens: 1_000_000, output_tokens: 1_000_000 },
+      undefined,
+      join(scanDirectory, "nested", "artifacts"),
+      "2026-07-26T12:03:00Z",
+    );
+    const tracker = new ScanCostTracker({
+      codexHome: home,
+      model: "gpt-5.6-sol",
+      scanDirectory,
+    });
+    tracker.start("scan-thread");
+
+    expect((await tracker.stop()).usage).toMatchObject({
+      input_tokens: 1_425,
+      output_tokens: 14,
     });
   });
 


### PR DESCRIPTION
## Changes

- Include independent Deep Scan discovery and reducer workers in scan costs.
- Include delegated child workers without counting other scans.
- Keep existing session parsing, polling, and unreadable-session behavior.

## Checks

- All 31 scan cost tests passed.
- TypeScript checks passed.
- Formatting checks passed.