### PR TITLE
chore: remove stale comments and redundant test indirection

### DIFF
--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -2693,12 +2693,6 @@ function reconnectDetails(message: string): ScanReconnectDetails | undefined {
 }
 
 // A failed turn must fail the scan whatever its error payload looks like.
-//
-// Only `error.message` is reused, because that is the single shape the previous
-// code already surfaced. No other shape is forwarded or stringified: this message
-// reaches `fail-scan --message` and is stored unchanged in `scans.failure_message`,
-// so widening what is copied out of the payload would add a new
-// credential-disclosure path to persistent scan history.
 function turnFailureMessage(error: unknown): string {
   if (isRecord(error) && typeof error["message"] === "string") {
     const message = error["message"].trim();

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -5,7 +5,6 @@ const PACKAGE_VERSIONS = packageVersions(
   new URL("../package.json", import.meta.url),
 );
 
-/** npm-compatible successor to the Python package version 0.1.0b3. */
 export const VERSION = PACKAGE_VERSIONS.package;
 export const CODEX_SDK_VERSION = PACKAGE_VERSIONS.sdk;
 export const CODEX_EXECUTABLE_VERSION = PACKAGE_VERSIONS.executable;

--- a/sdk/typescript/tests-ts/api-events.test.ts
+++ b/sdk/typescript/tests-ts/api-events.test.ts
@@ -796,8 +796,6 @@ describe("one-shot scan events", () => {
       message: "retry budget exhausted",
     });
 
-    // A bare string is deliberately NOT reused: it was never surfaced before, and
-    // this message is stored by fail-scan without redaction.
     await expect(
       runEvents(
         await copyCompletedScan(await temporaryDirectory()),

--- a/sdk/typescript/tests-ts/cli-authentication.test.ts
+++ b/sdk/typescript/tests-ts/cli-authentication.test.ts
@@ -22,7 +22,7 @@ import {
   dependencies as cliDependencies,
   fakePreflight,
   fakeResult,
-} from "./support/cli.js";
+} from "./cli-fixtures.js";
 
 let stateDirectory: string;
 

--- a/sdk/typescript/tests-ts/cli-launcher.test.ts
+++ b/sdk/typescript/tests-ts/cli-launcher.test.ts
@@ -13,7 +13,7 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, test } from "bun:test";
 import { VERSION } from "../src/index.js";
-import { SYNTHETIC_CREDENTIALS } from "./support/cli.js";
+import { SYNTHETIC_CREDENTIALS } from "./cli-fixtures.js";
 
 const packageRoot = join(import.meta.dir, "..");
 

--- a/sdk/typescript/tests-ts/cli-signals.test.ts
+++ b/sdk/typescript/tests-ts/cli-signals.test.ts
@@ -6,7 +6,7 @@ import {
   dependencies,
   fakePreflight,
   fakeResult,
-} from "./support/cli.js";
+} from "./cli-fixtures.js";
 
 describe("CLI signals", () => {
   test("maps Ctrl-C and SIGTERM to conventional exits and preserves partial output", async () => {

--- a/sdk/typescript/tests-ts/cli-skills.test.ts
+++ b/sdk/typescript/tests-ts/cli-skills.test.ts
@@ -10,7 +10,7 @@ import {
   runCodexSkillCommand,
   skillCommandFailure,
 } from "../src/cli.js";
-import { capture, dependencies } from "./support/cli.js";
+import { capture, dependencies } from "./cli-fixtures.js";
 
 describe("CLI skill commands", () => {
   test("runs validation and patch skills with file and literal inputs", async () => {

--- a/sdk/typescript/tests-ts/cli-workbench.test.ts
+++ b/sdk/typescript/tests-ts/cli-workbench.test.ts
@@ -10,7 +10,7 @@ import {
   dependencies,
   fakeResult,
   SYNTHETIC_CREDENTIALS,
-} from "./support/cli.js";
+} from "./cli-fixtures.js";
 
 describe("CLI workbench", () => {
   test("lists and summarizes open findings for the current repository", async () => {

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -1418,6 +1418,13 @@ describe("idempotent GitHub release verification", () => {
 });
 
 describe("GitHub release workflow safeguards", () => {
+  const checkedOutVersion = releaseVersion(
+    JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    ) as ReleaseMetadata,
+  );
+  const checkedOutTag = `npm-v${checkedOutVersion}`;
+
   test("requires a real tag for protected npm publication", () => {
     expect(protectedReleaseWorkflow).toContain("release-tag");
     expect(protectedReleaseWorkflow).toContain('"$GITHUB_REF_TYPE"');
@@ -1913,12 +1920,6 @@ describe("GitHub release workflow safeguards", () => {
         protectedReleaseWorkflow,
         "Revalidate protected release tag",
       );
-      const checkedOutVersion = releaseVersion(
-        JSON.parse(
-          readFileSync(new URL("../package.json", import.meta.url), "utf8"),
-        ) as ReleaseMetadata,
-      );
-      const checkedOutTag = `npm-v${checkedOutVersion}`;
       const mock = [
         "gh() {",
         '  if [[ "$1" != "api" ]]; then return 64; fi',
@@ -1969,12 +1970,6 @@ describe("GitHub release workflow safeguards", () => {
       protectedReleaseWorkflow,
       "Validate release tag",
     );
-    const checkedOutVersion = releaseVersion(
-      JSON.parse(
-        readFileSync(new URL("../package.json", import.meta.url), "utf8"),
-      ) as ReleaseMetadata,
-    );
-    const checkedOutTag = `npm-v${checkedOutVersion}`;
     const mocks = [
       "git() { return 0; }",
       "sfw() { printf '%s\\n' '[\"0.1.1\",\"999999999999999999999999.0.0\"]'; }",
@@ -2004,12 +1999,6 @@ describe("GitHub release workflow safeguards", () => {
       protectedReleaseWorkflow,
       "Validate release tag",
     );
-    const checkedOutVersion = releaseVersion(
-      JSON.parse(
-        readFileSync(new URL("../package.json", import.meta.url), "utf8"),
-      ) as ReleaseMetadata,
-    );
-    const checkedOutTag = `npm-v${checkedOutVersion}`;
     const mocks = [
       "git() { return 0; }",
       `sfw() { printf '%s\\n' '["0.1.0","${checkedOutVersion}"]'; }`,

--- a/sdk/typescript/tests-ts/support/cli.ts
+++ b/sdk/typescript/tests-ts/support/cli.ts
@@ -1,1 +1,0 @@
-export * from "../cli-fixtures.js";


### PR DESCRIPTION
## Summary

Remove obsolete test indirection, duplicated release-test setup, and comments that no longer describe current behavior.

## Changes

- Import shared CLI fixtures directly and delete the one-line fixture re-export.
- Load the checked-out package version once for related release workflow tests.
- Remove stale failure-redaction and historical-version comments while preserving the actual redaction and scan-failure behavior.

## Testing

- `bun test tests-ts/cli-signals.test.ts tests-ts/cli-authentication.test.ts tests-ts/cli-launcher.test.ts tests-ts/cli-workbench.test.ts tests-ts/cli-skills.test.ts tests-ts/api-events.test.ts tests-ts/release-automation.test.ts --timeout 30000` — passed.
- `pnpm run types` — passed.
- `prettier --check` for every changed TypeScript file — passed.
- `git diff --check` — passed.

## Risk and rollout

CLI fixtures retain the same implementation and exports; their consumers import the original module directly. Release scenarios and assertions are unchanged. Production changes remove comments only, including outdated claims about persisted failure-message redaction.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
