### PR TITLE
fix(auth): require HTTPS login instructions

### DIFF
--- a/sdk/typescript/src/auth.ts
+++ b/sdk/typescript/src/auth.ts
@@ -243,7 +243,9 @@ function preferredAuthUrl(value: string): string | null {
   )) {
     const url = match[0].replace(/[.,;:!?)\]}]+$/, "");
     try {
-      const hostname = new URL(url).hostname.toLowerCase().replace(/\.$/, "");
+      const parsed = new URL(url);
+      if (parsed.protocol !== "https:") continue;
+      const hostname = parsed.hostname.toLowerCase().replace(/\.$/, "");
       if (
         hostname !== "localhost" &&
         !hostname.endsWith(".localhost") &&

--- a/sdk/typescript/tests-ts/auth-http-url.test.ts
+++ b/sdk/typescript/tests-ts/auth-http-url.test.ts
@@ -1,0 +1,33 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { CodexLoginHandle } from "../src/auth.js";
+
+test("skips external plaintext HTTP authentication URLs", async () => {
+  const root = await mkdtemp(join(tmpdir(), "codex-security-auth-http-"));
+  const script = join(root, "login.mjs");
+  try {
+    await writeFile(
+      script,
+      `
+console.error("Open http://auth.example.test/insecure");
+console.error("Open https://auth.example.test/device");
+console.error("User code: ABCD-EFGH");
+process.exit(0);
+`,
+    );
+    const handle = new CodexLoginHandle(
+      { command: process.execPath },
+      [script],
+      process.env,
+      () => {},
+    );
+
+    await expect(handle.wait()).resolves.toMatchObject({ success: true });
+    expect(handle.verificationUrl).toBe("https://auth.example.test/device");
+    expect(handle.userCode).toBe("ABCD-EFGH");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Reject external plaintext HTTP authentication URLs when extracting interactive Codex login instructions.

Fixes #550.

## Reproduction / evidence

Current upstream `main` at `37bf87a692fc72d41f7312cc48808d699d204fba` searches login output with an `https?://` pattern and then validates only hostname locality. A fake login child that prints:

```text
Open http://auth.example.test/insecure
Open https://auth.example.test/device
User code: ABCD-EFGH
```

causes current `main` to retain the first external URL, `http://auth.example.test/insecure`, as `verificationUrl`.

The existing authentication boundary already filters local HTTP listener/callback URLs and retains remote HTTPS verification URLs.

## Root cause

`preferredAuthUrl()` parsed candidate URLs and checked whether their hostname was localhost, loopback, or unspecified, but never checked the parsed protocol. Because the initial matcher accepts both `http` and `https`, any external plaintext HTTP URL survived.

## Fix

Parse each candidate once and require `parsed.protocol === "https:"` before applying the existing hostname exclusions. Local HTTP listener lines continue to be ignored, and a later HTTPS verification URL can still be selected.

## Tests / validation

Added `auth-http-url.test.ts`, which launches a real child process that emits an external HTTP URL before an HTTPS URL plus a device code. The test requires the handle to expose only the HTTPS URL and preserve the code.

The branch is based directly on current upstream `main` at `37bf87a692fc72d41f7312cc48808d699d204fba` and is not behind it. Production change: 3 additions and 1 deletion.

Full repository tests cannot be run in this execution environment because the repository cannot be cloned here. Pushed-head CI remains the authoritative full-suite validation.

## Risk

Low. The change narrows accepted remote authentication destinations to HTTPS while preserving the existing local-address filtering and terminal parsing behavior.