### PR TITLE
fix(deps): replace extract-zip

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -58,18 +58,19 @@
     "@openai/codex": "0.148.0-alpha.8",
     "@openai/codex-sdk": "0.148.0-alpha.8",
     "ajv": "8.20.0",
-    "extract-zip": "2.0.1",
     "fast-uri": "3.1.5",
     "fflate": "0.8.2",
     "incur": "0.4.13",
     "papaparse": "5.5.3",
     "pdfjs-dist": "6.2.108",
-    "smol-toml": "1.6.1"
+    "smol-toml": "1.6.1",
+    "yauzl": "3.4.0"
   },
   "devDependencies": {
     "@types/bun": "1.3.13",
     "@types/node": "22.19.17",
     "@types/papaparse": "5.3.15",
+    "@types/yauzl": "3.4.0",
     "json-schema-to-typescript": "15.0.4",
     "prettier": "3.2.5",
     "typescript": "5.7.3"

--- a/sdk/typescript/pnpm-lock.yaml
+++ b/sdk/typescript/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       ajv:
         specifier: 8.20.0
         version: 8.20.0
-      extract-zip:
-        specifier: 2.0.1
-        version: 2.0.1
       fast-uri:
         specifier: 3.1.5
         version: 3.1.5
@@ -44,6 +41,9 @@ importers:
       smol-toml:
         specifier: 1.6.1
         version: 1.6.1
+      yauzl:
+        specifier: 3.4.0
+        version: 3.4.0
     devDependencies:
       '@types/bun':
         specifier: 1.3.13
@@ -54,6 +54,9 @@ importers:
       '@types/papaparse':
         specifier: 5.3.15
         version: 5.3.15
+      '@types/yauzl':
+        specifier: 3.4.0
+        version: 3.4.0
       json-schema-to-typescript:
         specifier: 15.0.4
         version: 15.0.4
@@ -390,8 +393,8 @@ packages:
   '@types/papaparse@5.3.15':
     resolution: {integrity: sha512-JHe6vF6x/8Z85nCX4yFdDslN11d+1pr12E526X8WAfhadOeaOTx5AuIkvDKIBopfvlzpzkdMx4YyvSKCM9oqtw==}
 
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+  '@types/yauzl@3.4.0':
+    resolution: {integrity: sha512-NRPn5w6h8dhcnmx3YIRQcqMywY/+nND/uOkJessedcrowO3C0AssHp3tMJpxKAwOhFOo0OV1y9VtsC5hbKKBAw==}
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
@@ -401,9 +404,6 @@ packages:
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
-
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   bun-types@1.3.13:
     resolution: {integrity: sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA==}
@@ -418,23 +418,6 @@ packages:
   content-type@2.0.0:
     resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
     engines: {node: '>=18'}
-
-  debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
-
-  extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -451,9 +434,6 @@ packages:
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
-
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -465,10 +445,6 @@ packages:
 
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
-
-  get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
 
   iconv-lite@0.7.3:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
@@ -508,15 +484,9 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
   mute-stream@3.0.0:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
-
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   papaparse@5.5.3:
     resolution: {integrity: sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==}
@@ -536,9 +506,6 @@ packages:
     resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
     engines: {node: '>=14'}
     hasBin: true
-
-  pump@3.0.4:
-    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -573,16 +540,14 @@ packages:
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+  yauzl@3.4.0:
+    resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
+    engines: {node: '>=12'}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -868,10 +833,9 @@ snapshots:
     dependencies:
       '@types/node': 22.19.17
 
-  '@types/yauzl@2.10.3':
+  '@types/yauzl@3.4.0':
     dependencies:
       '@types/node': 22.19.17
-    optional: true
 
   ajv@8.20.0:
     dependencies:
@@ -884,8 +848,6 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  buffer-crc32@0.2.13: {}
-
   bun-types@1.3.13:
     dependencies:
       '@types/node': 22.19.17
@@ -895,24 +857,6 @@ snapshots:
   cli-width@4.1.0: {}
 
   content-type@2.0.0: {}
-
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
-
-  end-of-stream@1.4.5:
-    dependencies:
-      once: 1.4.0
-
-  extract-zip@2.0.1:
-    dependencies:
-      debug: 4.4.3
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
 
   fast-deep-equal@3.1.3: {}
 
@@ -928,19 +872,11 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
-
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
 
   fflate@0.8.2: {}
-
-  get-stream@5.2.0:
-    dependencies:
-      pump: 3.0.4
 
   iconv-lite@0.7.3:
     dependencies:
@@ -986,13 +922,7 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  ms@2.1.3: {}
-
   mute-stream@3.0.0: {}
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
 
   papaparse@5.5.3: {}
 
@@ -1005,11 +935,6 @@ snapshots:
   picomatch@4.0.5: {}
 
   prettier@3.2.5: {}
-
-  pump@3.0.4:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
 
   require-from-string@2.0.2: {}
 
@@ -1032,13 +957,10 @@ snapshots:
 
   universal-user-agent@7.0.3: {}
 
-  wrappy@1.0.2: {}
-
   yaml@2.9.0: {}
 
-  yauzl@2.10.0:
+  yauzl@3.4.0:
     dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
+      pend: 1.2.0
 
   zod@4.4.3: {}

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -1,6 +1,12 @@
 import { execFile as execFileCallback, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { constants, existsSync, readdirSync, type Stats } from "node:fs";
+import {
+  constants,
+  createWriteStream,
+  existsSync,
+  readdirSync,
+  type Stats,
+} from "node:fs";
 import {
   chmod,
   cp,
@@ -24,12 +30,14 @@ import { homedir, tmpdir } from "node:os";
 import { createRequire } from "node:module";
 import { basename, dirname, extname, join, relative, resolve } from "node:path";
 import { createInterface } from "node:readline";
+import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { crc32 } from "node:zlib";
 import { setTimeout as delay } from "node:timers/promises";
-import extractZip from "extract-zip";
 import { parse } from "smol-toml";
+import * as yauzl from "yauzl";
+import type { Entry as ZipEntry, ZipFile } from "yauzl";
 import {
   CodexSecurityError,
   OutputDirectoryError,
@@ -1740,84 +1748,130 @@ export async function extractPluginZip(
   signal?: AbortSignal,
 ): Promise<string> {
   const archivePath = resolve(expandHome(archive));
-  await mkdir(dirname(destination), { recursive: true, mode: 0o700 });
-  const staging = await realpath(
-    await mkdtemp(join(dirname(destination), ".codex-security-plugin-")),
-  );
+  let staging: string | undefined;
   try {
     throwIfSignalAborted(signal);
     await rejectBackslashZipNames(archivePath, signal);
-    let expandedSize = 0;
-    const paths = new Set<string>();
-    const checksums: Array<{ path: string; checksum: number }> = [];
-    await extractZip(archivePath, {
-      dir: staging,
-      defaultDirMode: 0o700,
-      defaultFileMode: 0o600,
-      onEntry(entry, archive) {
-        throwIfSignalAborted(signal);
-        if (archive.entryCount > MAX_ZIP_ENTRIES) {
-          throw new PluginBootstrapError(
-            `Plugin ZIP contains too many entries: ${archive.entryCount}.`,
-          );
-        }
-        const path = safeArchivePath(entry.fileName);
-        const collisionKey = path.toLowerCase();
-        if (paths.has(collisionKey)) {
-          throw new PluginBootstrapError(
-            `Plugin ZIP contains a duplicate path: ${entry.fileName}`,
-          );
-        }
-        paths.add(collisionKey);
-        if (((entry.externalFileAttributes >>> 16) & 0o170000) === 0o120000) {
-          throw new PluginBootstrapError(
-            `Plugin ZIP contains an unsafe path: ${entry.fileName}`,
-          );
-        }
-        if (entry.uncompressedSize > MAX_ZIP_ENTRY_SIZE) {
-          throw new PluginBootstrapError(
-            `Plugin ZIP entry exceeds the safety limit: ${entry.fileName}`,
-          );
-        }
-        expandedSize += entry.uncompressedSize;
-        if (expandedSize > MAX_ZIP_EXPANDED_SIZE) {
-          throw new PluginBootstrapError(
-            "Plugin ZIP expanded size exceeds the safety limit.",
-          );
-        }
-        const mode = (entry.externalFileAttributes >>> 16) & 0o170000;
-        const directory =
-          entry.fileName.endsWith("/") ||
-          mode === 0o040000 ||
-          (entry.versionMadeBy >>> 8 === 0 &&
-            entry.externalFileAttributes === 16);
-        if (!directory) {
-          checksums.push({ path, checksum: entry.crc32 >>> 0 });
-        }
-      },
+    const zipfile = await yauzl.openPromise(archivePath, {
+      autoClose: false,
+      decodeStrings: true,
+      lazyEntries: true,
+      strictFileNames: true,
+      validateEntrySizes: true,
     });
-    for (const { path, checksum } of checksums) {
+    try {
+      const entries = await inspectPluginZipEntries(zipfile, signal);
       throwIfSignalAborted(signal);
-      const bytes = await readFile(join(staging, ...path.split("/")));
-      if (crc32(bytes) !== checksum) {
-        throw new PluginBootstrapError(
-          `Plugin ZIP entry failed CRC-32 validation: ${path}`,
-        );
+      await mkdir(dirname(destination), { recursive: true, mode: 0o700 });
+      staging = await realpath(
+        await mkdtemp(join(dirname(destination), ".codex-security-plugin-")),
+      );
+      for (const item of entries) {
+        throwIfSignalAborted(signal);
+        const target = join(staging, ...item.path.split("/"));
+        if (item.directory) {
+          await mkdir(target, { recursive: true, mode: item.mode });
+          continue;
+        }
+        await mkdir(dirname(target), { recursive: true, mode: 0o700 });
+        const readStream = await zipfile.openReadStreamPromise(item.entry);
+        const writeStream = createWriteStream(target, {
+          flags: "wx",
+          mode: item.mode,
+        });
+        if (signal === undefined) {
+          await pipeline(readStream, writeStream);
+        } else {
+          await pipeline(readStream, writeStream, { signal });
+        }
+        throwIfSignalAborted(signal);
+        const bytes = await readFile(target);
+        if (crc32(bytes) !== item.entry.crc32 >>> 0) {
+          throw new PluginBootstrapError(
+            `Plugin ZIP entry failed CRC-32 validation: ${item.path}`,
+          );
+        }
       }
+    } finally {
+      zipfile.close();
     }
+    if (staging === undefined) throw new Error("missing plugin ZIP staging");
     const pluginRoot = await discoverPluginRoot(staging);
     throwIfSignalAborted(signal);
     const relativeRoot = relative(staging, pluginRoot);
     await rename(staging, destination);
     return await validatePluginRoot(join(destination, relativeRoot));
   } catch (error) {
-    await rm(staging, { recursive: true, force: true }).catch(() => undefined);
+    if (staging !== undefined) {
+      await rm(staging, { recursive: true, force: true }).catch(
+        () => undefined,
+      );
+    }
     throwIfSignalAborted(signal);
     if (error instanceof PluginBootstrapError) throw error;
     throw new PluginBootstrapError(`Invalid plugin ZIP: ${archivePath}`, {
       cause: error,
     });
   }
+}
+
+interface PluginZipEntry {
+  entry: ZipEntry;
+  path: string;
+  directory: boolean;
+  mode: number;
+}
+
+async function inspectPluginZipEntries(
+  zipfile: ZipFile,
+  signal?: AbortSignal,
+): Promise<PluginZipEntry[]> {
+  if (zipfile.entryCount > MAX_ZIP_ENTRIES) {
+    throw new PluginBootstrapError(
+      `Plugin ZIP contains too many entries: ${zipfile.entryCount}.`,
+    );
+  }
+  let expandedSize = 0;
+  const paths = new Set<string>();
+  const entries: PluginZipEntry[] = [];
+  for await (const entry of zipfile.eachEntry()) {
+    throwIfSignalAborted(signal);
+    if (entry.fileName.startsWith("__MACOSX/")) continue;
+    const path = safeArchivePath(entry.fileName);
+    const collisionKey = path.toLowerCase();
+    if (paths.has(collisionKey)) {
+      throw new PluginBootstrapError(
+        `Plugin ZIP contains a duplicate path: ${entry.fileName}`,
+      );
+    }
+    paths.add(collisionKey);
+    const archivedMode = (entry.externalFileAttributes >>> 16) & 0xffff;
+    const type = archivedMode & 0o170000;
+    if (type === 0o120000) {
+      throw new PluginBootstrapError(
+        `Plugin ZIP contains an unsafe path: ${entry.fileName}`,
+      );
+    }
+    if (entry.uncompressedSize > MAX_ZIP_ENTRY_SIZE) {
+      throw new PluginBootstrapError(
+        `Plugin ZIP entry exceeds the safety limit: ${entry.fileName}`,
+      );
+    }
+    expandedSize += entry.uncompressedSize;
+    if (expandedSize > MAX_ZIP_EXPANDED_SIZE) {
+      throw new PluginBootstrapError(
+        "Plugin ZIP expanded size exceeds the safety limit.",
+      );
+    }
+    const directory =
+      entry.fileName.endsWith("/") ||
+      type === 0o040000 ||
+      (entry.versionMadeBy >>> 8 === 0 && entry.externalFileAttributes === 16);
+    const mode =
+      archivedMode === 0 ? (directory ? 0o700 : 0o600) : archivedMode & 0o777;
+    entries.push({ entry, path, directory, mode });
+  }
+  return entries;
 }
 
 async function rejectBackslashZipNames(

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -1137,12 +1137,13 @@ describe("plugin runtime preparation", () => {
     ).toBe(false);
   });
 
-  test("extracts a plugin in one top-level directory", async () => {
+  test("extracts a plugin in one top-level directory and ignores macOS metadata", async () => {
     const root = await temporaryDirectory();
     const archive = join(root, "plugin.zip");
     await writeFile(
       archive,
       zipSync({
+        "__MACOSX/release/._plugin.json": strToU8("metadata"),
         "release/.codex-plugin/plugin.json": strToU8(
           JSON.stringify({ name: "codex-security", version: "1.2.3" }),
         ),
@@ -1150,6 +1151,14 @@ describe("plugin runtime preparation", () => {
     );
     const extracted = await extractPluginZip(archive, join(root, "extracted"));
     expect(extracted).toBe(join(root, "extracted", "release"));
+    expect(existsSync(join(root, "extracted", "__MACOSX"))).toBe(false);
+    if (process.platform !== "win32") {
+      expect((await stat(join(root, "extracted"))).mode & 0o777).toBe(0o700);
+      expect(
+        (await stat(join(extracted, ".codex-plugin", "plugin.json"))).mode &
+          0o777,
+      ).toBe(0o600);
+    }
   });
 
   test("decodes flag-clear ZIP filenames with the legacy CP437 encoding", async () => {
@@ -1226,7 +1235,10 @@ describe("plugin runtime preparation", () => {
           "release/.codex-plugin/plugin.json": strToU8(
             JSON.stringify({ name: "codex-security", version: "1.2.3" }),
           ),
-          "release/link": [strToU8("target"), { os: 3, attrs: 0o120777 << 16 }],
+          "release/link": [
+            strToU8("../../outside"),
+            { os: 3, attrs: 0o120777 << 16 },
+          ],
         }),
       ],
     ];
@@ -1237,6 +1249,15 @@ describe("plugin runtime preparation", () => {
       await expect(
         extractPluginZip(path, join(root, "extract")),
       ).rejects.toThrow(PluginBootstrapError);
+      if (name === "symlink") {
+        expect(existsSync(join(root, "outside"))).toBe(false);
+        expect(existsSync(join(root, "extract"))).toBe(false);
+        expect(
+          (await readdir(root)).some((entry) =>
+            entry.startsWith(".codex-security-plugin-"),
+          ),
+        ).toBe(false);
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

Replace the unpatched `extract-zip@2.0.1` dependency affected by GHSA-jmr9-qjv8-65gv. The existing call site already rejected symlink entries before `extract-zip` could create them, but removing the package clears the flagged dependency and avoids future exposure to its unsafe default behavior.

## Changes

- use `yauzl@3.4.0` directly for lazy ZIP parsing and streaming extraction
- validate every entry before creating archive-directed paths, while preserving strict path, collision, symlink, size, CRC-32, permission, cancellation, and cleanup behavior
- retain CP437 filename decoding and `__MACOSX` filtering
- add an advisory-shaped escaping-symlink regression and compatibility assertions
- regenerate the pnpm lockfile without unrelated churn

## Testing

- `pnpm install --frozen-lockfile` — passed
- focused Bun ZIP extraction tests — 9 passed
- `pnpm run types` — passed
- `pnpm run format` — passed
- `pnpm audit --prod --audit-level high` — passed with no known vulnerabilities
- `pnpm pack` and installed-tarball `check:package` — passed

The full local runtime test file reached 97 passed and 7 skipped; 24 unrelated tests require a trusted temporary-directory ancestry that this sandbox does not provide. All ZIP extraction tests passed, and GitHub Actions will run the complete Linux, macOS, and Windows matrix.

## Risk and rollout

The behavior change is limited to plugin ZIP extraction. The replacement keeps the existing fail-closed archive policy and uses the parser that `extract-zip` previously wrapped, upgraded to its current release. No migration is required. Dependabot alerts should close after this lands and GitHub refreshes the dependency graph.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.