### PR TITLE
fix(progress): ignore code-fenced status markers

### DIFF
--- a/sdk/typescript/src/worker-progress.ts
+++ b/sdk/typescript/src/worker-progress.ts
@@ -68,13 +68,8 @@ export function scanProgressUpdatesFromEvent(
         : null;
   if (typeof output !== "string") return [];
   const updates: ScanProgress[] = [];
-  let codeFence = false;
-  for (const line of output.split(/\r?\n/u)) {
-    if (/^\s*```/u.test(line)) {
-      codeFence = !codeFence;
-      continue;
-    }
-    if (codeFence || !line.startsWith(SCAN_PROGRESS_PREFIX)) continue;
+  for (const line of linesOutsideCodeFences(output)) {
+    if (!line.startsWith(SCAN_PROGRESS_PREFIX)) continue;
     const progress = scanProgressFromMarker(line);
     if (progress !== null) updates.push(progress);
   }
@@ -165,9 +160,9 @@ function dispatchStatus(
   item: Readonly<Record<string, unknown>>,
 ): ScanWorkerStatus | null {
   if (typeof item["text"] !== "string") return null;
-  const markers = item["text"]
-    .split(/\r?\n/u)
-    .filter((line) => line.startsWith(WORKER_STATUS_PREFIX));
+  const markers = linesOutsideCodeFences(item["text"]).filter((line) =>
+    line.startsWith(WORKER_STATUS_PREFIX),
+  );
   const marker = markers[0];
   if (markers.length !== 1 || marker === undefined) return null;
   let payload: unknown;
@@ -192,6 +187,34 @@ function dispatchStatus(
     planned: payload["planned"],
     started: payload["started"],
   };
+}
+
+function linesOutsideCodeFences(value: string): string[] {
+  const lines: string[] = [];
+  let fence: { marker: "`" | "~"; length: number } | null = null;
+  for (const line of value.split(/\r?\n/u)) {
+    if (fence !== null) {
+      const closing = /^[ \t]{0,3}(`{3,}|~{3,})[ \t]*$/u.exec(line)?.[1];
+      if (
+        closing !== undefined &&
+        closing[0] === fence.marker &&
+        closing.length >= fence.length
+      ) {
+        fence = null;
+      }
+      continue;
+    }
+    const opening = /^[ \t]{0,3}(`{3,}|~{3,})/u.exec(line)?.[1];
+    if (opening !== undefined) {
+      fence = {
+        marker: opening[0] as "`" | "~",
+        length: opening.length,
+      };
+      continue;
+    }
+    lines.push(line);
+  }
+  return lines;
 }
 
 function isProgressCount(value: unknown): value is number {

--- a/sdk/typescript/tests-ts/worker-progress-fences.test.ts
+++ b/sdk/typescript/tests-ts/worker-progress-fences.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import {
+  scanProgressUpdatesFromEvent,
+  workerStatusFromEvent,
+} from "../src/worker-progress.js";
+
+function messageEvent(text: string): Record<string, unknown> {
+  return {
+    type: "item.completed",
+    item: { id: "message-1", type: "agent_message", text },
+  };
+}
+
+describe("worker progress Markdown fences", () => {
+  test("does not close a longer outer fence with a shorter backtick run", () => {
+    const text = [
+      "````markdown",
+      "```text",
+      'CODEX_SECURITY_SCAN_PROGRESS {"phase":"discovery","filesCompleted":8,"filesTotal":8}',
+      "```",
+      "````",
+    ].join("\n");
+
+    expect(scanProgressUpdatesFromEvent(messageEvent(text))).toEqual([]);
+  });
+
+  test("ignores worker-status markers inside fenced examples", () => {
+    const text = [
+      "Example:",
+      "```text",
+      'CODEX_SECURITY_WORKER_STATUS {"phase":"file_review","planned":6,"started":6}',
+      "```",
+    ].join("\n");
+
+    expect(workerStatusFromEvent(messageEvent(text))).toBeNull();
+  });
+
+  test("supports tilde fences and still reads markers after a fence closes", () => {
+    const text = [
+      "~~~text",
+      'CODEX_SECURITY_SCAN_PROGRESS {"phase":"discovery","filesCompleted":7,"filesTotal":8}',
+      'CODEX_SECURITY_WORKER_STATUS {"phase":"file_review","planned":6,"started":5}',
+      "~~~",
+      'CODEX_SECURITY_SCAN_PROGRESS {"phase":"validation","filesCompleted":8,"filesTotal":8}',
+      'CODEX_SECURITY_WORKER_STATUS {"phase":"validation","planned":2,"started":2}',
+    ].join("\n");
+
+    expect(scanProgressUpdatesFromEvent(messageEvent(text))).toEqual([
+      { phase: "validation", filesCompleted: 8, filesTotal: 8 },
+    ]);
+    expect(workerStatusFromEvent(messageEvent(text))).toEqual({
+      kind: "dispatch",
+      phase: "validation",
+      planned: 2,
+      started: 2,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Keep Markdown examples and quoted code from being reported as live scan progress or worker dispatch state.

Fixes #525.

## Problem

Progress parsing currently toggles a single boolean for every line beginning with three backticks. A valid four-backtick outer fence can therefore be closed incorrectly by a shorter three-backtick run inside it, exposing a quoted progress marker as live state.

Worker-status parsing has no fence handling at all, so a marker inside an ordinary fenced example is accepted directly.

## Changes

- share one fenced-line filter between scan-progress and worker-status parsing;
- track the opening fence character and run length instead of toggling a boolean;
- close only with the same marker character and a run at least as long as the opener;
- handle both backtick and tilde Markdown fences;
- add focused regressions for a four-backtick outer fence, fenced worker-status examples, tilde fences, and genuine markers after the fence closes.

## Validation

The branch is based on current upstream `main` (`99c85613b0c4b8202b33dfbd80f41884fb9eac11`) and is not behind it. Full repository tests cannot be run in this execution environment because the repository cannot be cloned here; pushed-head CI remains required.

## Risk

Low. JSON marker validation is unchanged. The change only removes marker-looking lines while they are inside Markdown fenced code blocks.