### PR TITLE
fix(scan): keep state and output paths disjoint

### DIFF
--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -262,6 +262,7 @@ export interface ScanPreflight extends DeepScanOptions {
 interface LocalScanInputs
   extends Omit<ScanPreflight, "model" | "reasoningEffort" | "authentication"> {
   protectedRoot: string;
+  stateDirectory: string;
 }
 
 export interface CodexSecurityMetadata {
@@ -450,11 +451,8 @@ export class CodexSecurity {
         mode,
         outputDir: requestedOutput,
         protectedRoot,
+        stateDirectory,
       } = await this.#validateLocalInputs(repository, options, signal);
-      const stateDirectory = codexSecurityStateDirectory(
-        this.#dependencies.environment,
-      );
-      requireOutputOutsideRepository(protectedRoot, stateDirectory);
       checkOpen();
       let temporaryRoot: string | undefined;
       if (
@@ -468,9 +466,6 @@ export class CodexSecurity {
           temporaryRoot,
           "temporary",
         );
-      }
-      if (requestedOutput !== null) {
-        requireOutputOutsideRepository(protectedRoot, requestedOutput);
       }
       if (options.knowledgeBasePaths?.length) {
         knowledgeBase = await prepareKnowledgeBase(
@@ -633,7 +628,11 @@ export class CodexSecurity {
           ? await preparePersistentScanRoot(stateDirectory, basename(repo))
           : temporaryRoot;
       if (scanOutputRoot !== undefined) {
-        requireOutputOutsideRepository(protectedRoot, scanOutputRoot);
+        requireOutputOutsideRepository(
+          protectedRoot,
+          scanOutputRoot,
+          scanOutputRoot === temporaryRoot ? "temporary" : "output",
+        );
       }
       scanDir = await (this.#dependencies.prepareOutputDir ?? prepareOutputDir)(
         requestedOutput ?? undefined,
@@ -1746,12 +1745,23 @@ export class CodexSecurity {
     if (requestedOutput !== null) {
       requireOutputOutsideRepository(protectedRoot, requestedOutput);
     }
+    const stateDirectory = codexSecurityStateDirectory(
+      this.#dependencies.environment,
+    );
+    const canonicalStateDirectory = await realpath(stateDirectory).catch(
+      (error: NodeJS.ErrnoException) => {
+        if (error.code === "ENOENT") return stateDirectory;
+        throw error;
+      },
+    );
+    requireOutputOutsideRepository(protectedRoot, canonicalStateDirectory);
     return {
       repository: repo,
       target: normalized,
       mode,
       outputDir: requestedOutput,
       protectedRoot,
+      stateDirectory,
     };
   }
 
@@ -2905,11 +2915,16 @@ function requireOutputOutsideRepository(
   pathKind: ProtectedScanPathKind = "output",
 ): void {
   const outputRelative = relative(repository, outputDirectory);
+  const repositoryRelative = relative(outputDirectory, repository);
   if (
     outputRelative === "" ||
     (outputRelative !== ".." &&
       !outputRelative.startsWith(`..${sep}`) &&
-      !isAbsolute(outputRelative))
+      !isAbsolute(outputRelative)) ||
+    (pathKind === "output" &&
+      repositoryRelative !== ".." &&
+      !repositoryRelative.startsWith(`..${sep}`) &&
+      !isAbsolute(repositoryRelative))
   ) {
     throw new OutputInsideProtectedRootError(
       outputDirectory,

--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -1748,12 +1748,21 @@ export class CodexSecurity {
     const stateDirectory = codexSecurityStateDirectory(
       this.#dependencies.environment,
     );
-    const canonicalStateDirectory = await realpath(stateDirectory).catch(
-      (error: NodeJS.ErrnoException) => {
-        if (error.code === "ENOENT") return stateDirectory;
-        throw error;
-      },
-    );
+    let canonicalStateDirectory = stateDirectory;
+    while (true) {
+      try {
+        canonicalStateDirectory = join(
+          await realpath(canonicalStateDirectory),
+          relative(canonicalStateDirectory, stateDirectory),
+        );
+        break;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+        const parent = dirname(canonicalStateDirectory);
+        if (parent === canonicalStateDirectory) throw error;
+        canonicalStateDirectory = parent;
+      }
+    }
     requireOutputOutsideRepository(protectedRoot, canonicalStateDirectory);
     return {
       repository: repo,

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -1272,9 +1272,18 @@ export async function preparePersistentScanRoot(
   stateDirectory: string,
   repositoryName: string,
 ): Promise<string> {
-  const root = join(stateDirectory, "scans", safePrefix(repositoryName));
-  await mkdir(root, { recursive: true, mode: 0o700 });
-  return await realpath(root);
+  await mkdir(stateDirectory, { recursive: true, mode: 0o700 });
+  let root = await realpath(stateDirectory);
+  for (const directory of ["scans", safePrefix(repositoryName)]) {
+    root = join(root, directory);
+    await mkdir(root, { recursive: true, mode: 0o700 });
+    if (!(await lstat(root)).isDirectory()) {
+      throw new OutputDirectoryError(
+        `Persistent scan output must use real directories: ${root}`,
+      );
+    }
+  }
+  return root;
 }
 
 export async function runWorkbench(

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -3948,6 +3948,7 @@ describe("CodexSecurity orchestration", () => {
       join(repository, "state"),
       root,
       linkedState,
+      join(linkedState, "repository", "missing", "state"),
     ]) {
       const client = new TestClient(
         {},

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -1479,10 +1479,11 @@ describe("CodexSecurity orchestration", () => {
     await client.close();
   });
 
-  test("rejects scan output inside the repository before runtime initialization", async () => {
+  test("rejects overlapping scan output before runtime initialization", async () => {
     const root = await temporaryDirectory();
     const repository = join(root, "repository");
     await mkdir(repository);
+    await writeFile(join(repository, "preserved.txt"), "preserved\n");
     let runtimeStarted = false;
     const client = new TestClient(
       {},
@@ -1498,6 +1499,22 @@ describe("CodexSecurity orchestration", () => {
     await expect(
       client.run(repository, { outputDir: join(repository, "scan") }),
     ).rejects.toBeInstanceOf(OutputDirectoryError);
+    for (const operation of ["preflight", "run"] as const) {
+      await expect(
+        client[operation](repository, {
+          outputDir: root,
+          archiveExisting: true,
+        }),
+      ).rejects.toMatchObject({
+        name: OutputInsideProtectedRootError.name,
+        outputDirectory: root,
+        protectedRoot: repository,
+        pathKind: "output",
+      });
+      expect(await readFile(join(repository, "preserved.txt"), "utf8")).toBe(
+        "preserved\n",
+      );
+    }
     if (process.platform !== "win32") {
       const linkedRepository = join(root, "linked-repository");
       await symlink(repository, linkedRepository);
@@ -3917,30 +3934,44 @@ describe("CodexSecurity orchestration", () => {
     expect(existsSync(join(result.scanDir, "scan-manifest.json"))).toBe(true);
   });
 
-  test("rejects repository-local state even when scan output is outside", async () => {
+  test("rejects state directories overlapping the selected repository", async () => {
     const root = await temporaryDirectory();
     const repository = join(root, "repository");
-    const stateDirectory = join(repository, "state");
+    const linkedState = join(root, "linked-state");
     await mkdir(repository);
-    const client = new TestClient(
-      {},
-      {
-        environment: { CODEX_SECURITY_STATE_DIR: stateDirectory },
-        prepareRuntime: async () => {
-          throw new Error("Runtime must not start");
-        },
-        resolvePluginPython: async () => "/managed/python",
-        createCodex: () => {
-          throw new Error("Codex must not start");
-        },
-      },
+    await symlink(
+      root,
+      linkedState,
+      process.platform === "win32" ? "junction" : "dir",
     );
+    for (const stateDirectory of [
+      join(repository, "state"),
+      root,
+      linkedState,
+    ]) {
+      const client = new TestClient(
+        {},
+        {
+          environment: { CODEX_SECURITY_STATE_DIR: stateDirectory },
+          prepareRuntime: async () => {
+            throw new Error("Runtime must not start");
+          },
+          resolvePluginPython: async () => "/managed/python",
+          createCodex: () => {
+            throw new Error("Codex must not start");
+          },
+        },
+      );
 
-    await expect(
-      client.run(repository, { outputDir: join(root, "output") }),
-    ).rejects.toBeInstanceOf(OutputInsideProtectedRootError);
-    expect(existsSync(stateDirectory)).toBe(false);
-    await client.close();
+      for (const operation of ["preflight", "run"] as const) {
+        await expect(
+          client[operation](repository, { outputDir: join(root, "output") }),
+        ).rejects.toBeInstanceOf(OutputInsideProtectedRootError);
+      }
+      if (stateDirectory !== root && stateDirectory !== linkedState)
+        expect(existsSync(stateDirectory)).toBe(false);
+      await client.close();
+    }
   });
 
   test("rejects reruns when the original plugin version is unavailable", async () => {
@@ -5941,7 +5972,7 @@ if ([basename(process.argv[1]), ...process.argv.slice(2)].join(" ") !== "login s
       {},
       {
         environment: {
-          CODEX_SECURITY_STATE_DIR: root,
+          CODEX_SECURITY_STATE_DIR: join(root, "state"),
           OPENAI_API_KEY: "ambient-key",
         },
         prepareRuntime: async () => ({
@@ -6122,7 +6153,7 @@ if ([basename(process.argv[1]), ...process.argv.slice(2)].join(" ") !== "login s
       {},
       {
         environment: {
-          CODEX_SECURITY_STATE_DIR: root,
+          CODEX_SECURITY_STATE_DIR: join(root, "state"),
           OPENAI_API_KEY: "ambient-key",
         },
         prepareRuntime: async () => ({

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -3466,6 +3466,41 @@ describe("runtime directories and plugin Python boundary", () => {
     if (process.platform !== "win32") {
       expect((await stat(scanRoot)).mode & 0o777).toBe(0o700);
     }
+
+    const linkedState = join(root, "linked-state");
+    await symlink(
+      join(root, "state"),
+      linkedState,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    expect(
+      await preparePersistentScanRoot(linkedState, "linked repository"),
+    ).toBe(join(root, "state", "scans", "linked-repository"));
+  });
+
+  test("rejects symbolic children beneath persistent scan state", async () => {
+    const root = await temporaryDirectory();
+    const external = join(root, "external");
+    await mkdir(external);
+
+    for (const [name, path] of [
+      ["scans", "scans"],
+      ["repository", join("scans", "repository")],
+    ] as const) {
+      const state = join(root, `state-${name}`);
+      const linked = join(state, path);
+      await mkdir(dirname(linked), { recursive: true });
+      await symlink(
+        external,
+        linked,
+        process.platform === "win32" ? "junction" : "dir",
+      );
+
+      await expect(
+        preparePersistentScanRoot(state, "repository"),
+      ).rejects.toThrow("Persistent scan output must use real directories");
+      expect(await readdir(external)).toEqual([]);
+    }
   });
 
   test("expands a tilde CODEX_HOME when discovering preflight configuration", async () => {


### PR DESCRIPTION
## Summary

Keep configured scan state and output directories separate from the selected repository and preserve the intended boundaries of persistent scan directories.

## Changes

- Validate configured state and output directories during shared local-input preparation for both preflight and scan execution.
- Reject output or state directories that contain the selected repository while preserving normal system temporary roots.
- Resolve explicitly selected state-directory aliases before checking their relationship to the repository.
- Reconstruct nonexistent state paths from their nearest existing canonical parent before checking repository overlap.
- Create and validate each persistent scan-directory component independently while retaining trusted state-root aliases and Windows directory junctions.
- Remove duplicate runtime output validation and update synthetic test fixtures to use separate repository/state roots.

## Testing

- `bun test --timeout 30000 tests-ts/api.test.ts tests-ts/runtime.test.ts tests-ts/api-preflight-config.test.ts` — 244 passed, 7 platform-specific tests skipped, 2,511 assertions on the updated head.
- `bun test --timeout 30000 ./tests-ts` — 1,080 passed, 11 platform/integration-specific tests skipped, 7,283 assertions before the focused canonical-parent follow-up.
- `pnpm --pm-on-fail=ignore run types` — passed.
- `pnpm --pm-on-fail=ignore run format` — passed.
- `git diff --check` — passed.

## Risk and rollout

Low to moderate risk. Explicitly configuring scan state or output as an ancestor of the scanned repository is now rejected before runtime initialization or archival. Standard temporary directories, trusted user-selected state aliases, ordinary separate output directories, and existing authentication flows remain supported.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
