### PR TITLE
fix(activity): preserve Windows paths across casing

### DIFF
--- a/sdk/typescript/src/scan-activity.ts
+++ b/sdk/typescript/src/scan-activity.ts
@@ -353,9 +353,31 @@ function sessionCallArguments(
   }
 }
 
+function repositoryPathPrefix(repository: string): {
+  prefix: string;
+  caseInsensitive: boolean;
+} {
+  const normalized = repository.replaceAll("\\", "/").replace(/\/$/u, "");
+  return {
+    prefix: `${normalized}/`,
+    caseInsensitive:
+      /^[A-Za-z]:\//u.test(normalized) || normalized.startsWith("//"),
+  };
+}
+
+function startsWithPathPrefix(
+  value: string,
+  prefix: string,
+  caseInsensitive: boolean,
+): boolean {
+  return caseInsensitive
+    ? value.slice(0, prefix.length).toLowerCase() === prefix.toLowerCase()
+    : value.startsWith(prefix);
+}
+
 function commandRepositoryPaths(command: string, repository: string): string[] {
   const paths = new Set<string>();
-  const repositoryPrefix = repository.replaceAll("\\", "/").replace(/\/$/u, "");
+  const repositoryPrefix = repositoryPathPrefix(repository);
   for (const token of command.match(SHELL_TOKEN) ?? []) {
     let value = token;
     if (
@@ -365,12 +387,12 @@ function commandRepositoryPaths(command: string, repository: string): string[] {
       value = value.slice(1, -1);
     }
     value = value.replaceAll('\\"', '"').replaceAll("\\", "/");
-    for (const prefix of [
-      "$CODEX_SECURITY_REPOSITORY/",
-      "${CODEX_SECURITY_REPOSITORY}/",
-      `${repositoryPrefix}/`,
+    for (const { prefix, caseInsensitive } of [
+      { prefix: "$CODEX_SECURITY_REPOSITORY/", caseInsensitive: false },
+      { prefix: "${CODEX_SECURITY_REPOSITORY}/", caseInsensitive: false },
+      repositoryPrefix,
     ]) {
-      if (!value.startsWith(prefix)) continue;
+      if (!startsWithPathPrefix(value, prefix, caseInsensitive)) continue;
       const path = value
         .slice(prefix.length)
         .replace(/["'\r\n].*$/u, "")
@@ -394,11 +416,11 @@ function argumentRepositoryPaths(value: unknown, repository: string): string[] {
   if (!isRecord(value)) return [];
   const candidates = [value["path"], value["file_path"], value["paths"]].flat();
   const paths = new Set<string>();
-  const prefix = `${repository.replaceAll("\\", "/").replace(/\/$/u, "")}/`;
+  const { prefix, caseInsensitive } = repositoryPathPrefix(repository);
   for (const candidate of candidates) {
     if (typeof candidate !== "string") continue;
     const normalized = candidate.replaceAll("\\", "/");
-    if (normalized.startsWith(prefix)) {
+    if (startsWithPathPrefix(normalized, prefix, caseInsensitive)) {
       const path = normalized.slice(prefix.length);
       if (!path.split("/").includes("..")) paths.add(path);
     }

--- a/sdk/typescript/tests-ts/scan-activity-windows-case.test.ts
+++ b/sdk/typescript/tests-ts/scan-activity-windows-case.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import {
+  scanActivityFromEvent,
+  scanActivityFromSessionEvent,
+} from "../src/scan-activity.js";
+
+function toolEvent(path: string): Record<string, unknown> {
+  return {
+    type: "item.started",
+    item: {
+      id: "tool-1",
+      type: "mcp_tool_call",
+      tool: "read_file",
+      arguments: { path },
+      status: "in_progress",
+    },
+  };
+}
+
+function commandEvent(command: string): Record<string, unknown> {
+  return {
+    type: "item.started",
+    item: {
+      id: "command-1",
+      type: "command_execution",
+      command,
+      status: "in_progress",
+    },
+  };
+}
+
+describe("Windows activity path casing", () => {
+  test("preserves repository paths when Windows casing differs", () => {
+    const repository = "C:\\code\\juice-shop";
+    const path = "c:\\CODE\\JUICE-SHOP\\routes\\Login.ts";
+
+    expect(scanActivityFromEvent(toolEvent(path), repository)).toMatchObject({
+      paths: ["routes/Login.ts"],
+    });
+    expect(
+      scanActivityFromSessionEvent(
+        {
+          type: "response_item",
+          payload: {
+            type: "function_call",
+            name: "read_file",
+            call_id: "worker-tool-1",
+            arguments: JSON.stringify({ path }),
+          },
+        },
+        repository,
+      ),
+    ).toMatchObject({ paths: ["routes/Login.ts"] });
+    expect(
+      scanActivityFromEvent(
+        commandEvent('type "c:\\CODE\\JUICE-SHOP\\routes\\Login.ts"'),
+        repository,
+      ),
+    ).toMatchObject({ paths: ["routes/Login.ts"] });
+  });
+
+  test("matches UNC repository roots case-insensitively", () => {
+    expect(
+      scanActivityFromEvent(
+        toolEvent("\\\\server\\share\\REPO\\src\\auth.ts"),
+        "\\\\Server\\Share\\repo",
+      ),
+    ).toMatchObject({ paths: ["src/auth.ts"] });
+  });
+
+  test("keeps POSIX repository matching case-sensitive", () => {
+    expect(
+      scanActivityFromEvent(
+        toolEvent("/code/Juice-Shop/routes/login.ts"),
+        "/code/juice-shop",
+      ),
+    ).toMatchObject({ paths: [] });
+  });
+});


### PR DESCRIPTION
## Summary

Preserve live and saved scan activity paths when Windows repository/path casing differs.

Fixes #544.

## Reproduction / evidence

Current upstream `main` at `37bf87a692fc72d41f7312cc48808d699d204fba` normalizes Windows separators but compares the concrete repository prefix with case-sensitive `startsWith()`.

For example:

```ts
scanActivityFromEvent(
  toolEvent("c:\\CODE\\JUICE-SHOP\\routes\\Login.ts"),
  "C:\\code\\juice-shop",
)
```

The path denotes the same ordinary Windows repository location, but current `main` returns `paths: []`.

The same prefix logic is used for saved-session tool calls and absolute paths embedded in shell commands.

## Root cause

Path separators were normalized independently of path-comparison semantics. Windows drive and UNC roots therefore passed through POSIX-style case-sensitive prefix matching.

## Fix

- normalize the repository root once and detect Windows drive/UNC path shapes;
- compare only concrete Windows repository prefixes case-insensitively;
- keep `$CODEX_SECURITY_REPOSITORY` placeholder matching case-sensitive;
- slice the relative path from the original normalized value so source-path casing is preserved;
- keep POSIX repository comparisons case-sensitive.

The logic is based on the repository path shape rather than `process.platform`, so saved/synthetic Windows events remain correct when rendered on another host.

## Tests / validation

Added `scan-activity-windows-case.test.ts` covering:

- live tool events with different drive/directory casing;
- saved-session tool events;
- command path extraction;
- UNC repository roots;
- a POSIX case-sensitivity control.

The branch is based directly on current upstream `main` at `37bf87a692fc72d41f7312cc48808d699d204fba` and is not behind it.

Full repository tests cannot be run in this execution environment because the repository cannot be cloned here. Pushed-head CI remains the authoritative full-suite validation.

## Risk

Low. The behavior changes only for Windows-shaped absolute repository prefixes. Relative display casing is preserved and POSIX semantics are unchanged.