### PR TITLE
ci: remove redundant package builds and unreachable setup

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -68,33 +68,17 @@ jobs:
       - name: Typecheck
         run: pnpm --dir sdk/typescript run types
 
-      - name: Prepare private Windows test root
-        if: runner.os == 'Windows'
-        id: windows-temp
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $path = Join-Path $env:USERPROFILE '.codex-security-ci-temp'
-          New-Item -ItemType Directory -Path $path -Force | Out-Null
-          $sid = (whoami /user /fo csv /nh | ConvertFrom-Csv -Header Name, Sid).Sid
-          & icacls $path /inheritance:r /grant:r "*${sid}:(OI)(CI)F" '*S-1-5-18:(OI)(CI)F' '*S-1-5-32-544:(OI)(CI)F' | Out-Null
-          if ($LASTEXITCODE -ne 0) { throw 'Could not secure the Windows test root' }
-          "path=$path" >> $env:GITHUB_OUTPUT
-
       - name: Test
         timeout-minutes: 10
         env:
-          TEMP: ${{ steps.windows-temp.outputs.path || runner.temp }}
-          TMP: ${{ steps.windows-temp.outputs.path || runner.temp }}
-          TMPDIR: ${{ steps.windows-temp.outputs.path || runner.temp }}
-          CODEX_SECURITY_ALLOW_MACHINE_POLICY_TEST: ${{ runner.environment == 'github-hosted' && runner.os == 'Windows' && 'true' || 'false' }}
+          TEMP: ${{ runner.temp }}
+          TMP: ${{ runner.temp }}
+          TMPDIR: ${{ runner.temp }}
+          CODEX_SECURITY_ALLOW_MACHINE_POLICY_TEST: "false"
         run: pnpm --dir sdk/typescript run test
 
       - name: Check formatting
         run: pnpm --dir sdk/typescript run format
-
-      - name: Build
-        run: pnpm --dir sdk/typescript run build
 
       - name: Pack
         working-directory: sdk/typescript
@@ -217,10 +201,6 @@ jobs:
       - name: Install dependencies
         working-directory: sdk/typescript
         run: pnpm install --frozen-lockfile
-
-      - name: Build
-        working-directory: sdk/typescript
-        run: pnpm run build
 
       - name: Pack
         working-directory: sdk/typescript

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -127,7 +127,6 @@ jobs:
           pnpm --dir sdk/typescript run types
           pnpm --dir sdk/typescript run test
           pnpm --dir sdk/typescript run format
-          pnpm --dir sdk/typescript run build
 
       - name: Pack
         working-directory: sdk/typescript

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN corepack enable \
 COPY sdk/typescript/ ./
 
 RUN pnpm run types \
-    && pnpm run build \
     && pnpm pack --pack-destination /build/package \
     && node scripts/check-package.mjs /build/package/*.tgz
 


### PR DESCRIPTION
## Summary

Avoid repeated package builds and remove Windows-only setup from a job that never runs on Windows.

## Changes

- Rely on the existing `prepack` build in Node CI, release verification, and Docker packaging.
- Remove unreachable Windows setup from the Ubuntu/macOS test matrix.
- Preserve the actual Windows job's private temporary directory and security policy configuration.

## Testing

- `bun test tests-ts/release-automation.test.ts tests-ts/package-provenance.test.ts --timeout 30000` — 196 passed.
- `pnpm pack --pack-destination /private/tmp/codex-security-cleanup-tools/package-pr3` — confirmed `prepack` builds the package.
- `npm_config_cache=/private/tmp/codex-security-cleanup-tools/npm-cache node scripts/check-package.mjs /private/tmp/codex-security-cleanup-tools/package-pr3/openai-codex-security-0.1.11.tgz` — passed.
- `prettier --check ../../.github/workflows/node-ci.yml ../../.github/workflows/node-release.yml` — passed.
- `git diff --check` — passed.

## Risk and rollout

Packaging still builds through the package's existing `prepack` hook. Existing type checks, package inspection, installed-package smoke tests, release provenance, container checks, and real Windows security setup remain intact.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
