### PR TITLE
fix(triage): honor explicitly selected GitHub connectors

### DIFF
--- a/sdk/typescript/_bundled_plugin/skills/triage-finding/SKILL.md
+++ b/sdk/typescript/_bundled_plugin/skills/triage-finding/SKILL.md
@@ -73,10 +73,9 @@ classify a verdict, or emit the `triage-finding/v0` JSON contract. Ask the user 
 - security advisories and private vulnerability reports
 - all of the above
 
-If the user specifies a source, query only the matching GitHub REST endpoint family from `references/github-rest-intake.md`. If the user chooses all, query the REST sources listed there, but do not include GitHub Issues in all.
+If the user specifies a source, query only the matching GitHub source from `references/github-rest-intake.md` through the authorized transport. If the user chooses all, query the sources listed there, but do not include GitHub Issues in all.
 
-Use REST for all GitHub finding retrieval. Do not use the GitHub Connector to fetch findings, even when it is installed or the user explicitly asks for it.
-If the user asks to use the GitHub Connector, silently use it only as the first auth-token source when a connector token acquisition path is available, then retrieve finding data directly with REST. If connector token acquisition is not available, fall through to the next REST auth source in the reference.
+Use REST by default. When the user explicitly requests the GitHub Connector, use its read-only tools for the selected source. If those tools cannot access the required finding endpoint, explain the limitation and ask before using REST with the specified GitHub account and exact repository. Never silently switch transports, accounts, or credentials.
 
 Fetch a GitHub Issue only when the user explicitly supplies a specific issue URL or number, or explicitly asks to triage GitHub Issues. Normalize explicit issues as `source_type: "freeform"`.
 
@@ -92,7 +91,7 @@ SARIF results, CVE/GHSA or advisory descriptions, scanner tickets, bug bounty re
 Start by extracting:
 
 - repository path or current working repository
-- GitHub repository owner/name and selected GitHub REST source, when the input is a GitHub repository intake request
+- GitHub repository owner/name, selected finding source, and authorized transport, when the input is a GitHub repository intake request
 - Jira/Linear source query, issue key or identifier, URL, project, status,
   labels, components, priority, assignee, reporter, timestamps, and issue type when the input is imported from a ticketing system
 - input id, scanner id, SARIF rule/result id, CVE/GHSA id, ticket id, or Codex Security `findingId`/`occurrenceId` when present
@@ -325,7 +324,7 @@ Do not invoke `$fix-finding` unless the user explicitly asks to continue into fi
 - Do not search for unrelated vulnerabilities.
 - Do not claim exhaustive repository coverage.
 - Do not claim runtime validation happened.
-- Do not use the GitHub Connector for GitHub finding retrieval. It may be used only as the first auth-token source for REST requests when available.
+- Honor the user's explicitly selected GitHub transport, account, and repository; never silently fall back to another credential or transport.
 - Do not mutate Jira, Linear, or other backlog sources unless the user explicitly asks for writeback after triage.
 - Do not include GitHub Issues in default GitHub intake or in the all-source GitHub intake path.
 - Do not mark `confirmed` solely because attacker-influenced data reaches a dangerous sink; first establish the relevant product surface and supported security boundary.

--- a/sdk/typescript/_bundled_plugin/skills/triage-finding/SKILL.md
+++ b/sdk/typescript/_bundled_plugin/skills/triage-finding/SKILL.md
@@ -128,7 +128,7 @@ If no policy applies, record that absence as a proof gap and continue with the n
    - Do not write back to Jira or Linear unless the user explicitly asks.
 2. If the input is a GitHub repository intake request, follow `references/github-rest-intake.md`.
    - If the user did not specify a GitHub finding source, ask for the source and stop without emitting triage JSON.
-   - If REST auth is unavailable, ask for a supported auth source and stop without emitting triage JSON.
+   - If REST is the authorized transport and its approved credential is unavailable, ask for a supported auth source and stop without emitting triage JSON. Do not require REST credentials for connector retrieval.
    - Normalize retrieved GitHub findings into the existing source types: `sarif`, `cve`, `advisory`, or `freeform` for explicit GitHub Issues.
    - Preserve GitHub provenance in `input_id`, `normalized_input.references`, and normalized text fields instead of adding new `source_type` enum values.
 3. Normalize each supplied or imported finding into a triage item.

--- a/sdk/typescript/_bundled_plugin/skills/triage-finding/references/github-rest-intake.md
+++ b/sdk/typescript/_bundled_plugin/skills/triage-finding/references/github-rest-intake.md
@@ -65,7 +65,7 @@ The connector may not expose every security endpoint. If the requested connector
 
 ## Auth Priority
 
