### PR TITLE
refactor(release): remove unreachable DER parser guards

### DIFF
--- a/sdk/typescript/scripts/release-automation.mjs
+++ b/sdk/typescript/scripts/release-automation.mjs
@@ -164,14 +164,8 @@ function derChildren(bytes, element) {
   let cursor = element.start;
   while (cursor < element.end) {
     const child = derElement(bytes, cursor, element.end);
-    if (child.end <= cursor) {
-      throw invalidSigningCertificate();
-    }
     children.push(child);
     cursor = child.end;
-  }
-  if (cursor !== element.end) {
-    throw invalidSigningCertificate();
   }
   return children;
 }

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -992,12 +992,6 @@ describe("cryptographically verified npm provenance", () => {
     }
   });
 
-  test("fails closed when a certificate child does not advance", () => {
-    expect(readFileSync(automationScript, "utf8")).toMatch(
-      /const child = derElement\(bytes, cursor, element\.end\);\s*if \(child\.end <= cursor\) \{\s*throw invalidSigningCertificate\(\);\s*\}/u,
-    );
-  });
-
   test("rejects empty and noncanonical DER signing certificates", () => {
     const invalidCertificates = [
       Buffer.from([0x30, 0x00]),


### PR DESCRIPTION
## Summary

Remove unreachable DER parser checks and a test that snapshots their source text.

## Changes

- Rely on the existing DER element parser, which already guarantees cursor advancement and enforces the parent boundary.
- Delete the source-regex test while retaining behavioral malformed-certificate and provenance coverage.

## Testing

- `bun test tests-ts/release-automation.test.ts tests-ts/package-provenance.test.ts --timeout 30000` — passed.
- `pnpm run types` — passed.
- `prettier --check scripts/release-automation.mjs tests-ts/release-automation.test.ts` — passed.
- `git diff --check` — passed.

## Risk and rollout

Every accepted DER element consumes its tag and length bytes, and the parser rejects elements extending beyond their parent. Existing malformed-certificate, signing, and package-provenance tests continue to exercise the actual verification behavior.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
