### PR TITLE
ci: allow slower Windows integration tests

### DIFF
--- a/sdk/typescript/scripts/run-windows-ci-tests.mjs
+++ b/sdk/typescript/scripts/run-windows-ci-tests.mjs
@@ -103,7 +103,9 @@ const results = await Promise.all(
               ? ""
               : " --test-name-pattern " + testNamePattern),
         );
-        const args = ["test", "--timeout", "30000"];
+        // Native Windows credential and document checks can exceed 30 seconds.
+        // The workflow still bounds each complete shard to ten minutes.
+        const args = ["test", "--timeout", "120000"];
         if (testNamePattern !== undefined) {
           args.push("--test-name-pattern", testNamePattern);
         }


### PR DESCRIPTION
## Summary

Give Windows CI integration tests enough time to finish. In the [failed main run](https://github.com/openai/codex-security/actions/runs/32065855832), the API shard timed out while validating knowledge-base documents and preparing a managed credential home. The document test ran for about 58 seconds before reporting the existing 30-second timeout.

The separate multiscan failure in that run is already covered by #494. This PR does not duplicate that production fix.

## Changes

- Raise Bun's per-test timeout from 30 seconds to two minutes in the Windows shard runner.
- Keep all seven shards, test selection, failure propagation, and the ten-minute workflow step timeout unchanged.
- Leave the normal package test timeout and production code unchanged.

## Testing

Using Bun 1.3.14 and pnpm 11.9.0:

- Temporary subprocess harness: passed. It checks all seven timeout arguments, complete test-file assignment, single-shard selection, failed-child propagation, invalid shard rejection, and the unchanged package timeout. The timeout assertion failed before the change.
- Focused API and multiscan tests: 6 passed, 0 failed.
- `pnpm run types`: passed.
- `pnpm run format`: passed.
- `pnpm run test --randomize --seed 12345`: 1,318 passed, 11 skipped, 0 failed. The first run was blocked only by macOS refusing a nested sandbox; the complete rerun passed with the needed sandbox access.
- `pnpm run test`: 1,318 passed, 11 skipped, 0 failed.
- `node --check scripts/run-windows-ci-tests.mjs`: passed.
- `git diff --check`: passed.

## Risk and rollout

Test and CI configuration only. A stuck Windows test can now run up to 90 seconds longer, but the existing ten-minute shard timeout still bounds the job. Assertions and exit-code handling remain active. Hosted Windows CI must pass before merge. The separate lock fix in #494 is still needed.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
