### PR TITLE
test: isolate global mocks and authentication state

### DIFF
--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -52,6 +52,7 @@ import {
 import { normalizeTarget } from "../src/targets.js";
 import { SYNTHETIC_CREDENTIALS } from "./cli-fixtures.js";
 import { INTEGRATION_TARGET, PLUGIN_ROOT } from "./plugin-root.js";
+import { runMockInSubprocess } from "./support/isolated-mock.js";
 
 type ScanObserverName = Parameters<
   NonNullable<ScanOptions["onObserverError"]>
@@ -5921,6 +5922,14 @@ if ([basename(process.argv[1]), ...process.argv.slice(2)].join(" ") !== "login s
   });
 
   test("cleans the bootstrap workspace when credential-home cleanup fails", async () => {
+    if (
+      runMockInSubprocess(
+        import.meta.path,
+        "cleans the bootstrap workspace when credential-home cleanup fails",
+      )
+    ) {
+      return;
+    }
     const root = await temporaryDirectory();
     const repository = join(root, "repository");
     const codexHome = join(root, "codex-home");
@@ -5976,6 +5985,14 @@ if ([basename(process.argv[1]), ...process.argv.slice(2)].join(" ") !== "login s
   });
 
   test("attempts both preparation cleanups and preserves the preparation and cleanup failures", async () => {
+    if (
+      runMockInSubprocess(
+        import.meta.path,
+        "attempts both preparation cleanups and preserves the preparation and cleanup failures",
+      )
+    ) {
+      return;
+    }
     const root = await temporaryDirectory();
     const repository = join(root, "repository");
     await mkdir(repository);

--- a/sdk/typescript/tests-ts/cli-authentication.test.ts
+++ b/sdk/typescript/tests-ts/cli-authentication.test.ts
@@ -62,6 +62,8 @@ describe("CLI authentication", () => {
       const stdout = capture();
       const stderr = capture();
       const deps = dependencies();
+      deps.prepareAuthenticationHome = async () =>
+        join(stateDirectory, "codex-home");
       let forwarded: readonly string[] | undefined;
       deps.createSecurity = () => {
         throw new Error("must not initialize Codex Security");

--- a/sdk/typescript/tests-ts/cli-authentication.test.ts
+++ b/sdk/typescript/tests-ts/cli-authentication.test.ts
@@ -10,7 +10,7 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { main } from "../src/cli.js";
 import { CodexSecurityError, type ScanOptions } from "../src/index.js";
 import {
@@ -24,16 +24,25 @@ import {
   fakeResult,
 } from "./support/cli.js";
 
+let stateDirectory: string;
+
+beforeEach(async () => {
+  stateDirectory = await realpath(
+    await mkdtemp(join(tmpdir(), "codex-security-cli-authentication-")),
+  );
+});
+
+afterEach(async () => {
+  await rm(stateDirectory, { recursive: true, force: true });
+});
+
 function dependencies(
   options: Parameters<typeof cliDependencies>[0] = {},
 ): ReturnType<typeof cliDependencies> {
   return cliDependencies({
     ...options,
     environment: {
-      CODEX_SECURITY_STATE_DIR: join(
-        tmpdir(),
-        `codex-security-cli-authentication-${process.pid}`,
-      ),
+      CODEX_SECURITY_STATE_DIR: stateDirectory,
       ...options.environment,
     },
   });
@@ -69,8 +78,6 @@ describe("CLI authentication", () => {
   });
 
   test("uses the same stable credential home for login, status, and logout", async () => {
-    const stateDirectory = join(tmpdir(), "codex-security-managed-auth-state");
-    await mkdir(stateDirectory, { recursive: true, mode: 0o700 });
     const expectedHome = await realpath(
       await prepareCodexSecurityCredentialHome({
         CODEX_SECURITY_STATE_DIR: stateDirectory,

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -74,6 +74,7 @@ import {
   verifyStableWindowsCredentialDescendants,
 } from "../src/runtime.js";
 import { PLUGIN_ROOT } from "./plugin-root.js";
+import { runMockInSubprocess } from "./support/isolated-mock.js";
 
 const temporaryDirectories: string[] = [];
 const testPosix = process.platform === "win32" ? test.skip : test;
@@ -838,6 +839,14 @@ describe("plugin runtime preparation", () => {
   });
 
   test("cancels configured plugin directory discovery", async () => {
+    if (
+      runMockInSubprocess(
+        import.meta.path,
+        "cancels configured plugin directory discovery",
+      )
+    ) {
+      return;
+    }
     const cancellationRoot = await temporaryDirectory();
     const cancellationSource = await plugin(cancellationRoot);
     const cancellationDirectory = join(cancellationSource, "many-files");
@@ -954,6 +963,14 @@ describe("plugin runtime preparation", () => {
   testPosix(
     "rejects a queued plugin directory replaced with a symlink",
     async () => {
+      if (
+        runMockInSubprocess(
+          import.meta.path,
+          "rejects a queued plugin directory replaced with a symlink",
+        )
+      ) {
+        return;
+      }
       const root = await temporaryDirectory();
       const selected = await plugin(root);
       const scripts = join(selected, "scripts");
@@ -1259,6 +1276,14 @@ describe("plugin runtime preparation", () => {
   });
 
   test("imports ambient auth when credential files do not support hard links", async () => {
+    if (
+      runMockInSubprocess(
+        import.meta.path,
+        "imports ambient auth when credential files do not support hard links",
+      )
+    ) {
+      return;
+    }
     const root = await temporaryDirectory();
     const ambient = join(root, "ambient");
     const isolated = join(root, "isolated");
@@ -2180,6 +2205,14 @@ describe("runtime directories and plugin Python boundary", () => {
   });
 
   test("retries Windows credential verification when a descendant disappears", async () => {
+    if (
+      runMockInSubprocess(
+        import.meta.path,
+        "retries Windows credential verification when a descendant disappears",
+      )
+    ) {
+      return;
+    }
     const root = await temporaryDirectory();
     const home = join(root, "home");
     const temporary = join(home, ".auth-temporary");
@@ -2217,6 +2250,14 @@ describe("runtime directories and plugin Python boundary", () => {
   });
 
   test("rejects Windows credential descendants that repeatedly disappear", async () => {
+    if (
+      runMockInSubprocess(
+        import.meta.path,
+        "rejects Windows credential descendants that repeatedly disappear",
+      )
+    ) {
+      return;
+    }
     const root = await temporaryDirectory();
     const home = join(root, "home");
     const credential = join(home, "auth.json");

--- a/sdk/typescript/tests-ts/support/isolated-mock.ts
+++ b/sdk/typescript/tests-ts/support/isolated-mock.ts
@@ -1,0 +1,18 @@
+import { spawnSync } from "node:child_process";
+import { expect } from "bun:test";
+
+export function runMockInSubprocess(file: string, name: string): boolean {
+  if (process.env["CODEX_SECURITY_ISOLATED_MOCK"] === "1") return false;
+
+  const result = spawnSync(
+    process.execPath,
+    ["test", "--timeout", "30000", "--test-name-pattern", name, file],
+    {
+      encoding: "utf8",
+      env: { ...process.env, CODEX_SECURITY_ISOLATED_MOCK: "1" },
+      windowsHide: true,
+    },
+  );
+  expect(result.status, result.stderr).toBe(0);
+  return true;
+}


### PR DESCRIPTION
## Summary

- Give every CLI authentication test its own temporary credential-state directory and remove it after the test.
- Run all seven persistent `node:fs/promises` module mocks in isolated Bun subprocesses.
- Preserve the existing plugin symlink, credential, cancellation, and cleanup-failure coverage.

## Verification

- `bun test --randomize --seed 12345 --timeout 30000 ./tests-ts` — 1,075 passed, 11 skipped, 0 failed.
- `bun test --timeout 30000 tests-ts/cli-authentication.test.ts` — 24 passed.
- Focused subprocess cases for all seven filesystem module mocks.
- `pnpm run types`.
- `pnpm run format`.
