### PR TITLE
fix(cli): keep optional update notices nonblocking

### DIFF
--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -366,7 +366,7 @@ interface CliDependencies {
   bulkScan?: BulkScanDiscoveryDependencies;
   runWorkbench(args: readonly string[]): Promise<JsonObject>;
   matchFindings: typeof matchScanFindings;
-  checkForUpdate(): Promise<UpdateNotice | undefined>;
+  checkForUpdate(signal: AbortSignal): Promise<UpdateNotice | undefined>;
 }
 
 const DEFAULT_DEPENDENCIES: CliDependencies = {
@@ -374,7 +374,8 @@ const DEFAULT_DEPENDENCIES: CliDependencies = {
     createSecurityInternal(config, { surface: "cli" }),
   environment: process.env,
   prepareAuthenticationHome: prepareCodexSecurityCredentialHome,
-  checkForUpdate: () => checkForUpdate({ environment: process.env }),
+  checkForUpdate: (signal) =>
+    checkForUpdate({ environment: process.env, signal }),
   hasStoredChatGPTSignIn: async () => {
     const environment = Object.fromEntries(
       Object.entries(process.env).filter(
@@ -704,6 +705,7 @@ export async function main(
     errorOutput.write(`codex-security: ${argumentError}\n`);
     return 2;
   }
+  const updateController = new AbortController();
   const pendingUpdate =
     errorOutput.isTTY === true &&
     argv.length > 0 &&
@@ -720,7 +722,9 @@ export async function main(
       ].includes(argument),
     ) &&
     updateNoticeEnabled(dependencies.environment)
-      ? dependencies.checkForUpdate().catch(() => undefined)
+      ? dependencies
+          .checkForUpdate(updateController.signal)
+          .catch(() => undefined)
       : undefined;
   let exitCode = 0;
   let frameworkExit: number | undefined;
@@ -1873,25 +1877,30 @@ export async function main(
       },
     });
 
-  await cli.serve(
-    argv.flatMap((argument) =>
-      argument.startsWith("--format=")
-        ? ["--format", argument.slice("--format=".length)]
-        : [argument],
-    ),
-    {
-      stdout: (value) => {
-        frameworkOutput += value;
+  let notice: UpdateNotice | undefined;
+  try {
+    await cli.serve(
+      argv.flatMap((argument) =>
+        argument.startsWith("--format=")
+          ? ["--format", argument.slice("--format=".length)]
+          : [argument],
+      ),
+      {
+        stdout: (value) => {
+          frameworkOutput += value;
+        },
+        exit: (code) => {
+          frameworkExit = code;
+        },
       },
-      exit: (code) => {
-        frameworkExit = code;
-      },
-    },
-  );
-  if (pendingUpdate !== undefined) {
-    const notice = await pendingUpdate;
-    if (notice !== undefined) errorOutput.write(formatUpdateNotice(notice));
+    );
+    if (pendingUpdate !== undefined) {
+      notice = await Promise.race([pendingUpdate, undefined]);
+    }
+  } finally {
+    updateController.abort();
   }
+  if (notice !== undefined) errorOutput.write(formatUpdateNotice(notice));
   if (frameworkExit !== undefined) {
     if (exitCode !== 0) return exitCode;
     errorOutput.write(

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -78,6 +78,7 @@ export async function checkForUpdate({
   entrypoint,
   currentVersion = VERSION,
   fetch: fetchLatest = fetch,
+  signal,
 }: {
   environment?: NodeJS.ProcessEnv;
   entrypoint?: string;
@@ -86,6 +87,7 @@ export async function checkForUpdate({
     input: Parameters<typeof fetch>[0],
     init?: Parameters<typeof fetch>[1],
   ) => ReturnType<typeof fetch>;
+  signal?: AbortSignal;
 } = {}): Promise<UpdateNotice | undefined> {
   if (!updateNoticeEnabled(environment)) return undefined;
 
@@ -95,12 +97,16 @@ export async function checkForUpdate({
       environment["npm_config_registry"] ??
       environment["NPM_CONFIG_REGISTRY"] ??
       "https://registry.npmjs.org/";
+    const timeout = AbortSignal.timeout(3_000);
     const response = await fetchLatest(
       new URL(
         `${encodeURIComponent(PACKAGE_NAME)}/latest`,
         registry.endsWith("/") ? registry : `${registry}/`,
       ),
-      { signal: AbortSignal.timeout(3_000) },
+      {
+        signal:
+          signal === undefined ? timeout : AbortSignal.any([signal, timeout]),
+      },
     );
     if (!response.ok) return undefined;
 

--- a/sdk/typescript/tests-ts/cli-fixtures.ts
+++ b/sdk/typescript/tests-ts/cli-fixtures.ts
@@ -194,7 +194,7 @@ export function dependencies(
     bulkScan?: MainDependencies["bulkScan"];
     onWorkbench?: (args: readonly string[]) => JsonObject | Promise<JsonObject>;
     onMatch?: MainDependencies["matchFindings"];
-    onUpdateCheck?: () => Promise<UpdateNotice | undefined>;
+    onUpdateCheck?: (signal: AbortSignal) => Promise<UpdateNotice | undefined>;
     currentDirectory?: string;
     preflight?: ScanPreflight;
     environment?: NodeJS.ProcessEnv;
@@ -243,7 +243,7 @@ export function dependencies(
       return security;
     },
     environment: options.environment ?? {},
-    checkForUpdate: async () => await options.onUpdateCheck?.(),
+    checkForUpdate: async (signal) => await options.onUpdateCheck?.(signal),
     currentDirectory: () => options.currentDirectory ?? "/current/repository",
     now: () => 0,
     setInterval: () => ({}) as NodeJS.Timeout,

--- a/sdk/typescript/tests-ts/update-notice.test.ts
+++ b/sdk/typescript/tests-ts/update-notice.test.ts
@@ -49,6 +49,29 @@ describe("CLI update notice", () => {
     );
   });
 
+  test("cancels registry requests when the caller aborts", async () => {
+    const controller = new AbortController();
+    let requestSignal: AbortSignal | undefined;
+    const pending = checkForUpdate({
+      environment: {},
+      signal: controller.signal,
+      fetch: async (_url, options) => {
+        requestSignal = options?.signal ?? undefined;
+        return await new Promise<Response>((_resolve, reject) => {
+          requestSignal?.addEventListener(
+            "abort",
+            () => reject(requestSignal?.reason),
+            { once: true },
+          );
+        });
+      },
+    });
+
+    controller.abort();
+    expect(requestSignal?.aborted).toBe(true);
+    await expect(pending).resolves.toBeUndefined();
+  });
+
   test("recognizes npx and local or global npm, pnpm, Yarn, and Bun", () => {
     const installed = "/workspace/node_modules/pkg/dist/version.js";
     const packageName = "@openai/codex-security@latest";
@@ -189,6 +212,37 @@ describe("CLI update notice", () => {
     });
     expect(stderr.text()).toBe(formatUpdateNotice(notice));
     expect(stderr.text()).not.toContain("CODEX_SECURITY_NO_UPDATE_NOTICE");
+  });
+
+  test("finishes the command and aborts an unfinished update check", async () => {
+    const stdout = capture();
+    const stderr = capture(true);
+    let updateSignal: AbortSignal | undefined;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const result = await Promise.race([
+      main(
+        ["info", "--json"],
+        stdout.stream,
+        stderr.stream,
+        dependencies({
+          onUpdateCheck: async (signal) => {
+            updateSignal = signal;
+            return await new Promise<undefined>(() => {});
+          },
+        }),
+      ),
+      new Promise<"pending">((resolve) => {
+        timer = setTimeout(() => resolve("pending"), 1_000);
+      }),
+    ]);
+    clearTimeout(timer);
+
+    expect(result).toBe(0);
+    expect(updateSignal?.aborted).toBe(true);
+    expect(JSON.parse(stdout.text())).toMatchObject({
+      cliVersion: expect.any(String),
+    });
+    expect(stderr.text()).toBe("");
   });
 
   test("skips checks for noninteractive output, help, dry runs, and disabled notices", async () => {

--- a/sdk/typescript/tests-ts/update-notice.test.ts
+++ b/sdk/typescript/tests-ts/update-notice.test.ts
@@ -218,24 +218,17 @@ describe("CLI update notice", () => {
     const stdout = capture();
     const stderr = capture(true);
     let updateSignal: AbortSignal | undefined;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const result = await Promise.race([
-      main(
-        ["info", "--json"],
-        stdout.stream,
-        stderr.stream,
-        dependencies({
-          onUpdateCheck: async (signal) => {
-            updateSignal = signal;
-            return await new Promise<undefined>(() => {});
-          },
-        }),
-      ),
-      new Promise<"pending">((resolve) => {
-        timer = setTimeout(() => resolve("pending"), 1_000);
+    const result = await main(
+      ["info", "--json"],
+      stdout.stream,
+      stderr.stream,
+      dependencies({
+        onUpdateCheck: async (signal) => {
+          updateSignal = signal;
+          return await new Promise<undefined>(() => {});
+        },
       }),
-    ]);
-    clearTimeout(timer);
+    );
 
     expect(result).toBe(0);
     expect(updateSignal?.aborted).toBe(true);


### PR DESCRIPTION
## Summary

Keep optional update checks from delaying CLI output or leaving registry requests active after a command finishes.

## Changes

- Pass a command-scoped cancellation signal to the existing npm update check.
- Preserve its existing bounded registry timeout while honoring command cancellation.
- Display an update notice only when it is already available after command execution.
- Abort unfinished checks on successful and exceptional command completion.
- Add focused regressions for caller cancellation and an update check that never settles.

## Testing

- Confirmed the caller-cancellation regression failed before the production change.
- `bun test tests-ts/update-notice.test.ts tests-ts/cli.test.ts tests-ts/cli-signals.test.ts tests-ts/cli-authentication.test.ts --timeout 30000` (168 passed).
- Re-ran `bun test tests-ts/update-notice.test.ts --timeout 30000` after the final simplification (11 passed).
- `pnpm --pm-on-fail=ignore run types`.
- `prettier --check src/cli.ts src/version.ts tests-ts/cli-fixtures.ts tests-ts/update-notice.test.ts`.
- `git diff --check`.

## Risk and rollout

Only optional update reporting changes. Ready notices, registry configuration, command output, credential handling, signal behavior, timeout limits, and suppression for CI, help, dry runs, and noninteractive output remain covered.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
