### PR TITLE
release: bump Codex Security to 0.1.15

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-security",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "TypeScript SDK and CLI for Codex Security",
   "license": "Apache-2.0",
   "author": "OpenAI",


### PR DESCRIPTION
## Summary

Prepare the `@openai/codex-security` patch release `0.1.15`.

## Changes

- Update `sdk/typescript/package.json` from `0.1.14` to `0.1.15`.
- Merge current `main`; the release-specific diff remains limited to the package manifest.

## Testing

- Focused release-version and release-workflow tests: 34 passed, 0 failed, 51 assertions.
- The existing `release-automation.mjs` version, release-tag, and version-increase checks returned `0.1.15`.
- `pnpm run types`, `pnpm run format`, build, and pack passed.
- Static package-contract checks and bounded installed-package checks passed, including public SDK import, CLI version/help, npm version `0.1.15`, and the unchanged bundled-plugin version `0.1.20`.
- The full Bun suite and full installed-package smoke were not run locally.

## Risk and rollout

- The release-specific change is only the package version; it adds no runtime or dependency changes.
- After a separately approved merge, successful `node-ci` on `main` allows release automation to create `npm-v0.1.15` and start the protected npm publishing workflow.
- Publication still requires approval for the protected npm environment. No tag or release was created as part of this update.

## Public disclosure review

Reviewed the public PR material and current-head CI logs. Removed access-restricted report links from automated review comments while preserving their review results.

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
