### PR TITLE
fix: preserve exact multiscan lock identities

### DIFF
--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -419,7 +419,7 @@ async function acquireLock(output: string): Promise<() => Promise<void>> {
       await rm(stale, { recursive: true, force: true });
     }
   }
-  const createdLock = await lstat(path);
+  const createdLock = await lstat(path, { bigint: true });
   const owner = `${JSON.stringify({
     pid: process.pid,
     ownerId: randomUUID(),
@@ -429,7 +429,7 @@ async function acquireLock(output: string): Promise<() => Promise<void>> {
   try {
     await writeFile(ownerPath, owner, { flag: "wx", mode: 0o600 });
   } catch (error) {
-    const currentLock = await lstat(path).catch(
+    const currentLock = await lstat(path, { bigint: true }).catch(
       (cleanup: NodeJS.ErrnoException) => {
         if (cleanup.code !== "ENOENT") throw cleanup;
         return undefined;

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -1388,8 +1388,16 @@ describe("multiscan", () => {
   });
 
   test.each([false, true])(
-    "never removes a replacement lock when owner creation fails (owner published: %s)",
+    "never removes a replacement lock when owner creation fails (owner published: %p)",
     async (ownerPublished) => {
+      if (
+        runTestInSubprocess(
+          import.meta.path,
+          `never removes a replacement lock when owner creation fails (owner published: ${ownerPublished})`,
+        )
+      ) {
+        return;
+      }
       const paths = await fixture();
       const source = await repository(paths.root, "owner-creation-race");
       await writeFile(
@@ -1404,7 +1412,23 @@ describe("multiscan", () => {
         hostname: hostname(),
         processStartedAt: performance.timeOrigin,
       });
+      const createdInode = 2n ** 60n;
+      const replacementInode = createdInode + 1n;
+      expect(Number(createdInode)).toBe(Number(replacementInode));
+      let replaced = false;
+      const originalLstat = filesystem.lstat;
       const originalWriteFile = filesystem.writeFile;
+      const readLock = spyOn(filesystem, "lstat").mockImplementation((async (
+        ...args: Parameters<typeof filesystem.lstat>
+      ) => {
+        const metadata = await originalLstat(...args);
+        if (String(args[0]) === lock) {
+          const inode = replaced ? replacementInode : createdInode;
+          metadata.ino =
+            typeof metadata.ino === "bigint" ? inode : Number(inode);
+        }
+        return metadata;
+      }) as typeof filesystem.lstat);
       const writeOwner = spyOn(filesystem, "writeFile").mockImplementation(
         async (path, data, options) => {
           if (String(path) !== ownerPath) {
@@ -1413,6 +1437,7 @@ describe("multiscan", () => {
           writeOwner.mockRestore();
           await rename(lock, join(paths.output, ".lock.stale-owner-creation"));
           await mkdir(lock, { mode: 0o700 });
+          replaced = true;
           if (ownerPublished) {
             await originalWriteFile(ownerPath, replacement, { mode: 0o600 });
           }
@@ -1439,6 +1464,7 @@ describe("multiscan", () => {
         }
       } finally {
         writeOwner.mockRestore();
+        readLock.mockRestore();
       }
     },
   );


### PR DESCRIPTION
## Summary

Prevent failed multiscan owner publication from removing a replacement supervisor's empty lock directory when distinct large file IDs round to the same JavaScript number.

## Changes

- Read both lock-directory identities with `lstat(..., { bigint: true })` before deciding whether cleanup owns the directory.
- Extend the existing replacement-lock tests with distinct inode IDs that collide as numbers. Keep empty and published replacement cases separate, and isolate the filesystem spies in subprocesses.
- Preserve the existing cleanup of an empty lock owned by the failed supervisor.

## Testing

Using Bun 1.3.14:

- `bun test --timeout 30000 --seed 1 --test-name-pattern 'owner creation fails' ./tests-ts/multiscan.test.ts`: before the fix, two cases passed and the empty-replacement case failed with `ENOENT`; after the fix, all three passed.
- `bun test --timeout 30000 --seed 1 ./tests-ts/multiscan.test.ts`: 50 passed, zero failed.
- `pnpm run types`, `pnpm run format`, and `git diff --check`: passed.
- Three fresh native reviews and independent verification of `0cc84eca`: no findings.

The full [supported-runtime CI matrix](https://github.com/openai/codex-security/actions/runs/32166539337), including Windows and installed-package checks, passed on this exact commit.

## Risk and rollout

The production diff changes only the two identity reads in failed-owner cleanup. Lock leases, owner records, heartbeat behavior, and cleanup error handling are unchanged. This uses the same bigint stat API already used by the CLI. There are no public API, dependency, package-format, or migration changes.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
