### PR TITLE
refactor(workbench): remove duplicate migration relocation

### DIFF
--- a/sdk/typescript/_bundled_plugin/scripts/workbench_schema.py
+++ b/sdk/typescript/_bundled_plugin/scripts/workbench_schema.py
@@ -744,7 +744,6 @@ def normalize_pre_release_execution_profile_migrations(
         12: "scan continuation threads",
     }
     model_migration_name = "persist scan model settings"
-    warnings_migration_name = "persist scan completion warnings"
     if execution_migrations.get(25) == "dynamic scan execution profiles":
         connection.execute(
             "UPDATE schema_migrations SET name = ? WHERE version = 25 AND name = ?",
@@ -752,9 +751,6 @@ def normalize_pre_release_execution_profile_migrations(
         )
         execution_migrations[25] = model_migration_name
     has_legacy_profile_history = execution_migrations.get(11) == legacy_names[11]
-    has_public_warnings_history = (
-        execution_migrations.get(25) == warnings_migration_name
-    )
 
     scan_columns = {
         row["name"] for row in connection.execute("PRAGMA table_info(scans)")
@@ -765,11 +761,7 @@ def normalize_pre_release_execution_profile_migrations(
     has_legacy_profile_columns = (
         "execution_model" in scan_columns or "execution_model" in workspace_columns
     )
-    if not (
-        has_legacy_profile_history
-        or has_public_warnings_history
-        or has_legacy_profile_columns
-    ):
+    if not (has_legacy_profile_history or has_legacy_profile_columns):
         return
 
     if (
@@ -810,17 +802,6 @@ def normalize_pre_release_execution_profile_migrations(
         raise SystemExit(
             "The Codex Security database has an unsupported execution-profile migration history."
         )
-
-    if has_public_warnings_history:
-        if execution_migrations.get(26) is not None:
-            raise SystemExit(
-                "The Codex Security database has an unsupported pre-release migration history."
-            )
-        connection.execute(
-            "UPDATE schema_migrations SET version = 26 WHERE version = 25 AND name = ?",
-            (warnings_migration_name,),
-        )
-        execution_migrations.pop(25)
 
     if execution_migrations.get(25) not in (None, model_migration_name):
         raise SystemExit(


### PR DESCRIPTION
## Summary

Remove a duplicate legacy migration relocation that is unreachable during normal workbench upgrades.

## Changes

- Keep warning-migration relocation and conflicting-history checks in the existing outer migration normalizer.
- Delete the inner execution-profile helper's duplicate relocation branch and related bookkeeping.

## Testing

- `bun test tests-ts/runtime.test.ts tests-ts/deep-scan-workbench.test.ts --timeout 30000` — passed, including colliding historical migrations, existing public databases, preserved completion warnings, rejected malformed histories, and Deep Scan schema repairs.
- `pnpm run types` — passed.
- `python3 -I -B` Python syntax validation — passed.
- `git diff --check` — passed.

## Risk and rollout

The outer normalizer already relocates the historical warning migration, or rejects conflicting history, before the inner execution-profile helper runs. Existing append-only migrations, persisted warning data, legacy execution settings, and unsupported-history checks remain unchanged.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
