### PR TITLE
test(api): share prepared runtime fixtures

### DIFF
--- a/sdk/typescript/tests-ts/api-post-scan.test.ts
+++ b/sdk/typescript/tests-ts/api-post-scan.test.ts
@@ -4,10 +4,10 @@ import { dirname, join } from "node:path";
 import type { ThreadEvent } from "@openai/codex-sdk";
 import { afterEach, describe, expect, test } from "bun:test";
 import { CodexSecurity } from "../src/index.js";
-import { PLUGIN_ROOT } from "./plugin-root.js";
 import {
   completedEvents,
   createApiTestFixtures,
+  preparedRuntime,
 } from "./support/api-events.js";
 
 const { cleanup, copyCompletedScan, temporaryDirectory } =
@@ -19,22 +19,6 @@ const TestClient = CodexSecurity as unknown as new (
   config: Record<string, unknown>,
   dependencies: Record<string, unknown>,
 ) => CodexSecurity;
-
-function preparedRuntime(codexHome: string): Record<string, unknown> {
-  return {
-    codexHome,
-    plugin: {
-      pluginRoot: PLUGIN_ROOT,
-      marketplaceRoot: PLUGIN_ROOT,
-      installedRoot: PLUGIN_ROOT,
-      marketplaceName: "codex-security-sdk",
-      name: "codex-security",
-      version: "0.1.0",
-    },
-    environment: {},
-    credentialsAvailable: true,
-  };
-}
 
 function runWorkbench(_options: unknown, args: readonly string[]) {
   if (args[0] === "register-cli-scan") {

--- a/sdk/typescript/tests-ts/api-surface.test.ts
+++ b/sdk/typescript/tests-ts/api-surface.test.ts
@@ -3,10 +3,10 @@ import { join } from "node:path";
 import type { CodexOptions } from "@openai/codex-sdk";
 import { afterEach, describe, expect, test } from "bun:test";
 import { CodexSecurity } from "../src/index.js";
-import { PLUGIN_ROOT } from "./plugin-root.js";
 import {
   completedEvents,
   createApiTestFixtures,
+  preparedRuntime,
 } from "./support/api-events.js";
 
 const fixtures = createApiTestFixtures();
@@ -19,22 +19,6 @@ const InternalCodexSecurity = CodexSecurity as unknown as new (
 afterEach(async () => {
   await fixtures.cleanup();
 });
-
-function preparedRuntime(codexHome: string): Record<string, unknown> {
-  return {
-    codexHome,
-    plugin: {
-      pluginRoot: PLUGIN_ROOT,
-      marketplaceRoot: PLUGIN_ROOT,
-      installedRoot: PLUGIN_ROOT,
-      marketplaceName: "codex-security-sdk",
-      name: "codex-security",
-      version: "0.1.0",
-    },
-    environment: {},
-    credentialsAvailable: true,
-  };
-}
 
 function mockWorkbench(args: readonly string[]) {
   if (args[0] === "register-cli-scan") {

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -52,6 +52,7 @@ import {
 import { normalizeTarget } from "../src/targets.js";
 import { SYNTHETIC_CREDENTIALS } from "./cli-fixtures.js";
 import { INTEGRATION_TARGET, PLUGIN_ROOT } from "./plugin-root.js";
+import { preparedRuntime } from "./support/api-events.js";
 import { runMockInSubprocess } from "./support/isolated-mock.js";
 
 type ScanObserverName = Parameters<
@@ -265,22 +266,6 @@ async function* completedEvents(): AsyncGenerator<ThreadEvent> {
       output_tokens: 3,
       reasoning_output_tokens: 1,
     },
-  };
-}
-
-function preparedRuntime(codexHome: string): Record<string, unknown> {
-  return {
-    codexHome,
-    plugin: {
-      pluginRoot: PLUGIN_ROOT,
-      marketplaceRoot: PLUGIN_ROOT,
-      installedRoot: PLUGIN_ROOT,
-      marketplaceName: "codex-security-sdk",
-      name: "codex-security",
-      version: "0.1.0",
-    },
-    environment: {},
-    credentialsAvailable: true,
   };
 }
 

--- a/sdk/typescript/tests-ts/support/api-events.ts
+++ b/sdk/typescript/tests-ts/support/api-events.ts
@@ -6,6 +6,22 @@ import { runScanEvents } from "../../src/api.js";
 import type { ScanOptions } from "../../src/index.js";
 import { PLUGIN_ROOT } from "../plugin-root.js";
 
+export function preparedRuntime(codexHome: string): Record<string, unknown> {
+  return {
+    codexHome,
+    plugin: {
+      pluginRoot: PLUGIN_ROOT,
+      marketplaceRoot: PLUGIN_ROOT,
+      installedRoot: PLUGIN_ROOT,
+      marketplaceName: "codex-security-sdk",
+      name: "codex-security",
+      version: "0.1.0",
+    },
+    environment: {},
+    credentialsAvailable: true,
+  };
+}
+
 export type ScanObserverName = Parameters<
   NonNullable<ScanOptions["onObserverError"]>
 >[0];


### PR DESCRIPTION
## Summary

Share the identical prepared-runtime fixture used by three API test suites.

## Changes

- Move the existing fixture into the API test support module.
- Import the shared fixture from the orchestration, post-scan, and API-surface tests.
- Remove duplicate plugin-root imports and unchanged local fixture implementations.

## Testing

- `bun test tests-ts/api.test.ts tests-ts/api-post-scan.test.ts tests-ts/api-surface.test.ts tests-ts/api-events.test.ts --timeout 30000` (158 passed).
- `pnpm --pm-on-fail=ignore run types`.
- `prettier --check` for all four changed test files.
- `git diff --check`.

## Risk and rollout

Test-only cleanup. The shared helper returns the same values as each removed local helper, and no production or packaged files change.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
