### PR TITLE
fix(config): honor selected profile approval policy

### DIFF
--- a/sdk/typescript/src/config.ts
+++ b/sdk/typescript/src/config.ts
@@ -115,10 +115,13 @@ export function scanModelProvider(config: Readonly<JsonObject>): unknown {
 export function scanApprovalPolicy(
   config: Readonly<JsonObject>,
 ): "never" | "on-request" {
-  return config["approval_policy"] === "never" ||
-    selectedScanProfile(config)?.["approval_policy"] === "never"
-    ? "never"
-    : "on-request";
+  const selectedProfile = selectedScanProfile(config);
+  const configured =
+    selectedProfile !== undefined &&
+    Object.hasOwn(selectedProfile, "approval_policy")
+      ? selectedProfile["approval_policy"]
+      : config["approval_policy"];
+  return configured === "never" ? "never" : "on-request";
 }
 
 function selectedScanProfile(

--- a/sdk/typescript/tests-ts/config-approval-policy.test.ts
+++ b/sdk/typescript/tests-ts/config-approval-policy.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { scanApprovalPolicy } from "../src/config.js";
+
+describe("scan approval policy", () => {
+  test("lets the selected profile override the root approval policy", () => {
+    expect(
+      scanApprovalPolicy({
+        approval_policy: "never",
+        profile: "interactive",
+        profiles: {
+          interactive: { approval_policy: "on-request" },
+        },
+      }),
+    ).toBe("on-request");
+
+    expect(
+      scanApprovalPolicy({
+        approval_policy: "on-request",
+        profile: "unattended",
+        profiles: {
+          unattended: { approval_policy: "never" },
+        },
+      }),
+    ).toBe("never");
+  });
+
+  test("falls back to the root policy when the profile does not set one", () => {
+    expect(
+      scanApprovalPolicy({
+        approval_policy: "never",
+        profile: "review",
+        profiles: { review: { model: "gpt-5.6-terra" } },
+      }),
+    ).toBe("never");
+  });
+});


### PR DESCRIPTION
## Summary

Resolve scan approval policy with the same selected-profile precedence already used for model, reasoning effort, and provider settings.

Fixes #528.

## Reproduction / evidence

Use an effective Codex configuration with a restrictive root policy and an explicitly selected profile that overrides it:

```toml
approval_policy = "never"
profile = "interactive"

[profiles.interactive]
approval_policy = "on-request"
```

On current `main`, `scanApprovalPolicy()` evaluates the root and profile with an OR condition:

```ts
return config["approval_policy"] === "never" ||
  selectedScanProfile(config)?.["approval_policy"] === "never"
  ? "never"
  : "on-request";
```

Actual result on `main`: `never`.

Expected result: `on-request`, because an explicitly selected profile should take precedence over the root setting, just as selected-profile `model`, `model_reasoning_effort`, and `model_provider` already do.

This is operational rather than display-only. The resolved value is passed to `codex.startThread({ approvalPolicy })`, written into scan setup, and projected into the hardened runtime config.

The regression coverage also checks the reverse direction and fallback behavior:

- root `never`, selected profile `on-request` -> `on-request`;
- root `on-request`, selected profile `never` -> `never`;
- selected profile omits the field -> use the root policy.

## Root cause

`scanApprovalPolicy()` implemented an independent restrictive merge rule instead of using the selected-profile precedence used by the other effective scan settings.

## Fix

- inspect the selected profile first;
- if it explicitly owns `approval_policy`, resolve that value;
- otherwise fall back to the root setting;
- preserve the existing public result surface of `never` or `on-request`.

## Tests / validation

Added a focused regression file covering both override directions and root fallback.

The branch was created from upstream `main` at `99c85613b0c4b8202b33dfbd80f41884fb9eac11`. The production diff is 7 additions and 4 deletions plus the focused 36-line test file.

Full repository tests cannot be run in this execution environment because the repository cannot be cloned here, so pushed-head CI remains the authoritative full-suite validation.

## Risk

Low. Behavior changes only when the selected profile explicitly sets `approval_policy` differently from the root. Profiles without their own approval policy retain root behavior.