### PR TITLE
release: bump Codex Security to 0.1.13

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-security",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "TypeScript SDK and CLI for Codex Security",
   "license": "Apache-2.0",
   "author": "OpenAI",


### PR DESCRIPTION
## Summary

Prepare the `@openai/codex-security` patch release `0.1.13`.

## Changes

- Update `sdk/typescript/package.json` from version `0.1.12` to `0.1.13`.
- Keep the release change limited to the package manifest.

## Testing

- `git diff --check` passed.
- `node sdk/typescript/scripts/release-automation.mjs version sdk/typescript/package.json` returned `0.1.13`.
- `node sdk/typescript/scripts/release-automation.mjs release-tag tag refs/tags/npm-v0.1.13 npm-v0.1.13 sdk/typescript/package.json` returned `0.1.13`.
- `node sdk/typescript/scripts/release-automation.mjs require-increase 0.1.13 0.1.12` returned `0.1.13`.
- Full Bun, type, format, and package test suites were not run locally because Bun and package dependencies are unavailable in this worktree; pull request CI will run the repository checks.

## Risk and rollout

- Low risk: this pull request changes only the package version, with no runtime or dependency changes.
- After merge, a successful `node-ci` run on `main` allows release automation to create `npm-v0.1.13` and start the protected npm publishing workflow.
- Publication still requires approval for the protected npm environment.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
