### PR TITLE
test: run MCP contract checks with Node

### DIFF
--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -107,6 +107,49 @@ async function plugin(root: string, version = "1.2.3"): Promise<string> {
   return path;
 }
 
+interface McpServerResponse {
+  id: number;
+  result: {
+    capabilities?: Record<string, unknown>;
+    tools?: Array<{
+      name: string;
+      inputSchema: {
+        properties: { userContext?: { maxLength?: number } };
+      };
+    }>;
+  };
+}
+
+async function inspectMcpServer(): Promise<McpServerResponse[]> {
+  const messages = [
+    {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "codex-security-test", version: "1.0.0" },
+      },
+    },
+    { jsonrpc: "2.0", method: "notifications/initialized", params: {} },
+    { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+  ];
+  const execution = promisify(execFile)(
+    "node",
+    [join(PLUGIN_ROOT, "mcp", "server.mjs"), "--stdio"],
+    { encoding: "utf8", timeout: 10_000, windowsHide: true },
+  );
+  execution.child.stdin?.end(
+    `${messages.map((message) => JSON.stringify(message)).join("\n")}\n`,
+  );
+  const { stdout } = await execution;
+  return stdout
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as McpServerResponse);
+}
+
 describe("plugin runtime preparation", () => {
   test("keeps installed-package plugin lookup inside the package", async () => {
     const root = await temporaryDirectory();
@@ -461,48 +504,8 @@ describe("plugin runtime preparation", () => {
     ]);
   });
 
-  test("accepts preserved context before starting a headless scan", () => {
-    const messages = [
-      {
-        jsonrpc: "2.0",
-        id: 1,
-        method: "initialize",
-        params: {
-          protocolVersion: "2025-11-25",
-          capabilities: {},
-          clientInfo: { name: "codex-security-test", version: "1.0.0" },
-        },
-      },
-      { jsonrpc: "2.0", method: "notifications/initialized", params: {} },
-      { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
-    ];
-    const server = spawnSync(
-      process.execPath,
-      [join(PLUGIN_ROOT, "mcp", "server.mjs"), "--stdio"],
-      {
-        input: `${messages.map((message) => JSON.stringify(message)).join("\n")}\n`,
-        encoding: "utf8",
-        timeout: 10_000,
-      },
-    );
-    expect(server.status, server.stderr).toBe(0);
-    const responses = server.stdout
-      .trim()
-      .split("\n")
-      .map(
-        (line) =>
-          JSON.parse(line) as {
-            id: number;
-            result: {
-              tools?: Array<{
-                name: string;
-                inputSchema: {
-                  properties: { userContext?: { maxLength?: number } };
-                };
-              }>;
-            };
-          },
-      );
+  test("accepts preserved context before starting a headless scan", async () => {
+    const responses = await inspectMcpServer();
     const tool = responses
       .find((response) => response.id === 2)
       ?.result.tools?.find(
@@ -521,43 +524,7 @@ describe("plugin runtime preparation", () => {
     expect(contract.shippedExact).not.toContain("mcp/mcp-app.html.br");
     expect(existsSync(join(PLUGIN_ROOT, "mcp", "mcp-app.html.br"))).toBe(false);
 
-    const messages = [
-      {
-        jsonrpc: "2.0",
-        id: 1,
-        method: "initialize",
-        params: {
-          protocolVersion: "2025-11-25",
-          capabilities: {},
-          clientInfo: { name: "codex-security-test", version: "1.0.0" },
-        },
-      },
-      { jsonrpc: "2.0", method: "notifications/initialized", params: {} },
-      { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
-    ];
-    const server = spawnSync(
-      process.execPath,
-      [join(PLUGIN_ROOT, "mcp", "server.mjs"), "--stdio"],
-      {
-        input: `${messages.map((message) => JSON.stringify(message)).join("\n")}\n`,
-        encoding: "utf8",
-        timeout: 10_000,
-      },
-    );
-    expect(server.status, server.stderr).toBe(0);
-    const responses = server.stdout
-      .trim()
-      .split("\n")
-      .map(
-        (line) =>
-          JSON.parse(line) as {
-            id: number;
-            result: {
-              capabilities?: Record<string, unknown>;
-              tools?: Array<{ name: string }>;
-            };
-          },
-      );
+    const responses = await inspectMcpServer();
     expect(
       responses.find((response) => response.id === 1)?.result.capabilities,
     ).not.toHaveProperty("resources");


### PR DESCRIPTION
## Summary

Run the MCP contract tests with Node, which is what the shipped plugin uses. This is the independent test-only part of #567.

## Changes

The two tests now share one async helper for starting the server, sending the initialize and tools/list messages, and reading its replies. Launch errors reject the test directly. No production code changes.

## Testing

From `sdk/typescript`, run:

```bash
bun test --timeout 30000 tests-ts/runtime.test.ts --test-name-pattern 'accepts preserved context|keeps native scan tools'
```

Both tests should inspect the real bundled MCP server without using credentials or making model calls.

Checks already run:

- Runtime tests: 123 passed, with 9 platform-specific skips.
- Type checks, formatting, and `git diff --check` passed.
- Three independent Codex reviews and a separate verifier found no actionable issues.
- The first local full-suite attempt was stopped after unchanged tests timed out on a heavily loaded machine. [GitHub checks passed](https://github.com/openai/codex-security/actions/runs/32314998326): 29 passed and 5 skipped. An unchanged release-workflow test passed on a failed-job-only rerun.
- [GitHub Codex review](https://github.com/openai/codex-security/pull/573#issuecomment-5349422257) found no major issues at `7b8bae9ec0`.

## Risk and rollout

This can merge independently of the finding-matching work. It changes only the test launcher and keeps the existing assertions. The normal Windows CI jobs also exercise this file.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
