### PR TITLE
fix(targets): reject special path targets in preflight

### DIFF
--- a/sdk/typescript/src/targets.ts
+++ b/sdk/typescript/src/targets.ts
@@ -266,6 +266,20 @@ export async function normalizeTarget(
         cause: error,
       });
     }
+    let metadata;
+    try {
+      metadata = await abortable(() => stat(canonical), signal);
+    } catch (error) {
+      throwIfAborted(signal);
+      throw new InvalidTargetError(`Path target does not exist: ${value}`, {
+        cause: error,
+      });
+    }
+    if (!metadata.isFile() && !metadata.isDirectory()) {
+      throw new InvalidTargetError(
+        `Path target must be a regular file or directory: ${value}`,
+      );
+    }
     const relativePath = relative(root, canonical);
     if (
       relativePath === ".." ||

--- a/sdk/typescript/src/targets.ts
+++ b/sdk/typescript/src/targets.ts
@@ -266,6 +266,16 @@ export async function normalizeTarget(
         cause: error,
       });
     }
+    const relativePath = relative(root, canonical);
+    if (
+      relativePath === ".." ||
+      relativePath.startsWith(`..${sep}`) ||
+      isAbsolute(relativePath)
+    ) {
+      throw new InvalidTargetError(
+        `Path target is outside the repository: ${value}`,
+      );
+    }
     let metadata;
     try {
       metadata = await abortable(() => stat(canonical), signal);
@@ -278,16 +288,6 @@ export async function normalizeTarget(
     if (!metadata.isFile() && !metadata.isDirectory()) {
       throw new InvalidTargetError(
         `Path target must be a regular file or directory: ${value}`,
-      );
-    }
-    const relativePath = relative(root, canonical);
-    if (
-      relativePath === ".." ||
-      relativePath.startsWith(`..${sep}`) ||
-      isAbsolute(relativePath)
-    ) {
-      throw new InvalidTargetError(
-        `Path target is outside the repository: ${value}`,
       );
     }
     const normalized = relativePath.split(sep).join("/") || ".";

--- a/sdk/typescript/tests-ts/path-target-special-files.test.ts
+++ b/sdk/typescript/tests-ts/path-target-special-files.test.ts
@@ -1,0 +1,46 @@
+import { createServer } from "node:net";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { normalizeTarget } from "../src/targets.js";
+
+test.skipIf(process.platform === "win32")(
+  "rejects special filesystem nodes during path-target preflight",
+  async () => {
+    const root = await mkdtemp(join(tmpdir(), "codex-security-special-target-"));
+    const repository = join(root, "repository");
+    const socketPath = join(repository, "target.sock");
+    await mkdir(repository);
+    const server = createServer();
+
+    try {
+      await new Promise<void>((resolvePromise, reject) => {
+        server.once("error", reject);
+        server.listen(socketPath, () => resolvePromise());
+      });
+
+      await expect(normalizeTarget(repository, [socketPath])).rejects.toThrow(
+        "Path target must be a regular file or directory",
+      );
+    } finally {
+      await new Promise<void>((resolvePromise) => server.close(() => resolvePromise()));
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);
+
+test("keeps ordinary file and directory path targets valid", async () => {
+  const root = await mkdtemp(join(tmpdir(), "codex-security-regular-target-"));
+  const repository = join(root, "repository");
+  try {
+    await mkdir(join(repository, "src"), { recursive: true });
+    await writeFile(join(repository, "src", "app.ts"), "export {};\n");
+
+    await expect(
+      normalizeTarget(repository, ["src/app.ts", "src"]),
+    ).resolves.toEqual({ kind: "paths", paths: ["src/app.ts", "src"] });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Reject special filesystem nodes as path scan targets during local target normalization instead of allowing them to fail later in bundled scan setup.

Fixes #548.

## Reproduction / evidence

Current upstream `main` at `37bf87a692fc72d41f7312cc48808d699d204fba` checks only that a path target exists, resolves it, and stays inside the repository. It does not check whether the resolved target is a file or directory.

On POSIX, a Unix-domain socket inside the repository therefore passes `normalizeTarget()` and is returned as a valid `paths` target.

The bundled `generate_rank_input.py` scope resolver later rejects the same node because it explicitly requires `is_dir()` or `is_file()`.

That contradicts the public preflight boundary, which validates local inputs before runtime initialization.

## Root cause

Existence and containment checks were present, but filesystem type validation was deferred to a later Python setup helper.

## Fix

After canonicalizing each path target, `stat()` the resolved path and require it to be a regular file or directory. A special node now raises `InvalidTargetError` during local target validation.

## Tests / validation

Added `path-target-special-files.test.ts`:

- POSIX regression creates a real Unix-domain socket inside the repository and requires `normalizeTarget()` to reject it;
- a control verifies ordinary file and directory targets still normalize normally.

The branch is based directly on current upstream `main` at `37bf87a692fc72d41f7312cc48808d699d204fba` and is not behind it. Production change: 14 additions, 0 deletions.

Full repository tests cannot be run in this execution environment because the repository cannot be cloned here. Pushed-head CI remains the authoritative full-suite validation.

## Risk

Low. The accepted target set now matches the file/directory invariant already enforced by bundled scan setup. Normal files, directories, and in-repository symlink targets that resolve to either remain supported.