### PR TITLE
refactor(sdk): share Codex session setup

### DIFF
--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -13,7 +13,12 @@ import {
 import { randomUUID } from "node:crypto";
 import { homedir, tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, sep } from "node:path";
-import { Codex, type CodexOptions } from "@openai/codex-sdk";
+import {
+  Codex,
+  type CodexOptions,
+  type ThreadOptions,
+  type TurnOptions,
+} from "@openai/codex-sdk";
 import {
   parse as parseToml,
   stringify as stringifyToml,
@@ -124,7 +129,7 @@ interface CodexThreadLike {
   readonly id: string | null;
   runStreamed(
     input: string,
-    options: { signal: AbortSignal },
+    options: TurnOptions,
   ): Promise<{ events: AsyncGenerator<ScanEvent> }>;
 }
 
@@ -134,11 +139,7 @@ interface ScanEvent {
 }
 
 interface CodexClientLike {
-  startThread(options: {
-    workingDirectory: string;
-    skipGitRepoCheck: boolean;
-    approvalPolicy: "never" | "on-request";
-  }): CodexThreadLike;
+  startThread(options: ThreadOptions): CodexThreadLike;
 }
 
 interface PreparedRuntime {
@@ -151,6 +152,24 @@ interface PreparedRuntime {
   environment: Record<string, string>;
   credentialsAvailable: boolean;
   effectiveConfig?: JsonObject;
+}
+
+interface PreparedSession {
+  runtime: PreparedRuntime;
+  runtimeHome: string;
+  effectiveConfig: JsonObject;
+  preflightConfig: JsonObject;
+  sessionConfig: JsonObject;
+  modelProvider: unknown;
+  externalProvider:
+    | (typeof EXTERNAL_CODEX_PROVIDERS)[keyof typeof EXTERNAL_CODEX_PROVIDERS]
+    | null;
+  apiKey: string | null;
+  scanEnvironment: ProcessEnvironment;
+  authentication: ScanAuthentication;
+  approvalPolicy: "never" | "on-request";
+  python: string;
+  releaseCredentialHome: (() => Promise<void>) | null;
 }
 
 const DEEP_SCAN_CONFIG_PATH_ENVIRONMENT =
@@ -369,6 +388,13 @@ export class CodexSecurity {
       options,
       options.signal,
     );
+    return await this.#preflightInputs(inputs, options);
+  }
+
+  async #preflightInputs(
+    inputs: LocalScanInputs,
+    options: ScanOptions,
+  ): Promise<ScanPreflight> {
     requireOutputOutsideRepository(
       inputs.protectedRoot,
       await realpath(tmpdir()),
@@ -480,74 +506,24 @@ export class CodexSecurity {
       }
       checkOpen();
 
-      const requestedConfig = await mergedCodexConfig(this.config);
-      const modelProvider = scanModelProvider(requestedConfig);
-      const externalProvider = isExternalModelProvider(modelProvider)
-        ? EXTERNAL_CODEX_PROVIDERS[modelProvider]
-        : null;
-      let authentication = scanAuthentication(
-        this.#dependencies.environment,
-        options.auth,
-        modelProvider,
-      );
-      const apiKey =
-        authentication.method === "api_key"
-          ? environmentApiKey(this.#dependencies.environment, modelProvider)
-          : null;
-      if (externalProvider !== null && apiKey === null) {
-        throw new AuthenticationRequiredError(
-          `Set ${externalProvider.env_key} to run a scan through ${externalProvider.name}.`,
-        );
-      }
-      const scanEnvironment = selectedScanEnvironment(
-        this.#dependencies.environment,
-        options.auth,
-        modelProvider,
-      );
-      if (this.#dependencies.prepareRuntime === undefined) {
-        const credentialHome = await prepareCodexSecurityCredentialHome(
-          scanEnvironment,
-          (path) =>
-            requireOutputOutsideRepository(protectedRoot, path, "runtime"),
-        );
-        releaseCredentialHome = await acquireCodexSecurityCredentialHomeLock(
-          credentialHome,
-          signal,
-        );
-      }
-      const previousRuntime = this.#runtime;
-      const runtime = await this.#ensureRuntime(
+      const session = await this.#prepareSession(
+        { protectedRoot, stateDirectory },
+        options,
         signal,
         temporaryRoot,
-        (path) =>
-          requireOutputOutsideRepository(protectedRoot, path, "runtime"),
-        options.auth,
-        requestedConfig,
+        mode === "deep",
       );
-      if (
-        runtime === previousRuntime &&
-        this.#dependencies.prepareRuntime === undefined
-      ) {
-        await this.#refreshPersistentRuntime(
-          runtime,
-          scanEnvironment,
-          signal,
-          requestedConfig,
-        );
-      }
-      const effectiveConfig = runtime.effectiveConfig ?? requestedConfig;
-      const approvalPolicy = scanApprovalPolicy(effectiveConfig);
-      const preflightConfig = scanPreflightCodexConfig(effectiveConfig);
-      if (runtime.configPath !== undefined) {
-        await writeCodexConfig(runtime.configPath, preflightConfig);
-      }
-      const runtimeHome = await realpath(runtime.codexHome);
-      requireOutputOutsideRepository(protectedRoot, runtimeHome, "runtime");
-      const sessionConfig = scanRuntimeCodexConfig(
-        effectiveConfig,
-        stateDirectory,
+      const {
+        runtime,
         runtimeHome,
-      );
+        effectiveConfig,
+        preflightConfig,
+        modelProvider,
+        authentication,
+        approvalPolicy,
+        python,
+      } = session;
+      releaseCredentialHome = session.releaseCredentialHome;
       const deepScanConfigPath =
         mode === "deep"
           ? runtime.deepScanConfigPath ??
@@ -561,82 +537,6 @@ export class CodexSecurity {
           signal,
         );
       }
-      if (
-        options.expectedPluginVersion !== undefined &&
-        runtime.plugin.version !== options.expectedPluginVersion
-      ) {
-        throw new CodexSecurityError(
-          `The original scan used plugin version ${options.expectedPluginVersion}, but the installed version is ${runtime.plugin.version}.`,
-        );
-      }
-      checkOpen();
-      if (
-        authentication.method === "stored_credentials" &&
-        this.#runtimeCredentialSource === "api_key"
-      ) {
-        const ambientHome =
-          environmentValue(this.#dependencies.environment, "CODEX_HOME") ??
-          join(homedir(), ".codex");
-        runtime.credentialsAvailable = await importAmbientAuth(
-          ambientHome,
-          runtime.codexHome,
-        );
-        this.#runtimeCredentialSource = runtime.credentialsAvailable
-          ? "stored_credentials"
-          : null;
-      }
-      if (mode !== "deep" || runtime.deepScanConfigPath !== undefined) {
-        await releaseCredentialHome?.();
-        releaseCredentialHome = null;
-      }
-      if (externalProvider === null && apiKey !== null) {
-        this.#runtimeCredentialSource = "api_key";
-      }
-      if (
-        !runtime.credentialsAvailable &&
-        authentication.method === "stored_credentials"
-      ) {
-        const status = await accountStatus(
-          this.#codexCommand(),
-          runtime.environment,
-          signal,
-        );
-        runtime.credentialsAvailable = status.authenticated;
-        this.#runtimeCredentialSource = status.authenticated
-          ? "stored_credentials"
-          : null;
-      }
-      if (
-        !runtime.credentialsAvailable &&
-        apiKey === null &&
-        authentication.method !== "aws_credentials"
-      ) {
-        throw new AuthenticationRequiredError(
-          "No credentials were found. Run 'codex-security login', use " +
-            "'codex-security login --device-auth' on a remote or headless machine, or set " +
-            "OPENAI_API_KEY or CODEX_API_KEY for CI.",
-        );
-      }
-      authentication = await runtimeScanAuthentication(
-        this.#dependencies.environment,
-        runtime.codexHome,
-        options.auth,
-        modelProvider,
-      );
-      notifyObserver(
-        "onAuthentication",
-        options.onAuthentication,
-        options.onObserverError,
-        authentication,
-      );
-      const python = await (
-        this.#dependencies.resolvePluginPython ?? resolvePluginPython
-      )({
-        configuredPath: this.config.pythonPath,
-        environment: scanEnvironment,
-        protectedRoot,
-        signal,
-      });
       checkOpen();
       const scanOutputRoot =
         requestedOutput === null &&
@@ -1009,55 +909,11 @@ export class CodexSecurity {
           ? {}
           : { CODEX_SECURITY_TARGET_PATHS_FILE: targetPathsFile }),
       };
-      const environment = {
-        ...pluginExecutionEnvironment(
-          python,
-          withoutCodexHome(
-            selectedScanEnvironment(
-              runtime.environment,
-              options.auth,
-              modelProvider,
-            ),
-          ),
-        ),
-        ...(externalProvider === null
-          ? {}
-          : { [externalProvider.env_key]: apiKey! }),
-        CODEX_HOME: runtime.codexHome,
-        ...runtimePaths,
-      };
-      const sdkCodexConfig = { ...sessionConfig };
-      // Projects and permissions already live in generated TOML files; the SDK
-      // cannot safely encode their path and selector keys as dotted overrides.
-      delete sdkCodexConfig["projects"];
-      delete sdkCodexConfig["permissions"];
-      const configuredResponsesMetadata = isRecord(
-        sdkCodexConfig["responses_api_metadata"],
-      )
-        ? sdkCodexConfig["responses_api_metadata"]
-        : {};
-      const codexPathOverride =
-        environmentValue(this.#dependencies.environment, "CODEX_CLI_PATH") ===
-        undefined
-          ? undefined
-          : this.#codexCommand().command;
-      const codex = this.#dependencies.createCodex({
-        ...(codexPathOverride === undefined ? {} : { codexPathOverride }),
-        ...(externalProvider !== null || apiKey === null ? {} : { apiKey }),
-        env: definedEnvironment(
-          selectedScanEnvironment(environment, "chatgpt"),
-        ),
-        config: {
-          ...(sdkCodexConfig as NonNullable<CodexOptions["config"]>),
-          approvals_reviewer: "auto_review",
-          default_permissions: SCAN_PERMISSION_PROFILE,
-          allow_login_shell: false,
-          responses_api_metadata: {
-            ...configuredResponsesMetadata,
-            codex_security_surface: this.#surface,
-          },
-        },
-      });
+      const { codex, environment } = this.#createSessionCodex(
+        session,
+        runtimePaths,
+        options.auth,
+      );
       const thread = codex.startThread({
         workingDirectory: scanDir,
         skipGitRepoCheck: true,
@@ -1668,6 +1524,255 @@ export class CodexSecurity {
     }
   }
 
+  #createSessionCodex(
+    session: PreparedSession,
+    runtimePaths: Record<string, string>,
+    auth: ScanAuthMode = "auto",
+  ): { codex: CodexClientLike; environment: ProcessEnvironment } {
+    const {
+      runtime,
+      python,
+      modelProvider,
+      externalProvider,
+      apiKey,
+      sessionConfig,
+    } = session;
+    const environment = {
+      ...pluginExecutionEnvironment(
+        python,
+        withoutCodexHome(
+          selectedScanEnvironment(runtime.environment, auth, modelProvider),
+        ),
+      ),
+      ...(externalProvider === null
+        ? {}
+        : { [externalProvider.env_key]: apiKey! }),
+      CODEX_HOME: runtime.codexHome,
+      ...runtimePaths,
+    };
+    const sdkCodexConfig = { ...sessionConfig };
+    // Projects and permissions already live in generated TOML files; the SDK
+    // cannot safely encode their path and selector keys as dotted overrides.
+    delete sdkCodexConfig["projects"];
+    delete sdkCodexConfig["permissions"];
+    const configuredResponsesMetadata = isRecord(
+      sdkCodexConfig["responses_api_metadata"],
+    )
+      ? sdkCodexConfig["responses_api_metadata"]
+      : {};
+    const codexPathOverride =
+      environmentValue(this.#dependencies.environment, "CODEX_CLI_PATH") ===
+      undefined
+        ? undefined
+        : this.#codexCommand().command;
+    const codex = this.#dependencies.createCodex({
+      ...(codexPathOverride === undefined ? {} : { codexPathOverride }),
+      ...(externalProvider !== null || apiKey === null ? {} : { apiKey }),
+      env: definedEnvironment(selectedScanEnvironment(environment, "chatgpt")),
+      config: {
+        ...(sdkCodexConfig as NonNullable<CodexOptions["config"]>),
+        responses_api_metadata: {
+          ...configuredResponsesMetadata,
+          codex_security_surface: this.#surface,
+        },
+      },
+    });
+    return { codex, environment };
+  }
+
+  async #prepareSession(
+    {
+      protectedRoot,
+      stateDirectory,
+    }: { protectedRoot: string; stateDirectory: string },
+    options: Pick<
+      ScanOptions,
+      | "auth"
+      | "expectedPluginVersion"
+      | "onAuthentication"
+      | "onWarning"
+      | "onObserverError"
+    >,
+    signal: AbortSignal,
+    temporaryRoot?: string,
+    keepCredentialLock = false,
+  ): Promise<PreparedSession> {
+    let releaseCredentialHome: (() => Promise<void>) | null = null;
+    const checkOpen = (): void => {
+      this.#requireOpen();
+      throwIfAborted(signal);
+    };
+    try {
+      const requestedConfig = await mergedCodexConfig(this.config);
+      const modelProvider = scanModelProvider(requestedConfig);
+      const externalProvider = isExternalModelProvider(modelProvider)
+        ? EXTERNAL_CODEX_PROVIDERS[modelProvider]
+        : null;
+      let authentication = scanAuthentication(
+        this.#dependencies.environment,
+        options.auth,
+        modelProvider,
+      );
+      const apiKey =
+        authentication.method === "api_key"
+          ? environmentApiKey(this.#dependencies.environment, modelProvider)
+          : null;
+      if (externalProvider !== null && apiKey === null) {
+        throw new AuthenticationRequiredError(
+          `Set ${externalProvider.env_key} to run a scan through ${externalProvider.name}.`,
+        );
+      }
+      const scanEnvironment = selectedScanEnvironment(
+        this.#dependencies.environment,
+        options.auth,
+        modelProvider,
+      );
+      if (this.#dependencies.prepareRuntime === undefined) {
+        const credentialHome = await prepareCodexSecurityCredentialHome(
+          scanEnvironment,
+          (path) =>
+            requireOutputOutsideRepository(protectedRoot, path, "runtime"),
+        );
+        releaseCredentialHome = await acquireCodexSecurityCredentialHomeLock(
+          credentialHome,
+          signal,
+        );
+      }
+      const previousRuntime = this.#runtime;
+      const runtime = await this.#ensureRuntime(
+        signal,
+        temporaryRoot,
+        (path) =>
+          requireOutputOutsideRepository(protectedRoot, path, "runtime"),
+        options.auth,
+        requestedConfig,
+      );
+      if (
+        runtime === previousRuntime &&
+        this.#dependencies.prepareRuntime === undefined
+      ) {
+        await this.#refreshPersistentRuntime(
+          runtime,
+          scanEnvironment,
+          signal,
+          requestedConfig,
+        );
+      }
+      const effectiveConfig = runtime.effectiveConfig ?? requestedConfig;
+      const approvalPolicy = scanApprovalPolicy(effectiveConfig);
+      const preflightConfig = scanPreflightCodexConfig(effectiveConfig);
+      if (runtime.configPath !== undefined) {
+        await writeCodexConfig(runtime.configPath, preflightConfig);
+      }
+      const runtimeHome = await realpath(runtime.codexHome);
+      requireOutputOutsideRepository(protectedRoot, runtimeHome, "runtime");
+      const sessionConfig = scanRuntimeCodexConfig(
+        effectiveConfig,
+        stateDirectory,
+        runtimeHome,
+      );
+      if (
+        options.expectedPluginVersion !== undefined &&
+        runtime.plugin.version !== options.expectedPluginVersion
+      ) {
+        throw new CodexSecurityError(
+          `The original scan used plugin version ${options.expectedPluginVersion}, but the installed version is ${runtime.plugin.version}.`,
+        );
+      }
+      checkOpen();
+      if (
+        authentication.method === "stored_credentials" &&
+        this.#runtimeCredentialSource === "api_key"
+      ) {
+        const ambientHome =
+          environmentValue(this.#dependencies.environment, "CODEX_HOME") ??
+          join(homedir(), ".codex");
+        runtime.credentialsAvailable = await importAmbientAuth(
+          ambientHome,
+          runtime.codexHome,
+        );
+        this.#runtimeCredentialSource = runtime.credentialsAvailable
+          ? "stored_credentials"
+          : null;
+      }
+      if (!keepCredentialLock || runtime.deepScanConfigPath !== undefined) {
+        await releaseCredentialHome?.();
+        releaseCredentialHome = null;
+      }
+      if (externalProvider === null && apiKey !== null) {
+        this.#runtimeCredentialSource = "api_key";
+      }
+      if (
+        !runtime.credentialsAvailable &&
+        authentication.method === "stored_credentials"
+      ) {
+        const status = await accountStatus(
+          this.#codexCommand(),
+          runtime.environment,
+          signal,
+        );
+        runtime.credentialsAvailable = status.authenticated;
+        this.#runtimeCredentialSource = status.authenticated
+          ? "stored_credentials"
+          : null;
+      }
+      if (
+        !runtime.credentialsAvailable &&
+        apiKey === null &&
+        authentication.method !== "aws_credentials"
+      ) {
+        throw new AuthenticationRequiredError(
+          "No credentials were found. Run 'codex-security login', use " +
+            "'codex-security login --device-auth' on a remote or headless machine, or set " +
+            "OPENAI_API_KEY or CODEX_API_KEY for CI.",
+        );
+      }
+      authentication = await runtimeScanAuthentication(
+        this.#dependencies.environment,
+        runtime.codexHome,
+        options.auth,
+        modelProvider,
+      );
+      notifyObserver(
+        "onAuthentication",
+        options.onAuthentication,
+        options.onObserverError,
+        authentication,
+      );
+      const python = await (
+        this.#dependencies.resolvePluginPython ?? resolvePluginPython
+      )({
+        configuredPath: this.config.pythonPath,
+        environment: scanEnvironment,
+        protectedRoot,
+        signal,
+      });
+      checkOpen();
+      return {
+        runtime,
+        runtimeHome,
+        effectiveConfig,
+        preflightConfig,
+        sessionConfig,
+        modelProvider,
+        externalProvider,
+        apiKey,
+        scanEnvironment,
+        authentication,
+        approvalPolicy,
+        python,
+        releaseCredentialHome,
+      };
+    } catch (error) {
+      try {
+        await releaseCredentialHome?.();
+      } catch (cleanupError) {
+        warnCleanupFailed(options, cleanupError, "runtime preparation");
+      }
+      throw error;
+    }
+  }
+
   async #ensureRuntime(
     signal?: AbortSignal,
     temporaryRoot?: string,
