### PR TITLE
test: exercise real exporter file protections

### DIFF
--- a/sdk/typescript/tests-ts/cli-export.test.ts
+++ b/sdk/typescript/tests-ts/cli-export.test.ts
@@ -1,4 +1,6 @@
 import {
+  chmod,
+  cp,
   lstat,
   mkdir,
   mkdtemp,
@@ -20,6 +22,16 @@ import {
   capture,
   dependencies,
 } from "./cli-fixtures.js";
+import { PLUGIN_ROOT } from "./plugin-root.js";
+
+async function copyCompletedScan(root: string): Promise<string> {
+  const scan = join(root, "scan");
+  await cp(join(PLUGIN_ROOT, "examples", "completed-scan"), scan, {
+    recursive: true,
+  });
+  if (process.platform !== "win32") await chmod(scan, 0o700);
+  return scan;
+}
 
 describe("CLI", () => {
   test("does not pass credentials or Python startup paths to the exporter", () => {
@@ -307,27 +319,32 @@ describe("CLI", () => {
   test("writes exported findings to the requested file", async () => {
     const directory = await mkdtemp(join(tmpdir(), "codex-security-export-"));
     try {
-      for (const [format, filename, expected] of [
-        ["csv", "findings.csv", "occurrence_id,finding_id\n"],
-        [
-          "json",
-          "findings.json",
-          '{"documentType":"codex-security.findings"}\n',
-        ],
-        ["sarif", "results.sarif", '{"version":"2.1.0"}\n'],
+      const scan = await copyCompletedScan(directory);
+      for (const [format, filename] of [
+        ["csv", "findings.csv"],
+        ["json", "findings.json"],
+        ["sarif", "results.sarif"],
       ] as const) {
         const stdout = capture();
         const stderr = capture();
         const output = join(directory, filename);
         expect(
           await main(
-            ["export", "scan", "--export-format", format, "--output", output],
+            ["export", scan, "--export-format", format, "--output", output],
             stdout.stream,
             stderr.stream,
-            dependencies(),
           ),
         ).toBe(0);
-        expect(await readFile(output, "utf8")).toBe(expected);
+        const contents = await readFile(output, "utf8");
+        if (format === "csv") {
+          expect(contents).toContain("occurrence_id,finding_id,");
+        } else if (format === "json") {
+          expect(JSON.parse(contents)).toMatchObject({
+            documentType: "codex-security.findings",
+          });
+        } else {
+          expect(JSON.parse(contents)).toMatchObject({ version: "2.1.0" });
+        }
         if (process.platform !== "win32")
           expect((await stat(output)).mode & 0o777).toBe(0o600);
         expect(stdout.text()).toBe("");
@@ -366,6 +383,7 @@ describe("CLI", () => {
   test("rejects a repository-controlled output symlink without following it", async () => {
     const directory = await mkdtemp(join(tmpdir(), "codex-security-export-"));
     try {
+      const scan = await copyCompletedScan(directory);
       const outside = join(directory, "outside.txt");
       const output = join(directory, "results.sarif");
       await writeFile(outside, "unchanged\n");
@@ -373,10 +391,9 @@ describe("CLI", () => {
       const stderr = capture();
       expect(
         await main(
-          ["export", "scan", "--output", output],
+          ["export", scan, "--output", output],
           capture().stream,
           stderr.stream,
-          dependencies(),
         ),
       ).toBe(2);
       expect(await readFile(outside, "utf8")).toBe("unchanged\n");
@@ -422,18 +439,18 @@ describe("CLI", () => {
   test("creates the optional scan-local exports directory", async () => {
     const directory = await mkdtemp(join(tmpdir(), "codex-security-export-"));
     try {
-      const scan = join(directory, "scan");
+      const scan = await copyCompletedScan(directory);
       const output = join(scan, "exports", "results.sarif");
-      await mkdir(scan);
       expect(
         await main(
           ["export", scan, "--output", output],
           capture().stream,
           capture().stream,
-          dependencies(),
         ),
       ).toBe(0);
-      expect(await readFile(output, "utf8")).toBe('{"version":"2.1.0"}\n');
+      expect(JSON.parse(await readFile(output, "utf8"))).toMatchObject({
+        version: "2.1.0",
+      });
     } finally {
       await rm(directory, { recursive: true, force: true });
     }
@@ -442,11 +459,10 @@ describe("CLI", () => {
   test("exports through a symlinked output parent", async () => {
     const directory = await mkdtemp(join(tmpdir(), "codex-security-export-"));
     try {
-      const scan = join(directory, "scan");
+      const scan = await copyCompletedScan(directory);
       const actualOutput = join(directory, "actual-output");
       const linkedOutput = join(directory, "linked-output");
       const output = join(linkedOutput, "results.json");
-      await mkdir(scan);
       await mkdir(actualOutput);
       await writeFile(join(actualOutput, "results.json"), "old\n");
       await symlink(
@@ -462,7 +478,6 @@ describe("CLI", () => {
           ["export", scan, "--export-format", "json", "--output", output],
           stdout.stream,
           stderr.stream,
-          dependencies(),
         ),
       ).toBe(0);
       expect(

--- a/sdk/typescript/tests-ts/cli-export.test.ts
+++ b/sdk/typescript/tests-ts/cli-export.test.ts
@@ -398,8 +398,8 @@ describe("CLI", () => {
       ).toBe(2);
       expect(await readFile(outside, "utf8")).toBe("unchanged\n");
       expect((await lstat(output)).isSymbolicLink()).toBe(true);
-      expect(stderr.text()).toBe(
-        "codex-security: results.sarif: expected a regular non-symlink file\n",
+      expect(stderr.text()).toMatch(
+        /codex-security: results\.sarif: (?:expected a regular non-symlink file|\[Errno 22\] scan-local files must not be reparse points)/u,
       );
     } finally {
       await rm(directory, { recursive: true, force: true });

--- a/sdk/typescript/tests-ts/cli-fixtures.ts
+++ b/sdk/typescript/tests-ts/cli-fixtures.ts
@@ -1,5 +1,3 @@
-import { lstat, mkdir, writeFile } from "node:fs/promises";
-import { join } from "node:path";
 import type { main } from "../src/cli.js";
 import type {
   CodexSecurity,
@@ -16,7 +14,7 @@ import type {
   ScanWorkerStatus,
   SeverityLevel,
 } from "../src/index.js";
-import { CodexSecurityError, ScanResult } from "../src/index.js";
+import { ScanResult } from "../src/index.js";
 import type { UpdateNotice } from "../src/version.js";
 
 type MainDependencies = NonNullable<Parameters<typeof main>[3]>;
@@ -261,25 +259,13 @@ export function dependencies(
       (await options.onWorkbench?.(args)) ?? { scans: [] },
     matchFindings: async (input) =>
       (await options.onMatch?.(input)) ?? { matches: [], uncertain: [] },
-    exportFindings: async (arguments_) => {
-      const contents = new TextEncoder().encode(
+    exportFindings: async (arguments_) =>
+      new TextEncoder().encode(
         arguments_.format === "csv"
           ? "occurrence_id,finding_id\n"
           : arguments_.format === "json"
             ? '{"documentType":"codex-security.findings"}\n'
             : '{"version":"2.1.0"}\n',
-      );
-      if (arguments_.output !== "-") {
-        const metadata = await lstat(arguments_.output).catch(() => undefined);
-        if (metadata?.isSymbolicLink()) {
-          throw new CodexSecurityError(
-            "results.sarif: expected a regular non-symlink file",
-          );
-        }
-        await mkdir(join(arguments_.output, ".."), { recursive: true });
-        await writeFile(arguments_.output, contents, { mode: 0o600 });
-      }
-      return contents;
-    },
+      ),
   };
 }


### PR DESCRIPTION
## Summary

- Exercise the actual bundled Python exporter for CSV, JSON, and SARIF file output.
- Verify real output permissions, scan-local exports, symlinked parents, and rejection of output symlinks against sealed scan fixtures.
- Remove fake file writes, permission handling, and symlink policy from the shared CLI test double.

## Verification

- `bun test --timeout 30000 tests-ts/cli-export.test.ts` — 17 passed.
- `bun test --timeout 30000 tests-ts/cli-export.test.ts tests-ts/cli.test.ts tests-ts/cli-workbench.test.ts tests-ts/cli-authentication.test.ts tests-ts/cli-skills.test.ts tests-ts/cli-signals.test.ts tests-ts/cli-scan-prompts.test.ts tests-ts/update-notice.test.ts tests-ts/multiscan.test.ts` — 249 passed.
- `pnpm run types`.
- `pnpm run format`.
- `git diff --check`.
