### PR TITLE
fix(linear): advance through project issue pages

### DIFF
--- a/sdk/typescript/src/linear.ts
+++ b/sdk/typescript/src/linear.ts
@@ -83,9 +83,12 @@ export async function importLinearIssues(options: {
         );
       }
 
-      const page = await projects.nodes[0]!.issues({ first: 50, filter });
-      while (page.pageInfo.hasNextPage) await page.fetchNext();
-      issues.push(...page.nodes);
+      let page = await projects.nodes[0]!.issues({ first: 50, filter });
+      while (true) {
+        issues.push(...page.nodes);
+        if (!page.pageInfo.hasNextPage) break;
+        page = await page.fetchNext();
+      }
       if (issues.length === 0) {
         throw new CodexSecurityError(
           `No open Linear issues matched project "${options.project}" and its filter.`,

--- a/sdk/typescript/tests-ts/linear-pagination.test.ts
+++ b/sdk/typescript/tests-ts/linear-pagination.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test";
+import {
+  importLinearIssues,
+  type LinearClientFactory,
+} from "../src/linear.js";
+
+type LinearImportClient = ReturnType<LinearClientFactory>;
+
+function issue(identifier: string) {
+  return {
+    identifier,
+    title: `Finding ${identifier}`,
+    description: `Evidence for ${identifier}`,
+    url: `https://linear.app/example/issue/${identifier}`,
+  };
+}
+
+test("imports every page of issues from a Linear project", async () => {
+  let fetchNextCalls = 0;
+  const secondPage = {
+    nodes: [issue("SEC-102")],
+    pageInfo: { hasNextPage: false },
+  };
+  const firstPage = {
+    nodes: [issue("SEC-101")],
+    pageInfo: { hasNextPage: true },
+    fetchNext: async () => {
+      fetchNextCalls += 1;
+      return secondPage;
+    },
+  };
+
+  const imported = await importLinearIssues({
+    issues: [],
+    project: "Security backlog",
+    environment: { CODEX_SECURITY_LINEAR_API_KEY: "synthetic-key" },
+    linearClient: () =>
+      ({
+        projects: async () => ({
+          nodes: [
+            {
+              issues: async (options: { first: number }) => {
+                expect(options.first).toBe(50);
+                return firstPage;
+              },
+            },
+          ],
+        }),
+      }) as unknown as LinearImportClient,
+  });
+
+  expect(fetchNextCalls).toBe(1);
+  expect(imported.map(({ id }) => id)).toEqual(["SEC-101", "SEC-102"]);
+});


### PR DESCRIPTION
## Summary

Advance through the connection returned by Linear's pagination helper when importing a project.

Fixes #516.

## Problem

Project intake fetches the first 50 issues and then repeatedly checks the first connection's `pageInfo` while discarding the connection returned by `fetchNext()`:

```ts
const page = await project.issues({ first: 50, filter });
while (page.pageInfo.hasNextPage) await page.fetchNext();
issues.push(...page.nodes);
```

Linear's SDK pagination contract returns the next connection from `fetchNext()`. If the first page reports `hasNextPage`, continuing to inspect that same page can keep requesting without advancing, and the collected nodes never move beyond the original page.

## Changes

- append each current page's nodes exactly once;
- stop when the current page has no successor;
- assign the connection returned by `fetchNext()` before continuing;
- add a focused two-page regression that verifies the second page is consumed and `fetchNext()` is called once.

## Validation

- Confirmed the current Linear SDK documentation specifies `fetchNext()` as returning the next connection.
- Reviewed the branch diff against current `main`: 6 additions and 3 deletions in production code plus the focused regression file.
- Full repository tests were not run locally because this execution environment cannot clone the repository; pushed-head CI remains required.

## Risk

Low. Single-page imports take the same path without calling `fetchNext()`. The change only affects project imports whose issue connection reports another page.