### PR TITLE
fix(contract): constrain deferred coverage paths

### DIFF
--- a/sdk/typescript/_bundled_plugin/schemas/coverage.schema.json
+++ b/sdk/typescript/_bundled_plugin/schemas/coverage.schema.json
@@ -154,7 +154,8 @@
             "type": "array",
             "items": {
               "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "pattern": "^(?!/)(?!\\.$)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*\\\\)(?!.*:)(?!.*\\u0000).+$"
             }
           },
           "surfaceIds": {

--- a/sdk/typescript/tests-ts/deferred-coverage-paths.test.ts
+++ b/sdk/typescript/tests-ts/deferred-coverage-paths.test.ts
@@ -1,0 +1,88 @@
+import { createHash } from "node:crypto";
+import { chmod, cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import { loadContract } from "../src/index.js";
+import { PLUGIN_ROOT } from "./plugin-root.js";
+
+const EXAMPLE = join(PLUGIN_ROOT, "examples", "completed-scan");
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+async function scanWithDeferredPath(path: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "codex-security-deferred-path-"));
+  temporaryDirectories.push(root);
+  const scanDir = join(root, "scan");
+  await cp(EXAMPLE, scanDir, { recursive: true });
+  if (process.platform !== "win32") await chmod(scanDir, 0o700);
+
+  const coveragePath = join(scanDir, "coverage.json");
+  const coverage = JSON.parse(await readFile(coveragePath, "utf8")) as Record<
+    string,
+    unknown
+  >;
+  coverage["completeness"] = "partial";
+  coverage["deferred"] = [
+    {
+      id: "deferred-source-review",
+      reason: "Source review remains incomplete.",
+      paths: [path],
+    },
+  ];
+  await writeFile(coveragePath, `${JSON.stringify(coverage, null, 2)}\n`);
+
+  const manifestPath = join(scanDir, "scan-manifest.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as {
+    scan: { artifacts: Array<{ path: string; sha256: string }> };
+  };
+  const artifact = manifest.scan.artifacts.find(
+    (candidate) => candidate.path === "coverage.json",
+  );
+  expect(artifact).toBeDefined();
+  artifact!.sha256 = createHash("sha256")
+    .update(await readFile(coveragePath))
+    .digest("hex");
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  return scanDir;
+}
+
+describe("canonical deferred coverage paths", () => {
+  test("rejects paths outside the repository-relative POSIX boundary", async () => {
+    for (const path of [
+      "../../outside.ts",
+      "/etc/passwd",
+      "C:/outside.ts",
+      "src\\outside.ts",
+      ".",
+      "src:stream.ts",
+      "src/\0outside.ts",
+    ]) {
+      const scanDir = await scanWithDeferredPath(path);
+      await expect(
+        loadContract(scanDir, { pluginRoot: PLUGIN_ROOT }),
+      ).rejects.toThrow("coverage.json");
+    }
+  });
+
+  test("accepts a repository-relative deferred path", async () => {
+    const scanDir = await scanWithDeferredPath("src/extract.py");
+    await expect(
+      loadContract(scanDir, { pluginRoot: PLUGIN_ROOT }),
+    ).resolves.toMatchObject({
+      coverage: {
+        completeness: "partial",
+        deferred: [
+          expect.objectContaining({ paths: ["src/extract.py"] }),
+        ],
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Require canonical `coverage.deferred[].paths` values to remain safe repository-relative POSIX paths.

Fixes #557.

## Reproduction / evidence

Current upstream `main` at `37bf87a692fc72d41f7312cc48808d699d204fba` documents deferred coverage units with optional source paths, but the shared coverage schema constrains each path only to a non-empty string.

A sealed partial-coverage bundle can therefore contain a deferred path such as `../../outside.ts`, `/etc/passwd`, `C:/outside.ts`, or `src\\outside.ts` and still pass `loadContract()` after the coverage artifact is correctly resealed.

This differs from manifest scope paths, finding locations, code-evidence paths and artifact/receipt paths, which already enforce the repository-relative path model.

## Root cause

`coverage.schema.json` added the optional deferred `paths` field without the safe-path constraint used by the other canonical source-path fields. `_validate_coverage()` does not independently normalize those paths before shared schema validation.

## Fix

Apply the canonical repository-relative safe-path pattern to every deferred path, rejecting:

- absolute paths;
- `..` traversal segments;
- backslashes / Windows-style paths;
- colon-bearing paths;
- standalone `.`;
- NUL characters.

Because the same schema is consumed by finalization and the TypeScript contract loader, the invariant is enforced at both producer and consumer boundaries.

## Tests / validation

Added `deferred-coverage-paths.test.ts`. It copies the real bundled completed-scan example, switches it to partial coverage, inserts a deferred path, reseals the `coverage.json` digest in the manifest, and calls the real `loadContract()`.

The regression covers traversal, absolute, Windows-style, dot, colon and NUL-bearing paths, plus a valid `src/extract.py` control.

The branch is based directly on current upstream `main` at `37bf87a692fc72d41f7312cc48808d699d204fba` and is not behind it. Production diff: 2 additions, 1 deletion.

Full repository tests cannot be run in this execution environment because the repository cannot be cloned here. Pushed-head CI remains the authoritative full-suite validation.

## Risk

Low. The change only narrows a documented canonical path field to the repository-relative format already required by the rest of the contract.