### PR TITLE
chore: ignore internal-only directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ dist/
 /codex-security.json
 /findings.json
 /*.sarif
+
+# Never publish internal-only plugin data.
+.internal/


### PR DESCRIPTION
## Summary

Prevent internal-only plugin data from being accidentally picked up as untracked content in this public repository.

## Changes

- Add `.internal/` to the root `.gitignore`, which ignores directories with that name at any depth.
- Document why the ignore rule exists.

## Testing

- `git check-ignore --no-index -v sdk/typescript/_bundled_plugin/.internal/example.json` (passed)
- `git diff --check origin/main...dev/kyleb/ignore-internal-directories` (passed)

## Risk and rollout

Low risk. This affects only untracked files; already tracked files are unchanged. The ignore rule is defense in depth and does not replace public-disclosure review.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.