### PR TITLE
feat(cli): support maximum reasoning effort

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -322,7 +322,7 @@ mode.
 
 Scans use `gpt-5.6-sol` with extra-high reasoning effort by default. OpenAI is
 the implied provider. Use `--model gpt-5.6-terra` to switch models and
-`--effort minimal|low|medium|high|xhigh` to set reasoning effort. Repeat
+`--effort minimal|low|medium|high|xhigh|max` to set reasoning effort. Repeat
 `--codex KEY=VALUE` for other Codex settings; existing
 `--codex 'model_reasoning_effort="high"'` overrides remain supported.
 

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -26,7 +26,6 @@ import { createInterface } from "node:readline";
 import { Readable, Writable as NodeWritable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import type { ModelReasoningEffort } from "@openai/codex-sdk";
 import { Cli, z } from "incur";
 import { parse as parseToml } from "smol-toml";
 import {
@@ -153,7 +152,9 @@ const MODEL_REASONING_EFFORTS = [
   "medium",
   "high",
   "xhigh",
-] as const satisfies readonly ModelReasoningEffort[];
+  "max",
+] as const;
+type ScanReasoningEffort = (typeof MODEL_REASONING_EFFORTS)[number];
 const DEFAULT_SCAN_MODEL_CONFIGURATION =
   scanModelConfiguration(DEFAULT_CODEX_CONFIG);
 const CODEX_OVERRIDE_DESCRIPTION =
@@ -214,7 +215,7 @@ function optionValue(flag: string) {
 function effortOption() {
   return z
     .enum(MODEL_REASONING_EFFORTS, {
-      error: "--effort must be minimal, low, medium, high, or xhigh.",
+      error: "--effort must be minimal, low, medium, high, xhigh, or max.",
     })
     .optional()
     .describe(
@@ -288,7 +289,7 @@ interface ScanArguments extends DeepScanOptions {
   base?: string;
   mode: ScanMode;
   model?: string;
-  effort?: ModelReasoningEffort;
+  effort?: ScanReasoningEffort;
   provider?: "openai" | "amazon-bedrock" | ExternalModelProvider;
   outputDir?: string;
   archiveExisting: boolean;
@@ -2348,7 +2349,7 @@ async function runSkill(
   skill: "validation" | "fix-finding",
   inputs: readonly string[],
   codexOverrides: readonly string[],
-  effort: ModelReasoningEffort | undefined,
+  effort: ScanReasoningEffort | undefined,
   stdout: Writable,
   stderr: Writable,
   dependencies: CliDependencies,
@@ -3660,7 +3661,7 @@ function targetFromArguments(arguments_: ScanArguments): ScanTarget {
 export function parseCodexOverrides(
   values: readonly string[],
   model?: string,
-  effort?: ModelReasoningEffort,
+  effort?: ScanReasoningEffort,
   provider?: "openai" | "amazon-bedrock" | ExternalModelProvider,
 ): JsonObject {
   const result = Object.create(null) as JsonObject;

--- a/sdk/typescript/tests-ts/cli-skills.test.ts
+++ b/sdk/typescript/tests-ts/cli-skills.test.ts
@@ -95,7 +95,7 @@ describe("CLI skill commands", () => {
           `Usage: codex-security ${command} <${argument}>`,
         );
         expect(help.text()).toContain(
-          "--effort <minimal|low|medium|high|xhigh>",
+          "--effort <minimal|low|medium|high|xhigh|max>",
         );
         expect(help.text()).toContain("--codex <array>");
         expect(help.text()).toContain('model="gpt-5.6-terra"');
@@ -299,7 +299,7 @@ describe("CLI skill commands", () => {
             command,
             "a candidate finding",
             "--effort",
-            "high",
+            "max",
             "--codex",
             'model="gpt-5.6-terra"',
           ],
@@ -314,13 +314,13 @@ describe("CLI skill commands", () => {
         ),
       ).toBe(0);
       expect(invocation).toContain('model="gpt-5.6-terra"');
-      expect(invocation).toContain('model_reasoning_effort="high"');
+      expect(invocation).toContain('model_reasoning_effort="max"');
       expect(stderr.text()).toBe("");
 
       for (const [options, message] of [
         [
           ["--effort", "ultra"],
-          "--effort must be minimal, low, medium, high, or xhigh",
+          "--effort must be minimal, low, medium, high, xhigh, or max",
         ],
         [
           ["--effort", "high", "--codex", 'model_reasoning_effort="medium"'],

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -120,7 +120,9 @@ describe("CLI", () => {
           maxTimeHours: { type: "number", maximum: 96 },
           model: { type: "string" },
           verbose: { type: "boolean" },
-          effort: { enum: ["minimal", "low", "medium", "high", "xhigh"] },
+          effort: {
+            enum: ["minimal", "low", "medium", "high", "xhigh", "max"],
+          },
           provider: {
             enum: ["openai", "openrouter", "fireworks", "amazon-bedrock"],
           },
@@ -902,6 +904,7 @@ describe("CLI", () => {
       ["bulk-scan", "--model=gpt-5.6-terra"],
       ["bulk-scan", "--effort", "high"],
       ["bulk-scan", "--effort=high"],
+      ["bulk-scan", "--effort", "max"],
       ["bulk-scan", "--codex", 'model_reasoning_effort="high"'],
       ["bulk-scan", '--codex=model_reasoning_effort="high"'],
       ["bulk-scan", "--model", "gpt-5.6-terra", "--effort", "high"],
@@ -2094,7 +2097,9 @@ describe("CLI", () => {
     expect(help.text()).toContain(
       `OpenAI model to use (default: ${DEFAULT_SCAN_MODEL_CONFIGURATION.model}).`,
     );
-    expect(help.text()).toContain("--effort <minimal|low|medium|high|xhigh>");
+    expect(help.text()).toContain(
+      "--effort <minimal|low|medium|high|xhigh|max>",
+    );
     expect(help.text()).toContain(
       `Model reasoning effort (default: ${DEFAULT_SCAN_MODEL_CONFIGURATION.reasoningEffort}).`,
     );
@@ -2130,7 +2135,9 @@ describe("CLI", () => {
     expect(help.text()).toContain(
       `OpenAI model for each repository (default: ${DEFAULT_SCAN_MODEL_CONFIGURATION.model}).`,
     );
-    expect(help.text()).toContain("--effort <minimal|low|medium|high|xhigh>");
+    expect(help.text()).toContain(
+      "--effort <minimal|low|medium|high|xhigh|max>",
+    );
     expect(help.text()).toContain(
       `Model reasoning effort (default: ${DEFAULT_SCAN_MODEL_CONFIGURATION.reasoningEffort}).`,
     );
@@ -2168,6 +2175,7 @@ describe("CLI", () => {
       [["--model=gpt-5.6-sol"], { model: "gpt-5.6-sol" }],
       [["--effort", "minimal"], { model_reasoning_effort: "minimal" }],
       [["--effort=xhigh"], { model_reasoning_effort: "xhigh" }],
+      [["--effort", "max"], { model_reasoning_effort: "max" }],
       [
         ["--model", "gpt-5.6-terra", "--effort", "high"],
         { model: "gpt-5.6-terra", model_reasoning_effort: "high" },
@@ -2505,7 +2513,7 @@ describe("CLI", () => {
       ],
       [
         ["scan", ".", "--effort", "ultra"],
-        "--effort must be minimal, low, medium, high, or xhigh",
+        "--effort must be minimal, low, medium, high, xhigh, or max",
       ],
       [["scan", ".", "--mode", "bogus"], "Invalid option"],
       [["scan", ".", "--unknown"], "Unknown flag: --unknown"],


### PR DESCRIPTION
## Summary

Accept the maximum reasoning-effort option across the CLI without depending on an older SDK effort type.

## Changes

- Add `max` to scan, bulk-scan, validation, and patch reasoning options.
- Keep the existing default model and reasoning effort unchanged.
- Update CLI schemas, help output, documentation, and regression tests.

## Testing

- `bun test --timeout 30000 ./tests-ts` — 1,114 passed, 11 skipped, 0 failed.
- `pnpm run types`
- `pnpm run format`
- `pnpm run build`
- `node sdk/typescript/bin/codex-security.mjs scan . --model gpt-5.6-sol --effort max --dry-run --format json`

## Risk and rollout

Existing defaults and invalid-effort handling remain unchanged. Models that do not support a selected effort continue to enforce their own capabilities.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
