### PR TITLE
fix(scripts): accept CRLF tar listings in check-package

### DIFF
--- a/sdk/typescript/scripts/check-package.mjs
+++ b/sdk/typescript/scripts/check-package.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { brotliDecompressSync, gunzipSync } from "node:zlib";
 import { assertExpectedGitHead } from "./package-provenance.mjs";
 import { packageSmokeTimeouts } from "./package-smoke-timeouts.mjs";
+import { hasOnlyRegularEntries, tarListingLines } from "./tar-listing.mjs";
 
 const PACKAGE_SMOKE_PROCESS_TIMEOUT_MS =
   packageSmokeTimeouts().processTimeoutMs;
@@ -91,7 +92,7 @@ function archiveFile(path) {
   return contents;
 }
 
-const entries = tar(["-tzf", archive], "utf8").split(/\r?\n/u).filter(Boolean);
+const entries = tarListingLines(tar(["-tzf", archive], "utf8"));
 const files = new Set(entries);
 if (files.size !== entries.length) {
   throw new Error("npm tarball contains duplicate paths.");
@@ -209,12 +210,12 @@ for (const file of files) {
 }
 
 const listing = tar(["-tvzf", archive], "utf8");
-if (/^[^d-]/mu.test(listing)) {
+const listingLines = tarListingLines(listing);
+if (!hasOnlyRegularEntries(listingLines)) {
   throw new Error(
     "npm tarball contains a non-regular entry (symbolic or hard link, device, or pipe).",
   );
 }
-const listingLines = listing.split(/\r?\n/u).filter(Boolean);
 if (
   listingLines.length !== entries.length ||
   listingLines.some(

--- a/sdk/typescript/scripts/tar-listing.mjs
+++ b/sdk/typescript/scripts/tar-listing.mjs
@@ -1,0 +1,23 @@
+const REGULAR_ENTRY_TYPES = ["d", "-"];
+
+/**
+ * Split a `tar -tv` verbose listing into entry lines.
+ *
+ * `tar` implementations differ in line endings: some on Windows emit CRLF. The
+ * listing must be normalized before entry types are inspected, because a
+ * multiline `^` also matches between CR and LF, which would test the LF as the
+ * first character of a line.
+ */
+export function tarListingLines(listing) {
+  return listing.split(/\r?\n/u).filter(Boolean);
+}
+
+/**
+ * Whether every listed entry is a directory or a regular file, rather than a
+ * symbolic or hard link, device, or pipe.
+ */
+export function hasOnlyRegularEntries(listingLines) {
+  return listingLines.every((line) =>
+    REGULAR_ENTRY_TYPES.includes(line[0] ?? ""),
+  );
+}

--- a/sdk/typescript/tests-ts/tar-listing.test.ts
+++ b/sdk/typescript/tests-ts/tar-listing.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+
+type TarListing = {
+  tarListingLines: (listing: string) => string[];
+  hasOnlyRegularEntries: (listingLines: string[]) => boolean;
+};
+
+const { tarListingLines, hasOnlyRegularEntries } = (await import(
+  new URL("../scripts/tar-listing.mjs", import.meta.url).href
+)) as TarListing;
+
+const directory = "drwxr-xr-x  0 owner group      0 Jan  1 00:00 package/";
+const regularFile =
+  "-rw-r--r--  0 owner group     26 Jan  1 00:00 package/package.json";
+const launcher =
+  "-rwxr-xr-x  0 owner group    128 Jan  1 00:00 package/bin/cli.mjs";
+const symbolicLink =
+  "lrwxrwxrwx  0 owner group      0 Jan  1 00:00 package/link -> package/package.json";
+
+const listingWith = (lineEnding: string, ...lines: string[]) =>
+  lines.map((line) => `${line}${lineEnding}`).join("");
+
+describe("tar verbose listing parsing", () => {
+  test("splits a listing that ends its lines with LF", () => {
+    expect(tarListingLines(listingWith("\n", directory, regularFile))).toEqual([
+      directory,
+      regularFile,
+    ]);
+  });
+
+  test("splits a listing that ends its lines with CRLF", () => {
+    expect(
+      tarListingLines(listingWith("\r\n", directory, regularFile)),
+    ).toEqual([directory, regularFile]);
+  });
+
+  test("drops the trailing empty line of an unterminated listing", () => {
+    expect(tarListingLines(`${regularFile}\n`)).toEqual([regularFile]);
+    expect(tarListingLines(regularFile)).toEqual([regularFile]);
+    expect(tarListingLines("")).toEqual([]);
+  });
+});
+
+describe("tar entry types", () => {
+  test("accepts directories, regular files, and executables", () => {
+    expect(hasOnlyRegularEntries([directory, regularFile, launcher])).toBe(
+      true,
+    );
+  });
+
+  test("accepts a CRLF listing of only regular entries", () => {
+    // A `tar` that emits CRLF must not be mistaken for a tarball carrying
+    // links, devices, or pipes: a multiline `^` also matches between CR and
+    // LF, which tests the LF as the first character of a line.
+    const listing = listingWith("\r\n", directory, regularFile, launcher);
+
+    expect(hasOnlyRegularEntries(tarListingLines(listing))).toBe(true);
+  });
+
+  test("rejects a symbolic link regardless of the line ending", () => {
+    for (const lineEnding of ["\n", "\r\n"]) {
+      const listing = listingWith(
+        lineEnding,
+        directory,
+        regularFile,
+        symbolicLink,
+      );
+
+      expect(hasOnlyRegularEntries(tarListingLines(listing))).toBe(false);
+    }
+  });
+
+  test("rejects hard links, devices, and pipes", () => {
+    const nonRegular = [
+      "hrw-r--r--  0 owner group      0 Jan  1 00:00 package/hard-link",
+      "crw-rw-rw-  0 owner group    1,3 Jan  1 00:00 package/device",
+      "prw-r--r--  0 owner group      0 Jan  1 00:00 package/pipe",
+    ];
+
+    for (const entry of nonRegular) {
+      expect(hasOnlyRegularEntries([directory, entry])).toBe(false);
+    }
+  });
+
+  test("accepts an empty listing", () => {
+    expect(hasOnlyRegularEntries([])).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`sdk/typescript/scripts/check-package.mjs` rejects a valid npm tarball when the local `tar` emits CRLF line endings for `tar -tvzf`, as reported in #32.

The non-regular entry check ran a multiline regular expression directly over the raw listing:

```js
if (/^[^d-]/mu.test(listing)) {
  throw new Error(
    "npm tarball contains a non-regular entry (symbolic or hard link, device, or pipe).",
  );
}
```

In JavaScript both CR and LF are line terminators for multiline anchors, so `^` matches *between* the CR and the LF. The following `\n` is then tested as if it were the first character of a new line, it is neither `d` nor `-`, and a tarball containing only regular files and directories is reported as containing a link, device, or pipe.

The check immediately below already normalized the very same output with `split(/\r?\n/u)`, so the two validations disagreed about what a line is.

## Changes

- Add `sdk/typescript/scripts/tar-listing.mjs` with two small helpers: `tarListingLines()` normalizes a `tar -tv` listing to entry lines (LF or CRLF), and `hasOnlyRegularEntries()` checks the entry-type column of already-split lines.
- Use them in `check-package.mjs` so entry types are inspected per line instead of via a multiline regex over the raw output. `entries` now reuses `tarListingLines()` rather than repeating the same split expression.
- Add `sdk/typescript/tests-ts/tar-listing.test.ts` covering LF and CRLF listings, unterminated and empty listings, and rejection of symbolic links, hard links, devices, and pipes under both line endings.

Behavior is unchanged for LF listings, and genuinely non-regular entries are still rejected — the symbolic-link, hard-link, device, and pipe cases are asserted with CRLF as well as LF, so the fix cannot silently weaken the check.

## Testing

Run from `sdk/typescript` on Linux (Node.js 22.23.2, pnpm 11.9.0, bun 1.3.14):

- `bun test tests-ts/tar-listing.test.ts` — 8 pass, 0 fail.
- `pnpm run types` — passes.
- `pnpm run format` — "All matched files use Prettier code style!".
- `pnpm run build` && `pnpm pack` then `node scripts/check-package.mjs ../../dist/<tarball>.tgz` — every tar listing and entry-type check passes. The run then stops in the later installed-package smoke step, because installing the packed tarball resolves an upstream dependency version that is not published to the registry from this environment (`ETARGET ... @openai/codex@<alpha>`). That failure is unrelated to this change and reproduces on an unmodified checkout.

I confirmed the fix addresses the reported cause rather than the symptom, by exercising the old and new logic against the same fixtures:

```
OLD accepts CRLF regular-only listing? false
OLD accepts LF   regular-only listing? true
NEW accepts CRLF regular-only listing? true
NEW accepts LF   regular-only listing? true
```

I do not have a Windows machine available, so the CRLF path is covered by the fixtures above rather than by a real CRLF-emitting `tar`.

## Risk and rollout

Low. The change is confined to a build-time packaging validation script; no runtime or published SDK code is touched. It makes the check accept listings it should always have accepted, and adds no new dependency.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.

Fixes #32
