### PR TITLE
fix(plugin): retain remediation guidance in finding previews

### DIFF
--- a/sdk/typescript/_bundled_plugin/scripts/finding_preview.py
+++ b/sdk/typescript/_bundled_plugin/scripts/finding_preview.py
@@ -253,11 +253,14 @@ def bounded_json_value(value: Any, budget: list[int], *, depth: int = 0) -> Any:
         for key, item in list(value.items())[:20]:
             if budget[0] <= 0 or not isinstance(key, str):
                 break
+            remaining = budget[0]
             separator = 0 if not result else 1
             if not consume_json_budget(budget, separator):
+                budget[0] = remaining
                 break
             bounded_key, key_size = bounded_json_text(key, min(budget[0], 512))
             if not consume_json_budget(budget, key_size + 1):
+                budget[0] = remaining
                 break
             item_budget = budget
             if depth == 0 and key == "remediationTests":
@@ -288,10 +291,18 @@ def bounded_json_value(value: Any, budget: list[int], *, depth: int = 0) -> Any:
                         if budget[0] >= minimum_tests + reserved:
                             item_budget = [budget[0] - reserved]
                             break
-            allocated = item_budget[0]
-            result[bounded_key] = bounded_json_value(item, item_budget, depth=depth + 1)
-            if item_budget is not budget:
-                budget[0] -= allocated - item_budget[0]
+            bounded_item = bounded_json_value(item, item_budget, depth=depth + 1)
+            size = (
+                separator
+                + key_size
+                + 1
+                + len(json.dumps(bounded_item, separators=(",", ":")).encode("utf-8"))
+            )
+            if size > remaining or (isinstance(item, str) and item and bounded_item == ""):
+                budget[0] = remaining
+                break
+            budget[0] = remaining - size
+            result[bounded_key] = bounded_item
         return result
     consume_json_budget(budget, 4)
     return None

--- a/sdk/typescript/_bundled_plugin/scripts/finding_preview.py
+++ b/sdk/typescript/_bundled_plugin/scripts/finding_preview.py
@@ -259,7 +259,39 @@ def bounded_json_value(value: Any, budget: list[int], *, depth: int = 0) -> Any:
             bounded_key, key_size = bounded_json_text(key, min(budget[0], 512))
             if not consume_json_budget(budget, key_size + 1):
                 break
-            result[bounded_key] = bounded_json_value(item, budget, depth=depth + 1)
+            item_budget = budget
+            if depth == 0 and key == "remediationTests":
+                controls = value.get("preventiveControls")
+                if (
+                    isinstance(item, list)
+                    and item
+                    and isinstance(item[0], str)
+                    and item[0]
+                    and isinstance(controls, list)
+                    and controls
+                    and isinstance(controls[0], str)
+                    and controls[0]
+                ):
+                    minimum_tests = len(
+                        json.dumps([item[0][0]], separators=(",", ":")).encode("utf-8")
+                    )
+                    for control in (controls[0], controls[0][0]):
+                        reserved = (
+                            len(
+                                json.dumps(
+                                    {"preventiveControls": [control]},
+                                    separators=(",", ":"),
+                                ).encode("utf-8")
+                            )
+                            - 1
+                        )
+                        if budget[0] >= minimum_tests + reserved:
+                            item_budget = [budget[0] - reserved]
+                            break
+            allocated = item_budget[0]
+            result[bounded_key] = bounded_json_value(item, item_budget, depth=depth + 1)
+            if item_budget is not budget:
+                budget[0] -= allocated - item_budget[0]
         return result
     consume_json_budget(budget, 4)
     return None

--- a/sdk/typescript/_bundled_plugin/scripts/finding_preview.py
+++ b/sdk/typescript/_bundled_plugin/scripts/finding_preview.py
@@ -150,8 +150,22 @@ def bounded_finding_details(value: Any) -> dict[str, Any]:
                 else value[key]
             )
 
