### PR TITLE
fix(runtime): allow safe relative executable PATH entries

### DIFF
--- a/sdk/typescript/src/trusted-executable.ts
+++ b/sdk/typescript/src/trusted-executable.ts
@@ -20,7 +20,7 @@ export async function resolveTrustedExecutable(
   )?.[1];
   const entries: string[] = [];
   for (const entry of path?.split(delimiter) ?? []) {
-    if (entry.length === 0 || !isAbsolute(entry)) continue;
+    if (entry.length === 0) continue;
     const canonical = await realpath(entry).catch(() => null);
     if (canonical === null || isWithin(root, canonical)) continue;
     if (!entries.includes(canonical)) entries.push(canonical);

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -4677,7 +4677,7 @@ describe("runtime directories and plugin Python boundary", () => {
             PATH: [
               unsafeBin,
               linkedBin,
-              "node_modules/.bin",
+              relative(process.cwd(), unsafeBin),
               "",
               trustedBin,
             ].join(delimiter),

--- a/sdk/typescript/tests-ts/trusted-executable.test.ts
+++ b/sdk/typescript/tests-ts/trusted-executable.test.ts
@@ -9,7 +9,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, delimiter, dirname, join } from "node:path";
+import { basename, delimiter, dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, test } from "bun:test";
 import { resolveTrustedExecutable } from "../src/trusted-executable.js";
@@ -77,6 +77,42 @@ async function resolveWindowsExecutable(
 }
 
 describe("trusted executable resolution", () => {
+  test("accepts safe relative PATH entries without trusting repository links", async () => {
+    const root = await temporaryDirectory();
+    const repository = join(root, "repository");
+    const unsafe = join(repository, "bin");
+    const linked = join(root, "linked");
+    const trusted = join(root, "trusted");
+    const executable = process.platform === "win32" ? "git.exe" : "git";
+    await Promise.all([mkdir(unsafe, { recursive: true }), mkdir(trusted)]);
+    await Promise.all([
+      writeFile(join(unsafe, executable), "untrusted executable"),
+      writeFile(join(trusted, executable), "trusted executable"),
+    ]);
+    await chmod(join(trusted, executable), 0o700);
+    await symlink(
+      unsafe,
+      linked,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+
+    expect(
+      await resolveTrustedExecutable(
+        "git",
+        {
+          PATH: ["", unsafe, linked, trusted]
+            .map((entry) => (entry ? relative(process.cwd(), entry) : entry))
+            .join(delimiter),
+          KEEP: "ok",
+        },
+        repository,
+      ),
+    ).toEqual({
+      executable: join(trusted, executable),
+      environment: { KEEP: "ok", PATH: trusted },
+    });
+  });
+
   test.skipIf(process.platform === "win32")(
     "preserves the invocation name of a trusted symlinked executable",
     async () => {


### PR DESCRIPTION
## Summary

Allow a user-selected relative executable search path when it resolves outside the scanned repository.

## Changes

- Resolve nonempty relative PATH entries through the existing canonical-path checks.
- Continue excluding repository directories, repository-linked symlinks or junctions, empty entries, and unsafe executables.
- Add a cross-platform regression covering a trusted relative entry alongside repository-local and repository-linked entries.

## Testing

- Confirmed the new regression failed before the production change.
- `bun test tests-ts/trusted-executable.test.ts tests-ts/targets.test.ts tests-ts/multiscan.test.ts tests-ts/bulk-scan-discovery.test.ts --timeout 30000` (71 passed; 1 Windows-only test skipped).
- `bun test tests-ts/runtime.test.ts --timeout 30000` (117 passed; 7 Windows-only tests skipped).
- `pnpm --pm-on-fail=ignore run types`.
- `prettier --check src/trusted-executable.ts tests-ts/trusted-executable.test.ts`.
- `git diff --check`.

## Risk and rollout

The resolved executable and inherited PATH remain canonical absolute paths outside the protected repository. Existing repository-shim, symlink, Windows extension, case-insensitive PATH, and credential-configuration protections are unchanged.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
