### PR TITLE
docs(cli): codify integration option naming

### DIFF
--- a/sdk/typescript/AGENTS.md
+++ b/sdk/typescript/AGENTS.md
@@ -14,7 +14,7 @@ outside an approved path.
 ## Keep it simple
 
 - Prefer one source of truth for types, schemas, arguments, and state.
-- Keep `--to` as the only generic integration selector. Namespace all other
+- Keep `--to` as the only generic integration selector. Namespace other
   integration-specific options, such as `--linear-*` and `--jira-*`; do not
   generalize fields whose semantics differ across integrations.
 - Reuse Codex APIs and shared helpers instead of adding extra trust gates or orchestration.

--- a/sdk/typescript/AGENTS.md
+++ b/sdk/typescript/AGENTS.md
@@ -14,6 +14,9 @@ outside an approved path.
 ## Keep it simple
 
 - Prefer one source of truth for types, schemas, arguments, and state.
+- Keep `--to` as the only generic integration selector. Namespace all other
+  integration-specific options, such as `--linear-*` and `--jira-*`; do not
+  generalize fields whose semantics differ across integrations.
 - Reuse Codex APIs and shared helpers instead of adding extra trust gates or orchestration.
 - Root read and workspace write are enough for the sandbox.
 - Treat repository paths, symlinks, archives, and other repository-controlled data as untrusted.


### PR DESCRIPTION
## Summary

Codify the CLI integration option naming decision in agent guidance.

## Changes

- Reserve `--to` for generic integration routing.
- Keep integration-specific options namespaced, such as `--linear-*` and future `--jira-*` options, instead of flattening semantics that differ across integrations.

## Testing

- `prettier --check` on `sdk/typescript/AGENTS.md` (passed).
- `git diff --check` (passed).
- Runtime tests were not run because this changes agent guidance only.

## Risk and rollout

Documentation-only change with no runtime or release impact. The guidance takes effect when merged.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