-    priority = (
+    guidance = {
+        key: prepared[key]
+        for key in ("remediationTests", "preventiveControls")
+        if key in prepared and isinstance(prepared[key], list)
+    }
+    diagnostics = (
+        "rootCause",
+        "root_cause",
+        "validation",
+        "attackPath",
+        "codeEvidence",
+        "code_evidence",
+    )
+    core_keys = (
         "writeup",
+        *diagnostics,
         "confidence",
         "detectedAt",
         "identity",
@@ -160,12 +174,40 @@ def bounded_finding_details(value: Any) -> dict[str, Any]:
         "severity",
         "status",
         "taxonomy",
-        "remediationTests",
-        "preventiveControls",
+        "evidence",
+        "evidenceExcerpt",
     )
-    prepared = {**{key: prepared[key] for key in priority if key in prepared}, **prepared}
-    budget = [FINDING_DETAILS_PREVIEW_BYTES]
-    bounded = bounded_json_value(prepared, budget)
+    core = {key: prepared[key] for key in core_keys if key in prepared}
+    extras = {
+        key: item
+        for key, item in prepared.items()
+        if key not in core and key not in guidance
+    }
+    complete_guidance = {key: items[:1] for key, items in guidance.items()}
+    minimum_guidance = {
+        key: [items[0][:1]] if items and isinstance(items[0], str) else []
+        for key, items in guidance.items()
+    }
+    projected_core = {}
+    for selected_guidance in (complete_guidance, minimum_guidance):
+        reserved = (
+            len(json.dumps(selected_guidance, separators=(",", ":")).encode("utf-8")) - 1
+            if selected_guidance
+            else 0
+        )
+        if reserved >= FINDING_DETAILS_PREVIEW_BYTES:
+            continue
+        projected_core = bounded_json_value(
+            core,
+            [FINDING_DETAILS_PREVIEW_BYTES - reserved],
+        )
+        if all(key in projected_core for key in core):
+            break
+    ordered_guidance = dict(sorted(guidance.items(), key=lambda entry: bool(entry[1])))
+    bounded = bounded_json_value(
+        {**projected_core, **ordered_guidance, **extras},
+        [FINDING_DETAILS_PREVIEW_BYTES],
+    )
     return bounded if isinstance(bounded, dict) else {}
 
 

--- a/sdk/typescript/_bundled_plugin/scripts/finding_preview.py
+++ b/sdk/typescript/_bundled_plugin/scripts/finding_preview.py
@@ -140,6 +140,8 @@ def bounded_finding_details(value: Any) -> dict[str, Any]:
         "severity",
         "status",
         "taxonomy",
+        "preventiveControls",
+        "remediationTests",
     ):
         if key in value:
             prepared[key] = (

--- a/sdk/typescript/_bundled_plugin/scripts/finding_preview.py
+++ b/sdk/typescript/_bundled_plugin/scripts/finding_preview.py
@@ -150,6 +150,20 @@ def bounded_finding_details(value: Any) -> dict[str, Any]:
                 else value[key]
             )
 
+    priority = (
+        "writeup",
+        "confidence",
+        "detectedAt",
+        "identity",
+        "provenance",
+        "ruleId",
+        "severity",
+        "status",
+        "taxonomy",
+        "remediationTests",
+        "preventiveControls",
+    )
+    prepared = {**{key: prepared[key] for key in priority if key in prepared}, **prepared}
     budget = [FINDING_DETAILS_PREVIEW_BYTES]
     bounded = bounded_json_value(prepared, budget)
     return bounded if isinstance(bounded, dict) else {}
@@ -217,11 +231,20 @@ def bounded_json_value(value: Any, budget: list[int], *, depth: int = 0) -> Any:
         if not consume_json_budget(budget, 2):
             return []
         result = []
-        for item in value[:20]:
+        for item in value:
+            remaining = budget[0]
             separator = 0 if not result else 1
             if not consume_json_budget(budget, separator):
                 break
-            result.append(bounded_json_value(item, budget, depth=depth + 1))
+            bounded_item = bounded_json_value(item, budget, depth=depth + 1)
+            size = len(json.dumps(bounded_item, separators=(",", ":")).encode("utf-8"))
+            if separator + size > remaining or (
+                isinstance(item, str) and item and bounded_item == ""
+            ):
+                budget[0] = remaining
+                break
+            budget[0] = remaining - separator - size
+            result.append(bounded_item)
         return result
     if isinstance(value, dict):
         if not consume_json_budget(budget, 2):

