### PR TITLE
docs: add public pull request disclosure safeguards

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- Describe the technical problem and outcome without identifying customers or private systems. -->
+
+## Changes
+
+<!-- Summarize the specific changes that reviewers should understand. -->
+
+## Testing
+
+<!-- List the checks you actually ran and their results, or explain why testing was unnecessary. -->
+
+## Risk and rollout
+
+<!-- Describe compatibility, security, operational, or release considerations. -->
+
+## Public disclosure review
+
+<!-- Review every public artifact before checking all three attestations. -->
+
+- [ ] No customer, partner, prospect, or user identities, data, or identifying details are included.
+- [ ] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
+- [ ] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,31 @@ Codex Security is a thin wrapper around Codex and its security plugin.
 - Mention another `openai/` repository in comments or pull request descriptions
   only after checking that it is public. If you cannot confirm its visibility,
   leave it out.
+
+## Public repository and pull requests
+
+Everything published in this repository is public. Review branch names before
+pushing. Before creating or updating a pull request, inspect its branch name,
+title, description, commits, changed files, comments, logs, screenshots,
+attachments, and links for sensitive information.
+
+- Never identify customers, partners, prospects, or users. Remove names,
+  domains, repository URLs, account or tenant identifiers, support cases,
+  incidents, and environment details that could identify them.
+- Never publish credentials, personal data, private source or configuration,
+  scan targets or findings, undisclosed vulnerabilities, or nonpublic links,
+  documents, conversations, or issue identifiers.
+- Describe the technical behavior generically. Use synthetic names,
+  repositories, fixtures, identifiers, logs, and credentials in examples and
+  tests.
+- Start from `.github/PULL_REQUEST_TEMPLATE.md`, complete every section, report
+  the checks you actually ran, and check every disclosure attestation only
+  after reviewing the entire pull request.
+- Do not use `gh pr create --fill` or `--fill-verbose`: commit messages can
+  expose private context. Use a reviewed title and body or
+  `gh pr create --template .github/PULL_REQUEST_TEMPLATE.md`.
+- Bots and automation are not exempt. Review generated content before
+  publication when possible; maintainers must review and correct existing bot
+  pull requests before merging them.
+- Review material before publishing it. Editing or deleting it afterward does
+  not guarantee removal from notifications, caches, or public history.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,44 +14,6 @@ Search [existing issues](https://github.com/openai/codex-security/issues)
 before opening a new one. Maintainers can carry accepted changes into the
 canonical source or invite a focused pull request for this public repository.
 
-## Open a public pull request
-
-Everything you post here is public. Review branch names before pushing. Before
-opening or updating a pull request, review its branch name, title, description,
-commits, changed files, comments, logs, screenshots, attachments, and links.
-
-Never include customer, partner, prospect, or user names, identifying domains
-or repository URLs, account or tenant identifiers, support cases, incidents,
-or customer-specific environment details. Keep credentials, personal data,
-private source or configuration, security findings, undisclosed
-vulnerabilities, internal documents or conversations, nonpublic links, and
-private issue identifiers out of every public artifact.
-
-Describe the technical problem without identifying the affected organization
-or system. Use synthetic repositories, names, identifiers, logs, credentials,
-and test fixtures. Link only to information you have confirmed is public. If
-you cannot confidently remove identifying context, do not publish it.
-
-Use the [pull request template](.github/PULL_REQUEST_TEMPLATE.md). Complete the
-summary, changes, testing, risk and rollout, and public disclosure review
-sections; report only checks you actually ran; and check every disclosure
-attestation after inspecting the complete change. Use a supported
-Conventional Commit title, such as `fix: handle missing configuration`.
-
-When using the GitHub CLI, start with
-`gh pr create --template .github/PULL_REQUEST_TEMPLATE.md` and review the
-title and description before submitting them. Do not use `--fill` or
-`--fill-verbose` without manually reviewing every generated field: commit
-messages can contain private context. Later edits cannot reliably undo a
-public disclosure.
-
-Bots and automation follow the same requirements without exception. Review
-generated content before publication when possible; maintainers must review
-and correct existing bot pull requests before merging them.
-
-Report security vulnerabilities privately as described in
-[SECURITY.md](SECURITY.md); never include them in a public pull request.
-
 ## Support for open-source projects
 
 If you maintain an open-source project,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,44 @@ Search [existing issues](https://github.com/openai/codex-security/issues)
 before opening a new one. Maintainers can carry accepted changes into the
 canonical source or invite a focused pull request for this public repository.
 
+## Open a public pull request
+
+Everything you post here is public. Review branch names before pushing. Before
+opening or updating a pull request, review its branch name, title, description,
+commits, changed files, comments, logs, screenshots, attachments, and links.
+
+Never include customer, partner, prospect, or user names, identifying domains
+or repository URLs, account or tenant identifiers, support cases, incidents,
+or customer-specific environment details. Keep credentials, personal data,
+private source or configuration, security findings, undisclosed
+vulnerabilities, internal documents or conversations, nonpublic links, and
+private issue identifiers out of every public artifact.
+
+Describe the technical problem without identifying the affected organization
+or system. Use synthetic repositories, names, identifiers, logs, credentials,
+and test fixtures. Link only to information you have confirmed is public. If
+you cannot confidently remove identifying context, do not publish it.
+
+Use the [pull request template](.github/PULL_REQUEST_TEMPLATE.md). Complete the
+summary, changes, testing, risk and rollout, and public disclosure review
+sections; report only checks you actually ran; and check every disclosure
+attestation after inspecting the complete change. Use a supported
+Conventional Commit title, such as `fix: handle missing configuration`.
+
+When using the GitHub CLI, start with
+`gh pr create --template .github/PULL_REQUEST_TEMPLATE.md` and review the
+title and description before submitting them. Do not use `--fill` or
+`--fill-verbose` without manually reviewing every generated field: commit
+messages can contain private context. Later edits cannot reliably undo a
+public disclosure.
+
+Bots and automation follow the same requirements without exception. Review
+generated content before publication when possible; maintainers must review
+and correct existing bot pull requests before merging them.
+
+Report security vulnerabilities privately as described in
+[SECURITY.md](SECURITY.md); never include them in a public pull request.
+
 ## Support for open-source projects
 
 If you maintain an open-source project,


### PR DESCRIPTION
## Summary

Help contributors and agents prepare clear public pull requests without disclosing confidential or identifying information.

## Changes

- Add a default pull request template with summary, changes, testing, risk, and disclosure-review sections.
- Add matching agent instructions for branch names, commit messages, generated content, and pull requests.

## Testing

- Targeted Prettier formatting checks passed for both changed files.
- `git diff --check` passed.
- Confirmed the change contains only `AGENTS.md` and the pull request template.

## Risk and rollout

Low risk: agent guidance and GitHub's default pull request template only. No runtime, contributor-guideline, or workflow changes.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
