### PR TITLE
fix(errors): redact supported provider API keys

### DIFF
--- a/sdk/typescript/src/errors.ts
+++ b/sdk/typescript/src/errors.ts
@@ -9,7 +9,7 @@ export function errorMessage(error: unknown): string {
 export function safeErrorMessage(error: unknown): string {
   const message = errorMessage(error);
   const recognizableCredential =
-    /(?:\b(?:sk-(?:proj-)?|github_pat_|gh[pousr]_|npm_|lin_api_)\S+|\b(?:bearer|basic|token)(?:\s|%20|\+)+\S+|:\/\/[^\s/@]+@|-----BEGIN [A-Z ]*PRIVATE KEY(?: BLOCK)?-----)/iu.test(
+    /(?:\b(?:sk-(?:proj-)?|github_pat_|gh[pousr]_|npm_|lin_api_|fw_)\S+|\b(?:bearer|basic|token)(?:\s|%20|\+)+\S+|:\/\/[^\s/@]+@|-----BEGIN [A-Z ]*PRIVATE KEY(?: BLOCK)?-----)/iu.test(
       message,
     );
   const assignments = message.matchAll(

--- a/sdk/typescript/src/errors.ts
+++ b/sdk/typescript/src/errors.ts
@@ -9,7 +9,7 @@ export function errorMessage(error: unknown): string {
 export function safeErrorMessage(error: unknown): string {
   const message = errorMessage(error);
   const recognizableCredential =
-    /(?:\b(?:sk-(?:proj-)?|github_pat_|gh[pousr]_|npm_)\S+|\b(?:bearer|basic|token)(?:\s|%20|\+)+\S+|:\/\/[^\s/@]+@|-----BEGIN [A-Z ]*PRIVATE KEY(?: BLOCK)?-----)/iu.test(
+    /(?:\b(?:sk-(?:proj-)?|github_pat_|gh[pousr]_|npm_|lin_api_)\S+|\b(?:bearer|basic|token)(?:\s|%20|\+)+\S+|:\/\/[^\s/@]+@|-----BEGIN [A-Z ]*PRIVATE KEY(?: BLOCK)?-----)/iu.test(
       message,
     );
   const assignments = message.matchAll(

--- a/sdk/typescript/tests-ts/errors.test.ts
+++ b/sdk/typescript/tests-ts/errors.test.ts
@@ -17,6 +17,7 @@ describe("error messages", () => {
     for (const message of [
       "request failed: token=SYNTHETIC_TOKEN",
       "Authorization: Bearer sk-proj-SYNTHETIC_KEY_123",
+      "Linear failed for lin_api_SYNTHETIC_SECRET",
       'upstream failed: {"clientSecret":"correct horse battery staple"}',
       JSON.stringify(JSON.stringify({ clientSecret: "SYNTHETIC_SECRET" })),
       "authorizationHeaderValue=SYNTHETIC_SECRET",

--- a/sdk/typescript/tests-ts/errors.test.ts
+++ b/sdk/typescript/tests-ts/errors.test.ts
@@ -18,6 +18,7 @@ describe("error messages", () => {
       "request failed: token=SYNTHETIC_TOKEN",
       "Authorization: Bearer sk-proj-SYNTHETIC_KEY_123",
       "Linear failed for lin_api_SYNTHETIC_SECRET",
+      "Fireworks failed for fw_SYNTHETIC_SECRET",
       'upstream failed: {"clientSecret":"correct horse battery staple"}',
       JSON.stringify(JSON.stringify({ clientSecret: "SYNTHETIC_SECRET" })),
       "authorizationHeaderValue=SYNTHETIC_SECRET",


### PR DESCRIPTION
## Summary

Recognize supported Linear and Fireworks API-key prefixes in the shared credential-bearing error redactor.

Fixes #521.

## Reproduction / evidence

`safeErrorMessage()` is the persistence/display boundary for errors. Current upstream `main` at `37bf87a692fc72d41f7312cc48808d699d204fba` recognizes several credential prefixes, but not the supported Linear `lin_api_` or Fireworks `fw_` forms.

Deterministic examples on the unfixed implementation:

```ts
safeErrorMessage(new Error("Linear failed for lin_api_SYNTHETIC_SECRET"))
safeErrorMessage(new Error("Fireworks failed for fw_SYNTHETIC_SECRET"))
```

Both messages can pass through unchanged because neither token is presented as a `Bearer` value or a named assignment.

The Linear prefix is already represented by this repository's integration fixtures. Fireworks is also an explicit Codex Security inference provider (`FIREWORKS_API_KEY`), and Fireworks' API-key documentation shows issued keys using the `fw_` prefix.

Expected result for both examples: `[redacted]`.

## Root cause

The shared redactor uses a finite known-prefix branch. Linear and Fireworks support were added without adding their bare credential prefixes to that branch, leaving callers dependent on incidental formatting or caller-specific secret comparisons.

## Fix

- add `lin_api_` to the known credential-prefix branch;
- add `fw_` to the same branch;
- keep assignment, bearer-token, URL-credential, and private-key detection unchanged.

## Tests / validation

The existing table-driven error-redaction regression now includes synthetic Linear and Fireworks credentials and requires both complete messages to become `[redacted]`.

The original branch was created from upstream `main` at `99c85613b0c4b8202b33dfbd80f41884fb9eac11`. I re-verified the same missing-prefix behavior on current upstream `main` at `37bf87a692fc72d41f7312cc48808d699d204fba` before adding the Fireworks case.

Full repository tests cannot be run in this execution environment because the repository cannot be cloned here. Pushed-head CI remains the authoritative full-suite validation.

## Risk

Low. Newly redacted messages are limited to strings containing supported credential prefixes. Ordinary words and existing redaction behavior are unchanged.