--- a/sdk/typescript/tests-ts/plugin-report-limits.test.ts
+++ b/sdk/typescript/tests-ts/plugin-report-limits.test.ts
@@ -51,8 +51,8 @@ describe("bundled scan report and source limits", () => {
       "large = {'preventiveControls': ['x' * 900 for _ in range(20)], 'remediationTests': ['Verify authorization.'], 'writeup': {'reportPath': 'findings/example/example.md'}, 'provenance': {'source': 'scan'}, 'severity': {'level': 'high', 'rationale': 'Verified impact'}, 'status': 'open', 'taxonomy': {'category': 'injection', 'cwe': ['CWE-79']}}",
       "code_evidence = [{'id': f'evidence-{index}', 'label': 'example', 'path': 'example.py', 'startLine': 1, 'code': 'c' * 1500, 'explanation': 'e' * 1500} for index in range(4)]",
       "rich = {'rootCause': {'summary': 'r' * 2000}, 'validation': {'summary': 'v' * 3000}, 'attackPath': {'narrative': 'a' * 4000}, 'codeEvidence': code_evidence, 'evidenceExcerpt': 'e' * 8000, 'identity': {'anchor': 'finding'}, 'preventiveControls': ['Centralize authorization.'], 'remediationTests': ['Verify authorization.']}",
-      "boundary = {'remediationTests': ['x'] * 4000}",
-      "unicode_boundary = {'preventiveControls': ['😀'] * 2000}",
+      "boundary = {'remediationTests': ['x'] * 4000, 'preventiveControls': ['Keep authorization centralized.']}",
+      "unicode_boundary = {'remediationTests': ['😀'] * 2000, 'preventiveControls': ['🛡'] * 2000}",
       "projections = {key: bounded_finding_details(value) for key, value in {'details': details, 'large': large, 'rich': rich, 'boundary': boundary, 'unicodeBoundary': unicode_boundary}.items()}",
       "print(json.dumps({'projections': projections, 'bytes': {key: len(json.dumps(value, separators=(',', ':')).encode()) for key, value in projections.items()}}))",
     ].join("\n");
@@ -69,8 +69,11 @@ describe("bundled scan report and source limits", () => {
         details: Record<string, unknown>;
         large: Record<string, unknown>;
         rich: Record<string, unknown>;
-        boundary: { remediationTests: string[] };
-        unicodeBoundary: { preventiveControls: string[] };
+        boundary: { remediationTests: string[]; preventiveControls: string[] };
+        unicodeBoundary: {
+          remediationTests: string[];
+          preventiveControls: string[];
+        };
       };
       bytes: Record<string, number>;
     };
@@ -100,11 +103,20 @@ describe("bundled scan report and source limits", () => {
     expect(
       projections.boundary.remediationTests.every((value) => value !== ""),
     ).toBe(true);
+    expect(projections.boundary.preventiveControls).toEqual([
+      "Keep authorization centralized.",
+    ]);
+    expect(projections.unicodeBoundary.remediationTests.length).toBeGreaterThan(
+      0,
+    );
     expect(
       projections.unicodeBoundary.preventiveControls.every(
-        (value) => value === "😀",
+        (value) => value === "🛡",
       ),
     ).toBe(true);
+    expect(
+      projections.unicodeBoundary.preventiveControls.length,
+    ).toBeGreaterThan(0);
     expect(Object.values(bytes).every((value) => value <= 16_000)).toBe(true);
   });
 });