@@ -2055,6 +2160,7 @@ export async function initialCredentialsAvailable(
 function warnCleanupFailed(
   options: Pick<ScanOptions, "onWarning" | "onObserverError">,
   reason: unknown,
+  operation = "scan",
 ): void {
   // This runs where a throw would replace the scan result, so every step is inside the
   // guard: reading the reason, coercing it, and reading the observers off the options can
@@ -2066,7 +2172,7 @@ function warnCleanupFailed(
       "onWarning",
       options.onWarning,
       options.onObserverError,
-      `Could not clean up after the Codex Security scan: ${message}`,
+      `Could not clean up after the Codex Security ${operation}: ${message}`,
     );
   } catch {}
 }
@@ -2112,110 +2218,83 @@ interface ScanEventRunOptions {
 export async function runScanEvents(
   options: ScanEventRunOptions,
 ): Promise<ScanResult> {
-  let threadId = options.thread.id;
   let scanStarted = false;
-  let status = "in_progress";
-  let finalResponse = "";
-  let usage: unknown = null;
-  let lastStreamError: string | null = null;
   let tacStatusReported = false;
   try {
-    for await (const event of scanEventsWithOptionalUsage(options.events)) {
-      if (!tacStatusReported) {
-        const tacStatus = trustedAccessStatusFromEvent(event);
-        if (tacStatus !== null) {
-          tacStatusReported = true;
-          notifyObserver(
-            "onTrustedAccessStatus",
-            options.onTrustedAccessStatus,
-            options.onObserverError,
-            tacStatus,
-          );
-          if (tacStatus !== "granted") {
+    const turn = await readCodexTurn({
+      thread: options.thread,
+      events: options.events,
+      onEvent: async (event) => {
+        if (!tacStatusReported) {
+          const tacStatus = trustedAccessStatusFromEvent(event);
+          if (tacStatus !== null) {
+            tacStatusReported = true;
             notifyObserver(
-              "onWarning",
-              options.onWarning,
+              "onTrustedAccessStatus",
+              options.onTrustedAccessStatus,
               options.onObserverError,
-              trustedAccessWarning(tacStatus, options.authentication),
+              tacStatus,
+            );
+            if (tacStatus !== "granted") {
+              notifyObserver(
+                "onWarning",
+                options.onWarning,
+                options.onObserverError,
+                trustedAccessWarning(tacStatus, options.authentication),
+              );
+            }
+          }
+        }
+        for (const activity of scanActivitiesFromEvent(
+          event,
+          options.expectation.repository,
+        )) {
+          notifyObserver(
+            "onActivity",
+            options.onActivity,
+            options.onObserverError,
+            activity,
+          );
+        }
+        for (const progress of scanProgressUpdatesFromEvent(event)) {
+          if (
+            options.expectedFilesTotal !== undefined &&
+            progress.filesTotal !== options.expectedFilesTotal
+          ) {
+            continue;
+          }
+          notifyObserver(
+            "onProgress",
+            options.onProgress,
+            options.onObserverError,
+            progress,
+          );
+        }
+        const workerStatus = workerStatusFromEvent(event);
+        if (workerStatus !== null) {
+          notifyObserver(
+            "onWorkerStatus",
+            options.onWorkerStatus,
+            options.onObserverError,
+            workerStatus,
+          );
+        }
+        if (event.type === "thread.started") {
+          const startedThreadId = event["thread_id"];
+          if (typeof startedThreadId === "string") {
+            await options.onThreadStarted?.(startedThreadId);
+          }
+          if (!scanStarted) {
+            scanStarted = true;
+            notifyObserver(
+              "onScanStarted",
+              options.onScanStarted,
+              options.onObserverError,
             );
           }
         }
-      }
-      for (const activity of scanActivitiesFromEvent(
-        event,
-        options.expectation.repository,
-      )) {
-        notifyObserver(
-          "onActivity",
-          options.onActivity,
-          options.onObserverError,
-          activity,
-        );
-      }
-      for (const progress of scanProgressUpdatesFromEvent(event)) {
-        if (
-          options.expectedFilesTotal !== undefined &&
-          progress.filesTotal !== options.expectedFilesTotal
-        ) {
-          continue;
-        }
-        notifyObserver(
-          "onProgress",
-          options.onProgress,
-          options.onObserverError,
-          progress,
-        );
-      }
-      const workerStatus = workerStatusFromEvent(event);
-      if (workerStatus !== null) {
-        notifyObserver(
-          "onWorkerStatus",
-          options.onWorkerStatus,
-          options.onObserverError,
-          workerStatus,
-        );
-      }
-      if (event.type === "thread.started") {
-        const startedThreadId = event["thread_id"];
-        if (typeof startedThreadId === "string") {
-          threadId = startedThreadId;
-          await options.onThreadStarted?.(startedThreadId);
-        }
-        if (!scanStarted) {
-          scanStarted = true;
-          notifyObserver(
-            "onScanStarted",
-            options.onScanStarted,
-            options.onObserverError,
-          );
-        }
-      } else if (
-        event.type === "item.completed" &&
-        isRecord(event["item"]) &&
-        event["item"]["type"] === "agent_message" &&
-        typeof event["item"]["text"] === "string"
-      ) {
-        finalResponse = event["item"]["text"];
-      } else if (event.type === "turn.completed") {
-        status = "completed";
-        usage = event["usage"];
-      } else if (event.type === "turn.failed") {
-        throw new CodexSecurityError(turnFailureMessage(event["error"]));
-      } else if (
-        event.type === "error" &&
-        typeof event["message"] === "string"
-      ) {
-        const message = event["message"];
-        const classification = classifyConnectionFailure(message);
-        if (
-          classification === "unauthorized" ||
-          classification === "forbidden"
-        ) {
-          throw new CodexSecurityError(message);
-        }
-        const reconnect = reconnectAttempt(message);
-        if (reconnect === null) throw new CodexSecurityError(message);
-        lastStreamError = message;
+      },
+      onReconnect: (message, reconnect) => {
         notifyObserver(
           "onReconnect",
           options.onReconnect,
@@ -2223,8 +2302,10 @@ export async function runScanEvents(
           ...reconnect,
           reconnectDetails(message),
         );
-      }
-    }
+      },
+    });
+    const { status, threadId, finalResponse, lastStreamError } = turn;
+    let { usage } = turn;
     if (options.signal.aborted) {
       throw new ScanInterruptedError(
         `Codex Security scan was interrupted; partial output remains at ${options.scanDir}.`,
@@ -2281,7 +2362,58 @@ export async function runScanEvents(
   }
 }
 
-async function* scanEventsWithOptionalUsage(
+async function readCodexTurn(options: {
+  thread: CodexThreadLike;
+  events: AsyncGenerator<ScanEvent>;
+  onEvent?: (event: ScanEvent) => Promise<void> | void;
+  onReconnect?: (message: string, attempts: [number, number]) => void;
+}): Promise<{
+  threadId: string | null;
+  status: "in_progress" | "completed";
+  finalResponse: string;
+  usage: unknown;
+  lastStreamError: string | null;
+}> {
+  let threadId = options.thread.id;
+  let status: "in_progress" | "completed" = "in_progress";
+  let finalResponse = "";
+  let usage: unknown = null;
+  let lastStreamError: string | null = null;
+  for await (const event of eventsWithOptionalUsage(options.events)) {
+    await options.onEvent?.(event);
+    if (
+      event.type === "thread.started" &&
+      typeof event["thread_id"] === "string"
+    ) {
+      threadId = event["thread_id"];
+    } else if (
+      event.type === "item.completed" &&
+      isRecord(event["item"]) &&
+      event["item"]["type"] === "agent_message" &&
+      typeof event["item"]["text"] === "string"
+    ) {
+      finalResponse = event["item"]["text"];
+    } else if (event.type === "turn.completed") {
+      status = "completed";
+      usage = event["usage"];
+    } else if (event.type === "turn.failed") {
+      throw new CodexSecurityError(turnFailureMessage(event["error"]));
+    } else if (event.type === "error" && typeof event["message"] === "string") {
+      const message = event["message"];
+      const classification = classifyConnectionFailure(message);
+      if (classification === "unauthorized" || classification === "forbidden") {
+        throw new CodexSecurityError(message);
+      }
+      const reconnect = reconnectAttempt(message);
+      if (reconnect === null) throw new CodexSecurityError(message);
+      lastStreamError = message;
+      options.onReconnect?.(message, reconnect);
+    }
+  }
+  return { threadId, status, finalResponse, usage, lastStreamError };
+}
+
+async function* eventsWithOptionalUsage(
   events: AsyncGenerator<ScanEvent>,
 ): AsyncGenerator<ScanEvent> {
   try {

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -4513,8 +4513,7 @@ describe("CodexSecurity orchestration", () => {
     await mkdir(repository);
     await mkdir(ambientHome);
     await writeFile(join(ambientHome, "auth.json"), "{}\n");
-    let activeScans = 0;
-    let maximumActiveScans = 0;
+    let scansStarted = 0;
     const deepScanConfigPaths = new Set<string>();
     let releaseScans!: () => void;
     const concurrentScans = new Promise<void>((resolve) => {
@@ -4558,40 +4557,28 @@ describe("CodexSecurity orchestration", () => {
                         join(credentialHome, ".codex-security-scan.lock"),
                       ),
                     ).toBe(false);
-                    activeScans += 1;
-                    maximumActiveScans = Math.max(
-                      maximumActiveScans,
-                      activeScans,
+                    if (++scansStarted === 2) releaseScans();
+                    const credentialConfig = parseToml(
+                      await readFile(
+                        join(credentialHome, "config.toml"),
+                        "utf8",
+                      ),
                     );
-                    if (activeScans === 2) releaseScans();
-                    try {
-                      const credentialConfig = parseToml(
-                        await readFile(
-                          join(credentialHome, "config.toml"),
-                          "utf8",
-                        ),
-                      );
-                      expect(credentialConfig["model"]).toBeUndefined();
-                      const before = parseToml(
-                        await readFile(deepScanConfigPath!, "utf8"),
-                      );
-                      expect(before["deep_scan"]).toMatchObject({
-                        workers: index + 2,
-                      });
-                      await Promise.race([
-                        concurrentScans,
-                        new Promise((resolve) => setTimeout(resolve, 5_000)),
-                      ]);
-                      const after = parseToml(
-                        await readFile(deepScanConfigPath!, "utf8"),
-                      );
-                      expect(after["deep_scan"]).toMatchObject({
-                        workers: index + 2,
-                      });
-                      throw new Error("parallel managed scan reached");
-                    } finally {
-                      activeScans -= 1;
-                    }
+                    expect(credentialConfig["model"]).toBeUndefined();
+                    const before = parseToml(
+                      await readFile(deepScanConfigPath!, "utf8"),
+                    );
+                    expect(before["deep_scan"]).toMatchObject({
+                      workers: index + 2,
+                    });
+                    await concurrentScans;
+                    const after = parseToml(
+                      await readFile(deepScanConfigPath!, "utf8"),
+                    );
+                    expect(after["deep_scan"]).toMatchObject({
+                      workers: index + 2,
+                    });
+                    throw new Error("parallel managed scan reached");
                   },
                 }),
               };
@@ -4616,7 +4603,7 @@ describe("CodexSecurity orchestration", () => {
         });
       }
       expect(existsSync(credentialHome)).toBe(true);
-      expect(maximumActiveScans).toBe(2);
+      expect(scansStarted).toBe(2);
       expect(deepScanConfigPaths.size).toBe(2);
       const pluginConfiguration = JSON.parse(
         await readFile(join(PLUGIN_ROOT, ".mcp.json"), "utf8"),


### PR DESCRIPTION
## Summary

Move scan startup and Codex event handling into shared methods so the policy command can reuse them. This is the first part of the smaller stack extracted from #489. It adds no command and does not change scan output.

## Changes

- Share runtime preparation, authentication, credential locking, and Codex client setup.
- Share turn completion and reconnect handling while keeping scan-specific progress and result collection in the scan path.
- Remove repeated permission settings that the shared configuration already supplies.
- Make the parallel-scan test wait for both scans instead of relying on a timer.

## Testing

- Focused runtime, cost, and dashboard tests after merging main: 199 passed.
- Full normal and randomized suites: each had 1,318 passed, 11 skipped, and 0 failed.
- Type checking, formatting, and `git diff --check`: passed.
- Three independent native Codex reviews of `e8adefbb`, followed by a separate verification of their raw outputs: no confirmed findings.

## Risk and rollout

This moves code used by every scan, including authentication and cleanup. The branch includes main's live scan-session changes through `b88216a7`, and the regression suites cover those paths. There are no new dependencies, public SDK methods, or scan-format changes. The policy feature remains in the following PRs. This does not publish a package.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [ ] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.

An automated review contains a report link that is visible only to its requester. That link and report are not reproduced here.
