### PR TITLE
fix(history): preserve repeated stable scan matches

### DIFF
--- a/sdk/typescript/src/scan-comparison.ts
+++ b/sdk/typescript/src/scan-comparison.ts
@@ -189,7 +189,10 @@ export async function matchCompletedScan(
   );
   if (batch === undefined) return;
 
-  const historical = new Map<string, { scanId: string; finding: Finding }>();
+  const historical = new Map<
+    string,
+    { scanId: string; finding: Finding }[]
+  >();
   for (const { scanId, findings } of batch.beforeScans) {
     for (const finding of findings) {
       const findingId = finding["findingId"] as string;
@@ -197,19 +200,26 @@ export async function matchCompletedScan(
         openOccurrences.has(finding.occurrenceId) ||
         falsePositiveScans.get(findingId) === scanId
       ) {
-        historical.set(findingId, { scanId, finding });
+        const entries = historical.get(findingId) ?? [];
+        entries.push({ scanId, finding });
+        historical.set(findingId, entries);
       }
     }
   }
   if (historical.size === 0) return;
 
-  const groups = Map.groupBy(historical.values(), ({ scanId }) => scanId);
+  const groups = Map.groupBy(
+    [...historical.values()].flat(),
+    ({ scanId }) => scanId,
+  );
   const matches: ScanComparisonResult["matches"] = [];
   const after = batch.afterFindings.filter((finding) => {
     const previous = historical.get(finding["findingId"] as string);
     if (previous === undefined) return true;
     matches.push({
-      beforeOccurrenceIds: [previous.finding.occurrenceId],
+      beforeOccurrenceIds: previous.map(
+        ({ finding: historicalFinding }) => historicalFinding.occurrenceId,
+      ),
       afterOccurrenceIds: [finding.occurrenceId],
       confidence: "high",
       reason: "The findings have the same stable identity.",
@@ -222,7 +232,9 @@ export async function matchCompletedScan(
   if (historical.size > 0 && after.length > 0) {
     semanticComparison = await (options.matchFindings ?? matchScanFindings)(
       {
-        before: [...historical.values()].map(({ finding }) => finding),
+        before: [...historical.values()]
+          .flat()
+          .map(({ finding }) => finding),
         after,
       },
       {

--- a/sdk/typescript/tests-ts/scan-comparison-history.test.ts
+++ b/sdk/typescript/tests-ts/scan-comparison-history.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test";
+import {
+  matchCompletedScan,
+  type ScanComparisonResult,
+} from "../src/scan-comparison.js";
+
+test("preserves a stable finding across multiple earlier scans", async () => {
+  const earlierA = { findingId: "stable", occurrenceId: "old-a" };
+  const earlierB = { findingId: "stable", occurrenceId: "old-b" };
+  const current = { findingId: "stable", occurrenceId: "current" };
+  const commands: (readonly string[])[] = [];
+  let modelCalled = false;
+
+  await matchCompletedScan({
+    scanId: "current-scan",
+    repository: "/repository",
+    previousFindings: [earlierA, earlierB],
+    falsePositives: [],
+    findings: [current],
+    async workbench(args) {
+      commands.push(args);
+      return args[0] === "list-unmatched-scan-pairs"
+        ? {
+            batches: [
+              {
+                afterScanId: "current-scan",
+                afterFindings: [current],
+                beforeScans: [
+                  { scanId: "scan-a", findings: [earlierA] },
+                  { scanId: "scan-b", findings: [earlierB] },
+                ],
+              },
+            ],
+          }
+        : {};
+    },
+    async matchFindings() {
+      modelCalled = true;
+      return { matches: [], uncertain: [] };
+    },
+  });
+
+  expect(modelCalled).toBe(false);
+  const saves = commands.filter(
+    ([command]) => command === "save-scan-comparison",
+  );
+  expect(saves).toHaveLength(2);
+  expect(saves.map((args) => args[2])).toEqual(["scan-a", "scan-b"]);
+
+  const saved = saves.map(
+    (args) => JSON.parse(args.at(-1)!) as ScanComparisonResult,
+  );
+  expect(saved[0]!.matches).toEqual([
+    {
+      beforeOccurrenceIds: ["old-a"],
+      afterOccurrenceIds: ["current"],
+      confidence: "high",
+      reason: "The findings have the same stable identity.",
+    },
+  ]);
+  expect(saved[1]!.matches).toEqual([
+    {
+      beforeOccurrenceIds: ["old-b"],
+      afterOccurrenceIds: ["current"],
+      confidence: "high",
+      reason: "The findings have the same stable identity.",
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary

Preserve every eligible historical occurrence when the same stable finding ID appears in multiple earlier scans.

Fixes #518.

## Problem

`matchCompletedScan()` stored historical findings in a `Map` keyed only by `findingId`. Repeated observations of the same stable finding therefore overwrote one another before matching began.

The stable-identity fast path then had at most one earlier occurrence available, despite the comparison contract explicitly requiring every earlier occurrence of the same issue to be grouped with the matching later finding.

## Changes

- store all eligible historical `{ scanId, finding }` entries for each stable `findingId`;
- preserve every earlier occurrence in the stable-identity match;
- flatten only when grouping by prior scan or preparing unmatched findings for semantic comparison;
- add a regression with the same stable finding in two prior scans and the current scan.

The regression proves both prior scan pairs receive a saved confirmed match and that the semantic model is not invoked for an exact stable identity.

## Validation

- Reviewed the branch diff against the current implementation: 17 additions and 5 deletions in production code plus the focused regression file.
- Existing single-occurrence behavior remains the one-element case of the new collection.
- Full repository tests were not run locally because this execution environment cannot clone the repository; pushed-head CI remains required.

## Risk

Low. Stable identity matching remains deterministic. The change only stops discarding duplicate historical observations before the existing per-scan projection step.