### PR TITLE
release: bump Codex Security to 0.1.16

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-security",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "TypeScript SDK and CLI for Codex Security",
   "license": "Apache-2.0",
   "author": "OpenAI",


### PR DESCRIPTION
## Summary

Prepare the next Codex Security patch release, 0.1.16.

## Changes

- Bump `@openai/codex-security` from `0.1.15` to `0.1.16`.
- No runtime, dependency, or API changes.

## Testing

- `git diff --check` passed.
- Prettier check for `sdk/typescript/package.json` passed.
- Release automation checks passed for the stable version, matching `npm-v0.1.16` tag, increase over `main` and all published npm versions, and `publish` mode.
- The full Bun suite was not run locally because Bun is not installed. PR CI must pass before merge.

## Risk and rollout

`main` still matches `npm-v0.1.15` at the time this PR was opened. Keep this PR open until the intended changes have landed. Recheck the release contents, current-head CI, and approvals before merging.

After merge, the normal release workflow cuts the matching tag and requests approval through the protected npm environment. This PR does not publish a package on its own.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
