### PR TITLE
fix(sdk): preserve Deep Scan coordinator artifacts

### DIFF
--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -2451,9 +2451,13 @@ function scanPrompt(
       ? [
           "Write the complete canonical scan-manifest.json, findings.json, and coverage.json, but do not finalize or seal them; the SDK workbench owns authoritative metadata, finalization, report generation, and sealing.",
         ]
-      : [
-          "Use record_codex_security_scan_draft and complete_codex_security_scan as directed by the selected skill; the workbench owns authoritative metadata, finalization, report generation, and sealing.",
-        ]),
+      : skillName === "deep-security-scan"
+        ? [
+            "The Deep Scan coordinator already wrote the canonical scan artifacts. Call complete_codex_security_scan exactly once without submitting another semantic draft; the workbench owns authoritative metadata, finalization, report generation, and sealing.",
+          ]
+        : [
+            "Use record_codex_security_scan_draft and complete_codex_security_scan as directed by the selected skill; the workbench owns authoritative metadata, finalization, report generation, and sealing.",
+          ]),
     ...(additionalPrompt?.trim()
       ? ["Additional scan instructions:", additionalPrompt]
       : []),

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -5183,6 +5183,7 @@ describe("CodexSecurity orchestration", () => {
       `Scan target: Git diff from ${revision} to ${revision}.`,
     );
     expect(prompt).toContain("$codex-security:security-diff-scan");
+    expect(prompt).toContain("record_codex_security_scan_draft");
     expect(prompt).toContain("complete_codex_security_scan");
     expect(prompt).not.toContain("do not finalize or seal them");
     expect(prompt).toContain(
@@ -5195,6 +5196,7 @@ describe("CodexSecurity orchestration", () => {
       "prompt captured",
     );
     expect(prompt).toContain("$codex-security:deep-security-scan");
+    expect(prompt).not.toContain("record_codex_security_scan_draft");
     expect(prompt).toContain("complete_codex_security_scan");
     expect(prompt).not.toContain("do not finalize or seal them");
     expect(prompt).toContain(


### PR DESCRIPTION
## Summary

Deep Scan coordinators already write the parent scan’s aggregated findings, coverage, and manifest. The SDK currently gives Deep and diff scans the same draft-plus-completion instruction, so a Deep parent can mistakenly replace those existing artifacts.

## Changes

- Tell unbudgeted Deep scans to complete the existing coordinator-authored artifacts without submitting another semantic draft.
- Keep diff scans on their existing draft-then-complete workflow.
- Preserve Standard scan and explicit cost-limit completion behavior.
- Assert that Deep prompts omit the draft tool while diff prompts retain both required tools.

## Testing

- `bun test --timeout 30000 tests-ts/api.test.ts` — 117 passed.
- `bun test --timeout 30000 tests-ts/scan-recovery.test.ts` — 31 passed.
- `node node_modules/typescript/bin/tsc --noEmit` — passed.
- `node scripts/generate-models.cjs --check` — passed.
- `node node_modules/prettier/bin/prettier.cjs --check --ignore-path .gitignore --ignore-path .prettierignore '**/*.{cjs,mjs,js,ts,json,md}'` — passed.

## Risk and rollout

Only the Deep scan instruction changes. Existing coordinator-written artifacts are preserved, while diff, Standard, and cost-limited scan ownership remain unchanged.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.