### PR TITLE
ci: skip Bun setup for Windows package verification

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -193,11 +193,6 @@ jobs:
       - name: Set up pnpm
         run: npm install --global pnpm@11.9.0 --no-audit --no-fund
 
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: "1.3.14"
-
       - name: Install dependencies
         working-directory: sdk/typescript
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

Skip Bun installation in the Windows package-verification jobs, which use only Node.js and pnpm.

## Changes

- Remove the unused Bun setup step from the two `windows-verify` matrix jobs.
- Keep Bun setup for the main test matrix and all Windows test shards.

## Testing

- `bun test tests-ts/release-automation.test.ts tests-ts/package-provenance.test.ts --timeout 30000` — 195 passed.
- `pnpm pack --pack-destination /private/tmp/codex-security-cleanup-tools/followup-1` — passed without Bun on `PATH`.
- `npm_config_cache=/private/tmp/codex-security-cleanup-tools/npm-cache node scripts/check-package.mjs /private/tmp/codex-security-cleanup-tools/followup-1/openai-codex-security-0.1.11.tgz` — passed.
- `prettier --check .github/workflows/node-ci.yml` — passed.
- `git diff --check` — passed.

## Risk and rollout

Package builds, installed-package smoke tests, and release provenance use Node.js and pnpm. Every job that actually runs Bun tests retains its existing Bun installation.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
