### PR TITLE
fix: recover cleanly when the scan dashboard cannot start

### DIFF
--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -2890,7 +2890,13 @@ async function runScan(
         arguments_.dryRun ? "Validating scan inputs" : "Preparing scan",
       );
     } else {
-      dashboard.start();
+      try {
+        dashboard.start();
+      } catch {
+        dashboard = null;
+        progress = new Progress(errorOutput, dependencies, false);
+        progress.startTimer("Preparing scan");
+      }
     }
     security = dependencies.createSecurity(config);
     const options: ScanOptions = {

--- a/sdk/typescript/src/scan-dashboard.ts
+++ b/sdk/typescript/src/scan-dashboard.ts
@@ -164,7 +164,9 @@ export class ScanDashboard {
         this.stop();
       } catch {
         try {
-          this.#stream.write(`${SHOW_CURSOR}${EXIT_ALTERNATE_SCREEN}`);
+          this.#stream.write(
+            `${DISABLE_ALTERNATE_SCROLL}${SHOW_CURSOR}${EXIT_ALTERNATE_SCREEN}`,
+          );
         } catch {}
       }
       throw error;

--- a/sdk/typescript/src/scan-dashboard.ts
+++ b/sdk/typescript/src/scan-dashboard.ts
@@ -160,7 +160,13 @@ export class ScanDashboard {
       }
       this.#render();
     } catch (error) {
-      this.stop();
+      try {
+        this.stop();
+      } catch {
+        try {
+          this.#stream.write(`${SHOW_CURSOR}${EXIT_ALTERNATE_SCREEN}`);
+        } catch {}
+      }
       throw error;
     }
   }

