### PR TITLE
fix(sdk): preserve sealed-file identity on Windows Node 22

### DIFF
--- a/sdk/typescript/scripts/smoke-package.mjs
+++ b/sdk/typescript/scripts/smoke-package.mjs
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import {
+  chmod,
+  cp,
+  lstat,
   mkdir,
   mkdtemp,
+  open,
   readFile,
   readdir,
   rm,
@@ -339,15 +343,63 @@ try {
     "Installed npm package does not match the complete bundled-plugin contract.",
   );
 
-  run(
-    process.execPath,
-    [
-      "--input-type=module",
-      "--eval",
-      `const sdk = await import(${JSON.stringify(packageManifest.name)}); if (typeof sdk.CodexSecurity !== "function") throw new Error("The installed package does not export CodexSecurity.");`,
-    ],
-    { cwd: consumer },
+  const installedPluginRoot = join(installedRoot, "_bundled_plugin");
+  const contractScan = join(consumer, "contract-scan");
+  await cp(
+    join(installedPluginRoot, "examples", "completed-scan"),
+    contractScan,
+    {
+      recursive: true,
+    },
   );
+  if (process.platform !== "win32") await chmod(contractScan, 0o700);
+
+  try {
+    run(
+      process.execPath,
+      [
+        "--input-type=module",
+        "--eval",
+        `const sdk = await import(${JSON.stringify(packageManifest.name)}); if (typeof sdk.CodexSecurity !== "function") throw new Error("The installed package does not export CodexSecurity."); if (typeof sdk.loadContract !== "function") throw new Error("The installed package does not export loadContract."); const contract = await sdk.loadContract(${JSON.stringify(contractScan)}, { pluginRoot: ${JSON.stringify(installedPluginRoot)} }); if (contract.manifest.scan.id !== "scan_example_001") throw new Error("The installed package did not load its sealed example scan.");`,
+      ],
+      { cwd: consumer },
+    );
+  } catch (error) {
+    if (process.platform === "win32") {
+      try {
+        const path = join(contractScan, "scan-manifest.json");
+        const file = await open(path, "r");
+        try {
+          const [pathIdentity, openedIdentity, exactPath, exactOpened] =
+            await Promise.all([
+              lstat(path),
+              file.stat(),
+              lstat(path, { bigint: true }),
+              file.stat({ bigint: true }),
+            ]);
+          console.error(
+            "Sealed scan identity checks:",
+            JSON.stringify({
+              numberDeviceEqual: pathIdentity.dev === openedIdentity.dev,
+              numberInodeEqual: pathIdentity.ino === openedIdentity.ino,
+              bigintInodeEqual: exactPath.ino === exactOpened.ino,
+              low32DeviceEqual:
+                BigInt.asUintN(32, exactPath.dev) ===
+                BigInt.asUintN(32, exactOpened.dev),
+              pathRegular: exactPath.isFile(),
+              pathSymlink: exactPath.isSymbolicLink(),
+              openedRegular: exactOpened.isFile(),
+            }),
+          );
+        } finally {
+          await file.close();
+        }
+      } catch {
+        console.error("Sealed scan identity checks unavailable.");
+      }
+    }
+    throw error;
+  }
 
   assert.equal(
     typeof installedManifest.bin?.["codex-security"],

--- a/sdk/typescript/src/contract.ts
+++ b/sdk/typescript/src/contract.ts
@@ -831,8 +831,8 @@ async function openCheckedScanFile(
     throwIfAborted(signal);
     if (
       !opened.isFile() ||
-      opened.dev !== checked.metadata.dev ||
-      opened.ino !== checked.metadata.ino
+      opened.ino !== checked.metadata.ino ||
+      !(await sameCheckedFileDevice(file, checked, opened))
     ) {
       throw new ContractValidationError(
         `${context}: expected the checked regular file.`,
@@ -874,6 +874,29 @@ async function openCheckedScanFile(
       { cause: error },
     );
   }
+}
+
+export async function sameCheckedFileDevice(
+  file: FileHandle,
+  checked: CheckedScanFile,
+  opened: Stats,
+  platform: NodeJS.Platform = process.platform,
+): Promise<boolean> {
+  if (opened.dev === checked.metadata.dev) return true;
+  if (platform !== "win32") return false;
+
+  const [openedIdentity, checkedIdentity] = await Promise.all([
+    file.stat({ bigint: true }),
+    lstat(checked.path, { bigint: true }),
+  ]);
+  return (
+    openedIdentity.isFile() &&
+    checkedIdentity.isFile() &&
+    !checkedIdentity.isSymbolicLink() &&
+    openedIdentity.ino === checkedIdentity.ino &&
+    BigInt.asUintN(32, openedIdentity.dev) ===
+      BigInt.asUintN(32, checkedIdentity.dev)
+  );
 }
 
 function throwIfAborted(signal?: AbortSignal): void {

--- a/sdk/typescript/src/contract.ts
+++ b/sdk/typescript/src/contract.ts
@@ -831,6 +831,7 @@ async function openCheckedScanFile(
     throwIfAborted(signal);
     if (
       !opened.isFile() ||
+      opened.ino !== checked.metadata.ino ||
       !(await sameCheckedFileDevice(file, checked, opened))
     ) {
       throw new ContractValidationError(
@@ -880,27 +881,39 @@ export async function sameCheckedFileDevice(
   checked: CheckedScanFile,
   opened: Stats,
   platform: NodeJS.Platform = process.platform,
+  openReference: (path: string, flags: number) => Promise<FileHandle> = open,
 ): Promise<boolean> {
-  if (
-    opened.dev === checked.metadata.dev &&
-    opened.ino === checked.metadata.ino
-  ) {
-    return true;
-  }
+  if (opened.ino !== checked.metadata.ino) return false;
+  if (opened.dev === checked.metadata.dev) return true;
   if (platform !== "win32") return false;
 
   const [openedIdentity, checkedIdentity] = await Promise.all([
     file.stat({ bigint: true }),
     lstat(checked.path, { bigint: true }),
   ]);
-  return (
-    openedIdentity.isFile() &&
-    checkedIdentity.isFile() &&
-    !checkedIdentity.isSymbolicLink() &&
-    openedIdentity.ino === checkedIdentity.ino &&
-    BigInt.asUintN(32, openedIdentity.dev) ===
-      BigInt.asUintN(32, checkedIdentity.dev)
+  if (
+    !openedIdentity.isFile() ||
+    !checkedIdentity.isFile() ||
+    checkedIdentity.isSymbolicLink() ||
+    openedIdentity.ino !== checkedIdentity.ino
+  ) {
+    return false;
+  }
+
+  const reference = await openReference(
+    checked.path,
+    constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
   );
+  try {
+    const referenceIdentity = await reference.stat({ bigint: true });
+    return (
+      referenceIdentity.isFile() &&
+      openedIdentity.dev === referenceIdentity.dev &&
+      openedIdentity.ino === referenceIdentity.ino
+    );
+  } finally {
+    await reference.close();
+  }
 }
 
 function throwIfAborted(signal?: AbortSignal): void {

--- a/sdk/typescript/src/contract.ts
+++ b/sdk/typescript/src/contract.ts
@@ -831,7 +831,6 @@ async function openCheckedScanFile(
     throwIfAborted(signal);
     if (
       !opened.isFile() ||
-      opened.ino !== checked.metadata.ino ||
       !(await sameCheckedFileDevice(file, checked, opened))
     ) {
       throw new ContractValidationError(
@@ -882,7 +881,12 @@ export async function sameCheckedFileDevice(
   opened: Stats,
   platform: NodeJS.Platform = process.platform,
 ): Promise<boolean> {
-  if (opened.dev === checked.metadata.dev) return true;
+  if (
+    opened.dev === checked.metadata.dev &&
+    opened.ino === checked.metadata.ino
+  ) {
+    return true;
+  }
   if (platform !== "win32") return false;
 
   const [openedIdentity, checkedIdentity] = await Promise.all([

--- a/sdk/typescript/tests-ts/contract.test.ts
+++ b/sdk/typescript/tests-ts/contract.test.ts
@@ -1,18 +1,22 @@
 import { createHash } from "node:crypto";
+import type { Stats } from "node:fs";
 import {
   chmod,
   cp,
+  lstat,
   mkdir,
   mkdtemp,
   readFile,
   rm,
   symlink,
+  type FileHandle,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 import { ContractValidationError, loadContract } from "../src/index.js";
+import { sameCheckedFileDevice } from "../src/contract.js";
 import type { NormalizedTarget, ScanExpectation } from "../src/index.js";
 import { PLUGIN_ROOT } from "./plugin-root.js";
 
@@ -101,6 +105,60 @@ function expectation(
 }
 
 describe("canonical scan contract", () => {
+  test("compares exact Windows volume serials without rounding file identity", async () => {
+    const scanDir = await copyExample();
+    const path = join(scanDir, "scan-manifest.json");
+    const metadata = await lstat(path);
+    const identity = await lstat(path, { bigint: true });
+    const volume = BigInt.asUintN(32, identity.dev);
+    const highDevice = (1n << 60n) | volume;
+    expect(highDevice).toBeGreaterThan(BigInt(Number.MAX_SAFE_INTEGER));
+
+    let device = highDevice;
+    let inode = identity.ino;
+    let regular = true;
+    let inspected = 0;
+    const file = {
+      stat: async () => {
+        inspected += 1;
+        return {
+          dev: device,
+          ino: inode,
+          isFile: () => regular,
+        };
+      },
+    } as unknown as FileHandle;
+    const checked = { path, metadata, parents: [] };
+    const opened = { dev: Number(highDevice) } as Stats;
+
+    await expect(
+      sameCheckedFileDevice(file, checked, opened, "win32"),
+    ).resolves.toBe(true);
+
+    device = highDevice ^ 1n;
+    await expect(
+      sameCheckedFileDevice(file, checked, opened, "win32"),
+    ).resolves.toBe(false);
+
+    device = highDevice;
+    inode = identity.ino + 1n;
+    await expect(
+      sameCheckedFileDevice(file, checked, opened, "win32"),
+    ).resolves.toBe(false);
+
+    inode = identity.ino;
+    regular = false;
+    await expect(
+      sameCheckedFileDevice(file, checked, opened, "win32"),
+    ).resolves.toBe(false);
+
+    const windowsInspections = inspected;
+    await expect(
+      sameCheckedFileDevice(file, checked, opened, "linux"),
+    ).resolves.toBe(false);
+    expect(inspected).toBe(windowsInspections);
+  });
+
   test("loads the unchanged plugin example with typed canonical names", async () => {
     const scanDir = await copyExample();
     const contract = await loadContract(scanDir, { pluginRoot: PLUGIN_ROOT });

--- a/sdk/typescript/tests-ts/contract.test.ts
+++ b/sdk/typescript/tests-ts/contract.test.ts
@@ -118,6 +118,10 @@ describe("canonical scan contract", () => {
     let inode = identity.ino;
     let regular = true;
     let inspected = 0;
+    let referenceDevice = highDevice;
+    let referenceInode = identity.ino;
+    let referenceRegular = true;
+    let referenceClosed = 0;
     const file = {
       stat: async () => {
         inspected += 1;
@@ -128,44 +132,79 @@ describe("canonical scan contract", () => {
         };
       },
     } as unknown as FileHandle;
+    const reference = {
+      stat: async () => ({
+        dev: referenceDevice,
+        ino: referenceInode,
+        isFile: () => referenceRegular,
+      }),
+      close: async () => {
+        referenceClosed += 1;
+      },
+    } as unknown as FileHandle;
+    const openReference = async () => reference;
     const checked = { path, metadata, parents: [] };
     const opened = { dev: Number(highDevice), ino: metadata.ino } as Stats;
 
     await expect(
-      sameCheckedFileDevice(file, checked, opened, "win32"),
+      sameCheckedFileDevice(file, checked, opened, "win32", openReference),
     ).resolves.toBe(true);
+    expect(referenceClosed).toBe(1);
 
     const inconsistentNumberInode = {
       dev: metadata.dev,
       ino: metadata.ino + 1024,
     } as Stats;
     await expect(
-      sameCheckedFileDevice(file, checked, inconsistentNumberInode, "win32"),
-    ).resolves.toBe(true);
-    await expect(
-      sameCheckedFileDevice(file, checked, inconsistentNumberInode, "linux"),
+      sameCheckedFileDevice(
+        file,
+        checked,
+        inconsistentNumberInode,
+        "win32",
+        openReference,
+      ),
     ).resolves.toBe(false);
 
     device = highDevice ^ 1n;
     await expect(
-      sameCheckedFileDevice(file, checked, opened, "win32"),
+      sameCheckedFileDevice(file, checked, opened, "win32", openReference),
     ).resolves.toBe(false);
+    expect(referenceClosed).toBe(2);
+
+    referenceDevice = device;
+    await expect(
+      sameCheckedFileDevice(file, checked, opened, "win32", openReference),
+    ).resolves.toBe(true);
+    expect(referenceClosed).toBe(3);
 
     device = highDevice;
+    referenceDevice = highDevice;
     inode = identity.ino + 1n;
     await expect(
-      sameCheckedFileDevice(file, checked, opened, "win32"),
+      sameCheckedFileDevice(file, checked, opened, "win32", openReference),
     ).resolves.toBe(false);
 
     inode = identity.ino;
     regular = false;
     await expect(
-      sameCheckedFileDevice(file, checked, opened, "win32"),
+      sameCheckedFileDevice(file, checked, opened, "win32", openReference),
+    ).resolves.toBe(false);
+
+    regular = true;
+    referenceInode = identity.ino + 1n;
+    await expect(
+      sameCheckedFileDevice(file, checked, opened, "win32", openReference),
+    ).resolves.toBe(false);
+
+    referenceInode = identity.ino;
+    referenceRegular = false;
+    await expect(
+      sameCheckedFileDevice(file, checked, opened, "win32", openReference),
     ).resolves.toBe(false);
 
     const windowsInspections = inspected;
     await expect(
-      sameCheckedFileDevice(file, checked, opened, "linux"),
+      sameCheckedFileDevice(file, checked, opened, "linux", openReference),
     ).resolves.toBe(false);
     expect(inspected).toBe(windowsInspections);
   });

--- a/sdk/typescript/tests-ts/contract.test.ts
+++ b/sdk/typescript/tests-ts/contract.test.ts
@@ -129,11 +129,22 @@ describe("canonical scan contract", () => {
       },
     } as unknown as FileHandle;
     const checked = { path, metadata, parents: [] };
-    const opened = { dev: Number(highDevice) } as Stats;
+    const opened = { dev: Number(highDevice), ino: metadata.ino } as Stats;
 
     await expect(
       sameCheckedFileDevice(file, checked, opened, "win32"),
     ).resolves.toBe(true);
+
+    const inconsistentNumberInode = {
+      dev: metadata.dev,
+      ino: metadata.ino + 1024,
+    } as Stats;
+    await expect(
+      sameCheckedFileDevice(file, checked, inconsistentNumberInode, "win32"),
+    ).resolves.toBe(true);
+    await expect(
+      sameCheckedFileDevice(file, checked, inconsistentNumberInode, "linux"),
+    ).resolves.toBe(false);
 
     device = highDevice ^ 1n;
     await expect(


### PR DESCRIPTION
## Summary

Accept the same checked regular file on Windows Node 22 when path and open-handle metadata represent the volume identifier differently.

## Changes

- Keep exact device identity checks on non-Windows platforms and whenever ordinary metadata already agrees.
- On Windows device mismatches only, compare the original file with a second independently opened no-follow handle using exact full-precision descriptor device and inode identities.
- Continue requiring a regular non-symlink file, unchanged original numeric inode, identical full-precision path inode, unchanged checked parents, and unchanged final path identity.
- Add regressions for volume identifiers larger than JavaScript's safe integer range, differently represented numeric inodes, changed exact inodes, non-regular files, and strict non-Windows behavior.
- Load the installed SDK's bundled sealed-scan example with the actual Node runtime during package verification so Windows Node 22 genuinely exercises this path.

## Testing

- Complete sealed-scan contract suite: 30 passed with 97 assertions.
- Built, packed, installed, and validated the public SDK, including its real Node-runtime sealed-scan contract smoke.
- Captured actual Windows Node 22 diagnostics proving path and file-handle device identifiers differ even in their low 32 bits, then verified exact same-API descriptor identity instead.

## Risk and rollout

- File access remains fail-closed; no symlink, ownership, parent, inode, or scan-seal checks are removed.
- Kept separate from the security-finding publication feature stack because it also protects existing scan consumers.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
