### PR TITLE
fix: keep bulk-scan progress observer failures nonfatal

### DIFF
--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -147,7 +147,7 @@ async function runCampaign(
           : await legacyIncompleteCoverage(receipt);
       if (coverage !== undefined) {
         incomplete += 1;
-        options.onProgress?.({
+        notifyProgress(options, {
           repository: task.id,
           status: "completed_with_incomplete_coverage",
           attempt: receipt.attempt,
@@ -193,7 +193,7 @@ async function runCampaign(
           `attempt-${attempt}`,
         );
         const progress = { repository: task.id, attempt };
-        options.onProgress?.({ ...progress, status: "started" });
+        notifyProgress(options, { ...progress, status: "started" });
         let failure: string | undefined;
         let warning: string | undefined;
         let coverage: CoverageDocument["completeness"] | undefined;
@@ -234,7 +234,11 @@ async function runCampaign(
               ? {}
               : { postScanPrompt: options.postScanPrompt }),
             onWarning: (warning) =>
-              options.onProgress?.({ ...progress, status: "started", warning }),
+              notifyProgress(options, {
+                ...progress,
+                status: "started",
+                warning,
+              }),
             ...(options.signal === undefined ? {} : { signal: options.signal }),
           });
           cost = result.cost;
@@ -272,7 +276,7 @@ async function runCampaign(
             ...(warning === undefined ? {} : { warning }),
           })}\n`,
         );
-        options.onProgress?.({
+        notifyProgress(options, {
           ...progress,
           status,
           ...(failure === undefined ? {} : { error: failure }),
@@ -310,6 +314,15 @@ async function runCampaign(
     skipped,
     resultsPath: ledger,
   };
+}
+
+function notifyProgress(
+  options: MultiscanOptions,
+  event: Parameters<NonNullable<MultiscanOptions["onProgress"]>>[0],
+): void {
+  try {
+    void Promise.resolve(options.onProgress?.(event)).catch(() => {});
+  } catch {}
 }
 
 async function ensureOutputDirectory(path: string): Promise<void> {

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -290,6 +290,50 @@ describe("multiscan", () => {
     });
   });
 
+  test.each([false, true])(
+    "continues scanning when a progress observer fails %s",
+    async (asynchronous) => {
+      const paths = await fixture();
+      const source = await repository(paths.root, "observer-failure");
+      await writeFile(
+        paths.input,
+        `id,repository,revision\nobserver-failure,${source.path},${source.revision}\n`,
+      );
+      let attempts = 0;
+      const progress: string[] = [];
+
+      const summary = await runMultiscan(
+        options(
+          paths,
+          client(async (_repository, scanOptions = {}) => {
+            attempts += 1;
+            scanOptions.onWarning?.("Optional post-scan warning.");
+            return await completedScan(scanOptions.outputDir!);
+          }),
+          {
+            onProgress: (event) => {
+              progress.push(event.warning ?? event.status);
+              const error = new Error("Optional progress observer failed.");
+              if (asynchronous) return Promise.reject(error);
+              throw error;
+            },
+          },
+        ),
+      );
+
+      expect(summary).toMatchObject({ completed: 1, incomplete: 0, failed: 0 });
+      expect(attempts).toBe(1);
+      expect(progress).toEqual([
+        "started",
+        "Optional post-scan warning.",
+        "completed",
+      ]);
+      expect(await results(summary.resultsPath)).toMatchObject([
+        { id: "observer-failure", status: "completed", attempt: 1 },
+      ]);
+    },
+  );
+
   test.each(["partial", "unknown"] as const)(
     "retains sealed %s coverage without retries or multiplied costs",
     async (completeness) => {
@@ -374,7 +418,12 @@ describe("multiscan", () => {
       ]);
 
       const resumed = await runMultiscan(
-        options(paths, security, { maxAttempts: 3 }),
+        options(paths, security, {
+          maxAttempts: 3,
+          onProgress: () => {
+            throw new Error("Optional progress observer failed.");
+          },
+        }),
       );
       expect(resumed).toMatchObject({
         completed: 0,


### PR DESCRIPTION
## Summary

Keep optional bulk-scan progress observers from interrupting repository scans or changing their recorded outcome.

## Changes

- Dispatch started, warning, completed, and resumed-progress events through one nonfatal helper.
- Preserve synchronous observer side effects while containing both thrown errors and rejected promises.
- Add regression coverage for successful scans, forwarded warnings, resumable incomplete coverage, and durable receipts.

## Testing

- `bun test --timeout 30000 tests-ts/multiscan.test.ts` — 41 passed.
- Confirmed the new synchronous and asynchronous observer regressions failed before the production fix.
- `pnpm run types`.
- `pnpm run format`.

## Risk and rollout

Limited to optional observer dispatch. Scan execution, cancellation, retries, repository boundaries, credentials, and persisted receipt formats are unchanged.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
