### PR TITLE
refactor: remove unused scan finalization helpers

### DIFF
--- a/sdk/typescript/_bundled_plugin/scripts/finalize_scan_contract.py
+++ b/sdk/typescript/_bundled_plugin/scripts/finalize_scan_contract.py
@@ -94,11 +94,6 @@ def _read_json(path: Path) -> dict[str, Any]:
     return payload
 
 
-def _write_json(path: Path, payload: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(_json_bytes(payload))
-
-
 def _generate_report_projection(
     manifest: dict[str, Any],
     findings: dict[str, Any],
@@ -176,14 +171,6 @@ def _sha256_text(value: str) -> str:
 
 def _sha256_bytes(value: bytes) -> str:
     return hashlib.sha256(value).hexdigest()
-
-
-def _sha256_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
 
 
 def _require_dict(payload: dict[str, Any], key: str, context: str) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

- Delete the unused private `_write_json` and `_sha256_file` helpers from the bundled scan finalizer.
- Keep the active descriptor-relative hashing, symlink-safe artifact writes, and canonical JSON handling unchanged.
- Repository-wide searches and Python AST inspection confirm neither removed helper has a caller.

## Verification

- `bun test --timeout 30000 tests-ts/scan-recovery.test.ts tests-ts/cli-export.test.ts tests-ts/contract.test.ts` — 73 passed, 0 failed.
- Bytecode-disabled Python compilation and imports of the finalizer, scan startup, workbench database, and validator.
- `pnpm run types`.
- `pnpm run format`.
