### PR TITLE
fix(preflight): accept valid Unicode progress issues

### DIFF
--- a/sdk/typescript/_bundled_plugin/scripts/workbench_progress.py
+++ b/sdk/typescript/_bundled_plugin/scripts/workbench_progress.py
@@ -13,7 +13,6 @@ from workbench.handoff import require_current_continuation
 from workbench_constants import PHASES
 from workbench_validation import optional_text, require_uuid, user_text
 
-MAX_PREFLIGHT_ISSUES_JSON_BYTES = 64 * 1024
 MAX_PREFLIGHT_ISSUES = 32
 
 
@@ -33,10 +32,6 @@ def _preflight_issue_text(value: Any, maximum: int, label: str) -> str:
 def preflight_issues_json(value: str | None) -> str | None:
     if value is None:
         return None
-    if len(value.encode("utf-8")) > MAX_PREFLIGHT_ISSUES_JSON_BYTES:
-        raise SystemExit(
-            f"Preflight issues must be no larger than {MAX_PREFLIGHT_ISSUES_JSON_BYTES} bytes."
-        )
     try:
         payload = json.loads(value)
     except json.JSONDecodeError as exc:

--- a/sdk/typescript/tests-ts/workbench-progress.test.ts
+++ b/sdk/typescript/tests-ts/workbench-progress.test.ts
@@ -1,0 +1,64 @@
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { PLUGIN_ROOT } from "./plugin-root.js";
+
+function validatePreflightIssues(issues: object[]) {
+  const python = Bun.which("python3") ?? Bun.which("python");
+  expect(python).not.toBeNull();
+  return spawnSync(
+    python!,
+    [
+      "-I",
+      "-B",
+      "-c",
+      [
+        "import json, sys",
+        "sys.path.insert(0, sys.argv[1])",
+        "from workbench_progress import preflight_issues_json",
+        "issues = json.loads(preflight_issues_json(sys.stdin.read()))",
+        "print(json.dumps({'count': len(issues), 'reasonLength': len(issues[0]['reason'])}))",
+      ].join("\n"),
+      join(PLUGIN_ROOT, "scripts"),
+    ],
+    { encoding: "utf8", input: JSON.stringify(issues) },
+  );
+}
+
+function issue(reason = "Preflight warning") {
+  return {
+    capability: "delegated_workers",
+    reason,
+    severity: "warn",
+    status: "fail",
+  };
+}
+
+describe("workbench preflight progress", () => {
+  test("accepts valid non-ASCII issues larger than 64 KiB", () => {
+    const issues = Array.from({ length: 32 }, () => issue("€".repeat(1_200)));
+    expect(Buffer.byteLength(JSON.stringify(issues))).toBeGreaterThan(
+      64 * 1024,
+    );
+
+    const result = validatePreflightIssues(issues);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      count: 32,
+      reasonLength: 1_200,
+    });
+  });
+
+  test("preserves upstream issue-count and reason-length limits", () => {
+    const excessIssues = validatePreflightIssues(
+      Array.from({ length: 33 }, () => issue()),
+    );
+    expect(excessIssues.status).not.toBe(0);
+    expect(excessIssues.stderr).toContain("at most 32 objects");
+
+    const excessReason = validatePreflightIssues([issue("€".repeat(1_201))]);
+    expect(excessReason.status).not.toBe(0);
+    expect(excessReason.stderr).toContain("1 to 1200 characters");
+  });
+});

--- a/sdk/typescript/tests-ts/workbench-progress.test.ts
+++ b/sdk/typescript/tests-ts/workbench-progress.test.ts
@@ -14,14 +14,21 @@ function validatePreflightIssues(issues: object[]) {
       "-c",
       [
         "import json, sys",
-        "sys.path.insert(0, sys.argv[1])",
+        "sys.path.insert(0, sys.argv.pop(1))",
+        "from workbench_cli import parse_args",
         "from workbench_progress import preflight_issues_json",
-        "issues = json.loads(preflight_issues_json(sys.stdin.read()))",
+        "args = parse_args('Synthetic workbench progress')",
+        "issues = json.loads(preflight_issues_json(args.preflight_issues_json))",
         "print(json.dumps({'count': len(issues), 'reasonLength': len(issues[0]['reason'])}))",
       ].join("\n"),
       join(PLUGIN_ROOT, "scripts"),
+      "update-progress",
+      "--scan-id",
+      "00000000-0000-4000-8000-000000000000",
+      "--preflight-issues-json",
+      JSON.stringify(issues),
     ],
-    { encoding: "utf8", input: JSON.stringify(issues) },
+    { encoding: "utf8" },
   );
 }
 
@@ -36,17 +43,17 @@ function issue(reason = "Preflight warning") {
 
 describe("workbench preflight progress", () => {
   test("accepts valid non-ASCII issues larger than 64 KiB", () => {
-    const issues = Array.from({ length: 32 }, () => issue("€".repeat(1_200)));
-    expect(Buffer.byteLength(JSON.stringify(issues))).toBeGreaterThan(
-      64 * 1024,
-    );
+    const issues = Array.from({ length: 24 }, () => issue("€".repeat(1_000)));
+    const serialized = JSON.stringify(issues);
+    expect(Buffer.byteLength(serialized)).toBeGreaterThan(64 * 1024);
+    expect(serialized.length).toBeLessThan(30_000);
 
     const result = validatePreflightIssues(issues);
 
     expect(result.status, result.stderr).toBe(0);
     expect(JSON.parse(result.stdout)).toEqual({
-      count: 32,
-      reasonLength: 1_200,
+      count: 24,
+      reasonLength: 1_000,
     });
   });
 


### PR DESCRIPTION
## Summary

Accept valid non-ASCII preflight issues that fit the existing upstream count and character limits but exceed an unnecessary local byte limit.

## Changes

- Remove the redundant 64 KiB serialized preflight-issue limit.
- Preserve the existing 32-issue limit, UTF-16-aware field limits, severity and status validation, scan ownership checks, and progress phase restrictions.
- Exercise the actual workbench argument parser and production `--preflight-issues-json` transport using a Unicode payload larger than 64 KiB that still fits the native Windows command-line limit.

## Testing

- `bun test tests-ts/workbench-progress.test.ts tests-ts/worker-progress.test.ts` passed: 14 tests.
- `bun test --timeout 30000 tests-ts/runtime.test.ts --test-name-pattern 'preflight|workbench commands'` passed: four tests.
- `pnpm --pm-on-fail=ignore run types` passed.
- `pnpm --pm-on-fail=ignore exec prettier --check tests-ts/workbench-progress.test.ts` passed.
- Python AST parsing and `git diff --check` passed.

## Risk and rollout

Low risk. Only a redundant byte-count rejection is removed; the actual upstream array and per-field contracts remain enforced. The regression follows the production argument transport and remains below the Windows command-line ceiling while exceeding the removed byte limit.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
