### PR TITLE
fix: pricing for Daybreak 

### DIFF
--- a/sdk/typescript/src/cost.ts
+++ b/sdk/typescript/src/cost.ts
@@ -866,9 +866,13 @@ export function estimateScanCost(
   usage: unknown,
 ): ScanCost | null {
   if (model === undefined) return null;
-  const pricingModel = model.startsWith("openai.")
+  let pricingModel = model.startsWith("openai.")
     ? model.slice("openai.".length)
     : model;
+  // https://developers.openai.com/api/docs/pricing#cyber-models
+  if (pricingModel === "gpt-daybreak-blue-latest") {
+    pricingModel = "gpt-5.6-sol";
+  }
   const pricing = MODEL_PRICING_NANODOLLARS[pricingModel];
   const normalized = tokenUsage(usage);
   if (pricing === undefined || normalized === null) return null;

--- a/sdk/typescript/src/cost.ts
+++ b/sdk/typescript/src/cost.ts
@@ -95,6 +95,9 @@ const MODEL_PRICING_NANODOLLARS: Readonly<Record<string, ModelPricing>> = {
   "gpt-5.6-sol": [5_000, 500, 6_250, 30_000],
   "gpt-5.6-terra": [2_000, 200, 2_500, 12_000],
   "gpt-5.6-luna": [200, 20, 250, 1_200],
+  // https://developers.openai.com/api/docs/pricing#cyber-models
+  "gpt-daybreak-blue-latest": [5_000, 500, 6_250, 30_000],
+  "gpt-daybreak-red-latest": [12_500, 1_250, 15_625, 75_000],
 };
 
 const COST_POLL_INTERVAL_MS = 100;
@@ -866,13 +869,9 @@ export function estimateScanCost(
   usage: unknown,
 ): ScanCost | null {
   if (model === undefined) return null;
-  let pricingModel = model.startsWith("openai.")
+  const pricingModel = model.startsWith("openai.")
     ? model.slice("openai.".length)
     : model;
-  // https://developers.openai.com/api/docs/pricing#cyber-models
-  if (pricingModel === "gpt-daybreak-blue-latest") {
-    pricingModel = "gpt-5.6-sol";
-  }
   const pricing = MODEL_PRICING_NANODOLLARS[pricingModel];
   const normalized = tokenUsage(usage);
   if (pricing === undefined || normalized === null) return null;

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -3117,7 +3117,8 @@ describe("CodexSecurity orchestration", () => {
     }
   });
 
-  test("uses selected profile pricing for live and persisted scan cost", async () => {
+  const pricedModels = ["gpt-5.6-terra", "gpt-daybreak-blue-latest"];
+  test.each(pricedModels)("tracks live and saved %s costs", async (model) => {
     const root = await temporaryDirectory();
     const repository = join(root, "repository");
     const codexHome = join(root, "codex-home");
@@ -3133,7 +3134,7 @@ describe("CodexSecurity orchestration", () => {
       output_tokens: 3,
       reasoning_output_tokens: 1,
     };
-    const expectedCost = estimateScanCost("gpt-5.6-terra", usage);
+    const expectedCost = estimateScanCost(model, usage);
     expect(expectedCost).not.toBeNull();
     if (expectedCost === null) throw new Error("Missing selected-model price");
 
@@ -3147,7 +3148,7 @@ describe("CodexSecurity orchestration", () => {
           model_reasoning_effort: "low",
           profiles: {
             review: {
-              model: "gpt-5.6-terra",
+              model,
               model_reasoning_effort: "high",
             },
           },
@@ -3190,7 +3191,7 @@ describe("CodexSecurity orchestration", () => {
       onCost: (cost) => costs.push({ ...cost }),
     });
 
-    expect(result.turnResult.model).toBe("gpt-5.6-terra");
+    expect(result.turnResult.model).toBe(model);
     expect(result.cost).toEqual(expectedCost);
     expect(costs).toEqual([expectedCost]);
 

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -3117,7 +3117,11 @@ describe("CodexSecurity orchestration", () => {
     }
   });
 
-  const pricedModels = ["gpt-5.6-terra", "gpt-daybreak-blue-latest"];
+  const pricedModels = [
+    "gpt-5.6-terra",
+    "gpt-daybreak-blue-latest",
+    "gpt-daybreak-red-latest",
+  ];
   test.each(pricedModels)("tracks live and saved %s costs", async (model) => {
     const root = await temporaryDirectory();
     const repository = join(root, "repository");

--- a/sdk/typescript/tests-ts/cost.test.ts
+++ b/sdk/typescript/tests-ts/cost.test.ts
@@ -184,6 +184,7 @@ describe("scan cost", () => {
     for (const [model, expectedUsd] of [
       ["openai.gpt-5.6", 35],
       ["openai.gpt-5.6-sol", 35],
+      ["openai.gpt-daybreak-blue-latest", 35],
       ["openai.gpt-5.6-terra", 14],
       ["openai.gpt-5.6-luna", 1.4],
     ] as const) {
@@ -196,8 +197,9 @@ describe("scan cost", () => {
     expect(estimateScanCost("openai.unknown-model", usage)).toBeNull();
   });
 
-  test("uses current Terra and Luna input, cache, and output rates", () => {
+  test("uses current input, cache, and output rates", () => {
     for (const [model, input, cached, write, output] of [
+      ["gpt-daybreak-blue-latest", 5, 0.5, 6.25, 30],
       ["gpt-5.6-terra", 2, 0.2, 2.5, 12],
       ["gpt-5.6-luna", 0.2, 0.02, 0.25, 1.2],
     ] as const) {

--- a/sdk/typescript/tests-ts/cost.test.ts
+++ b/sdk/typescript/tests-ts/cost.test.ts
@@ -185,6 +185,7 @@ describe("scan cost", () => {
       ["openai.gpt-5.6", 35],
       ["openai.gpt-5.6-sol", 35],
       ["openai.gpt-daybreak-blue-latest", 35],
+      ["openai.gpt-daybreak-red-latest", 87.5],
       ["openai.gpt-5.6-terra", 14],
       ["openai.gpt-5.6-luna", 1.4],
     ] as const) {
@@ -200,6 +201,7 @@ describe("scan cost", () => {
   test("uses current input, cache, and output rates", () => {
     for (const [model, input, cached, write, output] of [
       ["gpt-daybreak-blue-latest", 5, 0.5, 6.25, 30],
+      ["gpt-daybreak-red-latest", 12.5, 1.25, 15.625, 75],
       ["gpt-5.6-terra", 2, 0.2, 2.5, 12],
       ["gpt-5.6-luna", 0.2, 0.02, 0.25, 1.2],
     ] as const) {


### PR DESCRIPTION
## Summary

Cost estimates and cost limits are not available when a scan uses `gpt-daybreak-blue-latest` or `gpt-daybreak-red-latest`. The price table does not include these model names.

## Changes

- Add separate price-table entries for Blue and Red using the [public price list](https://developers.openai.com/api/docs/pricing#cyber-models).
- Remove the special-case model-name rewrite.
- Keep the requested model name in scan results.
- Extend the existing tests for token rates, model-name prefixes, cost limits, and live and saved costs.

## Testing

- Focused cost and API tests: 153 passed, 2 skipped.
- `pnpm run test --seed 12345`: 1,438 passed, 23 skipped.
- `pnpm run types`: passed.
- `pnpm run format`: passed.
- `pnpm run test`: 1,438 passed, 23 skipped.
- `git diff --check`: passed.

## Risk and rollout

This changes only the local price table. It does not change the selected model, default model, or scan behavior. The aliases can point to different models in the future. Update their table entries when the published prices change.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
