### PR TITLE
fix(progress): reject inconsistent preflight capability output

### DIFF
--- a/sdk/typescript/src/worker-progress.ts
+++ b/sdk/typescript/src/worker-progress.ts
@@ -108,6 +108,8 @@ function preflightStatus(
   item: Readonly<Record<string, unknown>>,
 ): ScanWorkerStatus | null {
   if (
+    item["status"] === "failed" ||
+    (typeof item["exit_code"] === "number" && item["exit_code"] !== 0) ||
     typeof item["command"] !== "string" ||
     !PREFLIGHT_COMMAND.test(item["command"]) ||
     typeof item["aggregated_output"] !== "string"

--- a/sdk/typescript/src/worker-progress.ts
+++ b/sdk/typescript/src/worker-progress.ts
@@ -109,7 +109,6 @@ function preflightStatus(
 ): ScanWorkerStatus | null {
   if (
     item["status"] === "failed" ||
-    (typeof item["exit_code"] === "number" && item["exit_code"] !== 0) ||
     typeof item["command"] !== "string" ||
     !PREFLIGHT_COMMAND.test(item["command"]) ||
     typeof item["aggregated_output"] !== "string"
@@ -129,6 +128,23 @@ function preflightStatus(
     !Array.isArray(payload["results"])
   ) {
     return null;
+  }
+  const exitCode = item["exit_code"];
+  if (typeof exitCode === "number") {
+    const expectedExitCode =
+      payload["status"] === "blocked"
+        ? 1
+        : payload["status"] === "incomplete"
+          ? 2
+          : payload["status"] === "ready"
+            ? 0
+            : null;
+    if (
+      (expectedExitCode !== null && exitCode !== expectedExitCode) ||
+      (expectedExitCode === null && exitCode !== 0)
+    ) {
+      return null;
+    }
   }
   const results = payload["results"];
   const delegated = results.filter(

--- a/sdk/typescript/tests-ts/worker-preflight-failure.test.ts
+++ b/sdk/typescript/tests-ts/worker-preflight-failure.test.ts
@@ -1,23 +1,25 @@
 import { expect, test } from "bun:test";
 import { workerStatusFromEvent } from "../src/worker-progress.js";
 
-const output = JSON.stringify({
-  profile: "security_scan",
-  status: "ready",
-  results: [
-    { capability: "delegated_workers", status: "pass", actual: true },
-    { capability: "usable_worker_slots_6", status: "pass", actual: 8 },
-  ],
-});
+function output(status: "ready" | "blocked" | "incomplete" = "ready") {
+  return JSON.stringify({
+    profile: "security_scan",
+    status,
+    results: [
+      { capability: "delegated_workers", status: "pass", actual: true },
+      { capability: "usable_worker_slots_6", status: "pass", actual: 8 },
+    ],
+  });
+}
 
-function event(overrides: Record<string, unknown>) {
+function event(overrides: Record<string, unknown> = {}) {
   return {
     type: "item.completed",
     item: {
       id: "preflight-1",
       type: "command_execution",
       command: "python3 /plugin/scripts/config_preflight.py --profile security_scan",
-      aggregated_output: output,
+      aggregated_output: output(),
       status: "completed",
       exit_code: 0,
       ...overrides,
@@ -25,15 +27,32 @@ function event(overrides: Record<string, unknown>) {
   };
 }
 
-test("ignores capability output from explicitly failed preflight commands", () => {
+const capability = {
+  kind: "preflight",
+  delegation: "available",
+  configuredSlots: 8,
+} as const;
+
+test("ignores capability output from failed or contradictory preflight commands", () => {
   expect(workerStatusFromEvent(event({ status: "failed" }))).toBeNull();
   expect(workerStatusFromEvent(event({ exit_code: 2 }))).toBeNull();
+  expect(
+    workerStatusFromEvent(
+      event({ aggregated_output: output("blocked"), exit_code: 2 }),
+    ),
+  ).toBeNull();
 });
 
-test("keeps successful preflight capability output", () => {
-  expect(workerStatusFromEvent(event({}))).toEqual({
-    kind: "preflight",
-    delegation: "available",
-    configuredSlots: 8,
-  });
+test("keeps capability output from valid ready, blocked, and incomplete preflights", () => {
+  expect(workerStatusFromEvent(event())).toEqual(capability);
+  expect(
+    workerStatusFromEvent(
+      event({ aggregated_output: output("blocked"), exit_code: 1 }),
+    ),
+  ).toEqual(capability);
+  expect(
+    workerStatusFromEvent(
+      event({ aggregated_output: output("incomplete"), exit_code: 2 }),
+    ),
+  ).toEqual(capability);
 });

--- a/sdk/typescript/tests-ts/worker-preflight-failure.test.ts
+++ b/sdk/typescript/tests-ts/worker-preflight-failure.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import { workerStatusFromEvent } from "../src/worker-progress.js";
+
+const output = JSON.stringify({
+  profile: "security_scan",
+  status: "ready",
+  results: [
+    { capability: "delegated_workers", status: "pass", actual: true },
+    { capability: "usable_worker_slots_6", status: "pass", actual: 8 },
+  ],
+});
+
+function event(overrides: Record<string, unknown>) {
+  return {
+    type: "item.completed",
+    item: {
+      id: "preflight-1",
+      type: "command_execution",
+      command: "python3 /plugin/scripts/config_preflight.py --profile security_scan",
+      aggregated_output: output,
+      status: "completed",
+      exit_code: 0,
+      ...overrides,
+    },
+  };
+}
+
+test("ignores capability output from explicitly failed preflight commands", () => {
+  expect(workerStatusFromEvent(event({ status: "failed" }))).toBeNull();
+  expect(workerStatusFromEvent(event({ exit_code: 2 }))).toBeNull();
+});
+
+test("keeps successful preflight capability output", () => {
+  expect(workerStatusFromEvent(event({}))).toEqual({
+    kind: "preflight",
+    delegation: "available",
+    configuredSlots: 8,
+  });
+});


### PR DESCRIPTION
## Summary

Do not report worker delegation/capacity from `config_preflight.py` execution metadata that is explicitly failed or inconsistent with the helper's own evaluated status.

Fixes #553.

## Reproduction / evidence

Current upstream `main` at `37bf87a692fc72d41f7312cc48808d699d204fba` parses capability JSON whenever an `item.completed` command matches `config_preflight.py`, without reconciling the command execution metadata with the helper result.

A command item marked `status: "failed"` can therefore carry otherwise valid-looking `status: "ready"` capability JSON and still be reported as:

```ts
{
  kind: "preflight",
  delegation: "available",
  configuredSlots: 8,
}
```

The helper has deliberate exit semantics that must be preserved: `ready` exits 0, `blocked` exits 1, and `incomplete` exits 2.

## Root cause

`preflightStatus()` validated the command name and JSON structure but treated execution status, exit code and top-level helper status as unrelated fields.

## Fix

- reject an explicitly failed command item;
- when a numeric exit code and recognized helper status are both present, require the documented mapping (`ready` 0, `blocked` 1, `incomplete` 2);
- reject unexplained nonzero exits from legacy payloads without a helper status;
- preserve capability observations from legitimate blocked and incomplete preflights.

## Tests / validation

`worker-preflight-failure.test.ts` covers:

- explicit command failure;
- a ready payload paired with exit 2;
- a blocked payload paired with the wrong exit code;
- valid ready, blocked and incomplete controls, including the helper's intentional nonzero exit codes.

The branch is based directly on current upstream `main` at `37bf87a692fc72d41f7312cc48808d699d204fba` and is not behind it.

Full repository tests cannot be run in this execution environment because the repository cannot be cloned here. Pushed-head CI remains the authoritative full-suite validation.

## Risk

Low. The parser now checks consistency rather than treating every nonzero exit as failure, so valid blocked/incomplete capability evidence remains visible.