### PR TITLE
fix(contract): constrain canonical code-evidence paths

### DIFF
--- a/sdk/typescript/_bundled_plugin/schemas/findings.schema.json
+++ b/sdk/typescript/_bundled_plugin/schemas/findings.schema.json
@@ -234,7 +234,8 @@
                 },
                 "path": {
                   "type": "string",
-                  "minLength": 1
+                  "minLength": 1,
+                  "pattern": "^(?!/)(?!\\.$)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*\\\\)(?!.*:)(?!.*\\u0000).+$"
                 },
                 "startLine": {
                   "type": "integer",

--- a/sdk/typescript/tests-ts/code-evidence-paths.test.ts
+++ b/sdk/typescript/tests-ts/code-evidence-paths.test.ts
@@ -1,0 +1,95 @@
+import { createHash } from "node:crypto";
+import { chmod, cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import { loadContract } from "../src/index.js";
+import { PLUGIN_ROOT } from "./plugin-root.js";
+
+const EXAMPLE = join(PLUGIN_ROOT, "examples", "completed-scan");
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+async function scanWithEvidencePath(path: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "codex-security-evidence-path-"));
+  temporaryDirectories.push(root);
+  const scanDir = join(root, "scan");
+  await cp(EXAMPLE, scanDir, { recursive: true });
+  if (process.platform !== "win32") await chmod(scanDir, 0o700);
+
+  const findingsPath = join(scanDir, "findings.json");
+  const findings = JSON.parse(await readFile(findingsPath, "utf8")) as {
+    findings: Array<Record<string, unknown>>;
+  };
+  findings.findings[0]!["codeEvidence"] = [
+    {
+      id: "evidence-1",
+      label: "Source evidence",
+      path,
+      startLine: 41,
+      endLine: 44,
+      language: "python",
+      role: "sink",
+      code: "target.write(data)",
+      explanation: "The selected path reaches the filesystem write.",
+    },
+  ];
+  await writeFile(findingsPath, `${JSON.stringify(findings, null, 2)}\n`);
+
+  const manifestPath = join(scanDir, "scan-manifest.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as {
+    scan: { artifacts: Array<{ path: string; sha256: string }> };
+  };
+  const artifact = manifest.scan.artifacts.find(
+    (candidate) => candidate.path === "findings.json",
+  );
+  expect(artifact).toBeDefined();
+  artifact!.sha256 = createHash("sha256")
+    .update(await readFile(findingsPath))
+    .digest("hex");
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  return scanDir;
+}
+
+describe("canonical code-evidence paths", () => {
+  test("rejects paths outside the repository-relative POSIX boundary", async () => {
+    for (const path of [
+      "../../outside.ts",
+      "/etc/passwd",
+      "C:/outside.ts",
+      "src\\outside.ts",
+      ".",
+      "src:stream.ts",
+      "src/\0outside.ts",
+    ]) {
+      const scanDir = await scanWithEvidencePath(path);
+      await expect(
+        loadContract(scanDir, { pluginRoot: PLUGIN_ROOT }),
+      ).rejects.toThrow("findings.json");
+    }
+  });
+
+  test("accepts a repository-relative code-evidence path", async () => {
+    const scanDir = await scanWithEvidencePath("src/extract.py");
+    await expect(
+      loadContract(scanDir, { pluginRoot: PLUGIN_ROOT }),
+    ).resolves.toMatchObject({
+      findings: {
+        findings: [
+          {
+            codeEvidence: [
+              expect.objectContaining({ path: "src/extract.py" }),
+            ],
+          },
+        ],
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Require canonical `codeEvidence[].path` values to stay inside the same repository-relative POSIX path boundary used elsewhere in the scan contract.

Fixes #541.

## Reproduction / evidence

Current upstream `main` at `37bf87a692fc72d41f7312cc48808d699d204fba` explicitly validates every ordinary finding location with the canonical safe-path helper, but the findings schema defines `codeEvidence[].path` as only a nonempty string.

A sealed-contract reproduction is:

1. copy the bundled completed-scan example;
2. add otherwise valid code evidence whose path is `../../outside.ts`;
3. recompute the sealed `findings.json` digest in `scan-manifest.json`;
4. call `loadContract()`.

On the unfixed schema, the traversal path satisfies the code-evidence schema and no separate canonical code-evidence path check rejects it.

The regression in this PR exercises the real sealed loader with these invalid shapes:

- `../../outside.ts`;
- `/etc/passwd`;
- `C:/outside.ts`;
- `src\\outside.ts`;
- `.`;
- `src:stream.ts`;
- a path containing NUL.

It also reseals and loads a valid `src/extract.py` control.

## Root cause

Location path safety was implemented in explicit validator code, while optional code evidence was added with only a schema-level nonempty-string requirement. The shared findings schema is consumed by both TypeScript validation and the Python finalizer, so the missing constraint crossed both validation surfaces.

## Fix

Add a safe repository-relative path pattern to `codeEvidence[].path`. It rejects absolute paths, traversal segments, backslashes, colon-bearing paths, the standalone dot path, and NUL characters.

The schema remains otherwise unchanged.

## Tests / validation

Added `code-evidence-paths.test.ts`, which mutates the real completed-scan fixture, recomputes the findings artifact digest, and calls `loadContract()` for every invalid path plus a valid control.

The branch is based directly on current upstream `main` at `37bf87a692fc72d41f7312cc48808d699d204fba` and is not behind it. Production change: 2 additions and 1 deletion in the shared findings schema. The remainder is focused regression coverage.

Full repository tests cannot be run in this execution environment because the repository cannot be cloned here. Pushed-head CI remains the authoritative full-suite validation.

## Risk

Low. This only rejects code-evidence paths that violate the repository-relative path model already enforced for canonical finding locations. Valid repository-relative paths are unchanged.