### PR TITLE
fix(plugin): decode diff Git paths as UTF-8

### DIFF
--- a/sdk/typescript/_bundled_plugin/scripts/generate_rank_input.py
+++ b/sdk/typescript/_bundled_plugin/scripts/generate_rank_input.py
@@ -622,6 +622,7 @@ def run_git_changed_paths(repo: Path, diff_args: list[str]) -> list[tuple[Path, 
         check=True,
         capture_output=True,
         text=True,
+        encoding="utf-8",
     )
     fields = result.stdout.split("\0")
     if fields and not fields[-1]:
@@ -650,6 +651,7 @@ def git_changed_paths(repo: Path, base: str, head: str, mode: str) -> list[tuple
             ["git", "-C", str(repo), "ls-files", "--others", "--exclude-standard", "-z"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             check=True,
         )
         combined = dict(staged)

--- a/sdk/typescript/tests-ts/diff-rank-git-encoding.test.ts
+++ b/sdk/typescript/tests-ts/diff-rank-git-encoding.test.ts
@@ -34,8 +34,8 @@ committed = module.run_git_changed_paths(repository, ["base..head"])
 working = module.git_changed_paths(repository, "base", "HEAD", "local-patch")
 print(json.dumps({
     "calls": len(calls),
-    "committed": [[str(path), status] for path, status in committed],
-    "working": [[str(path), status] for path, status in working],
+    "committed": [[path.as_posix(), status] for path, status in committed],
+    "working": [[path.as_posix(), status] for path, status in working],
 }, ensure_ascii=False))
 `;
 

--- a/sdk/typescript/tests-ts/diff-rank-git-encoding.test.ts
+++ b/sdk/typescript/tests-ts/diff-rank-git-encoding.test.ts
@@ -1,0 +1,54 @@
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { PLUGIN_ROOT } from "./plugin-root.js";
+
+test("diff ranking decodes Git path lists explicitly as UTF-8", () => {
+  const python = Bun.which("python3") ?? Bun.which("python") ?? Bun.which("py");
+  expect(python).not.toBeNull();
+  const helper = join(PLUGIN_ROOT, "scripts", "generate_rank_input.py");
+  const script = `
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+helper = ${JSON.stringify(helper)}
+spec = importlib.util.spec_from_file_location("codex_security_generate_rank_input", helper)
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+calls = []
+def fake_run(command, **kwargs):
+    assert kwargs.get("text") is True
+    assert kwargs.get("encoding") == "utf-8"
+    calls.append(command)
+    if "ls-files" in command:
+        return subprocess.CompletedProcess(command, 0, stdout="src/新規.py\\0", stderr="")
+    return subprocess.CompletedProcess(command, 0, stdout="M\\0src/測試.py\\0", stderr="")
+
+module.subprocess.run = fake_run
+repository = Path("/synthetic-repository")
+committed = module.run_git_changed_paths(repository, ["base..head"])
+working = module.git_changed_paths(repository, "base", "HEAD", "local-patch")
+print(json.dumps({
+    "calls": len(calls),
+    "committed": [[str(path), status] for path, status in committed],
+    "working": [[str(path), status] for path, status in working],
+}, ensure_ascii=False))
+`;
+
+  const result = spawnSync(python!, ["-B", "-c", script], {
+    encoding: "utf8",
+  });
+  expect(result.status, result.stderr).toBe(0);
+  expect(JSON.parse(result.stdout)).toEqual({
+    calls: 4,
+    committed: [["/synthetic-repository/src/測試.py", "M"]],
+    working: [
+      ["/synthetic-repository/src/新規.py", "A"],
+      ["/synthetic-repository/src/測試.py", "M"],
+    ],
+  });
+});


### PR DESCRIPTION
## Summary

Decode Git filename lists explicitly as UTF-8 in diff ranking instead of using Python's process-locale decoder.

Fixes #533.

## Reproduction / evidence

Current upstream `main` at `37bf87a692fc72d41f7312cc48808d699d204fba` has two direct text-mode Git subprocesses in `generate_rank_input.py` without an explicit encoding:

- `git diff --name-status -z` for committed, staged, and unstaged changed paths;
- `git ls-files --others --exclude-standard -z` for working-tree untracked paths.

With `text=True`, Python chooses the process locale encoding. On Windows with a non-UTF-8 ANSI code page, Git's UTF-8 filename output can therefore decode incorrectly or fail before ranking begins. The repository path itself can be ASCII; a changed filename containing non-ASCII characters is sufficient.

This exact call site was independently identified in the earlier closed #293 investigation while addressing #192. That PR documented failures for non-ASCII Git filenames and explicitly noted this helper as a second call site. The current helper still contained both locale-dependent subprocesses.

The regression in this PR instruments `subprocess.run` inside the actual Python helper and refuses every Git text invocation unless `encoding == "utf-8"`. It exercises both the changed-path and untracked-path flows using synthetic `測試.py` and `新規.py` names. On the unfixed helper the assertion fails because `encoding` is absent.

## Root cause

The diff-ranking helper launches Git directly rather than routing these path-list operations through the already-hardened workbench Git helper. Its text-mode subprocesses therefore inherited Python's locale decoder.

## Fix

Add `encoding="utf-8"` to both text-mode Git filename-list subprocesses:

- changed-path enumeration;
- untracked-file enumeration.

No error handler or replacement decoding is added. Invalid UTF-8 still fails rather than silently changing a filename.

## Tests / validation

Added `diff-rank-git-encoding.test.ts`. The test imports the real bundled Python helper, replaces only its subprocess boundary, and verifies:

- every text-mode Git call requests UTF-8;
- committed non-ASCII paths are parsed correctly;
- working-tree changed and untracked non-ASCII paths are preserved;
- synthetic path output is normalized for cross-platform CI.

The branch is based directly on current upstream `main` at `37bf87a692fc72d41f7312cc48808d699d204fba` and is not behind it. Production change: exactly 2 additions, 0 deletions. The remainder is focused regression coverage.

Full repository tests cannot be run in this execution environment because the repository cannot be cloned here. Pushed-head CI remains the authoritative full-suite validation.

## Risk

Low. Git filename decoding becomes deterministic UTF-8 instead of locale-dependent. ASCII paths are unchanged, and binary Git operations are untouched.