### PR TITLE
release: bump Codex Security to 0.1.12

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-security",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "TypeScript SDK and CLI for Codex Security",
   "license": "Apache-2.0",
   "author": "OpenAI",


### PR DESCRIPTION
## Summary

- Prepare the `@openai/codex-security` patch release `0.1.12`.
- Include the 39 changes merged since `npm-v0.1.11`, including scan reliability, cancellation, worker logs, path handling, and bulk-scan discovery improvements.

## Changes

- Bump the TypeScript SDK and CLI package version from `0.1.11` to `0.1.12`.
- Limit the release change to the existing package-version field.

## Testing

- `node scripts/release-automation.mjs version package.json` returned `0.1.12`.
- `node scripts/release-automation.mjs release-tag tag refs/tags/npm-v0.1.12 npm-v0.1.12 package.json` returned `0.1.12`.
- `node scripts/release-automation.mjs require-increase 0.1.12 0.1.11` returned `0.1.12`.
- Direct Node.js assertions verified release-tag matching, version monotonicity, previous-release comparison, valid JSON, and canonical package-manifest formatting.
- `git diff --check` passed, and the release diff contains one added line and one removed line in `sdk/typescript/package.json`.
- Full Bun, type, and formatting suites were not run locally because this checkout has no Bun executable or installed dependencies; the normal pull-request checks cover them.

## Risk and rollout

- Version-only patch release with no additional runtime or dependency changes.
- After merge, a successful `node-ci` run on `main` triggers `node-release-cut`, which creates `npm-v0.1.12` on the exact merged commit and dispatches the protected `node-release` workflow.
- Publication remains subject to the protected npm deployment gate.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
