### PR TITLE
test(release): remove redundant workflow source assertion

### DIFF
--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -3307,15 +3307,6 @@ describe("GitHub release workflow safeguards", () => {
     },
   );
 
-  test("recovers when another PR concurrently creates the skip label", () => {
-    expect(releaseLabelsWorkflow).toContain(
-      'if ! gh api --method POST "repos/$GITHUB_REPOSITORY/labels"',
-    );
-    expect(releaseLabelsWorkflow).toContain(
-      '"repos/$GITHUB_REPOSITORY/labels/skip-release-notes"',
-    );
-  });
-
   test.each([
     { title: "feat!: breaking feature", label: "enhancement" },
     { title: "feat(api)!: breaking feature", label: "enhancement" },


### PR DESCRIPTION
## Summary

Remove a brittle release-workflow source assertion already covered by an executable behavior test.

## Changes

- Delete the substring-only concurrent-label-creation test.
- Preserve the existing test that executes the workflow and verifies recovery when concurrent label creation fails.

## Testing

- `bun test tests-ts/release-automation.test.ts --timeout 30000` (189 passed).
- `pnpm --pm-on-fail=ignore run types`.
- `prettier --check tests-ts/release-automation.test.ts`.
- `git diff --check`.

## Risk and rollout

Test-only deletion. The stronger executable workflow regression and every production release safeguard remain unchanged.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