--- a/sdk/typescript/tests-ts/plugin-report-limits.test.ts
+++ b/sdk/typescript/tests-ts/plugin-report-limits.test.ts
@@ -53,7 +53,8 @@ describe("bundled scan report and source limits", () => {
       "rich = {'rootCause': {'summary': 'r' * 2000}, 'validation': {'summary': 'v' * 3000}, 'attackPath': {'narrative': 'a' * 4000}, 'codeEvidence': code_evidence, 'evidenceExcerpt': 'e' * 8000, 'identity': {'anchor': 'finding'}, 'preventiveControls': ['Centralize authorization.'], 'remediationTests': ['Verify authorization.']}",
       "boundary = {'remediationTests': ['x'] * 4000, 'preventiveControls': ['Keep authorization centralized.']}",
       "unicode_boundary = {'remediationTests': ['😀'] * 2000, 'preventiveControls': ['🛡'] * 2000}",
-      "projections = {key: bounded_finding_details(value) for key, value in {'details': details, 'large': large, 'rich': rich, 'boundary': boundary, 'unicodeBoundary': unicode_boundary}.items()}",
+      "nested_boundary = {'remediationTests': ['x'] * 3937, 'rootCause': {'summary': 'r' * 178, 'detail': {'x': {'y': 'z'}}}}",
+      "projections = {key: bounded_finding_details(value) for key, value in {'details': details, 'large': large, 'rich': rich, 'boundary': boundary, 'unicodeBoundary': unicode_boundary, 'nestedBoundary': nested_boundary}.items()}",
       "print(json.dumps({'projections': projections, 'bytes': {key: len(json.dumps(value, separators=(',', ':')).encode()) for key, value in projections.items()}}))",
     ].join("\n");
     const result = Bun.spawnSync(
@@ -73,6 +74,10 @@ describe("bundled scan report and source limits", () => {
         unicodeBoundary: {
           remediationTests: string[];
           preventiveControls: string[];
+        };
+        nestedBoundary: {
+          remediationTests: string[];
+          rootCause: { summary: string };
         };
       };
       bytes: Record<string, number>;
@@ -117,6 +122,7 @@ describe("bundled scan report and source limits", () => {
     expect(
       projections.unicodeBoundary.preventiveControls.length,
     ).toBeGreaterThan(0);
+    expect(projections.nestedBoundary.rootCause.summary).toContain("r");
     expect(Object.values(bytes).every((value) => value <= 16_000)).toBe(true);
   });
 });

--- a/sdk/typescript/tests-ts/plugin-report-limits.test.ts
+++ b/sdk/typescript/tests-ts/plugin-report-limits.test.ts
@@ -47,14 +47,19 @@ describe("bundled scan report and source limits", () => {
       "import json, sys",
       "sys.path.insert(0, sys.argv[1])",
       "from finding_preview import bounded_finding_details",
+      "diagnostics = {'rootCause': {'summary': 'Missing authorization check.'}, 'validation': {'summary': 'An untrusted request reaches the protected resource.'}, 'attackPath': {'narrative': 'The request bypasses the authorization boundary.'}, 'codeEvidence': [{'id': 'evidence', 'label': 'Missing check', 'path': 'example.py', 'startLine': 1, 'code': 'return resource', 'explanation': 'No authorization check runs.'}], 'evidence': 'The protected resource was exposed.', 'evidenceExcerpt': 'return resource'}",
       "details = {'remediationTests': [f'test-{index}' for index in range(40)], 'preventiveControls': [f'control-{index}' for index in range(40)]}",
-      "large = {'preventiveControls': ['x' * 900 for _ in range(20)], 'remediationTests': ['Verify authorization.'], 'writeup': {'reportPath': 'findings/example/example.md'}, 'provenance': {'source': 'scan'}, 'severity': {'level': 'high', 'rationale': 'Verified impact'}, 'status': 'open', 'taxonomy': {'category': 'injection', 'cwe': ['CWE-79']}}",
+      "large = {**diagnostics, 'preventiveControls': ['x' * 900 for _ in range(20)], 'remediationTests': ['Verify authorization.'], 'writeup': {'reportPath': 'findings/example/example.md'}, 'provenance': {'source': 'scan'}, 'severity': {'level': 'high', 'rationale': 'Verified impact'}, 'status': 'open', 'taxonomy': {'category': 'injection', 'cwe': ['CWE-79']}}",
       "code_evidence = [{'id': f'evidence-{index}', 'label': 'example', 'path': 'example.py', 'startLine': 1, 'code': 'c' * 1500, 'explanation': 'e' * 1500} for index in range(4)]",
       "rich = {'rootCause': {'summary': 'r' * 2000}, 'validation': {'summary': 'v' * 3000}, 'attackPath': {'narrative': 'a' * 4000}, 'codeEvidence': code_evidence, 'evidenceExcerpt': 'e' * 8000, 'identity': {'anchor': 'finding'}, 'preventiveControls': ['Centralize authorization.'], 'remediationTests': ['Verify authorization.']}",
-      "boundary = {'remediationTests': ['x'] * 4000, 'preventiveControls': ['Keep authorization centralized.']}",
-      "unicode_boundary = {'remediationTests': ['😀'] * 2000, 'preventiveControls': ['🛡'] * 2000}",
+      "boundary = {**diagnostics, 'remediationTests': ['x'] * 4000, 'preventiveControls': ['Keep authorization centralized.']}",
+      "unicode_boundary = {**diagnostics, 'remediationTests': ['😀'] * 2000, 'preventiveControls': ['🛡'] * 2000}",
+      "empty_controls = {**diagnostics, 'remediationTests': ['x'] * 4000, 'preventiveControls': []}",
+      "empty_tests = {**diagnostics, 'remediationTests': [], 'preventiveControls': ['control'] * 4000}",
+      "oversized_metadata = {**diagnostics, 'confidence': {'level': 'high', 'rationale': 'x' * 17000}, 'remediationTests': ['Verify authorization.'], 'preventiveControls': ['Centralize authorization.']}",
+      "oversized_guidance = {'rootCause': {'summary': 'root'}, 'validation': {'summary': 'validation'}, 'attackPath': {'narrative': 'attack'}, 'codeEvidence': [{'id': 'evidence', 'label': 'evidence', 'path': 'example.py', 'startLine': 1, 'code': 'x', 'explanation': 'evidence'}], 'evidence': 'legacy', 'evidenceExcerpt': 'excerpt', 'remediationTests': ['x' * 7800], 'preventiveControls': ['y' * 7930]}",
       "nested_boundary = {'remediationTests': ['x'] * 3937, 'rootCause': {'summary': 'r' * 178, 'detail': {'x': {'y': 'z'}}}}",
-      "projections = {key: bounded_finding_details(value) for key, value in {'details': details, 'large': large, 'rich': rich, 'boundary': boundary, 'unicodeBoundary': unicode_boundary, 'nestedBoundary': nested_boundary}.items()}",
+      "projections = {key: bounded_finding_details(value) for key, value in {'details': details, 'large': large, 'rich': rich, 'boundary': boundary, 'unicodeBoundary': unicode_boundary, 'emptyControls': empty_controls, 'emptyTests': empty_tests, 'oversizedMetadata': oversized_metadata, 'oversizedGuidance': oversized_guidance, 'nestedBoundary': nested_boundary}.items()}",
       "print(json.dumps({'projections': projections, 'bytes': {key: len(json.dumps(value, separators=(',', ':')).encode()) for key, value in projections.items()}}))",
     ].join("\n");
     const result = Bun.spawnSync(
@@ -72,6 +77,22 @@ describe("bundled scan report and source limits", () => {
         rich: Record<string, unknown>;
         boundary: { remediationTests: string[]; preventiveControls: string[] };
         unicodeBoundary: {
+          remediationTests: string[];
+          preventiveControls: string[];
+        };
+        emptyControls: {
+          remediationTests: string[];
+          preventiveControls: string[];
+        };
+        emptyTests: {
+          remediationTests: string[];
+          preventiveControls: string[];
+        };
+        oversizedMetadata: {
+          remediationTests: string[];
+          preventiveControls: string[];
+        };
+        oversizedGuidance: {
           remediationTests: string[];
           preventiveControls: string[];
         };
@@ -105,6 +126,45 @@ describe("bundled scan report and source limits", () => {
       preventiveControls: ["Centralize authorization."],
       remediationTests: ["Verify authorization."],
     });
+    for (const finding of [
+      projections.large,
+      projections.rich,
+      projections.boundary,
+      projections.unicodeBoundary,
+      projections.emptyControls,
+      projections.emptyTests,
+      projections.oversizedMetadata,
+      projections.oversizedGuidance,
+    ]) {
+      expect(finding).toMatchObject({
+        rootCause: { summary: expect.any(String) },
+        validation: { summary: expect.any(String) },
+        attackPath: { narrative: expect.any(String) },
+        codeEvidence: expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(String),
+            path: "example.py",
+          }),
+        ]),
+      });
+    }
+    for (const finding of [
+      projections.large,
+      projections.boundary,
+      projections.unicodeBoundary,
+      projections.emptyControls,
+      projections.emptyTests,
+    ]) {
+      expect(finding).toMatchObject({
+        evidence: "The protected resource was exposed.",
+        evidenceExcerpt: "return resource",
+      });
+    }
+    expect(projections.rich).toHaveProperty("evidenceExcerpt");
+    expect(projections.oversizedGuidance).toMatchObject({
+      evidence: "legacy",
+      evidenceExcerpt: "excerpt",
+    });
     expect(
       projections.boundary.remediationTests.every((value) => value !== ""),
     ).toBe(true);
@@ -122,6 +182,14 @@ describe("bundled scan report and source limits", () => {
     expect(
       projections.unicodeBoundary.preventiveControls.length,
     ).toBeGreaterThan(0);
+    expect(projections.emptyControls.preventiveControls).toEqual([]);
+    expect(projections.emptyControls.remediationTests.length).toBeGreaterThan(
+      20,
+    );
+    expect(projections.emptyTests.remediationTests).toEqual([]);
+    expect(projections.emptyTests.preventiveControls.length).toBeGreaterThan(
+      20,
+    );
     expect(projections.nestedBoundary.rootCause.summary).toContain("r");
     expect(Object.values(bytes).every((value) => value <= 16_000)).toBe(true);
   });

--- a/sdk/typescript/tests-ts/plugin-report-limits.test.ts
+++ b/sdk/typescript/tests-ts/plugin-report-limits.test.ts
@@ -39,4 +39,40 @@ describe("bundled scan report and source limits", () => {
       unsafePathRejected: true,
     });
   });
