### PR TITLE
perf(workbench): reuse ordinary scan context results

### DIFF
--- a/sdk/typescript/_bundled_plugin/scripts/workbench_db.py
+++ b/sdk/typescript/_bundled_plugin/scripts/workbench_db.py
@@ -2905,10 +2905,15 @@ def scan_context(
     occurrence_id: str | None = None,
 ) -> dict[str, Any]:
     scan = require_scan(connection, scan_id)
+    workspace = workspace_state(connection, scan["workspace_id"], result_scan_id=scan["id"])
     context = {
         "otherRunningDeepScans": deep_scan.other_running_deep_scans(connection, scan["id"]),
-        "scan": scan_result(connection, scan, occurrence_id=occurrence_id),
-        "workspace": workspace_state(connection, scan["workspace_id"], result_scan_id=scan["id"]),
+        "scan": (
+            workspace["results"]
+            if occurrence_id is None
+            else scan_result(connection, scan, occurrence_id=occurrence_id)
+        ),
+        "workspace": workspace,
     }
     if scan["recipe_json"] is not None:
         context["parentScanId"] = scan["parent_scan_id"]

--- a/sdk/typescript/tests-ts/scan-recovery.test.ts
+++ b/sdk/typescript/tests-ts/scan-recovery.test.ts
@@ -305,6 +305,80 @@ describe("malformed scan artifact recovery", () => {
     });
   });
 
+  test("builds each ordinary scan context once without losing selected findings", async () => {
+    const fixture = await startDraftScan();
+    const findingsPath = join(fixture.scanDir, "findings.json");
+    const document = await readJson<FindingsDocument>(findingsPath);
+    const original = document.findings[0]!;
+    document.findings = Array.from({ length: 21 }, (_, index) => {
+      const finding = structuredClone(original);
+      finding.identity.anchor = `scan-context-finding-${index}`;
+      return finding;
+    });
+    await writeJson(findingsPath, document);
+    await completeScan(fixture);
+
+    const page = await workbench(fixture, [
+      "list-findings",
+      "--scan-id",
+      fixture.scanId,
+      "--offset",
+      "20",
+      "--limit",
+      "1",
+    ]);
+    const occurrenceId = (
+      page["findingsPage"] as {
+        findings: Array<{ occurrenceId: string }>;
+      }
+    ).findings[0]!.occurrenceId;
+    const probe = spawnSync(
+      fixture.python,
+      [
+        "-I",
+        "-B",
+        "-c",
+        [
+          "import json, sys",
+          "sys.path.insert(0, sys.argv[1])",
+          "import workbench_db as workbench",
+          "calls = []",
+          "original = workbench.scan_result",
+          "def count_result(connection, scan, **kwargs):",
+          "    calls.append(kwargs.get('occurrence_id'))",
+          "    return original(connection, scan, **kwargs)",
+          "workbench.scan_result = count_result",
+          "with workbench.connect() as connection:",
+          "    ordinary = workbench.scan_context(connection, sys.argv[2])",
+          "    ordinary_calls = len(calls)",
+          "    calls.clear()",
+          "    selected = workbench.scan_context(connection, sys.argv[2], sys.argv[3])",
+          "print(json.dumps({'ordinaryCalls': ordinary_calls, 'selectedCalls': len(calls), 'ordinaryCount': len(ordinary['scan']['findings']), 'selectedCount': len(selected['scan']['findings']), 'workspaceCount': len(selected['workspace']['results']['findings']), 'selectedIncluded': any(finding['occurrenceId'] == sys.argv[3] for finding in selected['scan']['findings'])}))",
+        ].join("\n"),
+        join(PLUGIN_ROOT, "scripts"),
+        fixture.scanId,
+        occurrenceId,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          PATH: process.env["PATH"],
+          CODEX_SECURITY_STATE_DIR: fixture.stateDir,
+        },
+      },
+    );
+
+    expect(probe.status, probe.stderr).toBe(0);
+    expect(JSON.parse(probe.stdout)).toEqual({
+      ordinaryCalls: 1,
+      selectedCalls: 2,
+      ordinaryCount: 20,
+      selectedCount: 21,
+      workspaceCount: 20,
+      selectedIncluded: true,
+    });
+  }, 30_000);
+
   test("returns authoritative clean, dirty, and nested Git target contracts", async () => {
     for (const kind of ["clean", "dirty", "nested"] as const) {
       const fixture = await startDraftScan(kind);


### PR DESCRIPTION
## Summary

Avoid constructing the same workbench scan result twice for every ordinary scan-context request.

## Changes

- Reuse the scan result already produced while assembling workspace state.
- Preserve the separate selected-finding result when a requested occurrence lies outside the normal findings page.
- Add a real-workbench regression with 21 findings that verifies result construction counts and off-page finding visibility.

## Testing

- `bun test --timeout 30000 tests-ts/scan-recovery.test.ts` — 29 passed.
- `bun test --timeout 30000 tests-ts/compact-diff-scan.test.ts` — 5 passed.
- `pnpm --pm-on-fail=ignore run types` — passed.
- `pnpm --pm-on-fail=ignore exec prettier --check tests-ts/scan-recovery.test.ts` — passed.
- Python AST parsing and `git diff --check` — passed.

## Risk and rollout

Low risk. Ordinary JSON responses preserve the same scan and workspace results while avoiding duplicate database, artifact, and finding work. Explicit occurrence selection continues to build a separate result so off-page findings are not lost.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
