### PR TITLE
test(runtime): share bundled runtime source loader

### DIFF
--- a/sdk/typescript/tests-ts/completed-scan-handoff.test.ts
+++ b/sdk/typescript/tests-ts/completed-scan-handoff.test.ts
@@ -1,16 +1,8 @@
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
-import { brotliDecompressSync } from "node:zlib";
 import { expect, test } from "bun:test";
-import { PLUGIN_ROOT } from "./plugin-root.js";
+import { loadBundledRuntime } from "./plugin-root.js";
 
 test("does not request completed findings after a prompt-only scan", async () => {
-  const parts = await Promise.all(
-    ["000", "001"].map((part) =>
-      readFile(join(PLUGIN_ROOT, "mcp", `server.mjs.br.part-${part}`)),
-    ),
-  );
-  const runtime = brotliDecompressSync(Buffer.concat(parts)).toString("utf8");
+  const runtime = await loadBundledRuntime();
   const source = /function promptOnlyScanResult\([^\n]*\) \{[\s\S]*?\n\}/u.exec(
     runtime,
   )?.[0];

--- a/sdk/typescript/tests-ts/deep-scan-reducer-recovery.test.ts
+++ b/sdk/typescript/tests-ts/deep-scan-reducer-recovery.test.ts
@@ -1,17 +1,9 @@
 import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
-import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { brotliDecompressSync } from "node:zlib";
 import { expect, test } from "bun:test";
-import { PLUGIN_ROOT } from "./plugin-root.js";
-
-const bundledRuntime = Promise.all(
-  ["000", "001"].map((part) =>
-    readFile(join(PLUGIN_ROOT, "mcp", `server.mjs.br.part-${part}`)),
-  ),
-).then((parts) => brotliDecompressSync(Buffer.concat(parts)).toString("utf8"));
+import { loadBundledRuntime, PLUGIN_ROOT } from "./plugin-root.js";
 
 function bundledFunction(runtime: string, name: string): string {
   const source = new RegExp(
@@ -23,7 +15,7 @@ function bundledFunction(runtime: string, name: string): string {
 }
 
 test("keeps every advertised Deep worker tool within Codex's name limit", async () => {
-  const runtime = await bundledRuntime;
+  const runtime = await loadBundledRuntime();
   const method = /  compactArtifactServer\(request\) \{[\s\S]*?\n  \}/u.exec(
     runtime,
   )?.[0];
@@ -112,7 +104,7 @@ test("keeps every advertised Deep worker tool within Codex's name limit", async 
 });
 
 test("classifies owned worker tool failures without exposing their contents", async () => {
-  const runtime = await bundledRuntime;
+  const runtime = await loadBundledRuntime();
   const diagnosticSource = bundledFunction(runtime, "appendSafeItemDiagnostic");
   const recordHelper = /\b(isRecord\d*)\(item\)/u.exec(diagnosticSource)?.[1];
   expect(recordHelper).toBeDefined();
@@ -182,7 +174,7 @@ test("classifies owned worker tool failures without exposing their contents", as
 });
 
 test("resumes only when the exact reducer result is missing", async () => {
-  const runtime = await bundledRuntime;
+  const runtime = await loadBundledRuntime();
   const source = bundledFunction(runtime, "isMissingReducerResult");
   const pathImport = /\(0, (import_node_path\d+)\.join\)/u.exec(source)?.[1];
   expect(pathImport).toBeDefined();

--- a/sdk/typescript/tests-ts/deep-scan-worker-shutdown.test.ts
+++ b/sdk/typescript/tests-ts/deep-scan-worker-shutdown.test.ts
@@ -1,8 +1,5 @@
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
-import { brotliDecompressSync } from "node:zlib";
 import { expect, test } from "bun:test";
-import { PLUGIN_ROOT } from "./plugin-root.js";
+import { loadBundledRuntime } from "./plugin-root.js";
 
 type WorkerEvent =
   | { type: "thread.started"; thread_id: string }
@@ -26,12 +23,7 @@ type WorkerExecutorConstructor = new (settings: {
 async function bundledWorkerExecutor(
   events: (signal: AbortSignal) => AsyncGenerator<WorkerEvent>,
 ): Promise<WorkerExecutorConstructor> {
-  const chunks = await Promise.all(
-    ["000", "001"].map((part) =>
-      readFile(join(PLUGIN_ROOT, "mcp", `server.mjs.br.part-${part}`)),
-    ),
-  );
-  const runtime = brotliDecompressSync(Buffer.concat(chunks)).toString("utf8");
+  const runtime = await loadBundledRuntime();
   const source = /var CodexSdkWorkerExecutor = class \{[\s\S]*?\n\};/u.exec(
     runtime,
   )?.[0];

--- a/sdk/typescript/tests-ts/plugin-root.ts
+++ b/sdk/typescript/tests-ts/plugin-root.ts
@@ -1,5 +1,7 @@
 import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
+import { brotliDecompressSync } from "node:zlib";
 
 const sourcePlugin = new URL(
   "../../../plugins/codex-security/",
@@ -9,11 +11,22 @@ const bundledPlugin = new URL("../_bundled_plugin/", import.meta.url);
 const hasSourcePlugin = existsSync(
   new URL(".codex-plugin/plugin.json", sourcePlugin),
 );
+const plugin = hasSourcePlugin ? sourcePlugin : bundledPlugin;
 
-export const PLUGIN_ROOT = fileURLToPath(
-  hasSourcePlugin ? sourcePlugin : bundledPlugin,
-);
+export const PLUGIN_ROOT = fileURLToPath(plugin);
 
 export const INTEGRATION_TARGET = hasSourcePlugin
   ? "project/codex-security-sdk/src"
   : "sdk/typescript/src";
+
+let bundledRuntime: Promise<string> | undefined;
+
+export function loadBundledRuntime(): Promise<string> {
+  return (bundledRuntime ??= Promise.all(
+    ["000", "001"].map((part) =>
+      readFile(new URL(`mcp/server.mjs.br.part-${part}`, plugin)),
+    ),
+  ).then((parts) =>
+    brotliDecompressSync(Buffer.concat(parts)).toString("utf8"),
+  ));
+}

--- a/sdk/typescript/tests-ts/prompt-only-start-timeout.test.ts
+++ b/sdk/typescript/tests-ts/prompt-only-start-timeout.test.ts
@@ -1,16 +1,8 @@
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
-import { brotliDecompressSync } from "node:zlib";
 import { expect, test } from "bun:test";
-import { PLUGIN_ROOT } from "./plugin-root.js";
+import { loadBundledRuntime, PLUGIN_ROOT } from "./plugin-root.js";
 
 test("gives prompt-only scan startup the five-minute scan timeout", async () => {
-  const parts = await Promise.all(
-    ["000", "001"].map((part) =>
-      readFile(join(PLUGIN_ROOT, "mcp", `server.mjs.br.part-${part}`)),
-    ),
-  );
-  const runtime = brotliDecompressSync(Buffer.concat(parts)).toString("utf8");
+  const runtime = await loadBundledRuntime();
   const source =
     /async function executeWorkbench\([^\n]*\) \{[\s\S]*?\n\}/u.exec(
       runtime,


### PR DESCRIPTION
## Summary

Read and decompress the bundled runtime once for tests that inspect its immutable source.

## Changes

- Add a lazily cached runtime-source loader to the existing plugin test helper.
- Reuse it in completed-scan handoff, prompt-only timeout, Deep reducer recovery, and Deep worker shutdown tests.
- Keep each test's function evaluation and synthetic runtime dependencies independent.

## Testing

- `bun test tests-ts/completed-scan-handoff.test.ts tests-ts/prompt-only-start-timeout.test.ts tests-ts/deep-scan-reducer-recovery.test.ts tests-ts/deep-scan-worker-shutdown.test.ts --timeout 30000` (9 passed).
- `bun test tests-ts/runtime.test.ts --timeout 30000` (117 passed; 7 platform-specific tests skipped).
- `pnpm --pm-on-fail=ignore run types`.
- `prettier --check` for all five changed test files.
- `git diff --check`.

## Risk and rollout

Test-only cleanup. Only immutable decompressed source is cached; evaluated functions, fixture objects, cancellation behavior, and production packages remain unchanged.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