+
+  test("preserves bounded remediation tests and preventive controls", () => {
+    const python = Bun.which("python3") ?? Bun.which("python");
+    expect(python).not.toBeNull();
+    const program = [
+      "import json, sys",
+      "sys.path.insert(0, sys.argv[1])",
+      "from finding_preview import bounded_finding_details",
+      "details = {'remediationTests': [f'test-{index}' for index in range(21)], 'preventiveControls': ['Centralize authorization.']}",
+      "large = {'preventiveControls': ['x' * 900 for _ in range(20)], 'provenance': {'source': 'scan'}, 'severity': {'level': 'high', 'rationale': 'Verified impact'}, 'status': 'open', 'taxonomy': {'category': 'injection', 'cwe': ['CWE-79']}}",
+      "print(json.dumps({'details': bounded_finding_details(details), 'large': bounded_finding_details(large)}))",
+    ].join("\n");
+    const result = Bun.spawnSync(
+      [python!, "-I", "-B", "-c", program, join(PLUGIN_ROOT, "scripts")],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+
+    expect(result.exitCode, new TextDecoder().decode(result.stderr)).toBe(0);
+    const projections = JSON.parse(new TextDecoder().decode(result.stdout)) as {
+      details: Record<string, unknown>;
+      large: Record<string, unknown>;
+    };
+    expect(projections.details).toEqual({
+      preventiveControls: ["Centralize authorization."],
+      remediationTests: Array.from(
+        { length: 20 },
+        (_, index) => `test-${index}`,
+      ),
+    });
+    expect(projections.large).toMatchObject({
+      provenance: { source: "scan" },
+      severity: { level: "high", rationale: "Verified impact" },
+      status: "open",
+      taxonomy: { category: "injection", cwe: ["CWE-79"] },
+    });
+  });
 });

