### PR TITLE
test: remove redundant and brittle SDK assertions

### DIFF
--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -298,11 +298,7 @@ describe("CLI", () => {
     );
 
     for (const documentation of [readme, publicReadme]) {
-      expect(documentation).toContain(
-        "Some cybersecurity requests and protected findings require approval through\n" +
-          "Trusted Access for Cyber. To apply or check your access, visit\n" +
-          "[chatgpt.com/cyber](https://chatgpt.com/cyber).",
-      );
+      expect(documentation).toContain("https://chatgpt.com/cyber");
     }
 
     for (const setting of [

--- a/sdk/typescript/tests-ts/compact-diff-scan.test.ts
+++ b/sdk/typescript/tests-ts/compact-diff-scan.test.ts
@@ -11,7 +11,6 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { createInterface } from "node:readline";
-import { brotliDecompressSync } from "node:zlib";
 import { afterEach, describe, expect, test } from "bun:test";
 import { PLUGIN_ROOT } from "./plugin-root.js";
 
@@ -463,33 +462,5 @@ describe("compact diff scan", () => {
     } finally {
       await client.close();
     }
-  });
-
-  test("preserves stable finding identities from existing public scans", () => {
-    const runtime = brotliDecompressSync(
-      Buffer.concat(
-        ["000", "001"].map((part) =>
-          readFileSync(join(PLUGIN_ROOT, "mcp", `server.mjs.br.part-${part}`)),
-        ),
-      ),
-    ).toString("utf8");
-    const source = /function buildFindings\(findings\) \{[\s\S]*?\n\}/u.exec(
-      runtime,
-    )?.[0];
-    expect(source).toBeDefined();
-    const buildFindings = new Function(
-      "semanticIdentifier",
-      `${source}\nreturn buildFindings;`,
-    )((value: string) => value) as (findings: JsonObject[]) => JsonObject[];
-
-    const [finding] = buildFindings([
-      {
-        title: "Changed title",
-        extensions: { candidateId: "candidate-stable" },
-      },
-    ]);
-    expect((finding?.["identity"] as JsonObject)["anchor"]).toBe(
-      "candidate-stable",
-    );
   });
 });

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -403,30 +403,6 @@ describe("plugin runtime preparation", () => {
     );
   });
 
-  test("keeps focused Standard scans on native direct-start tools", async () => {
-    const skill = await readFile(
-      join(PLUGIN_ROOT, "skills", "security-scan", "SKILL.md"),
-      "utf8",
-    );
-    const desktop = await readFile(
-      join(
-        PLUGIN_ROOT,
-        "skills",
-        "security-scan",
-        "references",
-        "desktop-scan.md",
-      ),
-      "utf8",
-    );
-
-    expect(skill).toContain("Immediately launch one baseline subagent");
-    expect(skill).toContain("Launch focused investigator subagents");
-    expect(skill).toContain("record_codex_security_scan_draft");
-    expect(desktop).toContain("start_codex_security_prompt_only_scan");
-    expect(desktop).toContain("record_codex_security_scan_draft");
-    expect(desktop).not.toContain("await_codex_security_scan_start");
-  });
-
   test("keeps native scan tools without the obsolete setup widget", async () => {
     const contract = JSON.parse(
       await readFile(new URL("../plugin-files.json", import.meta.url), "utf8"),

--- a/sdk/typescript/tests-ts/skeleton.test.ts
+++ b/sdk/typescript/tests-ts/skeleton.test.ts
@@ -1,14 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { describe, expect, test } from "bun:test";
 import { CodexSecurity, CodexSecurityError, VERSION } from "../src/index.js";
-import type {
-  Finding,
-  FindingCodeEvidence,
-  FindingRootCause,
-  FindingWriteup,
-  ScanHardening,
-  ScanRecord,
-} from "../src/index.js";
 import { main } from "../src/cli.js";
 
 function capture(): {
@@ -117,29 +109,6 @@ describe("TypeScript package skeleton", () => {
         /- name: Audit production dependencies\n(?:\s+if: [^\n]+\n)?\s+continue-on-error: true\n\s+run: (?:sfw )?pnpm --dir sdk\/typescript run audit:prod/u,
       );
     }
-  });
-
-  test("exposes canonical finding and hardening fields with public types", () => {
-    const finding = {} as Finding;
-    const scan = {} as ScanRecord;
-    const writeup: FindingWriteup | undefined = finding.writeup;
-    const evidence: FindingCodeEvidence[] | undefined = finding.codeEvidence;
-    const rootCause: string | FindingRootCause | undefined = finding.rootCause;
-    const hardening: ScanHardening | undefined = scan.hardening;
-    const reportPath: string | undefined = finding.writeup?.reportPath;
-    const firstEvidencePath: string | undefined =
-      finding.codeEvidence?.[0]?.path;
-    const portfolioPath: "hardening/hardening.md" | undefined =
-      scan.hardening?.portfolioPath;
-    expect([
-      writeup,
-      evidence,
-      rootCause,
-      hardening,
-      reportPath,
-      firstEvidencePath,
-      portfolioPath,
-    ]).toEqual(new Array(7).fill(undefined));
   });
 
   test("exports the async client and curated error base", async () => {


### PR DESCRIPTION
## Summary

- Remove duplicate generated-runtime identity and prompt-prose tests already covered by direct runtime behavior.
- Drop the test that casts empty objects to public types and only verifies missing fields are undefined.
- Keep Trusted Access documentation coverage without pinning exact Markdown wording.

## Verification

- `bun test --timeout 30000 tests-ts/skeleton.test.ts tests-ts/cli.test.ts tests-ts/runtime.test.ts tests-ts/compact-diff-scan.test.ts` — 255 passed, 7 skipped, 0 failed.
- `pnpm run types`.
- `pnpm run format`.
- `git diff --check`.
