### PR TITLE
fix(scan): preserve completed scans when follow-up fails

### DIFF
--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -1217,26 +1217,7 @@ export class CodexSecurity {
                 mode: 0o600,
                 signal,
               });
-              try {
-                await rename(temporary, path);
-              } catch (error) {
-                if (
-                  process.platform !== "win32" ||
-                  (error as NodeJS.ErrnoException).code !== "EPERM"
-                ) {
-                  throw error;
-                }
-                await chmod(
-                  await requireScanFile(
-                    scanDir,
-                    artifact.name,
-                    artifact.name,
-                    signal,
-                  ),
-                  0o600,
-                );
-                await rename(temporary, path);
-              }
+              await rename(temporary, path);
             } finally {
               await rm(temporary, { force: true });
             }

--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -1217,7 +1217,26 @@ export class CodexSecurity {
                 mode: 0o600,
                 signal,
               });
-              await rename(temporary, path);
+              try {
+                await rename(temporary, path);
+              } catch (error) {
+                if (
+                  process.platform !== "win32" ||
+                  (error as NodeJS.ErrnoException).code !== "EPERM"
+                ) {
+                  throw error;
+                }
+                await chmod(
+                  await requireScanFile(
+                    scanDir,
+                    artifact.name,
+                    artifact.name,
+                    signal,
+                  ),
+                  0o600,
+                );
+                await rename(temporary, path);
+              }
             } finally {
               await rm(temporary, { force: true });
             }

--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -6,6 +6,7 @@ import {
   mkdir,
   readFile,
   realpath,
+  rename,
   rm,
   writeFile,
 } from "node:fs/promises";
