### PR TITLE
fix(plugin): preserve nested attack-path evidence in previews

### DIFF
--- a/sdk/typescript/_bundled_plugin/scripts/finding_preview.py
+++ b/sdk/typescript/_bundled_plugin/scripts/finding_preview.py
@@ -206,6 +206,7 @@ def bounded_finding_details(value: Any) -> dict[str, Any]:
         projected_core = bounded_json_value(
             core,
             [FINDING_DETAILS_PREVIEW_BYTES - reserved],
+            max_depth=5,
         )
         if all(key in projected_core for key in core):
             break
@@ -213,6 +214,7 @@ def bounded_finding_details(value: Any) -> dict[str, Any]:
     bounded = bounded_json_value(
         {**projected_core, **ordered_guidance, **extras},
         [FINDING_DETAILS_PREVIEW_BYTES],
+        max_depth=5,
     )
     return bounded if isinstance(bounded, dict) else {}
 
@@ -262,10 +264,16 @@ def bounded_code_evidence(value: Any) -> Any:
     return bounded
 
 
-def bounded_json_value(value: Any, budget: list[int], *, depth: int = 0) -> Any:
+def bounded_json_value(
+    value: Any,
+    budget: list[int],
+    *,
+    depth: int = 0,
+    max_depth: int = 4,
+) -> Any:
     if budget[0] <= 0:
         return None
-    if depth >= 4:
+    if depth >= max_depth:
         consume_json_budget(budget, 4)
         return None
     if isinstance(value, str):
@@ -284,7 +292,12 @@ def bounded_json_value(value: Any, budget: list[int], *, depth: int = 0) -> Any:
             separator = 0 if not result else 1
             if not consume_json_budget(budget, separator):
                 break
-            bounded_item = bounded_json_value(item, budget, depth=depth + 1)
+            bounded_item = bounded_json_value(
+                item,
+                budget,
+                depth=depth + 1,
+                max_depth=max_depth,
+            )
             size = len(json.dumps(bounded_item, separators=(",", ":")).encode("utf-8"))
             if separator + size > remaining or (
                 isinstance(item, str) and item and bounded_item == ""
@@ -339,7 +352,12 @@ def bounded_json_value(value: Any, budget: list[int], *, depth: int = 0) -> Any:
                         if budget[0] >= minimum_tests + reserved:
                             item_budget = [budget[0] - reserved]
                             break
-            bounded_item = bounded_json_value(item, item_budget, depth=depth + 1)
+            bounded_item = bounded_json_value(
+                item,
+                item_budget,
+                depth=depth + 1,
+                max_depth=max_depth,
+            )
             size = (
                 separator
                 + key_size

--- a/sdk/typescript/tests-ts/finding-preview.test.ts
+++ b/sdk/typescript/tests-ts/finding-preview.test.ts
@@ -62,4 +62,58 @@ describe("bundled finding previews", () => {
       original,
     });
   });
+
+  test("preserves nested attack-path string arrays without relaxing section depth", () => {
+    const python =
+      Bun.which("python3") ?? Bun.which("python") ?? Bun.which("py");
+    expect(python).not.toBeNull();
+
+    const original = {
+      supported: {
+        attackPath: {
+          dataflow: { evidenceRefs: ["source-to-sink"] },
+          reachability: { preconditions: ["The handler is reachable."] },
+        },
+      },
+      tooDeep: {
+        attackPath: {
+          dataflow: {
+            nested: { evidenceRefs: ["must remain depth-limited"] },
+          },
+        },
+      },
+    };
+    const program = [
+      "import json, sys",
+      "sys.path.insert(0, sys.argv[1])",
+      "from finding_preview import bounded_finding_details",
+      "original = json.loads(sys.argv[2])",
+      "projected = {name: bounded_finding_details(details) for name, details in original.items()}",
+      "print(json.dumps(projected))",
+    ].join("\n");
+    const result = Bun.spawnSync(
+      [
+        python!,
+        "-I",
+        "-B",
+        "-c",
+        program,
+        join(PLUGIN_ROOT, "scripts"),
+        JSON.stringify(original),
+      ],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+
+    expect(result.exitCode, new TextDecoder().decode(result.stderr)).toBe(0);
+    expect(JSON.parse(new TextDecoder().decode(result.stdout))).toEqual({
+      supported: original.supported,
+      tooDeep: {
+        attackPath: {
+          dataflow: {
+            nested: { evidenceRefs: [null] },
+          },
+        },
+      },
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Preserve valid nested attack-path string arrays in saved finding previews instead of replacing their elements with `null`.

Fixes #490.

## Changes

- Keep the existing depth limit for individually bounded finding sections.
- Allow one additional container level only when already-bounded sections are embedded into the complete finding preview.
- Thread the selected maximum depth through recursive JSON bounding rather than changing the default limit globally.
- Add regression coverage for `attackPath.dataflow.evidenceRefs` and `attackPath.reachability.preconditions`.
- Verify that an additional unsupported nesting level is still depth-limited.

## Why

`attackPath` is bounded as its own section and then bounded again as part of the complete finding preview. A valid shape such as:

```json
{
  "attackPath": {
    "dataflow": {
      "evidenceRefs": ["source-to-sink"]
    }
  }
}
```

places the string at depth 4 during the outer pass. The generic depth guard therefore replaced it with `null` even though the section-level pass had already accepted and bounded it.

The outer projection now accounts for its own wrapper level while section-level calls retain the existing default depth cap.

## Testing

- Added a focused regression in `tests-ts/finding-preview.test.ts` covering both reported nested string-array shapes.
- Added a negative case proving one additional arbitrary nesting level remains truncated.
- Reviewed the exact two-file diff against current `main` at `8a531126ec112f8322c8976d644d62ab9ae23dbe`.
- Full repository tests were not run locally because this execution environment cannot clone GitHub repositories; pushed-head CI remains required.

## Risk

Low. Byte budgets, field ordering, per-section depth limits, and existing guidance reservation behavior are unchanged. The only increased depth allowance is on the complete finding wrapper, where the extra level is required to represent already-bounded nested diagnostic data.