-When REST is the default transport, acquire a token in this order:
+When the user chooses a REST account or credential source, use only that account or source. Ask before selecting another. When REST is the default and the user did not select an account or credential, acquire a token in this order:
 
 1. GitHub Connector-provided auth token, if a connector token acquisition tool is available.
 2. `gh auth token`, if `gh` is installed and authenticated.
@@ -83,7 +83,7 @@ Accept: application/vnd.github+json
 X-GitHub-Api-Version: 2022-11-28
 ```
 
-If no REST auth source is available, ask the user to connect GitHub or provide one of the supported auth sources above. Do not continue with unauthenticated requests for private or owner-only security data.
+If REST is the authorized transport and its approved auth source is unavailable, ask the user to connect GitHub or provide one of the supported auth sources above. Do not require REST credentials for connector retrieval or continue with unauthenticated requests for private or owner-only security data.
 
 ## Endpoints
 

--- a/sdk/typescript/_bundled_plugin/skills/triage-finding/references/github-rest-intake.md
+++ b/sdk/typescript/_bundled_plugin/skills/triage-finding/references/github-rest-intake.md
@@ -53,20 +53,19 @@ If the user supplied a GitHub repository but did not name a finding source, do n
 - security advisories and private vulnerability reports
 - all of the above
 
-If the user names a source, query only the matching REST endpoint family. If the user chooses `all`, query code scanning, Dependabot vulnerabilities, Dependabot malware, and repository security advisories/private vulnerability reports.
+If the user names a source, query only the matching endpoint family through the authorized transport. If the user chooses `all`, query code scanning, Dependabot vulnerabilities, Dependabot malware, and repository security advisories/private vulnerability reports.
 
 GitHub Issues are not part of `all` and are not a default source. Fetch and normalize a GitHub Issue only when the user explicitly supplies a specific issue URL or number, or explicitly asks to triage GitHub Issues.
 
-## REST-Only Finding Retrieval
+## GitHub Finding Retrieval
 
-Use GitHub REST endpoints for all finding retrieval. Do not use the GitHub Connector to fetch repository finding data, even if the connector is installed or the user explicitly asks to use it. If the user asks for the GitHub Connector, silently use it only for auth token acquisition when available, then continue with REST.
+Use GitHub REST endpoints by default. If the user explicitly selects the GitHub Connector, use its read-only tools for the selected repository and finding source instead.
 
-The connector is auth-only in this workflow because the available connector surface does not cover all required GitHub security endpoints for code scanning,
-Dependabot alerts, repository security advisories, and private vulnerability reports.
+The connector may not expose every security endpoint. If the requested connector cannot retrieve the selected findings, explain which capability is unavailable and ask before switching to REST. Identify the GitHub hostname, exact repository, and proposed account when it can be verified safely. Do not acquire a different token, inspect another credential source, or use a different account before the user approves that fallback. After approval, use only the approved transport and credential source.
 
 ## Auth Priority
 
-Acquire a REST token in this order:
+When REST is the default transport, acquire a token in this order:
 
 1. GitHub Connector-provided auth token, if a connector token acquisition tool is available.
 2. `gh auth token`, if `gh` is installed and authenticated.


### PR DESCRIPTION
## Summary

Honor an explicitly selected GitHub Connector, REST account, or credential source instead of silently switching finding intake to another authorization boundary.

## Changes

- Keep authenticated GitHub REST as the default intake transport when no explicit transport or account was selected.
- Use read-only connector tools without requiring separate REST credentials when the user explicitly selects the GitHub Connector.
- Preserve an explicitly selected REST account or credential ahead of the default credential priority.
- Ask before falling back to REST, another account, or another credential when an approved transport cannot access the selected repository and source.
- Align the triage skill, its workflow gates, its intake reference, and its final authorization rules.

## Testing

- `bun test --timeout 30000 tests-ts/runtime.test.ts --test-name-pattern 'keeps installed-package plugin lookup inside the package|projects only the unchanged external payload|creates the SDK marketplace around a validated plugin'` passed: three tests and 223 assertions.
- `pnpm --pm-on-fail=ignore run types` passed.
- `pnpm --pm-on-fail=ignore exec prettier --check _bundled_plugin/skills/triage-finding/SKILL.md _bundled_plugin/skills/triage-finding/references/github-rest-intake.md` passed.
- Confirmed connector retrieval no longer requires REST auth and explicit account selection overrides credential fallback.
- `git diff --check` passed.

## Risk and rollout

Low risk. This modifies bundled instructions only. Existing default REST intake, source selection, read-only triage, token redaction, and explicit issue selection remain unchanged; explicit user transport and credential choices define the authorization boundary unless another choice is approved.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
