### PR TITLE
fix(git): preserve safe user Git configuration

### DIFF
--- a/sdk/typescript/src/targets.ts
+++ b/sdk/typescript/src/targets.ts
@@ -21,7 +21,12 @@ const GIT_REPOSITORY_ENVIRONMENT = new Set([
   ...UNSUPPORTED_GIT_ENVIRONMENT,
   "GIT_CEILING_DIRECTORIES",
   "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+  "GIT_GRAFT_FILE",
+  "GIT_IMPLICIT_WORK_TREE",
   "GIT_NAMESPACE",
+  "GIT_NO_REPLACE_OBJECTS",
+  "GIT_PREFIX",
+  "GIT_SHALLOW_FILE",
 ]);
 
 export type ScanMode = "standard" | "deep";
@@ -295,13 +300,7 @@ export async function validateCommittedDiffCheckout(
 
   const status = await gitOutput(
     repository,
-    [
-      "-c",
-      "core.fsmonitor=false",
-      "status",
-      "--porcelain=v1",
-      "--untracked-files=all",
-    ],
+    ["status", "--porcelain=v1", "--untracked-files=all"],
     signal,
   );
   if (status.length !== 0) {
@@ -409,7 +408,7 @@ async function gitOutput(
   throwIfAborted(signal);
   const { stdout } = await execFile(
     command.executable,
-    ["-C", repository, ...args],
+    ["-c", "core.fsmonitor=false", "-C", repository, ...args],
     {
       encoding: "utf8",
       signal,

--- a/sdk/typescript/src/targets.ts
+++ b/sdk/typescript/src/targets.ts
@@ -408,14 +408,7 @@ async function gitOutput(
   throwIfAborted(signal);
   const { stdout } = await execFile(
     command.executable,
-    [
-      "--no-lazy-fetch",
-      "-c",
-      "core.fsmonitor=false",
-      "-C",
-      repository,
-      ...args,
-    ],
+    ["-c", "core.fsmonitor=false", "-C", repository, ...args],
     {
       encoding: "utf8",
       signal,
@@ -453,11 +446,13 @@ function isolatedGitEnvironment(
     const normalized = name.toUpperCase();
     if (
       GIT_REPOSITORY_ENVIRONMENT.has(normalized) ||
+      normalized === "GIT_ALLOW_PROTOCOL" ||
       (!preserveGitConfiguration && normalized.startsWith("GIT_"))
     ) {
       delete environment[name];
     }
   }
+  environment["GIT_ALLOW_PROTOCOL"] = "";
   return environment;
 }
 

--- a/sdk/typescript/src/targets.ts
+++ b/sdk/typescript/src/targets.ts
@@ -17,6 +17,12 @@ const UNSUPPORTED_GIT_ENVIRONMENT = new Set([
   "GIT_COMMON_DIR",
   "GIT_REPLACE_REF_BASE",
 ]);
+const GIT_REPOSITORY_ENVIRONMENT = new Set([
+  ...UNSUPPORTED_GIT_ENVIRONMENT,
+  "GIT_CEILING_DIRECTORIES",
+  "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+  "GIT_NAMESPACE",
+]);
 
 export type ScanMode = "standard" | "deep";
 export type DiffTargetKind = "refs" | "working_tree";
@@ -436,7 +442,7 @@ async function outermostGitMarkerRoot(
 function isolatedGitEnvironment(): NodeJS.ProcessEnv {
   const environment = { ...process.env };
   for (const name of Object.keys(environment)) {
-    if (name.toUpperCase().startsWith("GIT_")) {
+    if (GIT_REPOSITORY_ENVIRONMENT.has(name.toUpperCase())) {
       delete environment[name];
     }
   }

--- a/sdk/typescript/src/targets.ts
+++ b/sdk/typescript/src/targets.ts
@@ -400,7 +400,7 @@ async function gitOutput(
   throwIfAborted(signal);
   const command = await resolveTrustedExecutable(
     "git",
-    isolatedGitEnvironment(),
+    isolatedGitEnvironment(args[0] === "rev-parse"),
     await outermostGitMarkerRoot(repository, signal),
   );
   if (command === null)
@@ -438,10 +438,16 @@ async function outermostGitMarkerRoot(
   }
 }
 
-function isolatedGitEnvironment(): NodeJS.ProcessEnv {
+function isolatedGitEnvironment(
+  preserveGitConfiguration: boolean,
+): NodeJS.ProcessEnv {
   const environment = { ...process.env };
   for (const name of Object.keys(environment)) {
-    if (GIT_REPOSITORY_ENVIRONMENT.has(name.toUpperCase())) {
+    const normalized = name.toUpperCase();
+    if (
+      GIT_REPOSITORY_ENVIRONMENT.has(normalized) ||
+      (!preserveGitConfiguration && normalized.startsWith("GIT_"))
+    ) {
       delete environment[name];
     }
   }

--- a/sdk/typescript/src/targets.ts
+++ b/sdk/typescript/src/targets.ts
@@ -408,7 +408,14 @@ async function gitOutput(
   throwIfAborted(signal);
   const { stdout } = await execFile(
     command.executable,
-    ["-c", "core.fsmonitor=false", "-C", repository, ...args],
+    [
+      "--no-lazy-fetch",
+      "-c",
+      "core.fsmonitor=false",
+      "-C",
+      repository,
+      ...args,
+    ],
     {
       encoding: "utf8",
       signal,

--- a/sdk/typescript/tests-ts/targets.test.ts
+++ b/sdk/typescript/tests-ts/targets.test.ts
@@ -4,6 +4,7 @@ import {
   chmod,
   mkdtemp,
   mkdir,
+  readFile,
   realpath,
   rm,
   symlink,
@@ -195,6 +196,72 @@ describe("scan target normalization", () => {
     await expect(
       normalizeTarget(repo, DiffTarget.refs({ base: "missing", head: "HEAD" })),
     ).rejects.toThrow("unknown Git ref");
+  });
+
+  test("preserves user Git settings while removing repository overrides", async () => {
+    const repo = await repository();
+    const root = join(repo, "..");
+    const trace = join(root, "git-events.jsonl");
+    const revision = git(repo, "rev-parse", "HEAD");
+    const repositoryOverrides = {
+      GIT_DIR: join(root, "missing-git-dir"),
+      GIT_WORK_TREE: join(root, "missing-work-tree"),
+      GIT_INDEX_FILE: join(root, "missing-index"),
+      GIT_OBJECT_DIRECTORY: join(root, "missing-objects"),
+      GIT_ALTERNATE_OBJECT_DIRECTORIES: join(root, "missing-alternates"),
+      GIT_COMMON_DIR: join(root, "missing-common"),
+      GIT_REPLACE_REF_BASE: "refs/unsafe/",
+      GIT_CEILING_DIRECTORIES: root,
+      GIT_DISCOVERY_ACROSS_FILESYSTEM: "1",
+      GIT_NAMESPACE: "unsafe",
+    };
+    const result = spawnSync(
+      process.execPath,
+      [
+        "-e",
+        "const { repositoryRevision } = await import(process.argv[1]); console.log(await repositoryRevision(process.argv[2]));",
+        fileURLToPath(new URL("../src/targets.ts", import.meta.url)),
+        repo,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          GIT_CONFIG_COUNT: "1",
+          GIT_CONFIG_KEY_0: "codex.security",
+          GIT_CONFIG_VALUE_0: "SYNTHETIC_GIT_SETTING",
+          GIT_TRACE2_EVENT: trace,
+          GIT_TRACE2_CONFIG_PARAMS: "codex.security",
+          GIT_TRACE2_ENV_VARS: [
+            "GIT_SSL_CAINFO",
+            "GIT_SSH_COMMAND",
+            ...Object.keys(repositoryOverrides),
+          ].join(","),
+          GIT_SSL_CAINFO: join(root, "ca.pem"),
+          GIT_SSH_COMMAND: "ssh -o BatchMode=yes",
+          ...repositoryOverrides,
+        },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe(revision);
+    const events = (await readFile(trace, "utf8"))
+      .trim()
+      .split(/\r?\n/u)
+      .map((line) => JSON.parse(line) as { param?: string; value?: string });
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        param: "codex.security",
+        value: "SYNTHETIC_GIT_SETTING",
+      }),
+    );
+    for (const name of ["GIT_SSL_CAINFO", "GIT_SSH_COMMAND"]) {
+      expect(events.some(({ param }) => param === name)).toBe(true);
+    }
+    for (const name of Object.keys(repositoryOverrides)) {
+      expect(events.some(({ param }) => param === name)).toBe(false);
+    }
   });
 
   test("does not execute repository-local Git shims from PATH", async () => {

--- a/sdk/typescript/tests-ts/targets.test.ts
+++ b/sdk/typescript/tests-ts/targets.test.ts
@@ -321,7 +321,7 @@ describe("scan target normalization", () => {
   test("does not expose Git configuration to repository clean filters", async () => {
     const repo = await repository();
     const root = join(repo, "..");
-    const filter = join(root, "clean-filter");
+    const filter = join(root, "clean-filter.js");
     const executed = join(root, "filter-executed");
     const leaked = join(root, "leaked-credential");
     await writeFile(
@@ -332,10 +332,19 @@ describe("scan target normalization", () => {
     git(repo, "commit", "-m", "configure attributes");
     await writeFile(
       filter,
-      `#!/bin/sh\nprintf 'executed' > ${JSON.stringify(executed)}\nif [ -n "$GIT_CONFIG_VALUE_0" ]; then printf '%s' "$GIT_CONFIG_VALUE_0" > ${JSON.stringify(leaked)}; fi\ncat\n`,
+      [
+        'import { readFileSync, writeFileSync } from "node:fs";',
+        `writeFileSync(${JSON.stringify(executed)}, "executed");`,
+        `if (process.env.GIT_CONFIG_VALUE_0) writeFileSync(${JSON.stringify(leaked)}, process.env.GIT_CONFIG_VALUE_0);`,
+        "process.stdout.write(readFileSync(0));",
+      ].join("\n"),
     );
-    await chmod(filter, 0o700);
-    git(repo, "config", "filter.capture.clean", filter);
+    git(
+      repo,
+      "config",
+      "filter.capture.clean",
+      `${JSON.stringify(process.execPath.replaceAll("\\", "/"))} ${JSON.stringify(filter.replaceAll("\\", "/"))}`,
+    );
     await utimes(join(repo, "src", "app.ts"), new Date(0), new Date(0));
 
     const result = spawnSync(
@@ -359,6 +368,60 @@ describe("scan target normalization", () => {
 
     expect(result.status).toBe(0);
     expect(existsSync(executed)).toBe(true);
+    expect(existsSync(leaked)).toBe(false);
+  });
+
+  test("does not expose Git configuration to repository promisor helpers", async () => {
+    const repo = await repository();
+    const root = join(repo, "..");
+    const helper = join(root, "promisor-helper.js");
+    const executed = join(root, "promisor-executed");
+    const leaked = join(root, "leaked-credential");
+    const revision = git(repo, "rev-parse", "HEAD");
+    await writeFile(
+      helper,
+      [
+        'import { writeFileSync } from "node:fs";',
+        `writeFileSync(${JSON.stringify(executed)}, "executed");`,
+        `if (process.env.GIT_CONFIG_VALUE_0) writeFileSync(${JSON.stringify(leaked)}, process.env.GIT_CONFIG_VALUE_0);`,
+        "process.exit(1);",
+      ].join("\n"),
+    );
+    git(repo, "config", "extensions.partialClone", "unsafe");
+    git(repo, "config", "remote.unsafe.promisor", "true");
+    git(repo, "config", "protocol.ext.allow", "always");
+    git(
+      repo,
+      "config",
+      "remote.unsafe.url",
+      `ext::${process.execPath.replaceAll("\\", "/")} ${helper.replaceAll("\\", "/")}`,
+    );
+    await rm(
+      join(repo, ".git", "objects", revision.slice(0, 2), revision.slice(2)),
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        "-e",
+        "const { repositoryRevision } = await import(process.argv[1]); console.log(await repositoryRevision(process.argv[2]));",
+        fileURLToPath(new URL("../src/targets.ts", import.meta.url)),
+        repo,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          GIT_CONFIG_COUNT: "1",
+          GIT_CONFIG_KEY_0: "http.extraHeader",
+          GIT_CONFIG_VALUE_0: "SYNTHETIC_GIT_CREDENTIAL",
+        },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("null");
+    expect(existsSync(executed)).toBe(false);
     expect(existsSync(leaked)).toBe(false);
   });
 

--- a/sdk/typescript/tests-ts/targets.test.ts
+++ b/sdk/typescript/tests-ts/targets.test.ts
@@ -202,7 +202,16 @@ describe("scan target normalization", () => {
     const repo = await repository();
     const root = join(repo, "..");
     const trace = join(root, "git-events.jsonl");
+    await writeFile(
+      join(repo, "src", "app.ts"),
+      "export const updated = true;\n",
+    );
+    git(repo, "add", ".");
+    git(repo, "commit", "-m", "updated");
     const revision = git(repo, "rev-parse", "HEAD");
+    const parent = git(repo, "rev-parse", "HEAD^");
+    const shallow = join(root, "shallow");
+    await writeFile(shallow, `${revision}\n`);
     const repositoryOverrides = {
       GIT_DIR: join(root, "missing-git-dir"),
       GIT_WORK_TREE: join(root, "missing-work-tree"),
@@ -213,13 +222,18 @@ describe("scan target normalization", () => {
       GIT_REPLACE_REF_BASE: "refs/unsafe/",
       GIT_CEILING_DIRECTORIES: root,
       GIT_DISCOVERY_ACROSS_FILESYSTEM: "1",
+      GIT_GRAFT_FILE: join(root, "missing-grafts"),
+      GIT_IMPLICIT_WORK_TREE: "0",
       GIT_NAMESPACE: "unsafe",
+      GIT_NO_REPLACE_OBJECTS: "1",
+      GIT_PREFIX: "unsafe/",
+      GIT_SHALLOW_FILE: shallow,
     };
     const result = spawnSync(
       process.execPath,
       [
         "-e",
-        "const { repositoryRevision } = await import(process.argv[1]); console.log(await repositoryRevision(process.argv[2]));",
+        "const { DiffTarget, normalizeTarget } = await import(process.argv[1]); console.log(JSON.stringify(await normalizeTarget(process.argv[2], DiffTarget.refs({ base: 'HEAD^' }))));",
         fileURLToPath(new URL("../src/targets.ts", import.meta.url)),
         repo,
       ],
@@ -245,7 +259,11 @@ describe("scan target normalization", () => {
     );
 
     expect(result.status).toBe(0);
-    expect(result.stdout.trim()).toBe(revision);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      kind: "refs",
+      base: parent,
+      head: revision,
+    });
     const events = (await readFile(trace, "utf8"))
       .trim()
       .split(/\r?\n/u)
@@ -262,6 +280,41 @@ describe("scan target normalization", () => {
     for (const name of Object.keys(repositoryOverrides)) {
       expect(events.some(({ param }) => param === name)).toBe(false);
     }
+  });
+
+  test("does not expose Git configuration to repository fsmonitor hooks", async () => {
+    const repo = await repository();
+    const root = join(repo, "..");
+    const hook = join(root, "fsmonitor-hook");
+    const leaked = join(root, "leaked-credential");
+    await writeFile(
+      hook,
+      `#!/bin/sh\nprintf '%s' "$GIT_CONFIG_VALUE_0" > ${JSON.stringify(leaked)}\nprintf '\\0'\n`,
+    );
+    await chmod(hook, 0o700);
+    git(repo, "config", "core.fsmonitor", hook);
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        "-e",
+        "const { DiffTarget, normalizeTarget, validateCommittedDiffCheckout } = await import(process.argv[1]); const target = await normalizeTarget(process.argv[2], DiffTarget.refs({ base: 'HEAD' })); await validateCommittedDiffCheckout(process.argv[2], target);",
+        fileURLToPath(new URL("../src/targets.ts", import.meta.url)),
+        repo,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          GIT_CONFIG_COUNT: "1",
+          GIT_CONFIG_KEY_0: "http.extraHeader",
+          GIT_CONFIG_VALUE_0: "SYNTHETIC_GIT_CREDENTIAL",
+        },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(existsSync(leaked)).toBe(false);
   });
 
   test("does not execute repository-local Git shims from PATH", async () => {

--- a/sdk/typescript/tests-ts/targets.test.ts
+++ b/sdk/typescript/tests-ts/targets.test.ts
@@ -415,6 +415,7 @@ describe("scan target normalization", () => {
           GIT_CONFIG_COUNT: "1",
           GIT_CONFIG_KEY_0: "http.extraHeader",
           GIT_CONFIG_VALUE_0: "SYNTHETIC_GIT_CREDENTIAL",
+          GIT_ALLOW_PROTOCOL: "ext",
         },
       },
     );

--- a/sdk/typescript/tests-ts/targets.test.ts
+++ b/sdk/typescript/tests-ts/targets.test.ts
@@ -8,6 +8,7 @@ import {
   realpath,
   rm,
   symlink,
+  utimes,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -314,6 +315,50 @@ describe("scan target normalization", () => {
     );
 
     expect(result.status).toBe(0);
+    expect(existsSync(leaked)).toBe(false);
+  });
+
+  test("does not expose Git configuration to repository clean filters", async () => {
+    const repo = await repository();
+    const root = join(repo, "..");
+    const filter = join(root, "clean-filter");
+    const executed = join(root, "filter-executed");
+    const leaked = join(root, "leaked-credential");
+    await writeFile(
+      join(repo, ".gitattributes"),
+      "src/app.ts filter=capture\n",
+    );
+    git(repo, "add", ".gitattributes");
+    git(repo, "commit", "-m", "configure attributes");
+    await writeFile(
+      filter,
+      `#!/bin/sh\nprintf 'executed' > ${JSON.stringify(executed)}\nif [ -n "$GIT_CONFIG_VALUE_0" ]; then printf '%s' "$GIT_CONFIG_VALUE_0" > ${JSON.stringify(leaked)}; fi\ncat\n`,
+    );
+    await chmod(filter, 0o700);
+    git(repo, "config", "filter.capture.clean", filter);
+    await utimes(join(repo, "src", "app.ts"), new Date(0), new Date(0));
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        "-e",
+        "const { DiffTarget, normalizeTarget, validateCommittedDiffCheckout } = await import(process.argv[1]); const target = await normalizeTarget(process.argv[2], DiffTarget.refs({ base: 'HEAD' })); await validateCommittedDiffCheckout(process.argv[2], target);",
+        fileURLToPath(new URL("../src/targets.ts", import.meta.url)),
+        repo,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          GIT_CONFIG_COUNT: "1",
+          GIT_CONFIG_KEY_0: "http.extraHeader",
+          GIT_CONFIG_VALUE_0: "SYNTHETIC_GIT_CREDENTIAL",
+        },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(existsSync(executed)).toBe(true);
     expect(existsSync(leaked)).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

Preserve user-selected Git configuration while continuing to remove every repository-scope environment override.

## Changes

- Replace blanket removal of `GIT_*` variables with the combined SDK and bundled-workbench repository-scope denylist.
- Keep existing early rejection behavior for explicitly unsupported target overrides.
- Preserve user-selected Git configuration, SSH, TLS, and diagnostic settings only for helper-free revision discovery.
- Remove all fifteen non-configuration repository-scope overrides reported by Git or the bundled workbench, including shallow-history and graft settings.
- Disable repository-controlled filesystem-monitor hooks for every Git inspection subprocess.
- Block Git transport protocols during target inspection so missing objects cannot invoke repository-controlled promisor helpers, including on older Git releases.
- Remove inherited Git configuration before checkout inspections that can execute repository clean filters.
- Add portable real Git subprocess regressions for complete scope isolation, shallow-history integrity, filesystem-monitor hooks, clean filters, and promisor helpers.

## Testing

- Confirmed the user-configuration regression failed before the production change.
- Confirmed the repository-history, filesystem-monitor, clean-filter, and promisor-helper credential-exfiltration regressions failed before their production fixes.
- `bun test tests-ts/targets.test.ts tests-ts/multiscan.test.ts tests-ts/trusted-executable.test.ts tests-ts/api.test.ts tests-ts/runtime.test.ts --timeout 30000` (296 passed; 8 Windows-only tests skipped).
- `pnpm --pm-on-fail=ignore run types`.
- `prettier --check src/targets.ts tests-ts/targets.test.ts`.
- `git diff --check`.

## Risk and rollout

Repository, worktree, index, object, common-directory, replacement-ref, ceiling, discovery, namespace, prefix, graft, and shallow-history overrides remain excluded case-insensitively. Filesystem-monitor commands and repository-controlled transports are disabled; commands that can execute repository clean filters cannot inherit Git credential configuration. Existing target validation, repository-local executable rejection, credential handling, older Git releases, and Windows behavior remain covered.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
