### PR TITLE
fix(plugin): avoid stale source excerpts for working-tree diffs

### DIFF
--- a/sdk/typescript/_bundled_plugin/scripts/workbench_source_excerpt.py
+++ b/sdk/typescript/_bundled_plugin/scripts/workbench_source_excerpt.py
@@ -62,6 +62,8 @@ def finding_source_excerpt(
 def scanned_source_text(scan: sqlite3.Row, target: Path, path: str) -> str | None:
     if safe_source_path(target, path) is None:
         return None
+    if scan["mode"] == "diff" and scan["diff_target_kind"] not in {"commit", "range"}:
+        return None
     revision = scan["target_revision"]
     if revision == "unversioned":
         return None

--- a/sdk/typescript/tests-ts/workbench-source-excerpt.test.ts
+++ b/sdk/typescript/tests-ts/workbench-source-excerpt.test.ts
@@ -1,0 +1,54 @@
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { PLUGIN_ROOT } from "./plugin-root.js";
+
+describe("workbench source excerpts", () => {
+  test("does not read HEAD for mutable or unknown diff targets", () => {
+    const python =
+      Bun.which("python3") ?? Bun.which("python") ?? Bun.which("py");
+    expect(python).not.toBeNull();
+
+    const program = [
+      "import json, sys",
+      "from pathlib import Path",
+      "sys.path.insert(0, sys.argv[1])",
+      "import workbench_source_excerpt as source_excerpt",
+      "calls = []",
+      "source_excerpt.safe_source_path = lambda target, path: target / path",
+      "def fake_git_bytes(target, *args):",
+      "    calls.append(list(args))",
+      "    return b'committed source\\n'",
+      "source_excerpt.git_bytes = fake_git_bytes",
+      "def read(kind):",
+      "    scan = {'mode': 'diff', 'diff_target_kind': kind, 'target_revision': 'abc123', 'target_snapshot_digest': None}",
+      "    return source_excerpt.scanned_source_text(scan, Path('/repo'), 'src/app.py')",
+      "results = {kind or 'unknown': read(kind) for kind in ('working_tree', None, 'commit', 'range')}",
+      "print(json.dumps({'results': results, 'calls': calls}))",
+    ].join("\n");
+    const result = Bun.spawnSync(
+      [
+        python!,
+        "-I",
+        "-B",
+        "-c",
+        program,
+        join(PLUGIN_ROOT, "scripts"),
+      ],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+
+    expect(result.exitCode, new TextDecoder().decode(result.stderr)).toBe(0);
+    expect(JSON.parse(new TextDecoder().decode(result.stdout))).toEqual({
+      results: {
+        working_tree: null,
+        unknown: null,
+        commit: "committed source\n",
+        range: "committed source\n",
+      },
+      calls: [
+        ["cat-file", "blob", "abc123:src/app.py"],
+        ["cat-file", "blob", "abc123:src/app.py"],
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Omit saved source excerpts when a diff scan reviewed mutable working-tree content or has an unknown migrated diff target kind.

Fixes #514.

## Problem

For diff scans, `scan_target_identity()` records the selected head revision and leaves `target_snapshot_digest` unset. Working-tree diffs keep their mutable-content identity separately in `diff_content_digest`.

`scanned_source_text()` previously treated the missing snapshot digest as safe for Git-object lookup and read:

```text
git cat-file blob <target_revision>:<path>
```

For a working-tree diff, `target_revision` is `HEAD`. That returns the committed pre-change file rather than the uncommitted content that was actually scanned, so `sourceExcerpt` could present stale evidence.

## Changes

- Fail closed for diff targets whose kind is not `commit` or `range`.
- Preserve source excerpts for committed diff targets, where the stored head revision identifies the reviewed immutable source.
- Add focused coverage proving `working_tree` and unknown diff kinds never call the Git blob reader, while `commit` and `range` continue to do so.

## Testing

- Added `tests-ts/workbench-source-excerpt.test.ts` with an injected Git reader to verify exact dispatch behavior.
- Reviewed the branch diff against current `main`: two production lines plus the focused regression file.
- Full repository tests were not run locally because this execution environment cannot clone GitHub repositories; pushed-head CI remains required.

## Risk

Low. The change only removes an excerpt when the helper cannot reconstruct the exact scanned source from an immutable Git revision. Finding data, locations, sealed artifacts, diff identity, and committed-diff excerpts are unchanged.