### PR TITLE
fix(runtime): preserve trusted explicit Python venv paths

### DIFF
--- a/sdk/typescript/src/trusted-executable.ts
+++ b/sdk/typescript/src/trusted-executable.ts
@@ -90,7 +90,8 @@ export async function resolveTrustedExecutable(
         process.platform === "win32" ? constants.F_OK : constants.X_OK,
       );
       if (!(await stat(canonical)).isFile()) continue;
-      executable ??= pathLike ? canonical : current.path;
+      executable ??=
+        pathLike && isWithin(root, current.path) ? canonical : current.path;
     } catch {
       continue;
     }

--- a/sdk/typescript/tests-ts/trusted-executable-explicit.test.ts
+++ b/sdk/typescript/tests-ts/trusted-executable-explicit.test.ts
@@ -1,0 +1,81 @@
+import { spawnSync } from "node:child_process";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { resolveTrustedExecutable } from "../src/trusted-executable.js";
+
+test.skipIf(process.platform === "win32")(
+  "preserves a trusted explicit symlink invocation outside the protected root",
+  async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), "trusted-explicit-executable-")),
+    );
+    try {
+      const repository = join(root, "repository");
+      const trusted = join(root, "trusted");
+      const target = join(trusted, "python-target");
+      const launcher = join(trusted, "python");
+      await Promise.all([mkdir(repository), mkdir(trusted)]);
+      await writeFile(target, "#!/bin/sh\nprintf '%s\\n' \"$0\"\n");
+      await chmod(target, 0o700);
+      await symlink(target, launcher);
+
+      const resolved = await resolveTrustedExecutable(
+        launcher,
+        { PATH: trusted },
+        repository,
+      );
+      expect(resolved?.executable).toBe(launcher);
+
+      const result = spawnSync(resolved!.executable, [], {
+        encoding: "utf8",
+        env: resolved!.environment,
+      });
+      expect(result.status).toBe(0);
+      expect(result.stdout.trim()).toBe(launcher);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);
+
+test.skipIf(process.platform === "win32")(
+  "still bypasses explicit symlinks controlled by the protected root",
+  async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), "trusted-explicit-executable-")),
+    );
+    try {
+      const repository = join(root, "repository");
+      const bin = join(repository, "bin");
+      const trusted = join(root, "trusted");
+      const target = join(trusted, "python-target");
+      const launcher = join(bin, "python");
+      await Promise.all([
+        mkdir(bin, { recursive: true }),
+        mkdir(trusted),
+      ]);
+      await writeFile(target, "#!/bin/sh\nprintf '%s\\n' \"$0\"\n");
+      await chmod(target, 0o700);
+      await symlink(target, launcher);
+
+      const resolved = await resolveTrustedExecutable(
+        launcher,
+        { PATH: trusted },
+        repository,
+      );
+      expect(resolved?.executable).toBe(await realpath(target));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);


### PR DESCRIPTION
## Summary

Preserve an explicit executable's invocation path when that path is already outside the protected repository root, while continuing to canonicalize repository-controlled explicit symlinks.

Fixes #194.

## Problem

`resolveTrustedExecutable()` currently canonicalizes every path-like candidate before returning it:

```ts
executable ??= pathLike ? canonical : current.path;
```

On POSIX, a virtualenv's `bin/python` is commonly a symlink to the system interpreter. Executing the canonical target loses the virtualenv launcher identity, so Python no longer discovers that venv's site-packages. On Python 3.10 this can make a documented explicit `--python` / `pythonPath` / `PYTHON` virtualenv unusable even when it contains the required `tomli` package.

## Changes

- preserve the explicit path when the invocation path itself is outside the protected root;
- retain canonical execution when an explicit path is inside the protected root but resolves to a trusted target, so a repository-controlled symlink cannot remain on the execution boundary;
- add focused POSIX regressions for both cases.

## Security boundary

The resolver still verifies the canonical target is outside the protected root, executable, and a regular file. The only path whose spelling is preserved is one whose invocation path is itself outside the protected root. Repository-local symlinks continue to be bypassed in favor of the canonical target.

## Validation

- Rebased the branch onto current upstream `main` before editing because this file had changed since the fork was created.
- Branch diff against that exact upstream commit is two production additions, one deletion, plus the focused regression file.
- The regression executes a trusted symlinked launcher and verifies its invocation name is preserved, then verifies a repository-controlled symlink to the same trusted target still resolves to the canonical target.
- Full repository tests were not run locally because this execution environment cannot clone the repository; pushed-head CI remains required.

## Risk

Low. PATH-discovered executables are unchanged. Windows behavior without an explicit symlink is unchanged. The protected-root symlink behavior remains fail-safe; this only restores the invocation identity of already-trusted explicit paths.