### PR TITLE
fix(sdk): cancel recursive knowledge-base discovery

### DIFF
--- a/sdk/typescript/src/knowledge-base.ts
+++ b/sdk/typescript/src/knowledge-base.ts
@@ -50,7 +50,9 @@ export async function prepareKnowledgeBase(
     }
 
     const source = await realpath(path);
-    const selected = metadata.isDirectory() ? await discover(source) : [source];
+    const selected = metadata.isDirectory()
+      ? await discover(source, signal)
+      : [source];
     if (selected.length === 0) {
       throw new Error(
         `Knowledge base directory contains no supported documents: ${path}`,
@@ -112,14 +114,22 @@ export async function prepareKnowledgeBase(
   };
 }
 
-async function discover(directory: string): Promise<string[]> {
+async function discover(
+  directory: string,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  signal?.throwIfAborted();
   const documents: string[] = [];
   const entries = await readdir(directory, { withFileTypes: true });
+  signal?.throwIfAborted();
   for (const entry of entries) {
+    signal?.throwIfAborted();
     const path = join(directory, entry.name);
     if (entry.isSymbolicLink()) continue;
     if (entry.isDirectory()) {
-      documents.push(...(await discover(path)));
+      for (const document of await discover(path, signal)) {
+        documents.push(document);
+      }
     } else if (
       entry.isFile() &&
       SUPPORTED_EXTENSIONS.has(extname(path).toLowerCase())

--- a/sdk/typescript/tests-ts/knowledge-base.test.ts
+++ b/sdk/typescript/tests-ts/knowledge-base.test.ts
@@ -10,6 +10,7 @@ import {
   symlink,
   writeFile,
 } from "node:fs/promises";
+import * as filesystem from "node:fs/promises";
 import * as os from "node:os";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -104,6 +105,93 @@ describe("scan knowledge bases", () => {
           0o600,
         );
       }
+    }
+  });
+
+  test("cancels recursive discovery before staging knowledge-base documents", async () => {
+    const root = await temporaryDirectory();
+    const nested = join(root, "nested", "deeper");
+    await mkdir(nested, { recursive: true });
+    await writeFile(join(nested, "scope.md"), "Review application boundaries.");
+
+    const controller = new AbortController();
+    const reason = new Error("Knowledge-base discovery canceled.");
+    let checks = 0;
+    const signalSpy = spyOn(controller.signal, "throwIfAborted");
+    signalSpy.mockImplementation(() => {
+      if (++checks === 8) controller.abort(reason);
+      if (controller.signal.aborted) throw controller.signal.reason;
+    });
+    const temporarySpy = spyOn(os, "tmpdir");
+
+    try {
+      const prepared = prepareKnowledgeBase([root], controller.signal).then(
+        (knowledgeBase) => {
+          temporaryDirectories.push(knowledgeBase.path);
+          return knowledgeBase;
+        },
+      );
+      await expect(prepared).rejects.toBe(reason);
+      expect(temporarySpy).not.toHaveBeenCalled();
+    } finally {
+      signalSpy.mockRestore();
+      temporarySpy.mockRestore();
+    }
+  });
+
+  test("handles large nested document listings without argument overflow", async () => {
+    const root = await temporaryDirectory();
+    const nested = join(root, "nested");
+    await mkdir(nested);
+    await writeFile(join(nested, "scope.md"), "Review application boundaries.");
+    const originalReaddir = filesystem.readdir;
+    const listingSpy = spyOn(filesystem, "readdir").mockImplementation(
+      async (...args) => {
+        const entries = await Reflect.apply(originalReaddir, filesystem, args);
+        return args[0] === nested ? Array(700_000).fill(entries[0]) : entries;
+      },
+    );
+
+    let knowledgeBase;
+    try {
+      knowledgeBase = await prepareKnowledgeBase([root]);
+      temporaryDirectories.push(knowledgeBase.path);
+    } finally {
+      listingSpy.mockRestore();
+    }
+
+    expect(await extractedDocuments(knowledgeBase.path)).toEqual([
+      "Review application boundaries.",
+    ]);
+  });
+
+  test("removes staged documents when knowledge-base preparation is canceled", async () => {
+    const root = await temporaryDirectory();
+    const staging = join(root, "staging");
+    await mkdir(staging);
+    const first = join(root, "first.md");
+    const second = join(root, "second.md");
+    await writeFile(first, "First document.");
+    await writeFile(second, "Second document.");
+
+    const controller = new AbortController();
+    const reason = new Error("Knowledge-base preparation canceled.");
+    let checks = 0;
+    const signalSpy = spyOn(controller.signal, "throwIfAborted");
+    signalSpy.mockImplementation(() => {
+      if (++checks === 4) controller.abort(reason);
+      if (controller.signal.aborted) throw controller.signal.reason;
+    });
+    const temporarySpy = spyOn(os, "tmpdir").mockImplementation(() => staging);
+
+    try {
+      await expect(
+        prepareKnowledgeBase([first, second], controller.signal),
+      ).rejects.toBe(reason);
+      expect(await readdir(staging)).toEqual([]);
+    } finally {
+      signalSpy.mockRestore();
+      temporarySpy.mockRestore();
     }
   });
 


### PR DESCRIPTION
## Summary

Honor scan cancellation while discovering knowledge-base documents and remove an accidental JavaScript argument-count limit on large nested directories.

## Changes

- Pass the existing abort signal through recursive document discovery.
- Append discovered documents individually instead of spreading an unbounded list into one call.
- Cover recursive cancellation, cleanup after cancellation, and a 700,000-entry nested listing.

## Testing

- `bun test --timeout 30000 tests-ts/knowledge-base.test.ts` — 11 passed.
- Randomized focused suite with three reruns — 33 passed.
- `pnpm run types` — passed.
- `pnpm run format` — passed.
- `git diff --check` — passed.

## Risk and rollout

Low risk. Existing symlink rejection, safe file opening, private staging permissions, document parsing, cleanup, and supported Windows paths remain unchanged.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
