### PR TITLE
fix(contract): reject reversed finding line ranges

### DIFF
--- a/sdk/typescript/src/contract.ts
+++ b/sdk/typescript/src/contract.ts
@@ -243,6 +243,14 @@ function validateCanonicalContract(
           { cause: error },
         );
       }
+      if (
+        location.endLine !== undefined &&
+        location.endLine < location.startLine
+      ) {
+        throw new ContractValidationError(
+          `${locationContext}.endLine: expected an integer >= startLine.`,
+        );
+      }
     }
 
     const fingerprint = `codex-security/v1:sha256:${sha256Text(

--- a/sdk/typescript/tests-ts/contract-location-line-ranges.test.ts
+++ b/sdk/typescript/tests-ts/contract-location-line-ranges.test.ts
@@ -1,0 +1,80 @@
+import { createHash } from "node:crypto";
+import { chmod, cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import { loadContract } from "../src/index.js";
+import { PLUGIN_ROOT } from "./plugin-root.js";
+
+const EXAMPLE = join(PLUGIN_ROOT, "examples", "completed-scan");
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+async function scanWithLocationRange(
+  startLine: number,
+  endLine: number,
+): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "codex-security-location-range-"));
+  temporaryDirectories.push(root);
+  const scanDir = join(root, "scan");
+  await cp(EXAMPLE, scanDir, { recursive: true });
+  if (process.platform !== "win32") await chmod(scanDir, 0o700);
+
+  const findingsPath = join(scanDir, "findings.json");
+  const findings = JSON.parse(await readFile(findingsPath, "utf8")) as {
+    findings: Array<{
+      locations: Array<{ startLine: number; endLine?: number }>;
+    }>;
+  };
+  const location = findings.findings[0]!.locations[0]!;
+  location.startLine = startLine;
+  location.endLine = endLine;
+  await writeFile(findingsPath, `${JSON.stringify(findings, null, 2)}\n`);
+
+  const manifestPath = join(scanDir, "scan-manifest.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as {
+    scan: { artifacts: Array<{ path: string; sha256: string }> };
+  };
+  const artifact = manifest.scan.artifacts.find(
+    (candidate) => candidate.path === "findings.json",
+  );
+  expect(artifact).toBeDefined();
+  artifact!.sha256 = createHash("sha256")
+    .update(await readFile(findingsPath))
+    .digest("hex");
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  return scanDir;
+}
+
+describe("canonical finding location line ranges", () => {
+  test("rejects an end line before the start line", async () => {
+    const scanDir = await scanWithLocationRange(41, 40);
+    await expect(
+      loadContract(scanDir, { pluginRoot: PLUGIN_ROOT }),
+    ).rejects.toThrow("endLine");
+  });
+
+  test("accepts a forward multi-line range", async () => {
+    const scanDir = await scanWithLocationRange(41, 44);
+    await expect(
+      loadContract(scanDir, { pluginRoot: PLUGIN_ROOT }),
+    ).resolves.toMatchObject({
+      findings: {
+        findings: [
+          {
+            locations: [
+              expect.objectContaining({ startLine: 41, endLine: 44 }),
+            ],
+          },
+        ],
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Require canonical finding locations loaded by the TypeScript SDK to satisfy `endLine >= startLine`, matching the existing Python finalizer invariant.

Fixes #560.

## Reproduction / evidence

Current upstream `main` at `37bf87a692fc72d41f7312cc48808d699d204fba` has asymmetric canonical validation:

- the bundled Python finalizer rejects an ordinary location whose `endLine` is before `startLine`;
- the JSON schema checks only that both values are positive integers;
- `validateCanonicalContract()` in the TypeScript loader validates the location path but does not compare the line numbers.

A copy of the real bundled completed-scan fixture can therefore be changed to `startLine: 41, endLine: 40`, resealed by updating the `findings.json` digest in `scan-manifest.json`, and still load through `loadContract()` on current main.

## Root cause

The relational line-range invariant is enforced during Python finalization but was not mirrored in the TypeScript canonical-validation pass. The existing JSON Schema cannot express this sibling-value comparison by itself.

## Fix

After validating each ordinary finding location path, reject a defined `endLine` that is less than its `startLine`.

The check is intentionally limited to the existing producer invariant and does not alter valid single-line or forward multi-line locations.

## Tests / validation

Added `contract-location-line-ranges.test.ts`. It copies the real bundled `examples/completed-scan` fixture, mutates the first location, rewrites `findings.json`, recomputes the sealed artifact digest, and calls the real `loadContract()`.

The regression verifies:

- `startLine: 41, endLine: 40` is rejected;
- `startLine: 41, endLine: 44` remains valid.

The branch is based directly on current upstream `main` at `37bf87a692fc72d41f7312cc48808d699d204fba` and is not behind it. Production diff: 8 additions, 0 deletions.

Full repository tests cannot be run in this execution environment because the repository cannot be cloned here. Pushed-head CI remains the authoritative full-suite validation.

## Risk

Low. This only makes the TypeScript loader reject a canonical location that the bundled producer already rejects.