### PR TITLE
fix(cli): read only regular prompt and finding files

### DIFF
--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -10,7 +10,14 @@ import {
   type Stats,
   writeSync,
 } from "node:fs";
-import { lstat, mkdir, readFile, realpath, writeFile } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  open,
+  readFile,
+  realpath,
+  writeFile,
+} from "node:fs/promises";
 import {
   basename,
   dirname,
@@ -258,14 +265,18 @@ async function readPromptFiles(
   directory: string,
   scanPromptFile?: string,
   postScanPromptFile?: string,
+  repository = directory,
 ): Promise<Pick<ScanOptions, "scanPrompt" | "postScanPrompt">> {
   const [scanPrompt, postScanPrompt] = await Promise.all([
     scanPromptFile === undefined
       ? undefined
-      : readRegularInputFile(resolve(directory, scanPromptFile)),
+      : readRegularInputFile(resolve(directory, scanPromptFile), repository),
     postScanPromptFile === undefined
       ? undefined
-      : readRegularInputFile(resolve(directory, postScanPromptFile)),
+      : readRegularInputFile(
+          resolve(directory, postScanPromptFile),
+          repository,
+        ),
   ]);
   return {
     ...(scanPrompt?.trim() ? { scanPrompt } : {}),
@@ -275,12 +286,39 @@ async function readPromptFiles(
 
 async function readRegularInputFile(
   path: string,
-  metadata?: Pick<Stats, "isFile">,
+  repository: string,
+  metadata?: Pick<Stats, "isFile" | "dev" | "ino">,
 ): Promise<string> {
-  if (!(metadata ?? (await lstat(path))).isFile()) {
+  const selected = metadata ?? (await lstat(path));
+  if (!selected.isFile()) {
     throw new CodexSecurityError("Input files must be regular files.");
   }
-  return await readFile(path, "utf8");
+  const canonicalParent = await realpath(dirname(path));
+  if (!isOutsidePath(relative(repository, path))) {
+    const canonicalRepository = await realpath(repository);
+    if (isOutsidePath(relative(canonicalRepository, canonicalParent))) {
+      throw new CodexSecurityError(
+        "Input files must not follow repository directory links outside the selected repository.",
+      );
+    }
+  }
+  const file = await open(
+    join(canonicalParent, basename(path)),
+    constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0),
+  );
+  try {
+    const opened = await file.stat();
+    if (
+      !opened.isFile() ||
+      opened.dev !== selected.dev ||
+      opened.ino !== selected.ino
+    ) {
+      throw new CodexSecurityError("Input files must remain regular files.");
+    }
+    return await file.readFile({ encoding: "utf8" });
+  } finally {
+    await file.close();
+  }
 }
 
 interface ScanArguments extends DeepScanOptions {
@@ -2404,7 +2442,11 @@ async function runSkill(
           );
         }
         try {
-          contentsOrLiteral = await readRegularInputFile(path, metadata);
+          contentsOrLiteral = await readRegularInputFile(
+            path,
+            directory,
+            metadata,
+          );
         } catch {
           throw new CodexSecurityError(
             "Could not read the finding or issue input.",
@@ -2750,12 +2792,14 @@ async function runScan(
   let failed = false;
   let failure: unknown;
   try {
-    const repository = arguments_.repository ?? dependencies.currentDirectory();
+    const directory = dependencies.currentDirectory();
+    const repository = arguments_.repository ?? directory;
     const target = targetFromArguments(arguments_);
     const prompts = await readPromptFiles(
-      dependencies.currentDirectory(),
+      directory,
       arguments_.scanPromptFile,
       arguments_.postScanPromptFile,
+      resolve(directory, repository),
     );
     const config: CodexSecurityConfig = {
       pluginPath: arguments_.pluginPath,

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -7,9 +7,10 @@ import {
   existsSync,
   lstatSync,
   realpathSync,
+  type Stats,
   writeSync,
 } from "node:fs";
-import { mkdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
+import { lstat, mkdir, readFile, realpath, writeFile } from "node:fs/promises";
 import {
   basename,
   dirname,
@@ -261,15 +262,25 @@ async function readPromptFiles(
   const [scanPrompt, postScanPrompt] = await Promise.all([
     scanPromptFile === undefined
       ? undefined
-      : readFile(resolve(directory, scanPromptFile), "utf8"),
+      : readRegularInputFile(resolve(directory, scanPromptFile)),
     postScanPromptFile === undefined
       ? undefined
-      : readFile(resolve(directory, postScanPromptFile), "utf8"),
+      : readRegularInputFile(resolve(directory, postScanPromptFile)),
   ]);
   return {
     ...(scanPrompt?.trim() ? { scanPrompt } : {}),
     ...(postScanPrompt?.trim() ? { postScanPrompt } : {}),
   };
+}
+
+async function readRegularInputFile(
+  path: string,
+  metadata?: Pick<Stats, "isFile">,
+): Promise<string> {
+  if (!(metadata ?? (await lstat(path))).isFile()) {
+    throw new CodexSecurityError("Input files must be regular files.");
+  }
+  return await readFile(path, "utf8");
 }
 
 interface ScanArguments extends DeepScanOptions {
@@ -2370,7 +2381,7 @@ async function runSkill(
         localDeviceRoot !== normalizedDeviceRoot);
     if (!windowsNetworkPath) {
       const path = resolve(directory, input);
-      const metadata = await stat(path).catch((error: unknown) => {
+      const metadata = await lstat(path).catch((error: unknown) => {
         if (
           typeof error === "object" &&
           error !== null &&
@@ -2393,7 +2404,7 @@ async function runSkill(
           );
         }
         try {
-          contentsOrLiteral = await readFile(path, "utf8");
+          contentsOrLiteral = await readRegularInputFile(path, metadata);
         } catch {
           throw new CodexSecurityError(
             "Could not read the finding or issue input.",

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -304,7 +304,9 @@ async function readRegularInputFile(
   }
   const file = await open(
     join(canonicalParent, basename(path)),
-    constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0),
+    constants.O_RDONLY |
+      (constants.O_NOFOLLOW ?? 0) |
+      (constants.O_NONBLOCK ?? 0),
   );
   try {
     const opened = await file.stat();

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -293,13 +293,20 @@ async function readRegularInputFile(
   if (!selected.isFile()) {
     throw new CodexSecurityError("Input files must be regular files.");
   }
+  const canonicalRepository = await realpath(repository);
   const canonicalParent = await realpath(dirname(path));
-  if (!isOutsidePath(relative(repository, path))) {
-    const canonicalRepository = await realpath(repository);
-    if (isOutsidePath(relative(canonicalRepository, canonicalParent))) {
-      throw new CodexSecurityError(
-        "Input files must not follow repository directory links outside the selected repository.",
-      );
+  if (isOutsidePath(relative(canonicalRepository, canonicalParent))) {
+    for (let ancestor = dirname(path); ; ancestor = dirname(ancestor)) {
+      if (
+        !isOutsidePath(relative(canonicalRepository, await realpath(ancestor)))
+      ) {
+        throw new CodexSecurityError(
+          "Input files must not follow repository directory links outside the selected repository.",
+        );
+      }
+      if (dirname(ancestor) === ancestor) {
+        break;
+      }
     }
   }
   const file = await open(

--- a/sdk/typescript/tests-ts/cli-scan-prompts.test.ts
+++ b/sdk/typescript/tests-ts/cli-scan-prompts.test.ts
@@ -47,31 +47,48 @@ describe("CLI scan prompts", () => {
     const root = await mkdtemp(join(tmpdir(), "codex-security-cli-prompts-"));
     try {
       const repository = join(root, "repository");
-      const external = join(root, "external-prompt.md");
+      const externalDirectory = join(root, "external");
+      const external = join(externalDirectory, "external-prompt.md");
       const linked = join(repository, "linked-prompt.md");
       await mkdir(repository);
+      await mkdir(externalDirectory);
       await writeFile(external, "SYNTHETIC_EXTERNAL_PROMPT\n");
       await symlink(external, linked);
+      await symlink(
+        externalDirectory,
+        join(repository, "linked-directory"),
+        process.platform === "win32" ? "junction" : "dir",
+      );
 
       for (const option of ["--scan-prompt-file", "--post-scan-prompt-file"]) {
-        let started = false;
-        const stderr = capture();
-        expect(
-          await main(
-            ["scan", ".", option, "linked-prompt.md", "--json"],
-            capture().stream,
-            stderr.stream,
-            dependencies({
-              currentDirectory: repository,
-              onTurn: () => {
-                started = true;
-              },
-            }),
-          ),
-        ).toBe(2);
-        expect(stderr.text()).toContain("Input files must be regular files");
-        expect(stderr.text()).not.toContain("SYNTHETIC_EXTERNAL_PROMPT");
-        expect(started).toBe(false);
+        for (const [directory, target, input] of [
+          [repository, ".", "linked-prompt.md"],
+          [repository, ".", join("linked-directory", "external-prompt.md")],
+          [
+            root,
+            repository,
+            join(repository, "linked-directory", "external-prompt.md"),
+          ],
+        ] as const) {
+          let started = false;
+          const stderr = capture();
+          expect(
+            await main(
+              ["scan", target, option, input, "--json"],
+              capture().stream,
+              stderr.stream,
+              dependencies({
+                currentDirectory: directory,
+                onTurn: () => {
+                  started = true;
+                },
+              }),
+            ),
+          ).toBe(2);
+          expect(stderr.text()).toContain("Input files must");
+          expect(stderr.text()).not.toContain("SYNTHETIC_EXTERNAL_PROMPT");
+          expect(started).toBe(false);
+        }
 
         let selected: unknown;
         expect(

--- a/sdk/typescript/tests-ts/cli-scan-prompts.test.ts
+++ b/sdk/typescript/tests-ts/cli-scan-prompts.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
@@ -38,6 +38,58 @@ describe("CLI scan prompts", () => {
         scanPrompt: "Review authentication boundaries.\n",
         postScanPrompt: "Draft confirmed fixes.\n",
       });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects linked prompt files without rejecting selected external files", async () => {
+    const root = await mkdtemp(join(tmpdir(), "codex-security-cli-prompts-"));
+    try {
+      const repository = join(root, "repository");
+      const external = join(root, "external-prompt.md");
+      const linked = join(repository, "linked-prompt.md");
+      await mkdir(repository);
+      await writeFile(external, "SYNTHETIC_EXTERNAL_PROMPT\n");
+      await symlink(external, linked);
+
+      for (const option of ["--scan-prompt-file", "--post-scan-prompt-file"]) {
+        let started = false;
+        const stderr = capture();
+        expect(
+          await main(
+            ["scan", ".", option, "linked-prompt.md", "--json"],
+            capture().stream,
+            stderr.stream,
+            dependencies({
+              currentDirectory: repository,
+              onTurn: () => {
+                started = true;
+              },
+            }),
+          ),
+        ).toBe(2);
+        expect(stderr.text()).toContain("Input files must be regular files");
+        expect(stderr.text()).not.toContain("SYNTHETIC_EXTERNAL_PROMPT");
+        expect(started).toBe(false);
+
+        let selected: unknown;
+        expect(
+          await main(
+            ["scan", ".", option, external, "--json"],
+            capture().stream,
+            capture().stream,
+            dependencies({
+              currentDirectory: repository,
+              onTurn: (_repository, value) => (selected = value),
+            }),
+          ),
+        ).toBe(0);
+        expect(selected).toMatchObject({
+          [option === "--scan-prompt-file" ? "scanPrompt" : "postScanPrompt"]:
+            "SYNTHETIC_EXTERNAL_PROMPT\n",
+        });
+      }
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/sdk/typescript/tests-ts/cli-scan-prompts.test.ts
+++ b/sdk/typescript/tests-ts/cli-scan-prompts.test.ts
@@ -1,5 +1,12 @@
 import { spawnSync } from "node:child_process";
-import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
@@ -47,10 +54,17 @@ describe("CLI scan prompts", () => {
     const root = await mkdtemp(join(tmpdir(), "codex-security-cli-prompts-"));
     try {
       const repository = join(root, "repository");
+      const repositoryAlias = join(root, "repository-alias");
       const externalDirectory = join(root, "external");
       const external = join(externalDirectory, "external-prompt.md");
       const linked = join(repository, "linked-prompt.md");
       await mkdir(repository);
+      await symlink(
+        repository,
+        repositoryAlias,
+        process.platform === "win32" ? "junction" : "dir",
+      );
+      const physicalRepository = await realpath(repository);
       await mkdir(externalDirectory);
       await writeFile(external, "SYNTHETIC_EXTERNAL_PROMPT\n");
       await symlink(external, linked);
@@ -68,6 +82,16 @@ describe("CLI scan prompts", () => {
             root,
             repository,
             join(repository, "linked-directory", "external-prompt.md"),
+          ],
+          [
+            physicalRepository,
+            repositoryAlias,
+            join("linked-directory", "external-prompt.md"),
+          ],
+          [
+            repositoryAlias,
+            physicalRepository,
+            join("linked-directory", "external-prompt.md"),
           ],
         ] as const) {
           let started = false;
@@ -90,22 +114,28 @@ describe("CLI scan prompts", () => {
           expect(started).toBe(false);
         }
 
-        let selected: unknown;
-        expect(
-          await main(
-            ["scan", ".", option, external, "--json"],
-            capture().stream,
-            capture().stream,
-            dependencies({
-              currentDirectory: repository,
-              onTurn: (_repository, value) => (selected = value),
-            }),
-          ),
-        ).toBe(0);
-        expect(selected).toMatchObject({
-          [option === "--scan-prompt-file" ? "scanPrompt" : "postScanPrompt"]:
-            "SYNTHETIC_EXTERNAL_PROMPT\n",
-        });
+        for (const [directory, target] of [
+          [repository, "."],
+          [physicalRepository, repositoryAlias],
+          [repositoryAlias, physicalRepository],
+        ] as const) {
+          let selected: unknown;
+          expect(
+            await main(
+              ["scan", target, option, external, "--json"],
+              capture().stream,
+              capture().stream,
+              dependencies({
+                currentDirectory: directory,
+                onTurn: (_repository, value) => (selected = value),
+              }),
+            ),
+          ).toBe(0);
+          expect(selected).toMatchObject({
+            [option === "--scan-prompt-file" ? "scanPrompt" : "postScanPrompt"]:
+              "SYNTHETIC_EXTERNAL_PROMPT\n",
+          });
+        }
       }
     } finally {
       await rm(root, { recursive: true, force: true });

--- a/sdk/typescript/tests-ts/cli-skills.test.ts
+++ b/sdk/typescript/tests-ts/cli-skills.test.ts
@@ -1,9 +1,10 @@
 import { spawn } from "node:child_process";
 import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import * as filesystem from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import {
   main,
   readSkillCommandOutput,
@@ -123,30 +124,40 @@ describe("CLI skill commands", () => {
         linkedDirectory,
         process.platform === "win32" ? "junction" : "dir",
       );
+      await symlink(
+        externalDirectory,
+        join(repository, "linked-directory"),
+        process.platform === "win32" ? "junction" : "dir",
+      );
 
       for (const command of ["validate", "patch"] as const) {
         let invocation: readonly string[] | undefined;
-        const stderr = capture();
-        expect(
-          await main(
-            [command, "linked-finding.txt"],
-            capture().stream,
-            stderr.stream,
-            dependencies({
-              currentDirectory: repository,
-              onCodex: (args) => {
-                invocation = args;
-                return 0;
-              },
-            }),
-          ),
-        ).toBe(2);
-        expect(stderr.text()).toContain("must be files or literal text");
-        expect(stderr.text()).not.toContain("SYNTHETIC_EXTERNAL_FINDING");
-        expect(invocation).toBeUndefined();
+        for (const input of [
+          "linked-finding.txt",
+          join("linked-directory", "finding.txt"),
+        ]) {
+          const stderr = capture();
+          expect(
+            await main(
+              [command, input],
+              capture().stream,
+              stderr.stream,
+              dependencies({
+                currentDirectory: repository,
+                onCodex: (args) => {
+                  invocation = args;
+                  return 0;
+                },
+              }),
+            ),
+          ).toBe(2);
+          expect(stderr.text()).not.toContain("SYNTHETIC_EXTERNAL_FINDING");
+          expect(invocation).toBeUndefined();
+        }
 
         for (const selected of [
           finding,
+          join("..", "external", "finding.txt"),
           join(linkedDirectory, "finding.txt"),
         ]) {
           expect(
@@ -167,6 +178,56 @@ describe("CLI skill commands", () => {
             "SYNTHETIC_EXTERNAL_FINDING\n",
           ]);
         }
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects finding files replaced after their metadata was inspected", async () => {
+    const root = await mkdtemp(join(tmpdir(), "codex-security-skill-inputs-"));
+    try {
+      const repository = join(root, "repository");
+      const selected = join(repository, "finding.txt");
+      const external = join(root, "external.txt");
+      await mkdir(repository);
+      await writeFile(selected, "ordinary finding\n");
+      await writeFile(external, "SYNTHETIC_EXTERNAL_FINDING\n");
+      const canonicalSelected = await filesystem.realpath(selected);
+
+      const originalOpen = filesystem.open;
+      const opening = spyOn(filesystem, "open").mockImplementation(
+        async (...args: Parameters<typeof filesystem.open>) => {
+          if (String(args[0]) === canonicalSelected) {
+            opening.mockRestore();
+            await rm(selected);
+            await symlink(external, selected);
+          }
+          return await originalOpen(...args);
+        },
+      );
+
+      try {
+        let started = false;
+        const stderr = capture();
+        expect(
+          await main(
+            ["validate", "finding.txt"],
+            capture().stream,
+            stderr.stream,
+            dependencies({
+              currentDirectory: repository,
+              onCodex: () => {
+                started = true;
+                return 0;
+              },
+            }),
+          ),
+        ).toBe(2);
+        expect(stderr.text()).not.toContain("SYNTHETIC_EXTERNAL_FINDING");
+        expect(started).toBe(false);
+      } finally {
+        opening.mockRestore();
       }
     } finally {
       await rm(root, { recursive: true, force: true });

--- a/sdk/typescript/tests-ts/cli-skills.test.ts
+++ b/sdk/typescript/tests-ts/cli-skills.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
@@ -104,6 +104,72 @@ describe("CLI skill commands", () => {
       }
     } finally {
       await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects linked findings while preserving selected external files", async () => {
+    const root = await mkdtemp(join(tmpdir(), "codex-security-skill-inputs-"));
+    try {
+      const repository = join(root, "repository");
+      const externalDirectory = join(root, "external");
+      const linkedDirectory = join(root, "external-alias");
+      const finding = join(externalDirectory, "finding.txt");
+      await mkdir(repository);
+      await mkdir(externalDirectory);
+      await writeFile(finding, "SYNTHETIC_EXTERNAL_FINDING\n");
+      await symlink(finding, join(repository, "linked-finding.txt"));
+      await symlink(
+        externalDirectory,
+        linkedDirectory,
+        process.platform === "win32" ? "junction" : "dir",
+      );
+
+      for (const command of ["validate", "patch"] as const) {
+        let invocation: readonly string[] | undefined;
+        const stderr = capture();
+        expect(
+          await main(
+            [command, "linked-finding.txt"],
+            capture().stream,
+            stderr.stream,
+            dependencies({
+              currentDirectory: repository,
+              onCodex: (args) => {
+                invocation = args;
+                return 0;
+              },
+            }),
+          ),
+        ).toBe(2);
+        expect(stderr.text()).toContain("must be files or literal text");
+        expect(stderr.text()).not.toContain("SYNTHETIC_EXTERNAL_FINDING");
+        expect(invocation).toBeUndefined();
+
+        for (const selected of [
+          finding,
+          join(linkedDirectory, "finding.txt"),
+        ]) {
+          expect(
+            await main(
+              [command, selected],
+              capture().stream,
+              capture().stream,
+              dependencies({
+                currentDirectory: repository,
+                onCodex: (args) => {
+                  invocation = args;
+                  return 0;
+                },
+              }),
+            ),
+          ).toBe(0);
+          expect(JSON.parse(invocation!.at(-1)!.split("\n").at(-1)!)).toEqual([
+            "SYNTHETIC_EXTERNAL_FINDING\n",
+          ]);
+        }
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
     }
   });
 

--- a/sdk/typescript/tests-ts/cli-skills.test.ts
+++ b/sdk/typescript/tests-ts/cli-skills.test.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import * as filesystem from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -184,7 +184,11 @@ describe("CLI skill commands", () => {
     }
   });
 
-  test("rejects finding files replaced after their metadata was inspected", async () => {
+  test.each(
+    process.platform === "win32"
+      ? ["symbolic link"]
+      : ["symbolic link", "FIFO"],
+  )("rejects finding files replaced with a %s", async (replacement) => {
     const root = await mkdtemp(join(tmpdir(), "codex-security-skill-inputs-"));
     try {
       const repository = join(root, "repository");
@@ -201,7 +205,8 @@ describe("CLI skill commands", () => {
           if (String(args[0]) === canonicalSelected) {
             opening.mockRestore();
             await rm(selected);
-            await symlink(external, selected);
+            if (replacement === "FIFO") execFileSync("mkfifo", [selected]);
+            else await symlink(external, selected);
           }
           return await originalOpen(...args);
         },


### PR DESCRIPTION
## Summary

Use the same regular-file checks for scan prompt files and validation/patching inputs without restricting explicitly selected external files.

## Changes

- Share one no-follow, descriptor-backed regular-file reader between scan prompts, post-scan prompts, validation findings, and patch inputs.
- Inspect positional finding files with `lstat` while preserving literal inputs and existing Windows device/network-path handling.
- Open input files without following links or blocking, validate the same handle that supplies their bytes, and reject files replaced after their initial metadata check.
- Reject repository-controlled directory links that leave the selected repository while keeping explicitly selected external directory aliases.
- Continue accepting selected absolute external files and files reached through trusted user-selected parent aliases.
- Add synthetic regression coverage for both prompt flags, both skill commands, symbolic-link and FIFO replacement, explicit repository arguments, external files, and safe versus unsafe directory aliases.

## Testing

- `bun test --timeout 30000 tests-ts/cli.test.ts tests-ts/cli-authentication.test.ts tests-ts/cli-workbench.test.ts tests-ts/cli-scan-prompts.test.ts tests-ts/cli-skills.test.ts tests-ts/multiscan.test.ts` — 223 tests passed with 2,601 assertions.
- `bun test --timeout 30000 tests-ts/cli-scan-prompts.test.ts tests-ts/cli-skills.test.ts` — 17 focused tests passed with 193 assertions.
- `pnpm --pm-on-fail=ignore run types` — passed.
- `pnpm --pm-on-fail=ignore run format` — passed.
- `git diff --check` — passed.

## Risk and rollout

Low risk. Symbolic-link leaves, repository-directed directory links that escape the selected repository, replaced files, FIFOs, and other non-regular inputs are rejected without blocking. Existing literal text, selected regular files outside the repository, trusted external directory aliases, bulk prompts, and platform-specific path behavior remain unchanged.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
