### PR TITLE
fix(version): compare prereleases by SemVer rules

### DIFF
--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -13,6 +13,7 @@ export const BUNDLED_PLUGIN_VERSION = "0.1.20" as const;
 const PACKAGE_NAME = "@openai/codex-security";
 const VERSION_PATTERN =
   /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/u;
+const NUMERIC_PRERELEASE_IDENTIFIER = /^\d+$/u;
 
 export interface UpdateNotice {
   readonly currentVersion: string;
@@ -159,12 +160,36 @@ function isNewerVersion(latest: string, current: string): boolean {
   if (candidate[4] === installed[4]) return false;
   if (candidate[4] === undefined) return true;
   if (installed[4] === undefined) return false;
-  return (
-    new Intl.Collator("en", { numeric: true }).compare(
-      candidate[4],
-      installed[4],
-    ) > 0
+  return comparePrerelease(candidate[4], installed[4]) > 0;
+}
+
+function comparePrerelease(candidate: string, installed: string): number {
+  const candidateIdentifiers = candidate.split(".");
+  const installedIdentifiers = installed.split(".");
+  const sharedLength = Math.min(
+    candidateIdentifiers.length,
+    installedIdentifiers.length,
   );
+
+  for (let index = 0; index < sharedLength; index += 1) {
+    const left = candidateIdentifiers[index]!;
+    const right = installedIdentifiers[index]!;
+    if (left === right) continue;
+
+    const leftNumeric = NUMERIC_PRERELEASE_IDENTIFIER.test(left);
+    const rightNumeric = NUMERIC_PRERELEASE_IDENTIFIER.test(right);
+    if (leftNumeric && rightNumeric) {
+      const leftValue = BigInt(left);
+      const rightValue = BigInt(right);
+      if (leftValue !== rightValue) return leftValue > rightValue ? 1 : -1;
+      continue;
+    }
+    if (leftNumeric !== rightNumeric) return leftNumeric ? -1 : 1;
+    return left > right ? 1 : -1;
+  }
+
+  if (candidateIdentifiers.length === installedIdentifiers.length) return 0;
+  return candidateIdentifiers.length > installedIdentifiers.length ? 1 : -1;
 }
 
 function packageVersions(url: URL): {

--- a/sdk/typescript/tests-ts/update-notice-semver.test.ts
+++ b/sdk/typescript/tests-ts/update-notice-semver.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { checkForUpdate } from "../src/version.js";
+
+const registryResponse = (version: string) => async () =>
+  new Response(JSON.stringify({ version }));
+
+async function updateAvailable(current: string, latest: string): Promise<boolean> {
+  return (
+    (await checkForUpdate({
+      environment: {},
+      currentVersion: current,
+      fetch: registryResponse(latest),
+    })) !== undefined
+  );
+}
+
+describe("update notice SemVer prerelease ordering", () => {
+  test("uses case-sensitive ASCII ordering for text identifiers", async () => {
+    expect(await updateAvailable("1.0.0-A", "1.0.0-a")).toBe(true);
+    expect(await updateAvailable("1.0.0-a", "1.0.0-A")).toBe(false);
+  });
+
+  test("orders numeric and text prerelease identifiers by SemVer rules", async () => {
+    expect(await updateAvailable("1.0.0-beta.1", "1.0.0-beta.alpha")).toBe(
+      true,
+    );
+    expect(await updateAvailable("1.0.0-beta.alpha", "1.0.0-beta.1")).toBe(
+      false,
+    );
+    expect(await updateAvailable("1.0.0-beta.9", "1.0.0-beta.10")).toBe(
+      true,
+    );
+  });
+
+  test("gives a longer equal prerelease identifier list higher precedence", async () => {
+    expect(await updateAvailable("1.0.0-alpha", "1.0.0-alpha.1")).toBe(true);
+    expect(await updateAvailable("1.0.0-alpha.1", "1.0.0-alpha")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Use deterministic SemVer prerelease precedence for CLI update notices instead of locale collation.

Fixes #534.

## Reproduction / evidence

Current `main` compares prerelease suffixes with:

```ts
new Intl.Collator("en", { numeric: true }).compare(candidate[4], installed[4])
```

SemVer does not use locale collation. Its prerelease identifiers are dot-separated, numeric identifiers compare numerically and have lower precedence than non-numeric identifiers, and non-numeric identifiers compare by ASCII code points.

Concrete reproduction:

- installed: `1.0.0-A`
- registry latest: `1.0.0-a`

SemVer says `1.0.0-a` is newer because ASCII lowercase `a` sorts after uppercase `A`. Locale collation does not preserve that SemVer ordering, so current `main` can suppress a valid update. Reversing the pair can create the opposite false-positive notice.

Additional cases covered by the regression:

- `beta.9` < `beta.10` numerically;
- numeric identifier < non-numeric identifier;
- `alpha` < `alpha.1` when all shared identifiers are equal;
- case-sensitive text ordering follows ASCII rather than locale rules.

## Root cause

`isNewerVersion()` delegated SemVer prerelease precedence to `Intl.Collator`, whose locale-sensitive comparison contract differs from SemVer.

## Fix

- split prereleases into dot-separated identifiers;
- compare numeric identifiers numerically without converting large identifiers through JavaScript `Number`;
- rank numeric identifiers below non-numeric identifiers;
- compare text identifiers deterministically by ASCII ordering;
- use identifier-list length when all shared identifiers are equal.

## Tests / validation

Added focused regression coverage for case ordering, numeric ordering, numeric-vs-text precedence, and prefix-length precedence.

The branch was created from upstream `main` at `99c85613b0c4b8202b33dfbd80f41884fb9eac11`. Production changes are 30 additions and 5 deletions plus the focused regression file.

Full repository tests cannot be run in this execution environment because the repository cannot be cloned here. Pushed-head CI remains the authoritative full-suite validation.

## Risk

Low. Stable major/minor/patch comparison is unchanged. This changes only prerelease-to-prerelease ordering and follows the SemVer precedence rules directly.