### PR TITLE
fix(cli): hide unavailable Deep scan stage and file progress

### DIFF
--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -2908,6 +2908,7 @@ async function executeScan(
     if (progress.interactive && !arguments_.dryRun && !verbose) {
       dashboard = new ScanDashboard(errorOutput, {
         repository,
+        mode: arguments_.mode,
         model: scanModelConfiguration(await mergedCodexConfig(config)),
         ...(arguments_.maxCostUsd === undefined
           ? {}

--- a/sdk/typescript/src/scan-dashboard.ts
+++ b/sdk/typescript/src/scan-dashboard.ts
@@ -4,6 +4,7 @@ import { stripVTControlCharacters } from "node:util";
 import type { ScanModelConfiguration } from "./config.js";
 import { formatUsd, type ScanCost } from "./cost.js";
 import type { ScanActivity } from "./scan-activity.js";
+import type { ScanMode } from "./targets.js";
 import type { ScanProgress } from "./worker-progress.js";
 
 const HIDE_CURSOR = "\u001B[?25l";
@@ -43,6 +44,7 @@ interface DashboardInput {
 
 interface ScanDashboardOptions {
   repository: string;
+  mode?: ScanMode;
   model?: ScanModelConfiguration;
   maxCostUsd?: number;
   clock: DashboardClock;
@@ -342,8 +344,9 @@ export class ScanDashboard {
       divider,
       ...activity,
       divider,
-      `  STAGE    ${this.#stage}`,
-      `  FILES    ${files}`,
+      ...(this.#options.mode === "deep"
+        ? []
+        : [`  STAGE    ${this.#stage}`, `  FILES    ${files}`]),
       `  TOKENS   ${tokens}`,
       `  COST     ${cost}`,
       `  TIME     ${time}  ·  ${scrollStatus}`,
@@ -390,7 +393,12 @@ export class ScanDashboard {
   }
 
   #activityRows(): number {
-    return Math.max(1, (this.#stream.rows ?? 24) - FIXED_SCREEN_ROWS);
+    return Math.max(
+      1,
+      (this.#stream.rows ?? 24) -
+        FIXED_SCREEN_ROWS +
+        (this.#options.mode === "deep" ? 2 : 0),
+    );
   }
 
   #activityLines(width: number): DashboardActivityLine[] {

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -1976,6 +1976,51 @@ describe("CLI", () => {
     expect(text).not.toContain("Estimated cost: $0.0248865 of $2.00 limit");
   });
 
+  test("omits stage and file counts from interactive Deep scan dashboards", async () => {
+    const stdout = capture();
+    const stderr = capture(true);
+    const result = fakeResult([], "complete", {
+      input_tokens: 1_250,
+      cached_input_tokens: 200,
+      output_tokens: 30,
+    });
+
+    expect(
+      await main(
+        ["scan", "/code/juice-shop", "--mode", "deep"],
+        stdout.stream,
+        stderr.stream,
+        dependencies({
+          environment: { NO_COLOR: "1" },
+          result,
+          activities: [
+            {
+              id: "worker-1:read-1",
+              kind: "command",
+              status: "completed",
+              description: "read routes/login.ts",
+              paths: ["routes/login.ts"],
+              worker: 1,
+            },
+          ],
+          costUpdates: [result.cost!],
+          scanProgress: [
+            { phase: "preflight", filesCompleted: 0, filesTotal: 1_258 },
+          ],
+        }),
+      ),
+    ).toBe(0);
+
+    const text = stripVTControlCharacters(stderr.text());
+    expect(text).not.toContain("STAGE");
+    expect(text).not.toContain("FILES");
+    expect(text).not.toContain("0 / 1,258 reviewed");
+    expect(text).toContain("worker 1 · read routes/login.ts");
+    expect(text).toContain("TOKENS");
+    expect(text).toContain("COST");
+    expect(text).toContain("TIME");
+  });
+
   test("rejects structured modes before starting interactive Codex commands", async () => {
     for (const [command, arguments_] of [
       ["validate", ["finding"]],

--- a/sdk/typescript/tests-ts/scan-dashboard.test.ts
+++ b/sdk/typescript/tests-ts/scan-dashboard.test.ts
@@ -243,6 +243,8 @@ describe("live scan dashboard", () => {
     expect(text).not.toContain("ACTIVITY");
     expect(text).not.toContain("events · live");
     expect(text).not.toContain("WORKERS");
+    expect(text).toContain("STAGE");
+    expect(text).toContain("FILES");
     expect(text).toContain(
       '[09:41:19] ◐ nl -ba "$CODEX_SECURITY_REPOSITORY/routes/login.ts"',
     );
@@ -260,6 +262,56 @@ describe("live scan dashboard", () => {
     expect(stderr.text()).toContain("\u001B[?25l");
     expect(stderr.text()).toContain("\u001B[?25h");
     expect(timers).toEqual([]);
+  });
+
+  test("hides stage and file counts during Deep scans without wasting screen rows", () => {
+    const stderr = capture(true);
+    const dashboard = new ScanDashboard(
+      { ...stderr.stream, columns: 80, rows: 12 },
+      {
+        repository: "/code/juice-shop",
+        mode: "deep",
+        clock: fakeClock(),
+      },
+    );
+
+    dashboard.start();
+    dashboard.setStage("inspecting repository files");
+    dashboard.setFiles({
+      phase: "preflight",
+      filesCompleted: 0,
+      filesTotal: 1_258,
+    });
+    for (let index = 1; index <= 6; index += 1) {
+      dashboard.record({
+        id: `worker-1:read-${index}`,
+        kind: "command",
+        status: "completed",
+        description: `Reviewed source file ${index}`,
+        paths: [],
+        worker: 1,
+      });
+    }
+    dashboard.setCost(
+      fakeResult([], "complete", {
+        input_tokens: 1_250,
+        cached_input_tokens: 200,
+        output_tokens: 30,
+      }).cost!,
+    );
+
+    const frame = lastFrame(stderr);
+    dashboard.stop();
+
+    expect(frame).not.toContain("STAGE");
+    expect(frame).not.toContain("FILES");
+    expect(frame).not.toContain("inspecting repository files");
+    expect(frame).not.toContain("0 / 1,258 reviewed");
+    expect(frame).toContain("worker 1 · Reviewed source file 1");
+    expect(frame).toContain("worker 1 · Reviewed source file 6");
+    expect(frame).toContain("TOKENS");
+    expect(frame).toContain("COST");
+    expect(frame).toContain("TIME");
   });
 
   test("updates the same activity when a command completes", () => {


### PR DESCRIPTION
## Summary

Deep scans can display misleading static stage and reviewed-file indicators while independent scan workers are actively reviewing the repository.

## Changes

- Hide the Stage and Files dashboard rows only for Deep scans.
- Preserve reviewed-file and stage indicators for Standard scans.
- Keep Deep-scan activity, token usage, cost, elapsed time, and terminal scrolling visible and accurate.
- Add focused dashboard and CLI regression tests for both scan modes.

## Testing

- Focused dashboard and CLI suites: 160 tests passed with zero failures.
- TypeScript type checking completed successfully.
- Formatting checks and `git diff --check` passed.

## Risk and rollout

This is a presentation-only change. Scan execution, workers, artifacts, billing, configuration, and package versions remain unchanged. Existing running CLI processes must be restarted before they can display the updated dashboard.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
