### PR TITLE
fix: paginate GitHub organizations in bulk-scan discovery

### DIFF
--- a/sdk/typescript/src/bulk-scan-discovery.ts
+++ b/sdk/typescript/src/bulk-scan-discovery.ts
@@ -197,12 +197,24 @@ async function selectGitHubOwner(
   prompt: BulkScanPrompt,
   signal?: AbortSignal,
 ): Promise<string> {
-  const [orgs, user] = await Promise.all([
+  const [firstPage, user] = await Promise.all([
     github.request("GET /user/orgs", { per_page: 100, request: { signal } }),
     github.request("GET /user", { request: { signal } }),
   ]);
+  const organizations = [...firstPage.data];
+  let response = firstPage;
+  let page = 1;
+  while (response.headers.link?.includes('rel="next"')) {
+    signal?.throwIfAborted();
+    response = await github.request("GET /user/orgs", {
+      per_page: 100,
+      page: ++page,
+      request: { signal },
+    });
+    organizations.push(...response.data);
+  }
   const personal = user.data.login;
-  const owners = [personal, ...orgs.data.map(({ login }) => login)].sort();
+  const owners = [personal, ...organizations.map(({ login }) => login)].sort();
   if (owners.length > 1) {
     return await prompt.select(
       "Which account or organization should we scan?",

--- a/sdk/typescript/tests-ts/bulk-scan-discovery.test.ts
+++ b/sdk/typescript/tests-ts/bulk-scan-discovery.test.ts
@@ -159,10 +159,21 @@ function discoveryDependencies(
               });
 
               if (path === "/user/orgs") {
+                const organizations = options.organizations ?? [];
+                const page = Number(url.searchParams.get("page") ?? "1");
+                const perPage = Number(
+                  url.searchParams.get("per_page") ?? "30",
+                );
+                const offset = (page - 1) * perPage;
+                const next = new URL(url);
+                next.searchParams.set("page", String(page + 1));
                 return Response.json(
-                  (options.organizations ?? []).map((login) => ({
-                    login,
-                  })),
+                  organizations
+                    .slice(offset, offset + perPage)
+                    .map((login) => ({ login })),
+                  offset + perPage < organizations.length
+                    ? { headers: { link: `<${next.href}>; rel="next"` } }
+                    : undefined,
                 );
               }
               if (path === "/user") {
@@ -347,6 +358,30 @@ describe("bulk scan repository discovery", () => {
     expect(
       requests.find(({ path }) => path === "/graphql")?.variables?.owner,
     ).toBe("personal-account");
+  });
+
+  test("includes organizations beyond the first GitHub results page", async () => {
+    const root = await temporaryDirectory();
+    const organizations = Array.from(
+      { length: 101 },
+      (_value, index) => `organization-${String(index).padStart(3, "0")}`,
+    );
+    const { dependencies, prompt, requests } = discoveryDependencies(root, {
+      organizations,
+    });
+    prompt.confirms = [true];
+    prompt.choices = ["organization-100"];
+
+    await runBulkScanWizard(dependencies);
+
+    expect(prompt.searchOptions[0]).toContain("organization-100");
+    expect(prompt.searchOptions[0]).toHaveLength(102);
+    expect(requests.filter(({ path }) => path === "/user/orgs")).toHaveLength(
+      2,
+    );
+    expect(
+      requests.find(({ path }) => path === "/graphql")?.variables?.owner,
+    ).toBe("organization-100");
   });
 
   test("does not write an inventory when canceled or no repositories match", async () => {


### PR DESCRIPTION
## Summary

Show every available GitHub organization during interactive bulk-scan discovery instead of silently stopping after the first 100 organizations.

## Changes

- Follow GitHub organization pagination links with the existing authenticated Octokit client.
- Preserve the existing first-page request, GitHub Enterprise support, cancellation, and repository discovery.
- Update the GitHub test double to return realistic paginated responses and cover selecting an organization from the second page.

## Testing

- Confirmed the 101-organization regression failed before the production fix.
- `bun test --timeout 30000 tests-ts/bulk-scan-discovery.test.ts tests-ts/cli.test.ts` — 138 passed.
- `pnpm run types`.
- `pnpm run format`.

## Risk and rollout

Additive organization discovery only. Existing authentication, host selection, scan execution, output paths, and artifact handling remain unchanged; no dependencies were added.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
