### PR TITLE
refactor(workbench): share safe source path validation

### DIFF
--- a/sdk/typescript/_bundled_plugin/scripts/workbench_db.py
+++ b/sdk/typescript/_bundled_plugin/scripts/workbench_db.py
@@ -97,7 +97,7 @@ from workbench_schema import (
 from workbench_schema import (
     sql_statements as sql_statements,
 )
-from workbench_source_excerpt import finding_source_excerpt
+from workbench_source_excerpt import finding_source_excerpt, safe_source_path
 from workbench_target import (
     clean_worktree_content_digest,
     copy_directory_excluding,
@@ -3460,20 +3460,6 @@ def patch_artifact_preview(
         "fileCount": file_count or min(old_headers, new_headers),
         "previewTruncated": preview_truncated,
     }
-
-
-def safe_source_path(target: Path, relative_path: str) -> Path | None:
-    if "\\" in relative_path:
-        return None
-    parsed = PurePosixPath(relative_path)
-    if parsed.is_absolute() or ".." in parsed.parts:
-        return None
-    try:
-        path = (target / parsed.as_posix()).resolve()
-        path.relative_to(target)
-    except (OSError, RuntimeError, ValueError):
-        return None
-    return path
 
 
 def available_artifact_path(scan_dir: Path, candidate: Path) -> Path | None:


### PR DESCRIPTION
## Summary

Use one implementation for validating finding source paths.

## Changes

- Import the existing source-excerpt path validator into the workbench database module.
- Delete the identical duplicate implementation while preserving both modules' existing helper names.

## Testing

- `bun test tests-ts/plugin-report-limits.test.ts tests-ts/scan-recovery.test.ts --timeout 30000` — passed.
- `python3 -I -B` import and path-boundary smoke test — confirmed both modules share the same helper, safe paths remain accepted, and traversal/backslash paths remain rejected.
- `pnpm run types` — passed.
- `git diff --check` — passed.

## Risk and rollout

The shared helper is byte-for-byte equivalent to the removed implementation. Existing repository containment, path traversal, and source-excerpt protections remain unchanged.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
