### PR TITLE
docs: align container and completed-scan examples

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -657,7 +657,7 @@ from the root of the Codex Security repository:
 mkdir -p results state
 chmod 700 results state
 export CODEX_SECURITY_USER="$(id -u):$(id -g)"
-export CODEX_SECURITY_IMAGE=ghcr.io/openai/codex-security:0.1.4
+export CODEX_SECURITY_IMAGE=ghcr.io/openai/codex-security:latest
 docker compose pull codex-security
 docker compose run --rm codex-security login --device-auth
 docker compose run --rm codex-security

--- a/sdk/typescript/_bundled_plugin/examples/completed-scan/coverage.json
+++ b/sdk/typescript/_bundled_plugin/examples/completed-scan/coverage.json
@@ -6,7 +6,7 @@
   "completeness": "complete",
   "inventoryStrategy": "repository",
   "includePaths": [
-    "src/"
+    "."
   ],
   "excludePaths": [],
   "surfaces": [

--- a/sdk/typescript/_bundled_plugin/examples/completed-scan/scan-manifest.json
+++ b/sdk/typescript/_bundled_plugin/examples/completed-scan/scan-manifest.json
@@ -21,7 +21,7 @@
     },
     "scope": {
       "includePaths": [
-        "src/"
+        "."
       ],
       "excludePaths": []
     },
@@ -35,7 +35,7 @@
       },
       {
         "path": "coverage.json",
-        "sha256": "ca91e7a3a89a477796b912232bb3473dead1d342f8b6b37b073bda168819aaa6",
+        "sha256": "d55b9b98d48323b4659dfee6531ec83ec538f2084325412b7188bf85ad68b01b",
         "mediaType": "application/json"
       }
     ]

--- a/sdk/typescript/tests-ts/contract.test.ts
+++ b/sdk/typescript/tests-ts/contract.test.ts
@@ -911,9 +911,15 @@ describe("canonical scan contract", () => {
 
   test("binds requested path scope, mode, and plugin version", async () => {
     const scanDir = await copyExample();
+    const manifestPath = join(scanDir, "scan-manifest.json");
+    const manifest = await readJson(manifestPath);
+    manifest["scan"]["scope"]["includePaths"] = ["src"];
+    await writeJson(manifestPath, manifest);
     const coveragePath = join(scanDir, "coverage.json");
     const coverage = await readJson(coveragePath);
     coverage["mode"] = "scoped_path";
+    coverage["inventoryStrategy"] = "scoped_path";
+    coverage["includePaths"] = ["src"];
     await writeJson(coveragePath, coverage);
     await reseal(scanDir);
 


### PR DESCRIPTION
## Summary

- Use the approved `latest` container release instead of a stale hard-coded image version.
- Make the bundled repository-scan example cover the repository root and refresh its sealed coverage digest.
- Set up the scoped-path contract test explicitly instead of depending on the example's old inconsistent scope.

## Verification

- `pnpm run test` — 1,075 passed, 11 skipped, 0 failed.
- `pnpm run types`.
- `pnpm run format`.
- `git diff --check`.