--- a/sdk/typescript/src/scan-dashboard.ts
+++ b/sdk/typescript/src/scan-dashboard.ts
@@ -145,17 +145,24 @@ export class ScanDashboard {
 
   public start(): void {
     if (this.#timer !== null) return;
-    this.#stream.write(`${ENTER_ALTERNATE_SCREEN}${HIDE_CURSOR}`);
     const input = this.#options.input;
     if (input?.isTTY === true) {
       this.#inputWasRaw = input.isRaw === true;
-      input.setRawMode?.(true);
-      input.resume?.();
-      input.on("data", this.#onInput);
-      this.#stream.write(ENABLE_ALTERNATE_SCROLL);
     }
-    this.#render();
     this.#timer = this.#options.clock.setInterval(() => this.#render(), 1_000);
+    try {
+      this.#stream.write(`${ENTER_ALTERNATE_SCREEN}${HIDE_CURSOR}`);
+      if (input?.isTTY === true) {
+        input.setRawMode?.(true);
+        input.resume?.();
+        input.on("data", this.#onInput);
+        this.#stream.write(ENABLE_ALTERNATE_SCROLL);
+      }
+      this.#render();
+    } catch (error) {
+      this.stop();
+      throw error;
+    }
   }
 
   public stop(): void {

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -1629,6 +1629,35 @@ describe("CLI", () => {
     expect(stderr.text()).not.toContain("\r");
   });
 
+  test("falls back to plain progress when the dashboard cannot initialize", async () => {
+    const stdout = capture();
+    const stderr = capture(true);
+    let scans = 0;
+    let closed = 0;
+    let timers = 0;
+    const deps = dependencies({
+      onRun: () => {
+        scans += 1;
+      },
+      onClose: () => {
+        closed += 1;
+      },
+    });
+    deps.setInterval = () => {
+      timers += 1;
+      throw new Error("Dashboard timer unavailable.");
+    };
+
+    expect(await main(["scan", "."], stdout.stream, stderr.stream, deps)).toBe(
+      0,
+    );
+    expect(scans).toBe(1);
+    expect(closed).toBe(1);
+    expect(timers).toBe(1);
+    expect(stderr.text()).toContain("Preparing scan");
+    expect(stderr.text()).toContain("Running scan");
+  });
+
   test("keeps terminal scans in one live dashboard", async () => {
     const stdout = capture();
     const stderr = capture(true);

--- a/sdk/typescript/tests-ts/scan-dashboard.test.ts
+++ b/sdk/typescript/tests-ts/scan-dashboard.test.ts
@@ -94,6 +94,32 @@ describe("live scan dashboard", () => {
     expect(input.listenerCount("data")).toBe(0);
   });
 
+  test("disables alternate scrolling when dashboard rollback fails", () => {
+    const input = new DashboardTestInput();
+    const output: string[] = [];
+    input.setRawMode = (enabled) => {
+      if (!enabled) throw new Error("Raw mode cleanup failed.");
+      input.isRaw = enabled;
+      return input;
+    };
+    const dashboard = new ScanDashboard(
+      {
+        write(chunk: string): boolean {
+          output.push(chunk);
+          if (chunk.includes("\u001B[H")) {
+            throw new Error("Dashboard rendering failed.");
+          }
+          return true;
+        },
+      },
+      { repository: "/synthetic/repository", input, clock: fakeClock() },
+    );
+
+    expect(() => dashboard.start()).toThrow("Dashboard rendering failed.");
+    expect(output.join("")).toContain("\u001B[?1007h");
+    expect(output.join("")).toContain("\u001B[?1007l\u001B[?25h\u001B[?1049l");
+  });
+
   test("redraws real scan activity and metrics in place", () => {
     const stderr = capture(true);
     const timers: NodeJS.Timeout[] = [];

--- a/sdk/typescript/tests-ts/scan-dashboard.test.ts
+++ b/sdk/typescript/tests-ts/scan-dashboard.test.ts
@@ -39,6 +39,40 @@ class DashboardTestInput extends EventEmitter {
 }
 
 describe("live scan dashboard", () => {
+  test("restores terminal state when dashboard initialization fails", () => {
+    const input = new DashboardTestInput();
+    const output: string[] = [];
+    let timerCleared = false;
+    const dashboard = new ScanDashboard(
+      {
+        write(chunk: string): boolean {
+          output.push(chunk);
+          if (chunk.includes("\u001B[H")) {
+            throw new Error("Dashboard rendering failed.");
+          }
+          return true;
+        },
+      },
+      {
+        repository: "/synthetic/repository",
+        input,
+        clock: {
+          ...fakeClock(),
+          clearInterval: () => {
+            timerCleared = true;
+          },
+        },
+      },
+    );
+
+    expect(() => dashboard.start()).toThrow("Dashboard rendering failed.");
+    expect(timerCleared).toBe(true);
+    expect(input.isRaw).toBe(false);
+    expect(input.listenerCount("data")).toBe(0);
+    expect(output.join("")).toContain("\u001B[?25h\u001B[?1049l");
+    dashboard.stop();
+  });
+
   test("redraws real scan activity and metrics in place", () => {
     const stderr = capture(true);
     const timers: NodeJS.Timeout[] = [];

--- a/sdk/typescript/tests-ts/scan-dashboard.test.ts
+++ b/sdk/typescript/tests-ts/scan-dashboard.test.ts
@@ -73,6 +73,27 @@ describe("live scan dashboard", () => {
     dashboard.stop();
   });
 
+  test("restores the screen when raw mode setup and cleanup both fail", () => {
+    const stderr = capture(true);
+    const input = new DashboardTestInput();
+    input.setRawMode = (enabled) => {
+      throw new Error(
+        enabled
+          ? "Raw mode initialization failed."
+          : "Raw mode cleanup failed.",
+      );
+    };
+    const dashboard = new ScanDashboard(stderr.stream, {
+      repository: "/synthetic/repository",
+      input,
+      clock: fakeClock(),
+    });
+
+    expect(() => dashboard.start()).toThrow("Raw mode initialization failed.");
+    expect(stderr.text()).toContain("\u001B[?25h\u001B[?1049l");
+    expect(input.listenerCount("data")).toBe(0);
+  });
+
   test("redraws real scan activity and metrics in place", () => {
     const stderr = capture(true);
     const timers: NodeJS.Timeout[] = [];


### PR DESCRIPTION
## Summary

Prevent optional interactive dashboard startup failures from corrupting terminal state or stopping an otherwise valid security scan.

## Changes

- Register dashboard cleanup before changing alternate-screen, cursor, raw-input, or listener state.
- Restore terminal state when dashboard initialization fails.
- Continue the scan with existing noninteractive progress when the dashboard cannot start.
- Add focused regressions for terminal restoration and successful fallback without changing signal handling.

## Testing

- Confirmed both new regressions failed against the original implementation.
- `bun test --timeout 30000 tests-ts/scan-dashboard.test.ts tests-ts/cli.test.ts tests-ts/cli-signals.test.ts` — 155 passed.
- `pnpm run types`.
- `pnpm run format`.

## Risk and rollout

Limited to interactive terminal startup and cleanup. Configuration validation, scan execution, cancellation, credentials, and requested cost limits remain unchanged.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
