### PR TITLE
[codex] Show security scans in the Codex app

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -162,6 +162,9 @@ when the dedicated home does not already contain stored credentials. Logging
 out prevents later scans from automatically reimporting that ambient sign-in
 until you explicitly log in again.
 
+Scan sessions also appear in the Codex app. Session files and credentials stay
+in the private Codex Security home while the app uses its normal task history.
+
 An environment API key takes precedence over a stored sign-in by default.
 When both a stored ChatGPT sign-in and an environment API key are available, an
 interactive scan asks which credential to use. JSON output, dry runs, CI, and

--- a/sdk/typescript/scripts/check-package.mjs
+++ b/sdk/typescript/scripts/check-package.mjs
@@ -167,6 +167,7 @@ const distFiles = new Set(
     "config",
     "contract",
     "cost",
+    "desktop-session",
     "errors",
     "index",
     "knowledge-base",

--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -37,6 +37,7 @@ import {
   writeCodexConfig,
 } from "./config.js";
 import { estimateScanCost, ScanCostTracker, type ScanCost } from "./cost.js";
+import { prepareDesktopSession } from "./desktop-session.js";
 import {
   loadContract,
   requireScanFile,
@@ -132,12 +133,15 @@ interface ScanEvent {
   readonly [key: string]: unknown;
 }
 
+interface CodexThreadOptions {
+  workingDirectory: string;
+  skipGitRepoCheck: boolean;
+  approvalPolicy: "never";
+}
+
 interface CodexClientLike {
-  startThread(options: {
-    workingDirectory: string;
-    skipGitRepoCheck: boolean;
-    approvalPolicy: "never";
-  }): CodexThreadLike;
+  startThread(options: CodexThreadOptions): CodexThreadLike;
+  resumeThread(id: string, options: CodexThreadOptions): CodexThreadLike;
 }
 
 interface PreparedRuntime {
@@ -285,6 +289,7 @@ interface CodexSecurityRuntimeOptions {
 interface ClientDependencies {
   createCodex(options: CodexOptions): CodexClientLike;
   environment: ProcessEnvironment;
+  prepareDesktopSession?: typeof prepareDesktopSession;
   prepareRuntime?: (
     config: Readonly<CodexSecurityConfig>,
     signal?: AbortSignal,
@@ -300,6 +305,7 @@ interface ClientDependencies {
 const DEFAULT_DEPENDENCIES: ClientDependencies = {
   createCodex: (options) => new Codex(options),
   environment: process.env,
+  prepareDesktopSession,
 };
 
 const SCAN_PERMISSION_PROFILE = "codex_security_scan";
@@ -1039,7 +1045,7 @@ export class CodexSecurity {
         undefined
           ? undefined
           : this.#codexCommand().command;
-      const codex = this.#dependencies.createCodex({
+      const codexOptions: CodexOptions = {
         ...(codexPathOverride === undefined ? {} : { codexPathOverride }),
         ...(externalProvider !== null || apiKey === null ? {} : { apiKey }),
         env: definedEnvironment(
@@ -1054,12 +1060,53 @@ export class CodexSecurity {
             codex_security_surface: this.#surface,
           },
         },
-      });
-      const thread = codex.startThread({
+      };
+      let desktopThreadId: string | undefined;
+      if (this.#dependencies.prepareDesktopSession !== undefined) {
+        const sqliteHome =
+          typeof effectiveConfig["sqlite_home"] === "string"
+            ? effectiveConfig["sqlite_home"]
+            : environmentValue(
+                this.#dependencies.environment,
+                "CODEX_SQLITE_HOME",
+              ) ??
+              environmentValue(this.#dependencies.environment, "CODEX_HOME") ??
+              join(homedir(), ".codex");
+        try {
+          requireOutputOutsideRepository(protectedRoot, sqliteHome, "runtime");
+          const desktopEnvironment = {
+            ...codexOptions.env!,
+            CODEX_SQLITE_HOME: sqliteHome,
+          };
+          desktopThreadId = await this.#dependencies.prepareDesktopSession({
+            command: this.#codexCommand(),
+            environment: desktopEnvironment,
+            config: codexOptions.config!,
+            workingDirectory: scanDir,
+            title: `Security scan: ${basename(repo)}`,
+            signal,
+          });
+          codexOptions.env = desktopEnvironment;
+        } catch (error) {
+          if (signal.aborted) throw error;
+          notifyObserver(
+            "onWarning",
+            options.onWarning,
+            options.onObserverError,
+            `Could not show scan in Codex: ${safeErrorMessage(error)}`,
+          );
+        }
+      }
+      const codex = this.#dependencies.createCodex(codexOptions);
+      const threadOptions: CodexThreadOptions = {
         workingDirectory: scanDir,
         skipGitRepoCheck: true,
         approvalPolicy: "never",
-      });
+      };
+      const thread =
+        desktopThreadId !== undefined
+          ? codex.resumeThread(desktopThreadId, threadOptions)
+          : codex.startThread(threadOptions);
       const serializedPaths =
         normalized.kind === "paths"
           ? JSON.stringify(normalized.paths)

--- a/sdk/typescript/src/desktop-session.ts
+++ b/sdk/typescript/src/desktop-session.ts
@@ -1,0 +1,81 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { createInterface } from "node:readline";
+import type { CodexOptions } from "@openai/codex-sdk";
+import type { CodexCommand } from "./runtime.js";
+import { CODEX_SDK_VERSION } from "./version.js";
+
+export interface DesktopSessionOptions {
+  command: CodexCommand;
+  environment: Record<string, string>;
+  config: NonNullable<CodexOptions["config"]>;
+  workingDirectory: string;
+  title: string;
+  signal: AbortSignal;
+}
+
+export async function prepareDesktopSession(
+  options: DesktopSessionOptions,
+): Promise<string> {
+  const child = spawn(options.command.command, ["app-server"], {
+    env: options.environment,
+    signal: options.signal,
+    stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: true,
+  });
+  child.stderr.resume();
+  const closed = once(child, "close");
+  void closed.catch(() => undefined);
+  const responses = createInterface({ input: child.stdout });
+  const lines = responses[Symbol.asyncIterator]();
+
+  const request = async (
+    id: number,
+    method: string,
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> => {
+    child.stdin.write(`${JSON.stringify({ id, method, params })}\n`);
+    while (true) {
+      const line = await lines.next();
+      if (line.done) throw new Error("Codex app server closed unexpectedly.");
+      const response = JSON.parse(line.value) as {
+        id?: number;
+        result: Record<string, unknown>;
+        error?: { message: string };
+      };
+      if (response.id !== id) continue;
+      if (response.error !== undefined) throw new Error(response.error.message);
+      return response.result;
+    }
+  };
+
+  try {
+    await request(0, "initialize", {
+      clientInfo: {
+        name: "codex-security",
+        title: "Codex Security",
+        version: CODEX_SDK_VERSION,
+      },
+      capabilities: { experimentalApi: true },
+    });
+    child.stdin.write(`${JSON.stringify({ method: "initialized" })}\n`);
+    const result = await request(1, "thread/start", {
+      cwd: options.workingDirectory,
+      approvalPolicy: "never",
+      config: options.config,
+    });
+    const threadId = (result["thread"] as { id: string }).id;
+    await request(2, "thread/name/set", {
+      threadId,
+      name: options.title,
+    });
+    child.stdin.end();
+    await closed;
+    return threadId;
+  } finally {
+    responses.close();
+    child.stdin.end();
+    if (child.exitCode === null && child.signalCode === null) child.kill();
+    await closed.catch(() => undefined);
+  }
+}

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -45,6 +45,7 @@ import {
   type JsonObject,
 } from "../src/config.js";
 import { estimateScanCost, type ScanCost } from "../src/cost.js";
+import type { DesktopSessionOptions } from "../src/desktop-session.js";
 import {
   resolveCodexCommand,
   runWorkbench,
@@ -4253,6 +4254,81 @@ describe("CodexSecurity orchestration", () => {
     }
 
     expect(runtimeHomes).toEqual([credentialHome, credentialHome]);
+  });
+
+  test.each([
+    ["resumes its visible task", false],
+    ["falls back when task creation fails", true],
+  ])("a desktop scan %s", async (_description, fails) => {
+    const root = await temporaryDirectory();
+    const repository = join(root, "repository");
+    const ambientHome = join(root, "ambient-codex-home");
+    const codexHome = join(root, "private-codex-home");
+    const scanDir = join(root, "scan");
+    await Promise.all(
+      [repository, ambientHome, codexHome, scanDir].map((path) =>
+        mkdir(path, { mode: 0o700 }),
+      ),
+    );
+    let codexOptions: CodexOptions | undefined;
+    let selectedThreadId: string | null | undefined;
+    const warnings: string[] = [];
+    const thread = (id: string | null) => {
+      selectedThreadId = id;
+      return {
+        id,
+        async runStreamed() {
+          throw new Error("scan reached");
+        },
+      };
+    };
+
+    const client = new TestClient(
+      {},
+      {
+        environment: {
+          CODEX_HOME: ambientHome,
+          CODEX_SECURITY_STATE_DIR: join(root, "state"),
+        },
+        prepareRuntime: async () => preparedRuntime(codexHome),
+        resolveCodexCommand: () => ({ command: "/synthetic/codex" }),
+        resolvePluginPython: async () => "/managed/python",
+        prepareOutputDir: async () => scanDir,
+        repositoryRevision: async () => "deadbeef",
+        prepareDesktopSession: async (options: DesktopSessionOptions) => {
+          expect(options.environment).toMatchObject({
+            CODEX_HOME: codexHome,
+            CODEX_SQLITE_HOME: ambientHome,
+          });
+          expect(options.title).toBe("Security scan: repository");
+          if (fails) throw new Error("synthetic app-server failure");
+          return "visible-thread";
+        },
+        createCodex: (options: CodexOptions) => {
+          codexOptions = options;
+          return {
+            startThread: () => thread(null),
+            resumeThread: thread,
+          };
+        },
+      },
+    );
+
+    await expect(
+      client.run(repository, {
+        onWarning: (warning) => warnings.push(warning),
+      }),
+    ).rejects.toThrow("scan reached");
+    expect(selectedThreadId).toBe(fails ? null : "visible-thread");
+    expect(codexOptions?.env?.["CODEX_SQLITE_HOME"]).toBe(
+      fails ? undefined : ambientHome,
+    );
+    expect(warnings).toEqual(
+      fails
+        ? ["Could not show scan in Codex: synthetic app-server failure"]
+        : [],
+    );
+    await client.close();
   });
 
   test.each([

--- a/sdk/typescript/tests-ts/desktop-session.test.ts
+++ b/sdk/typescript/tests-ts/desktop-session.test.ts
@@ -1,0 +1,72 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { expect, test } from "bun:test";
+import { prepareDesktopSession } from "../src/desktop-session.js";
+
+test("starts and names a Codex app task", async () => {
+  const directory = await mkdtemp(
+    join(tmpdir(), "codex-security-desktop-session-"),
+  );
+  const script = join(directory, "app-server.mjs");
+  const requestsPath = join(directory, "requests.jsonl");
+
+  try {
+    await writeFile(
+      script,
+      [
+        'import { appendFileSync } from "node:fs";',
+        'import { createInterface } from "node:readline";',
+        "for await (const line of createInterface({ input: process.stdin })) {",
+        "  const request = JSON.parse(line);",
+        '  appendFileSync(process.env.CODEX_SECURITY_TEST_REQUESTS, JSON.stringify(request) + "\\n");',
+        "  if (request.id === undefined) continue;",
+        '  const result = request.method === "thread/start" ? { thread: { id: "visible-thread" } } : {};',
+        '  process.stdout.write(JSON.stringify({ id: request.id, result }) + "\\n");',
+        "}",
+        "process.exit(0);",
+      ].join("\n"),
+    );
+    const nodeExecutable = execFileSync("node", ["-p", "process.execPath"], {
+      encoding: "utf8",
+    }).trim();
+
+    await expect(
+      prepareDesktopSession({
+        command: { command: nodeExecutable },
+        environment: {
+          NODE_OPTIONS: `--import=${pathToFileURL(script).href}`,
+          CODEX_SECURITY_TEST_REQUESTS: requestsPath,
+        },
+        config: { model: "synthetic-model" },
+        workingDirectory: directory,
+        title: "Security scan: example",
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toBe("visible-thread");
+
+    const requests = (await readFile(requestsPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(requests.map(({ method }) => method)).toEqual([
+      "initialize",
+      "initialized",
+      "thread/start",
+      "thread/name/set",
+    ]);
+    expect(requests[2]?.["params"]).toEqual({
+      cwd: directory,
+      approvalPolicy: "never",
+      config: { model: "synthetic-model" },
+    });
+    expect(requests[3]?.["params"]).toEqual({
+      threadId: "visible-thread",
+      name: "Security scan: example",
+    });
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Security scans use a private Codex home, so the Codex app cannot see their tasks. Show each scan in the app without moving its credentials or session files.

## Changes

- Start an app-visible Codex task and resume that task for the scan.
- Share the app task database while keeping scanner credentials and session files private.
- Continue the scan if app task creation fails.
- Add focused coverage and include the new module in package checks.

## Testing

- `bun test --timeout 30000 tests-ts/api.test.ts tests-ts/api-attribution-concurrency.test.ts tests-ts/desktop-session.test.ts` — 122 passed.
- `pnpm run types`
- `pnpm run format`
- `pnpm run build`
- `pnpm run check:package /private/tmp/openai-codex-security-0.1.12.tgz`
- Started a scan against a synthetic repository and confirmed its task appears in the app task list.

## Risk and rollout

Scan authentication, private session storage, and repository path checks do not change. If app task setup fails, scanning falls back to the existing behavior.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