--- a/sdk/typescript/tests-ts/plugin-report-limits.test.ts
+++ b/sdk/typescript/tests-ts/plugin-report-limits.test.ts
@@ -47,9 +47,14 @@ describe("bundled scan report and source limits", () => {
       "import json, sys",
       "sys.path.insert(0, sys.argv[1])",
       "from finding_preview import bounded_finding_details",
-      "details = {'remediationTests': [f'test-{index}' for index in range(21)], 'preventiveControls': ['Centralize authorization.']}",
-      "large = {'preventiveControls': ['x' * 900 for _ in range(20)], 'provenance': {'source': 'scan'}, 'severity': {'level': 'high', 'rationale': 'Verified impact'}, 'status': 'open', 'taxonomy': {'category': 'injection', 'cwe': ['CWE-79']}}",
-      "print(json.dumps({'details': bounded_finding_details(details), 'large': bounded_finding_details(large)}))",
+      "details = {'remediationTests': [f'test-{index}' for index in range(40)], 'preventiveControls': [f'control-{index}' for index in range(40)]}",
+      "large = {'preventiveControls': ['x' * 900 for _ in range(20)], 'remediationTests': ['Verify authorization.'], 'writeup': {'reportPath': 'findings/example/example.md'}, 'provenance': {'source': 'scan'}, 'severity': {'level': 'high', 'rationale': 'Verified impact'}, 'status': 'open', 'taxonomy': {'category': 'injection', 'cwe': ['CWE-79']}}",
+      "code_evidence = [{'id': f'evidence-{index}', 'label': 'example', 'path': 'example.py', 'startLine': 1, 'code': 'c' * 1500, 'explanation': 'e' * 1500} for index in range(4)]",
+      "rich = {'rootCause': {'summary': 'r' * 2000}, 'validation': {'summary': 'v' * 3000}, 'attackPath': {'narrative': 'a' * 4000}, 'codeEvidence': code_evidence, 'evidenceExcerpt': 'e' * 8000, 'identity': {'anchor': 'finding'}, 'preventiveControls': ['Centralize authorization.'], 'remediationTests': ['Verify authorization.']}",
+      "boundary = {'remediationTests': ['x'] * 4000}",
+      "unicode_boundary = {'preventiveControls': ['😀'] * 2000}",
+      "projections = {key: bounded_finding_details(value) for key, value in {'details': details, 'large': large, 'rich': rich, 'boundary': boundary, 'unicodeBoundary': unicode_boundary}.items()}",
+      "print(json.dumps({'projections': projections, 'bytes': {key: len(json.dumps(value, separators=(',', ':')).encode()) for key, value in projections.items()}}))",
     ].join("\n");
     const result = Bun.spawnSync(
       [python!, "-I", "-B", "-c", program, join(PLUGIN_ROOT, "scripts")],
@@ -57,22 +62,49 @@ describe("bundled scan report and source limits", () => {
     );
 
     expect(result.exitCode, new TextDecoder().decode(result.stderr)).toBe(0);
-    const projections = JSON.parse(new TextDecoder().decode(result.stdout)) as {
-      details: Record<string, unknown>;
-      large: Record<string, unknown>;
+    const { projections, bytes } = JSON.parse(
+      new TextDecoder().decode(result.stdout),
+    ) as {
+      projections: {
+        details: Record<string, unknown>;
+        large: Record<string, unknown>;
+        rich: Record<string, unknown>;
+        boundary: { remediationTests: string[] };
+        unicodeBoundary: { preventiveControls: string[] };
+      };
+      bytes: Record<string, number>;
     };
     expect(projections.details).toEqual({
-      preventiveControls: ["Centralize authorization."],
+      preventiveControls: Array.from(
+        { length: 40 },
+        (_, index) => `control-${index}`,
+      ),
       remediationTests: Array.from(
-        { length: 20 },
+        { length: 40 },
         (_, index) => `test-${index}`,
       ),
     });
     expect(projections.large).toMatchObject({
+      writeup: { reportPath: "findings/example/example.md" },
       provenance: { source: "scan" },
+      remediationTests: ["Verify authorization."],
       severity: { level: "high", rationale: "Verified impact" },
       status: "open",
       taxonomy: { category: "injection", cwe: ["CWE-79"] },
     });
+    expect(projections.rich).toMatchObject({
+      identity: { anchor: "finding" },
+      preventiveControls: ["Centralize authorization."],
+      remediationTests: ["Verify authorization."],
+    });
+    expect(
+      projections.boundary.remediationTests.every((value) => value !== ""),
+    ).toBe(true);
+    expect(
+      projections.unicodeBoundary.preventiveControls.every(
+        (value) => value === "😀",
+      ),
+    ).toBe(true);
+    expect(Object.values(bytes).every((value) => value <= 16_000)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Keep schema-supported remediation tests and preventive controls in saved finding previews.

## Changes

- Include both remediation-guidance fields in the existing bounded preview projection.
- Verify that the existing per-list size limit still applies and oversized guidance cannot evict existing finding metadata.

## Testing

- `bun test --timeout 30000 tests-ts/plugin-report-limits.test.ts` — 2 passed.
- `bun test tests-ts/plugin-report-limits.test.ts tests-ts/contract.test.ts tests-ts/scan-recovery.test.ts` — 59 passed.
- `pnpm run types` — passed.
- `pnpm run format` — passed.
- `git diff --check` — passed.

## Risk and rollout

Low risk. Only existing schema-defined fields are restored; existing metadata priority, the overall preview budget, the nesting limit, and the 20-item list limit remain unchanged.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
