### PR TITLE
fix(multiscan): keep campaign directories user-owned

### DIFF
--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -107,12 +107,15 @@ export async function runMultiscan(
     dirname(resolve(options.inputPath)),
     options.mode,
   );
-  const output = resolve(options.outputDir);
-  await ensureOutputDirectory(output);
-  await requireSecureOutputAncestry(await realpath(output));
+  const requestedOutput = resolve(options.outputDir);
+  const output = await ensureOutputDirectory(requestedOutput);
+  await requireSecureOutputAncestry(output);
   const unlock = await acquireLock(output);
   try {
-    return await runCampaign(options, tasks, output);
+    const result = await runCampaign(options, tasks, output);
+    return (await realpath(requestedOutput).catch(() => undefined)) === output
+      ? { ...result, resultsPath: join(requestedOutput, "results.jsonl") }
+      : result;
   } finally {
     await unlock();
   }
@@ -133,11 +136,24 @@ async function runCampaign(
   let incomplete = 0;
   for (const task of tasks) {
     const receipt = receipts.get(task.id.toLowerCase());
+    if (receipt === undefined) {
+      pending.push(task);
+      continue;
+    }
+    const artifactRoot = await ensureOutputDirectory(
+      join(output, "artifacts", task.id),
+    );
+    const artifactOutput = join(artifactRoot, `attempt-${receipt.attempt}`);
+    const selectedArtifactOutput = join(
+      resolve(options.outputDir),
+      "artifacts",
+      task.id,
+      `attempt-${receipt.attempt}`,
+    );
     if (
-      receipt !== undefined &&
-      receipt.outputDir ===
-        join(output, "artifacts", task.id, `attempt-${receipt.attempt}`) &&
-      (await hasArtifacts(receipt.outputDir))
+      (receipt.outputDir === artifactOutput ||
+        receipt.outputDir === selectedArtifactOutput) &&
+      (await hasArtifacts(artifactOutput))
     ) {
       if (receipt.status === "completed") {
         completed += 1;
@@ -146,7 +162,10 @@ async function runCampaign(
       const coverage =
         receipt.status === "completed_with_incomplete_coverage"
           ? receipt.coverage ?? "unknown"
-          : await legacyIncompleteCoverage(receipt);
+          : await legacyIncompleteCoverage({
+              ...receipt,
+              outputDir: artifactOutput,
+            });
       if (coverage !== undefined) {
         incomplete += 1;
         notifyProgress(options, {
@@ -327,7 +346,7 @@ function notifyProgress(
   } catch {}
 }
 
-async function ensureOutputDirectory(path: string): Promise<void> {
+async function ensureOutputDirectory(path: string): Promise<string> {
   const metadata = await lstat(path).catch((error: NodeJS.ErrnoException) => {
     if (error.code !== "ENOENT") throw error;
     return undefined;
@@ -336,8 +355,15 @@ async function ensureOutputDirectory(path: string): Promise<void> {
     throw new Error("Multiscan output directories must not be symbolic links.");
   }
   await mkdir(path, { recursive: true, mode: 0o700 });
-  if (process.platform === "win32") return;
-  const directory = metadata ?? (await lstat(path));
+  const canonical = await realpath(path);
+  const directory = await lstat(canonical);
+  if (
+    metadata !== undefined &&
+    (directory.dev !== metadata.dev || directory.ino !== metadata.ino)
+  ) {
+    throw new Error("Multiscan output directories changed during preparation.");
+  }
+  if (process.platform === "win32") return canonical;
   if ((directory.mode & 0o022) !== 0) {
     throw new Error(
       "Multiscan output directories must not be group- or world-writable.",
@@ -349,6 +375,7 @@ async function ensureOutputDirectory(path: string): Promise<void> {
       "Multiscan output directories must be owned by the current user.",
     );
   }
+  return canonical;
 }
 
 async function appendReceipt(path: string, receipt: string): Promise<void> {

--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -22,6 +22,7 @@ import type { CodexSecurityConfig } from "./config.js";
 import type { ScanCost } from "./cost.js";
 import { safeErrorMessage } from "./errors.js";
 import type { CoverageDocument } from "./models.js";
+import { requireSecureOutputAncestry } from "./runtime.js";
 import type { ScanMode } from "./targets.js";
 import { resolveTrustedExecutable } from "./trusted-executable.js";
 
@@ -108,6 +109,7 @@ export async function runMultiscan(
   );
   const output = resolve(options.outputDir);
   await ensureOutputDirectory(output);
+  await requireSecureOutputAncestry(await realpath(output));
   const unlock = await acquireLock(output);
   try {
     return await runCampaign(options, tasks, output);
@@ -199,7 +201,7 @@ async function runCampaign(
         let coverage: CoverageDocument["completeness"] | undefined;
         let cost: Readonly<ScanCost> | null = null;
         try {
-          await mkdir(dirname(scanDir), { recursive: true, mode: 0o700 });
+          await ensureOutputDirectory(dirname(scanDir));
           await rm(checkout, { recursive: true, force: true });
           await mkdir(checkout, { mode: 0o700 });
           await checkoutRevision(
@@ -334,6 +336,19 @@ async function ensureOutputDirectory(path: string): Promise<void> {
     throw new Error("Multiscan output directories must not be symbolic links.");
   }
   await mkdir(path, { recursive: true, mode: 0o700 });
+  if (process.platform === "win32") return;
+  const directory = metadata ?? (await lstat(path));
+  if ((directory.mode & 0o022) !== 0) {
+    throw new Error(
+      "Multiscan output directories must not be group- or world-writable.",
+    );
+  }
+  const owner = process.geteuid?.();
+  if (owner !== undefined && directory.uid !== owner) {
+    throw new Error(
+      "Multiscan output directories must be owned by the current user.",
+    );
+  }
 }
 
 async function appendReceipt(path: string, receipt: string): Promise<void> {

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -8,6 +8,7 @@ import {
   mkdtemp,
   readFile,
   readdir,
+  realpath,
   rename,
   rm,
   symlink,
@@ -43,7 +44,9 @@ async function fixture(): Promise<{
   input: string;
   output: string;
 }> {
-  const root = await mkdtemp(join(tmpdir(), "codex-security-multiscan-"));
+  const root = await realpath(
+    await mkdtemp(join(tmpdir(), "codex-security-multiscan-")),
+  );
   temporaryDirectories.push(root);
   return {
     root,
@@ -1594,6 +1597,50 @@ describe("multiscan", () => {
     );
   });
 
+  test("rejects linked task artifacts before accepting completed receipts", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "victim");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\nvictim,${source.path},${source.revision}\n`,
+    );
+    const external = join(paths.root, "external");
+    await completedScan(join(external, "attempt-1"));
+    await mkdir(join(paths.output, "artifacts"), { recursive: true });
+    await symlink(
+      external,
+      join(paths.output, "artifacts", "victim"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    await writeFile(
+      join(paths.output, "results.jsonl"),
+      `${JSON.stringify({
+        id: "victim",
+        repository: source.path,
+        revision: source.revision,
+        mode: "standard",
+        status: "completed",
+        attempt: 1,
+        outputDir: join(paths.output, "artifacts", "victim", "attempt-1"),
+      })}\n`,
+    );
+
+    let scans = 0;
+    await expect(
+      runMultiscan(
+        options(
+          paths,
+          client(async (_repository, scanOptions = {}) => {
+            scans += 1;
+            return await completedScan(scanOptions.outputDir!);
+          }),
+        ),
+      ),
+    ).rejects.toThrow("symbolic links");
+    expect(scans).toBe(0);
+    expect(await readdir(external)).toEqual(["attempt-1"]);
+  });
+
   testPosix(
     "rejects other-user-writable campaigns while preserving readable existing campaigns",
     async () => {
@@ -1673,23 +1720,84 @@ describe("multiscan", () => {
       process.platform === "win32" ? "junction" : "dir",
     );
     const output = join(linkedParent, "results");
+    let scans = 0;
+    const security = client(async (_repository, scanOptions = {}) => {
+      scans += 1;
+      return await completedScan(scanOptions.outputDir!);
+    });
+
+    const summary = await runMultiscan(
+      options(paths, security, { outputDir: output }),
+    );
+
+    expect(summary).toMatchObject({ total: 1, completed: 1, failed: 0 });
+    expect(summary.resultsPath).toBe(join(output, "results.jsonl"));
+    const [receipt] = await results(summary.resultsPath);
+    expect(receipt?.["outputDir"]).toBe(
+      join(canonicalParent, "results", "artifacts", "sample", "attempt-1"),
+    );
+    await writeFile(
+      summary.resultsPath,
+      `${JSON.stringify({
+        ...receipt,
+        outputDir: join(output, "artifacts", "sample", "attempt-1"),
+      })}\n`,
+    );
+    expect(
+      await runMultiscan(options(paths, security, { outputDir: output })),
+    ).toMatchObject({ completed: 1, skipped: 1 });
+    expect(scans).toBe(1);
+    expect(await readdir(join(canonicalParent, "results"))).toContain(
+      "results.jsonl",
+    );
+  });
+
+  test("keeps campaign operations on their validated canonical directory", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "sample");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\nsample,${source.path},${source.revision}\n`,
+    );
+    const canonicalParent = join(paths.root, "campaigns");
+    const redirectedParent = join(paths.root, "redirected");
+    const linkedParent = join(paths.root, "linked-campaigns");
+    await mkdir(canonicalParent);
+    await mkdir(join(redirectedParent, "results"), { recursive: true });
+    await writeFile(
+      join(redirectedParent, "results", "preserved.txt"),
+      "preserved\n",
+    );
+    await symlink(
+      canonicalParent,
+      linkedParent,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    const output = join(linkedParent, "results");
 
     const summary = await runMultiscan(
       options(
         paths,
-        client(
-          async (_repository, scanOptions = {}) =>
-            await completedScan(scanOptions.outputDir!),
-        ),
+        client(async (_repository, scanOptions = {}) => {
+          await rename(linkedParent, join(paths.root, "previous-alias"));
+          await symlink(
+            redirectedParent,
+            linkedParent,
+            process.platform === "win32" ? "junction" : "dir",
+          );
+          return await completedScan(scanOptions.outputDir!);
+        }),
         { outputDir: output },
       ),
     );
 
     expect(summary).toMatchObject({ total: 1, completed: 1, failed: 0 });
-    expect(summary.resultsPath).toBe(join(output, "results.jsonl"));
-    expect(await readdir(join(canonicalParent, "results"))).toContain(
-      "results.jsonl",
+    expect(summary.resultsPath).toBe(
+      join(canonicalParent, "results", "results.jsonl"),
     );
+    expect(await readdir(join(redirectedParent, "results"))).toEqual([
+      "preserved.txt",
+    ]);
   });
 
   test("rejects unsafe input without starting scans or exposing URL credentials", async () => {

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import {
   access,
   appendFile,
+  chmod,
   lstat,
   mkdir,
   mkdtemp,
@@ -27,6 +28,7 @@ type MultiscanOptions = Parameters<typeof runMultiscan>[0];
 type SecurityClient = ReturnType<MultiscanOptions["createSecurity"]>;
 
 const temporaryDirectories: string[] = [];
+const testPosix = process.platform === "win32" ? test.skip : test;
 
 afterEach(async () => {
   await Promise.all(
@@ -1550,6 +1552,144 @@ describe("multiscan", () => {
       expect(scans).toBe(0);
       expect(await readFile(preserved, "utf8")).toBe("preserved\n");
     }
+  });
+
+  test("rejects linked task artifact directories without touching external files", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "victim");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\nvictim,${source.path},${source.revision}\n`,
+    );
+    const external = join(paths.root, "external");
+    await mkdir(external);
+    await writeFile(join(external, "preserved.txt"), "preserved\n");
+    await mkdir(join(paths.output, "artifacts"), { recursive: true });
+    await symlink(
+      external,
+      join(paths.output, "artifacts", "victim"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
+
+    let scans = 0;
+    const summary = await runMultiscan(
+      options(
+        paths,
+        client(async (_repository, scanOptions = {}) => {
+          scans += 1;
+          return await completedScan(scanOptions.outputDir!);
+        }),
+        { maxAttempts: 1 },
+      ),
+    );
+
+    expect(summary).toMatchObject({ total: 1, completed: 0, failed: 1 });
+    expect(scans).toBe(0);
+    expect((await results(summary.resultsPath))[0]?.["error"]).toContain(
+      "symbolic links",
+    );
+    expect(await readdir(external)).toEqual(["preserved.txt"]);
+    expect(await readFile(join(external, "preserved.txt"), "utf8")).toBe(
+      "preserved\n",
+    );
+  });
+
+  testPosix(
+    "rejects other-user-writable campaigns while preserving readable existing campaigns",
+    async () => {
+      const paths = await fixture();
+      const source = await repository(paths.root, "sample");
+      await writeFile(
+        paths.input,
+        `id,repository,revision\nsample,${source.path},${source.revision}\n`,
+      );
+      await mkdir(paths.output, { mode: 0o755 });
+      let scans = 0;
+      const security = client(async (_repository, scanOptions = {}) => {
+        scans += 1;
+        return await completedScan(scanOptions.outputDir!);
+      });
+
+      for (const mode of [0o770, 0o777]) {
+        await chmod(paths.output, mode);
+        await expect(runMultiscan(options(paths, security))).rejects.toThrow(
+          "must not be group- or world-writable",
+        );
+        expect(scans).toBe(0);
+      }
+
+      await chmod(paths.output, 0o755);
+      expect(await runMultiscan(options(paths, security))).toMatchObject({
+        total: 1,
+        completed: 1,
+        failed: 0,
+      });
+      expect(scans).toBe(1);
+    },
+  );
+
+  testPosix("rejects campaigns beneath an unsafe shared parent", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "sample");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\nsample,${source.path},${source.revision}\n`,
+    );
+    const parent = join(paths.root, "shared");
+    await mkdir(parent, { mode: 0o777 });
+    await chmod(parent, 0o777);
+    let scans = 0;
+
+    await expect(
+      runMultiscan(
+        options(
+          paths,
+          client(async (_repository, scanOptions = {}) => {
+            scans += 1;
+            return await completedScan(scanOptions.outputDir!);
+          }),
+          { outputDir: join(parent, "results") },
+        ),
+      ),
+    ).rejects.toThrow(
+      "must not be group- or world-writable without the sticky bit",
+    );
+    expect(scans).toBe(0);
+  });
+
+  test("preserves trusted user-selected campaign parent aliases", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "sample");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\nsample,${source.path},${source.revision}\n`,
+    );
+    const canonicalParent = join(paths.root, "campaigns");
+    const linkedParent = join(paths.root, "linked-campaigns");
+    await mkdir(canonicalParent);
+    await symlink(
+      canonicalParent,
+      linkedParent,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    const output = join(linkedParent, "results");
+
+    const summary = await runMultiscan(
+      options(
+        paths,
+        client(
+          async (_repository, scanOptions = {}) =>
+            await completedScan(scanOptions.outputDir!),
+        ),
+        { outputDir: output },
+      ),
+    );
+
+    expect(summary).toMatchObject({ total: 1, completed: 1, failed: 0 });
+    expect(summary.resultsPath).toBe(join(output, "results.jsonl"));
+    expect(await readdir(join(canonicalParent, "results"))).toContain(
+      "results.jsonl",
+    );
   });
 
   test("rejects unsafe input without starting scans or exposing URL credentials", async () => {


### PR DESCRIPTION
## Summary

Apply the existing scan-output ownership, ancestry, and directory-link safeguards consistently to resumable bulk-scan campaigns.

## Changes

- Reuse the SDK's existing trusted-output-ancestry validation for campaign directories.
- Pin campaign I/O to the validated canonical output directory while preserving stable user-selected display paths.
- Reject campaign, checkout, and artifact directories that are writable by another user or owned by a different user on POSIX.
- Reuse the existing directory check for repository-specific artifact roots before preparing scan output.
- Validate task artifact roots before accepting existing completion receipts, and continue supporting legacy alias-spelled receipt paths.
- Preserve existing readable `0755` campaigns, user-selected parent aliases, Windows directory junctions, normal resume behavior, and platform-specific ownership handling.
- Add synthetic coverage for writable campaigns, unsafe shared parents, linked task artifacts, imported completion receipts, retargeted aliases, ordinary existing campaigns, and trusted parent aliases.

## Testing

- `bun test --timeout 30000 tests-ts/multiscan.test.ts tests-ts/cli.test.ts tests-ts/cli-scan-prompts.test.ts tests-ts/container-entrypoint.test.ts` — 188 tests passed with 2,084 assertions.
- `bun test --timeout 30000 --test-name-pattern 'output-directory symlinks|linked task artifact|other-user-writable|unsafe shared parent|parent aliases|validated canonical directory|resumes legacy|supervisor lock|structured output' tests-ts/multiscan.test.ts tests-ts/cli.test.ts` — 14 focused cases passed with 64 assertions.
- `pnpm --pm-on-fail=ignore run types` — passed.
- `pnpm --pm-on-fail=ignore run format` — passed.
- `git diff --check` — passed.

## Risk and rollout

Low risk. Only existing directories writable by another user, untrusted writable ancestors, symbolic-link task directories, and unsafe imported completion paths are rejected. Existing `0755` campaigns, supported resume flows, legacy alias-spelled receipts, sticky temporary parents, stable user-selected output paths, trusted directory aliases, and Windows-compatible behavior remain supported.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