@@ -1162,19 +1163,81 @@ export class CodexSecurity {
       if (runPostScan !== null) {
         const followUp = runPostScan;
         runPostScan = null;
-        await runScanEvents({
-          thread,
-          events: (await followUp()).events,
-          signal,
-          scanDir,
-          pluginRoot: runtime.plugin.installedRoot,
-          expectation,
-          model,
-          onReconnect: options.onReconnect,
-          onWorkerStatus: options.onWorkerStatus,
-          onObserverError: options.onObserverError,
-        });
-        checkOpen();
+        const completedArtifacts = await Promise.all(
+          [
+            ...new Set([
+              "scan-manifest.json",
+              "findings.json",
+              "coverage.json",
+              "report.md",
+              ...result.manifest.scan.artifacts.map(
+                (artifact) => artifact.path,
+              ),
+            ]),
+          ].map(async (name) => ({
+            name,
+            contents: await readFile(
+              await requireScanFile(scanDir, name, name, signal),
+              { signal },
+            ),
+          })),
+        );
+        try {
+          await runScanEvents({
+            thread,
+            events: (await followUp()).events,
+            signal,
+            scanDir,
+            pluginRoot: runtime.plugin.installedRoot,
+            expectation,
+            model,
+            onReconnect: options.onReconnect,
+            onWorkerStatus: options.onWorkerStatus,
+            onObserverError: options.onObserverError,
+          });
+          checkOpen();
+        } catch (error) {
+          if (signal.aborted || this.#closed) throw error;
+          for (const artifact of completedArtifacts) {
+            const path = join(scanDir, artifact.name);
+            const current = await readFile(path, { signal }).catch(
+              (readError: NodeJS.ErrnoException) => {
+                if (readError.code !== "ENOENT") throw readError;
+                return null;
+              },
+            );
+            if (current?.equals(artifact.contents)) continue;
+            const temporary = join(
+              dirname(path),
+              `.${randomUUID()}.${basename(path)}.restore`,
+            );
+            try {
+              await writeFile(temporary, artifact.contents, {
+                flag: "wx",
+                mode: 0o600,
+                signal,
+              });
+              await rename(temporary, path);
+            } finally {
+              await rm(temporary, { force: true });
+            }
+          }
+          await collectResult(
+            result.turnResult,
+            result.threadId,
+            scanDir,
+            runtime.plugin.installedRoot,
+            expectation,
+            signal,
+            true,
+          );
+          notifyObserver(
+            "onWarning",
+            options.onWarning,
+            options.onObserverError,
+            `Could not run post-scan instructions: ${errorMessage(error)}`,
+          );
+        }
       }
       try {
         const runWorkbench = (args: readonly string[]) =>

--- a/sdk/typescript/src/contract.ts
+++ b/sdk/typescript/src/contract.ts
@@ -793,11 +793,12 @@ async function sha256ScanFile(
   try {
     throwIfAborted(signal);
     const digest = createHash("sha256");
-    for await (const chunk of file.createReadStream({
-      signal,
-      autoClose: false,
-    })) {
-      digest.update(chunk);
+    const buffer = Buffer.alloc(64 * 1024);
+    while (true) {
+      throwIfAborted(signal);
+      const { bytesRead } = await file.read(buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+      digest.update(buffer.subarray(0, bytesRead));
     }
     throwIfAborted(signal);
     return digest.digest("hex");

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -233,6 +233,8 @@ async function runCampaign(
             ...(options.postScanPrompt === undefined
               ? {}
               : { postScanPrompt: options.postScanPrompt }),
+            onWarning: (warning) =>
+              options.onProgress?.({ ...progress, status: "started", warning }),
             ...(options.signal === undefined ? {} : { signal: options.signal }),
           });
           cost = result.cost;

--- a/sdk/typescript/tests-ts/api-post-scan.test.ts
+++ b/sdk/typescript/tests-ts/api-post-scan.test.ts
@@ -126,9 +126,10 @@ describe("completed scan follow-up instructions", () => {
         },
       );
 
-      await expect(
-        client.run(repository, { postScanPrompt: "Draft confirmed fixes." }),
-      ).resolves.toMatchObject({ scanDir });
+      const result = await client.run(repository, {
+        postScanPrompt: "Draft confirmed fixes.",
+      });
+      expect(result).toMatchObject({ scanDir });
       expect(await readFile(join(scanDir, artifact))).toEqual(original);
       await client.close();
     },

--- a/sdk/typescript/tests-ts/api-post-scan.test.ts
+++ b/sdk/typescript/tests-ts/api-post-scan.test.ts
@@ -1,0 +1,136 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { ThreadEvent } from "@openai/codex-sdk";
+import { afterEach, describe, expect, test } from "bun:test";
+import { CodexSecurity } from "../src/index.js";
+import { PLUGIN_ROOT } from "./plugin-root.js";
+import {
+  completedEvents,
+  createApiTestFixtures,
+} from "./support/api-events.js";
+
+const { cleanup, copyCompletedScan, temporaryDirectory } =
+  createApiTestFixtures();
+
+afterEach(cleanup);
+
+const TestClient = CodexSecurity as unknown as new (
+  config: Record<string, unknown>,
+  dependencies: Record<string, unknown>,
+) => CodexSecurity;
+
+function preparedRuntime(codexHome: string): Record<string, unknown> {
+  return {
+    codexHome,
+    plugin: {
+      pluginRoot: PLUGIN_ROOT,
+      marketplaceRoot: PLUGIN_ROOT,
+      installedRoot: PLUGIN_ROOT,
+      marketplaceName: "codex-security-sdk",
+      name: "codex-security",
+      version: "0.1.0",
+    },
+    environment: {},
+    credentialsAvailable: true,
+  };
+}
+
+function runWorkbench(_options: unknown, args: readonly string[]) {
+  if (args[0] === "register-cli-scan") {
+    return Promise.resolve({
+      scanId: "scan_example_001",
+      targetId: "target_sha256_example",
+      targetRevision: "deadbeef",
+      scanDir: args[args.indexOf("--scan-dir") + 1],
+      contract: { target: { allowedKinds: ["git_revision"] } },
+    });
+  }
+  if (args[0] === "get-scan-feedback") {
+    return Promise.resolve({
+      scanId: "scan_example_001",
+      targetId: "target_sha256_example",
+      falsePositives: [],
+    });
+  }
+  return Promise.resolve({});
+}
+
+describe("completed scan follow-up instructions", () => {
+  test.each([
+    ["missing report", "report.md", undefined],
+    ["partial report", "report.md", "# Incomplete draft\n"],
+    ["invalid findings", "findings.json", "{invalid"],
+    ["sealed nested artifact", "artifacts/worker.json", '{"partial":true}'],
+  ] as const)(
+    "restores completed scan artifacts damaged by post-scan instructions: %s",
+    async (_scenario, artifact, replacement) => {
+      const root = await temporaryDirectory();
+      const repository = join(root, "repository");
+      const codexHome = join(root, "codex-home");
+      const scanDir = join(root, "scan");
+      await mkdir(repository);
+      await mkdir(codexHome);
+      await mkdir(scanDir, { mode: 0o700 });
+      let turns = 0;
+      let original = Buffer.alloc(0);
+      const client = new TestClient(
+        {},
+        {
+          environment: {},
+          prepareRuntime: async () => preparedRuntime(codexHome),
+          resolvePluginPython: async () => "/managed/python",
+          prepareOutputDir: async () => scanDir,
+          repositoryRevision: async () => "deadbeef",
+          runWorkbench,
+          createCodex: () => ({
+            startThread: () => ({
+              id: "thread-1",
+              async runStreamed() {
+                turns += 1;
+                if (turns === 1) {
+                  await copyCompletedScan(root);
+                  if (artifact.startsWith("artifacts/")) {
+                    const artifactPath = join(scanDir, artifact);
+                    await mkdir(dirname(artifactPath), { recursive: true });
+                    await writeFile(artifactPath, '{"complete":true}\n');
+                    const manifestPath = join(scanDir, "scan-manifest.json");
+                    const manifest = JSON.parse(
+                      await readFile(manifestPath, "utf8"),
+                    );
+                    manifest.scan.artifacts.push({
+                      path: artifact,
+                      sha256: createHash("sha256")
+                        .update(await readFile(artifactPath))
+                        .digest("hex"),
+                      mediaType: "application/json",
+                    });
+                    await writeFile(manifestPath, JSON.stringify(manifest));
+                  }
+                  original = await readFile(join(scanDir, artifact));
+                  return { events: completedEvents() };
+                }
+                const artifactPath = join(scanDir, artifact);
+                if (replacement === undefined) await rm(artifactPath);
+                else await writeFile(artifactPath, replacement);
+                async function* failedEvents(): AsyncGenerator<ThreadEvent> {
+                  yield {
+                    type: "turn.failed",
+                    error: { message: "Could not draft fixes." },
+                  };
+                }
+                return { events: failedEvents() };
+              },
+            }),
+          }),
+        },
+      );
+
+      await expect(
+        client.run(repository, { postScanPrompt: "Draft confirmed fixes." }),
+      ).resolves.toMatchObject({ scanDir });
+      expect(await readFile(join(scanDir, artifact))).toEqual(original);
+      await client.close();
+    },
+  );
+});

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -3083,7 +3083,7 @@ describe("CodexSecurity orchestration", () => {
     await client.close();
   });
 
-  test("surfaces post-scan failures without reopening a completed scan", async () => {
+  test("warns about post-scan failures without failing a completed scan", async () => {
     const root = await temporaryDirectory();
     const repository = join(root, "repository");
     const codexHome = join(root, "codex-home");
@@ -3092,6 +3092,7 @@ describe("CodexSecurity orchestration", () => {
     await mkdir(codexHome);
     await mkdir(scanDir, { mode: 0o700 });
     const commands: Array<readonly string[]> = [];
+    const warnings: string[] = [];
     let turns = 0;
 
     const client = new TestClient(
@@ -3129,14 +3130,21 @@ describe("CodexSecurity orchestration", () => {
     );
 
     await expect(
-      client.run(repository, { postScanPrompt: "Draft confirmed fixes." }),
-    ).rejects.toThrow("Could not draft fixes.");
+      client.run(repository, {
+        postScanPrompt: "Draft confirmed fixes.",
+        onWarning: (warning) => warnings.push(warning),
+      }),
+    ).resolves.toMatchObject({ scanDir });
+    expect(warnings).toEqual([
+      "Could not run post-scan instructions: Could not draft fixes.",
+    ]);
     expect(commands.map((command) => command[0])).toEqual([
       "register-cli-scan",
       "get-scan-feedback",
       "set-scan-thread",
       "prepare-scan-completion",
       "complete-scan",
+      "list-global-findings",
     ]);
     await client.close();
   });

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -259,6 +259,37 @@ describe("multiscan", () => {
     ]);
   });
 
+  test("surfaces optional post-scan warnings without failing completed scans", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "follow-up-warning");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\nfollow-up-warning,${source.path},${source.revision}\n`,
+    );
+    const progress: Parameters<
+      NonNullable<MultiscanOptions["onProgress"]>
+    >[0][] = [];
+
+    const summary = await runMultiscan(
+      options(
+        paths,
+        client(async (_repository, scanOptions = {}) => {
+          scanOptions.onWarning?.("Could not run post-scan instructions.");
+          return await completedScan(scanOptions.outputDir!);
+        }),
+        { onProgress: (event) => progress.push(event) },
+      ),
+    );
+
+    expect(summary).toMatchObject({ completed: 1, incomplete: 0, failed: 0 });
+    expect(progress).toContainEqual({
+      repository: "follow-up-warning",
+      attempt: 1,
+      status: "started",
+      warning: "Could not run post-scan instructions.",
+    });
+  });
+
   test.each(["partial", "unknown"] as const)(
     "retains sealed %s coverage without retries or multiplied costs",
     async (completeness) => {


### PR DESCRIPTION
## Changes

- Keep a completed scan successful when optional follow-up instructions fail.
- Restore completed scan artifacts if the follow-up changed or removed them.
- Report follow-up failures as warnings, including during bulk scans.
- Preserve cancellation, client shutdown, and repository findings behavior.

## Checks

- All 118 scan and follow-up tests passed.
- All 39 bulk scan tests passed.
- TypeScript and formatting checks passed.