### PR TITLE
refactor(plugin): stream normalized candidate rows

### DIFF
--- a/sdk/typescript/_bundled_plugin/scripts/normalize_candidates.py
+++ b/sdk/typescript/_bundled_plugin/scripts/normalize_candidates.py
@@ -308,10 +308,6 @@ def main() -> None:
                         raise ValueError(f"{source} row {number}: {error}") from error
         combined = combine(rows)
         output.parent.mkdir(parents=True, exist_ok=True)
-        payload = "".join(
-            json.dumps(row, ensure_ascii=False, separators=(",", ":"), sort_keys=True) + "\n"
-            for row in combined
-        )
         temporary: Path | None = None
         try:
             with tempfile.NamedTemporaryFile(
@@ -323,7 +319,11 @@ def main() -> None:
                 delete=False,
             ) as handle:
                 temporary = Path(handle.name)
-                handle.write(payload)
+                for row in combined:
+                    handle.write(
+                        json.dumps(row, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+                        + "\n"
+                    )
             temporary.replace(output)
         finally:
             if temporary is not None:

--- a/sdk/typescript/tests-ts/compact-diff-scan.test.ts
+++ b/sdk/typescript/tests-ts/compact-diff-scan.test.ts
@@ -281,11 +281,20 @@ describe("compact diff scan", () => {
   test("keeps deleted inventory paths without accepting unsafe candidates", () => {
     const { root, repository } = createRepository();
     writeSource(repository, "src/handler.py", "value = 1\n");
+    writeSource(repository, "src/second.py", "value = 2\n");
     const inventory = join(root, "in-scope.txt");
     const input = join(root, "candidates.jsonl");
     const output = join(root, "normalized.jsonl");
-    writeFileSync(inventory, "src/deleted.py\nsrc/handler.py\n");
-    writeFileSync(input, `${JSON.stringify(candidate("src/handler.py"))}\n`);
+    writeFileSync(inventory, "src/deleted.py\nsrc/handler.py\nsrc/second.py\n");
+    writeFileSync(
+      input,
+      [
+        candidate("src/handler.py"),
+        { ...candidate("src/second.py"), summary: "Résumé: missing guard" },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+    );
     const args = [
       "--input",
       input,
@@ -304,10 +313,16 @@ describe("compact diff scan", () => {
       "--allow-missing-in-scope",
     );
     expect(accepted.status, accepted.stderr).toBe(0);
-    const normalized = JSON.parse(readFileSync(output, "utf8")) as {
-      locations: { path: string }[];
-    };
-    expect(normalized.locations[0]?.path).toBe("src/handler.py");
+    const contents = readFileSync(output, "utf8");
+    expect(contents).toContain("Résumé: missing guard");
+    const normalized = contents
+      .trimEnd()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { locations: { path: string }[] });
+    expect(normalized.map((entry) => entry.locations[0]?.path).sort()).toEqual([
+      "src/handler.py",
+      "src/second.py",
+    ]);
 
     writeFileSync(inventory, "../escaped.py\nsrc/handler.py\n");
     const escaped = python(


### PR DESCRIPTION
## Summary

Avoid building a second complete copy of normalized security-scan candidates in memory.

## Changes

- Write normalized JSONL rows directly to the existing atomic temporary file.
- Extend the existing compact diff regression to cover multiple candidates and literal Unicode text.

## Testing

- `bun test --timeout 30000 tests-ts/compact-diff-scan.test.ts` — 5 passed.
- `pnpm run types` — passed.
- `pnpm run format` — passed.
- `git diff --check` — passed.

## Risk and rollout

Low risk. Candidate ordering, JSON encoding, trailing newlines, atomic replacement, temporary-file cleanup, and invalid-path rejection are unchanged.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
