### PR TITLE
feat(cli): add draft pull requests for security patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Use `--patch --patch-severity high` to fix high and critical findings. Add
 `--create-pr`, or enable the pull request option during review, to commit the
 verified files and open a GitHub pull request. Use `--create-draft-pr` instead to
 open a draft pull request, review and update its verified patches, and request
-review when they are ready. Ordinary scans do not change repository files.
+review when they are ready. The two pull request flags cannot be combined.
+Ordinary scans do not change repository files.
 
 Deep-scan discovery stops after 96 hours by default. Set `--max-time-hours` to
 any positive number of hours, including fractional hours, up to 96. Completed

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ npx @openai/codex-security scan .
 npx @openai/codex-security scan . --patch
 npx @openai/codex-security scan . --patch --patch-severity high --json
 npx @openai/codex-security scan . --patch --patch-severity high --create-pr
+npx @openai/codex-security scan . --patch --patch-severity high --create-draft-pr
 npx @openai/codex-security scan . --model gpt-5.6-terra --effort high
 npx @openai/codex-security scan . --scan-prompt-file scan.md --post-scan-prompt-file follow-up.md
 npx @openai/codex-security scan . --mode deep --workers 2 --subagents 0 --stop-after-no-new 3 --max-discovery-runs 10 --max-time-hours 1.5
@@ -35,8 +36,9 @@ threshold, select individual findings, and add patch instructions for each one.
 Each selected finding runs in its own saved Codex desktop task.
 Use `--patch --patch-severity high` to fix high and critical findings. Add
 `--create-pr`, or enable the pull request option during review, to commit the
-verified files and open a GitHub pull request. Ordinary scans do not change
-repository files.
+verified files and open a GitHub pull request. Use `--create-draft-pr` instead to
+open a draft pull request, review and update its verified patches, and request
+review when they are ready. Ordinary scans do not change repository files.
 
 Deep-scan discovery stops after 96 hours by default. Set `--max-time-hours` to
 any positive number of hours, including fractional hours, up to 96. Completed
@@ -88,9 +90,11 @@ and identifies findings not confirmed in its latest scan.
 
 Use `patch OCCURRENCE_ID` to fix one saved finding, or
 `patch --scan SCAN_ID --severity high` to fix selected findings from a saved
-scan. Add `--json` for structured results or `--create-pr` to open a GitHub pull
-request after verification. If publication fails, use the printed
-`patch --resume-pr BRANCH` command to retry without running Codex again.
+scan. Add `--json` for structured results, `--create-pr` to open a GitHub pull
+request after verification, or `--create-draft-pr` to open a draft pull request
+for review and further changes. If publication fails, use the printed
+`patch --resume-pr BRANCH` command to retry without running Codex again; add
+`--create-draft-pr` when resuming a draft pull request.
 
 Use `patch --linear-issue SEC-123` to import and fix a Linear issue, or
 `patch --linear-project "Security backlog" --linear-filter '{"labels":{"name":{"eq":"security"}}}'`

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -208,6 +208,7 @@ npx @openai/codex-security scan /path/to/repository --headless
 npx @openai/codex-security scan /path/to/repository --patch
 npx @openai/codex-security scan /path/to/repository --patch --patch-severity high --json
 npx @openai/codex-security scan /path/to/repository --patch --patch-severity high --create-pr
+npx @openai/codex-security scan /path/to/repository --patch --patch-severity high --create-draft-pr
 npx @openai/codex-security scan /path/to/repository --model gpt-5.6-terra
 npx @openai/codex-security scan /path/to/repository --model gpt-5.6-terra --effort high
 npx @openai/codex-security scan /path/to/repository --path src --path tests
@@ -259,7 +260,9 @@ npx @openai/codex-security patch "Missing authorization check" --effort high
 npx @openai/codex-security patch OCCURRENCE_ID
 npx @openai/codex-security patch --scan SCAN_ID --severity high --json
 npx @openai/codex-security patch --scan SCAN_ID --severity high --create-pr
+npx @openai/codex-security patch --scan SCAN_ID --severity high --create-draft-pr
 npx @openai/codex-security patch --resume-pr codex-security/patch-SCAN_ID
+npx @openai/codex-security patch --resume-pr codex-security/patch-SCAN_ID --create-draft-pr
 npx @openai/codex-security patch --scan latest --severity medium
 npx @openai/codex-security patch --linear-issue SEC-123 --linear-issue SEC-124
 npx @openai/codex-security patch --linear-project "Security backlog" --linear-filter '{"labels":{"name":{"eq":"security"}}}'
@@ -356,9 +359,12 @@ edit instructions for the focused finding, `1`–`4` to select by severity, and
 patch or `q` to keep the checkout unchanged. Each selected finding runs in its
 own saved Codex desktop task. Add `--create-pr` to `scan --patch` or a
 saved-finding `patch` command to commit only verified patch files and open a
-pull request with `gh`. If the push or pull request fails, run the printed
-`patch --resume-pr BRANCH` command from the same repository. It uses the saved
-commit without running Codex again and refuses to publish if the branch changed.
+pull request with `gh`. Use `--create-draft-pr` instead to open a draft pull
+request, review and update the verified patches, and send it for review when
+ready. If publication fails, run the printed
+`patch --resume-pr BRANCH` command from the same repository; add
+`--create-draft-pr` when resuming a draft. It uses the saved commit without
+running Codex again and refuses to publish if the branch changed.
 JSON scan results include `patchSeverity`. Scan and
 saved-finding results include one `patches` entry per selected finding with
 status `verified`, `no_change`, `blocked`, or `failed`, plus `pullRequest` when

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -361,7 +361,7 @@ own saved Codex desktop task. Add `--create-pr` to `scan --patch` or a
 saved-finding `patch` command to commit only verified patch files and open a
 pull request with `gh`. Use `--create-draft-pr` instead to open a draft pull
 request, review and update the verified patches, and send it for review when
-ready. If publication fails, run the printed
+ready. The flags are mutually exclusive. If publication fails, run the printed
 `patch --resume-pr BRANCH` command from the same repository; add
 `--create-draft-pr` when resuming a draft. It uses the saved commit without
 running Codex again and refuses to publish if the branch changed.

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -264,6 +264,20 @@ const CREATE_DRAFT_PR_OPTION = CREATE_PR_OPTION.describe(
   "Create a draft GitHub pull request after verified patches.",
 );
 
+function pullRequestOptionConflict(options: {
+  createPr: boolean;
+  createDraftPr: boolean;
+  resumePr?: string;
+}): string | undefined {
+  if (options.createPr && options.createDraftPr) {
+    return "--create-pr and --create-draft-pr are mutually exclusive.";
+  }
+  if (options.resumePr !== undefined && options.createPr) {
+    return "--resume-pr cannot be combined with patch inputs or options.";
+  }
+  return undefined;
+}
+
 function optionValue(flag: string) {
   return z.string().min(1, `${flag} must not be empty.`);
 }
@@ -2326,6 +2340,12 @@ export async function main(
         .refine((options) => !options.createDraftPr || options.patch, {
           message: "--create-draft-pr requires --patch.",
         })
+        .superRefine((options, context) => {
+          const conflict = pullRequestOptionConflict(options);
+          if (conflict !== undefined) {
+            context.addIssue({ code: "custom", message: conflict });
+          }
+        })
         .refine((options) => !options.patch || !options.dryRun, {
           message: "--patch cannot be combined with --dry-run.",
         })
@@ -3053,6 +3073,10 @@ export async function main(
       output: z.record(z.string(), z.unknown()).optional(),
       async run({ format, options }) {
         try {
+          const conflict = pullRequestOptionConflict(options);
+          if (conflict !== undefined) {
+            throw new CodexSecurityError(conflict);
+          }
           const linear =
             options.linearIssue.length > 0 || !!options.linearProject;
           if (options.resumePr !== undefined) {
@@ -3060,7 +3084,6 @@ export async function main(
               positionals.length > 0 ||
               options.scan !== undefined ||
               options.severity !== undefined ||
-              options.createPr ||
               linear ||
               options.linearFilter !== undefined ||
               options.linearApiKey !== undefined ||

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -260,6 +260,9 @@ const CREATE_PR_OPTION = z
   .boolean()
   .default(false)
   .describe("Create a GitHub pull request after verified patches.");
+const CREATE_DRAFT_PR_OPTION = CREATE_PR_OPTION.describe(
+  "Create a draft GitHub pull request after verified patches.",
+);
 
 function optionValue(flag: string) {
   return z.string().min(1, `${flag} must not be empty.`);
@@ -848,6 +851,7 @@ interface ScanArguments extends DeepScanOptions {
   patch?: boolean;
   patchSeverity?: FailureSeverity;
   createPr?: boolean;
+  createDraftPr?: boolean;
   maxCostUsd?: number;
   headless?: boolean;
   dryRun: boolean;
@@ -2267,6 +2271,7 @@ export async function main(
             .optional()
             .describe("Patch findings at or above LEVEL; requires --patch."),
           createPr: CREATE_PR_OPTION,
+          createDraftPr: CREATE_DRAFT_PR_OPTION,
           maxCost: z
             .number()
             .positive()
@@ -2317,6 +2322,9 @@ export async function main(
         )
         .refine((options) => !options.createPr || options.patch, {
           message: "--create-pr requires --patch.",
+        })
+        .refine((options) => !options.createDraftPr || options.patch, {
+          message: "--create-draft-pr requires --patch.",
         })
         .refine((options) => !options.patch || !options.dryRun, {
           message: "--patch cannot be combined with --dry-run.",
@@ -2389,6 +2397,7 @@ export async function main(
             patch: options.patch,
             patchSeverity: options.patchSeverity,
             createPr: options.createPr,
+            createDraftPr: options.createDraftPr,
             maxCostUsd: options.maxCost,
             headless: options.headless,
             dryRun: options.dryRun,
@@ -3028,6 +3037,7 @@ export async function main(
           .describe("JSON Linear issue filter for --linear-project."),
         linearApiKey: linearApiKeyOption(),
         createPr: CREATE_PR_OPTION,
+        createDraftPr: CREATE_DRAFT_PR_OPTION,
         resumePr: optionValue("--resume-pr")
           .optional()
           .describe(
@@ -3066,6 +3076,7 @@ export async function main(
               options.resumePr,
               errorOutput,
               dependencies,
+              options.createDraftPr,
             );
             if (format === "json" || format === "jsonl") {
               return { pullRequest };
@@ -3111,12 +3122,13 @@ export async function main(
             );
             exitCode = patchExitCode(patches);
             const pullRequest =
-              options.createPr && exitCode === 0
+              (options.createPr || options.createDraftPr) && exitCode === 0
                 ? await createPatchPullRequest(
                     selected,
                     patches,
                     errorOutput,
                     dependencies,
+                    options.createDraftPr,
                   )
                 : undefined;
             if (format === "json" || format === "jsonl") {
@@ -3139,9 +3151,12 @@ export async function main(
               "--severity requires a saved finding identifier or --scan.",
             );
           }
-          if (options.createPr) {
+          if (options.createPr || options.createDraftPr) {
+            const option = options.createDraftPr
+              ? "--create-draft-pr"
+              : "--create-pr";
             throw new CodexSecurityError(
-              "--create-pr requires a saved finding identifier or --scan.",
+              `${option} requires a saved finding identifier or --scan.`,
             );
           }
           if (format === "json" || format === "jsonl") {
@@ -3983,6 +3998,7 @@ async function publishPatchBranch(
   branch: string,
   stderr: Writable,
   dependencies: CliDependencies,
+  draft = false,
 ): Promise<{ branch: string; url: string }> {
   const run = (command: "git" | "gh", args: string[]) =>
     dependencies.runRepositoryCommand(command, args, repository);
@@ -4010,13 +4026,14 @@ async function publishPatchBranch(
         PATCH_PR_TITLE,
         "--body",
         PATCH_PR_BODY,
+        ...(draft ? ["--draft"] : []),
       ]);
     }
     stderr.write(`Pull request: ${safePatchText(url)}\n`);
     return { branch, url };
   } catch (error) {
     stderr.write(
-      `Patch commit saved. Retry from this repository with: codex-security patch --resume-pr ${safePatchText(branch)}\n`,
+      `Patch commit saved. Retry from this repository with: codex-security patch --resume-pr ${safePatchText(branch)}${draft ? " --create-draft-pr" : ""}\n`,
     );
     throw error;
   }
@@ -4027,6 +4044,7 @@ async function resumePatchPullRequest(
   branch: string,
   stderr: Writable,
   dependencies: CliDependencies,
+  draft = false,
 ): Promise<{ branch: string; url: string }> {
   const run = (args: string[]) =>
     dependencies.runRepositoryCommand("git", args, repository);
@@ -4049,7 +4067,7 @@ async function resumePatchPullRequest(
       "The patch branch has changed since verification. Review it before publishing.",
     );
   }
-  return publishPatchBranch(repository, branch, stderr, dependencies);
+  return publishPatchBranch(repository, branch, stderr, dependencies, draft);
 }
 
 async function createPatchPullRequest(
@@ -4057,6 +4075,7 @@ async function createPatchPullRequest(
   patches: readonly FindingPatch[],
   stderr: Writable,
   dependencies: CliDependencies,
+  draft = false,
 ): Promise<{ branch: string; url: string } | undefined> {
   const files = [
     ...new Set(
@@ -4084,7 +4103,9 @@ async function createPatchPullRequest(
   const branch = `codex-security/patch-${selected.scanId.replaceAll(/[^a-z\d._-]/giu, "-")}`;
   const run = (command: "git" | "gh", args: string[]) =>
     dependencies.runRepositoryCommand(command, args, selected.repository);
-  stderr.write("Creating a GitHub pull request for verified patches...\n");
+  stderr.write(
+    `Creating a${draft ? " draft" : ""} GitHub pull request for verified patches...\n`,
+  );
   await run("git", ["switch", "-c", branch]);
   await run("git", ["--literal-pathspecs", "add", "--", ...files]);
   await run("git", [
@@ -4098,7 +4119,13 @@ async function createPatchPullRequest(
   ]);
   const commit = await run("git", ["rev-parse", "HEAD"]);
   await run("git", ["config", "--local", patchCommitKey(branch), commit]);
-  return publishPatchBranch(selected.repository, branch, stderr, dependencies);
+  return publishPatchBranch(
+    selected.repository,
+    branch,
+    stderr,
+    dependencies,
+    draft,
+  );
 }
 
 function safePatchText(value: string): string {
@@ -5607,7 +5634,9 @@ async function executeScan(
       );
       scanData = { ...scanData, patchSeverity: patchThreshold, patches };
       if (
-        (arguments_.createPr || patchSelection?.createPullRequest) &&
+        (arguments_.createPr ||
+          arguments_.createDraftPr ||
+          patchSelection?.createPullRequest) &&
         patchExitCode(patches) === 0
       ) {
         const pullRequest = await createPatchPullRequest(
@@ -5615,6 +5644,7 @@ async function executeScan(
           patches,
           errorOutput,
           dependencies,
+          arguments_.createDraftPr,
         );
         if (pullRequest !== undefined) {
           scanData = { ...scanData, pullRequest };

--- a/sdk/typescript/tests-ts/cli-patch.test.ts
+++ b/sdk/typescript/tests-ts/cli-patch.test.ts
@@ -252,98 +252,117 @@ describe("scan and patch workflow", () => {
     );
   });
 
-  test("publishes only verified patch files and preserves unrelated staged changes", async () => {
-    const directory = await mkdtemp(join(tmpdir(), "codex-security-patch-pr-"));
-    const repository = join(directory, "repository");
-    const remote = join(directory, "remote.git");
-    const url = "https://github.example.test/example/repository/pull/15";
-    const result = resultWithFindings(["high", "medium"]);
-    result.findings.findings[0]!.title = "Synthetic private finding";
-    let pullRequestArguments: readonly string[] = [];
-    await mkdir(join(repository, "src"), { recursive: true });
-    const git = (...args: string[]) =>
-      execFileSync("git", args, {
-        cwd: repository,
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"],
-      }).trim();
+  test.each(["--create-pr", "--create-draft-pr"] as const)(
+    "publishes only verified patch files with %s and preserves unrelated staged changes",
+    async (pullRequestOption) => {
+      const directory = await mkdtemp(
+        join(tmpdir(), "codex-security-patch-pr-"),
+      );
+      const repository = join(directory, "repository");
+      const remote = join(directory, "remote.git");
+      const url = "https://github.example.test/example/repository/pull/15";
+      const result = resultWithFindings(["high", "medium"]);
+      result.findings.findings[0]!.title = "Synthetic private finding";
+      let pullRequestArguments: readonly string[] = [];
+      await mkdir(join(repository, "src"), { recursive: true });
+      const git = (...args: string[]) =>
+        execFileSync("git", args, {
+          cwd: repository,
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+        }).trim();
 
-    try {
-      git("init", "--initial-branch=main");
-      git("config", "user.name", "Synthetic User");
-      git("config", "user.email", "synthetic@example.test");
-      git("config", "commit.gpgsign", "false");
-      await writeFile(join(repository, "src", "finding-1.ts"), "unsafe\n");
-      await writeFile(join(repository, "unrelated.ts"), "original\n");
-      git("add", "--", ".");
-      git("commit", "-m", "Initial synthetic checkout");
-      git("init", "--bare", remote);
-      git("remote", "add", "origin", remote);
-      git("push", "--set-upstream", "origin", "main");
-      await writeFile(join(repository, "unrelated.ts"), "staged separately\n");
-      git("add", "--", "unrelated.ts");
+      try {
+        git("init", "--initial-branch=main");
+        git("config", "user.name", "Synthetic User");
+        git("config", "user.email", "synthetic@example.test");
+        git("config", "commit.gpgsign", "false");
+        await writeFile(join(repository, "src", "finding-1.ts"), "unsafe\n");
+        await writeFile(join(repository, "unrelated.ts"), "original\n");
+        git("add", "--", ".");
+        git("commit", "-m", "Initial synthetic checkout");
+        git("init", "--bare", remote);
+        git("remote", "add", "origin", remote);
+        git("push", "--set-upstream", "origin", "main");
+        await writeFile(
+          join(repository, "unrelated.ts"),
+          "staged separately\n",
+        );
+        git("add", "--", "unrelated.ts");
 
-      const outcome = await runWorkflow(
-        [
-          "scan",
-          "--patch",
-          "--patch-severity",
-          "high",
-          "--create-pr",
-          "--json",
-        ],
-        {
-          currentDirectory: repository,
-          result,
-          onCodex: async (args, output) => {
-            await writeFile(join(repository, "src", "finding-1.ts"), "fixed\n");
-            completePatches(args, output);
-            return 0;
+        const outcome = await runWorkflow(
+          [
+            "scan",
+            "--patch",
+            "--patch-severity",
+            "high",
+            pullRequestOption,
+            "--json",
+          ],
+          {
+            currentDirectory: repository,
+            result,
+            onCodex: async (args, output) => {
+              await writeFile(
+                join(repository, "src", "finding-1.ts"),
+                "fixed\n",
+              );
+              completePatches(args, output);
+              return 0;
+            },
+            onRepositoryCommand: (command, args, workingDirectory) => {
+              expect(workingDirectory).toBe(repository);
+              if (command === "git") return git(...args);
+              if (args[1] === "list") return "";
+              pullRequestArguments = args;
+              return url;
+            },
           },
-          onRepositoryCommand: (command, args, workingDirectory) => {
-            expect(workingDirectory).toBe(repository);
-            if (command === "git") return git(...args);
-            if (args[1] === "list") return "";
-            pullRequestArguments = args;
-            return url;
-          },
-        },
-      );
+        );
 
-      expect(outcome.exitCode).toBe(0);
-      expect(git("branch", "--show-current")).toBe("codex-security/patch-scan");
-      expect(git("show", "--format=", "--name-only", "HEAD")).toBe(
-        "src/finding-1.ts",
-      );
-      expect(git("diff", "--cached", "--name-only")).toBe("unrelated.ts");
-      expect(git("rev-parse", "HEAD")).toBe(
-        git("rev-parse", "origin/codex-security/patch-scan"),
-      );
-      expect(pullRequestArguments).toEqual([
-        "pr",
-        "create",
-        "--head",
-        "codex-security/patch-scan",
-        "--title",
-        "fix: patch verified security findings",
-        "--body",
-        "Applies verified security fixes from a completed scan.",
-      ]);
-      expect(JSON.stringify(pullRequestArguments)).not.toContain(
-        "Synthetic private finding",
-      );
-      expect(JSON.parse(outcome.stdout)).toMatchObject({
-        patchSeverity: "high",
-        pullRequest: { branch: "codex-security/patch-scan", url },
-      });
-    } finally {
-      await rm(directory, { recursive: true, force: true });
-    }
-  });
+        expect(outcome.exitCode).toBe(0);
+        expect(git("branch", "--show-current")).toBe(
+          "codex-security/patch-scan",
+        );
+        expect(git("show", "--format=", "--name-only", "HEAD")).toBe(
+          "src/finding-1.ts",
+        );
+        expect(git("diff", "--cached", "--name-only")).toBe("unrelated.ts");
+        expect(git("rev-parse", "HEAD")).toBe(
+          git("rev-parse", "origin/codex-security/patch-scan"),
+        );
+        expect(pullRequestArguments).toEqual([
+          "pr",
+          "create",
+          "--head",
+          "codex-security/patch-scan",
+          "--title",
+          "fix: patch verified security findings",
+          "--body",
+          "Applies verified security fixes from a completed scan.",
+          ...(pullRequestOption === "--create-draft-pr" ? ["--draft"] : []),
+        ]);
+        expect(JSON.stringify(pullRequestArguments)).not.toContain(
+          "Synthetic private finding",
+        );
+        expect(JSON.parse(outcome.stdout)).toMatchObject({
+          patchSeverity: "high",
+          pullRequest: { branch: "codex-security/patch-scan", url },
+        });
+      } finally {
+        await rm(directory, { recursive: true, force: true });
+      }
+    },
+  );
 
-  test.each(["push", "create"])(
-    "resumes publication after %s fails without patching again",
-    async (failure) => {
+  test.each([
+    ["push", false],
+    ["create", false],
+    ["push", true],
+    ["create", true],
+  ] as const)(
+    "resumes publication after %s fails (draft: %s) without patching again",
+    async (failure, draft) => {
       const directory = await mkdtemp(
         join(tmpdir(), "codex-security-pr-retry-"),
       );
@@ -406,6 +425,7 @@ describe("scan and patch workflow", () => {
             }
             if (args[1] === "list") return publishedUrl;
             expect(args[1]).toBe("create");
+            expect(args.includes("--draft")).toBe(draft);
             if (failure === "create" && failOnce) {
               failOnce = false;
               throw new Error("Synthetic PR service failure");
@@ -417,11 +437,19 @@ describe("scan and patch workflow", () => {
         };
 
         const first = await runWorkflow(
-          ["patch", "--scan", "scan-1", "--create-pr", "--json"],
+          [
+            "patch",
+            "--scan",
+            "scan-1",
+            draft ? "--create-draft-pr" : "--create-pr",
+            "--json",
+          ],
           fixtures,
         );
         expect(first.exitCode).toBe(2);
-        expect(first.stderr).toContain(`patch --resume-pr ${branch}`);
+        expect(first.stderr).toContain(
+          `patch --resume-pr ${branch}${draft ? " --create-draft-pr" : ""}`,
+        );
         const commit = git("rev-parse", "HEAD");
         expect(
           git("config", "--get", `branch.${branch}.codexSecurityPatchCommit`),
@@ -432,7 +460,13 @@ describe("scan and patch workflow", () => {
         await writeFile(join(repository, "unrelated.ts"), "later local work\n");
 
         const retry = await runWorkflow(
-          ["patch", "--resume-pr", branch, "--json"],
+          [
+            "patch",
+            "--resume-pr",
+            branch,
+            ...(draft ? ["--create-draft-pr"] : []),
+            "--json",
+          ],
           fixtures,
         );
         expect(retry.exitCode).toBe(0);
@@ -447,7 +481,12 @@ describe("scan and patch workflow", () => {
 
         const pushes = pushCalls;
         const repeated = await runWorkflow(
-          ["patch", "--resume-pr", branch],
+          [
+            "patch",
+            "--resume-pr",
+            branch,
+            ...(draft ? ["--create-draft-pr"] : []),
+          ],
           fixtures,
         );
         expect(repeated.exitCode).toBe(0);
@@ -896,28 +935,40 @@ describe("scan and patch workflow", () => {
     });
   });
 
-  test("creates a pull request for verified saved-finding patches", async () => {
-    const result = resultWithFindings(["high"]);
-    const url = "https://github.example.test/example/repository/pull/14";
-    let repository = "";
-    const outcome = await runWorkflow(
-      ["patch", "--scan", "scan-1", "--create-pr", "--json"],
-      {
-        onWorkbench: () => savedScan(result),
-        onRepositoryCommand: (command, args, target) => {
-          repository = target;
-          return command === "gh" && args[1] === "create" ? url : "";
+  test.each([
+    ["--create-pr", false],
+    ["--create-draft-pr", true],
+  ] as const)(
+    "creates a pull request for verified saved-finding patches with %s",
+    async (pullRequestOption, draft) => {
+      const result = resultWithFindings(["high"]);
+      const url = "https://github.example.test/example/repository/pull/14";
+      let repository = "";
+      let pullRequestArguments: readonly string[] = [];
+      const outcome = await runWorkflow(
+        ["patch", "--scan", "scan-1", pullRequestOption, "--json"],
+        {
+          onWorkbench: () => savedScan(result),
+          onRepositoryCommand: (command, args, target) => {
+            repository = target;
+            if (command === "gh" && args[1] === "create") {
+              pullRequestArguments = args;
+              return url;
+            }
+            return "";
+          },
         },
-      },
-    );
+      );
 
-    expect(outcome.exitCode).toBe(0);
-    expect(repository).toBe(SAVED_REPOSITORY);
-    expect(JSON.parse(outcome.stdout)).toMatchObject({
-      scanId: "scan-1",
-      pullRequest: { branch: "codex-security/patch-scan-1", url },
-    });
-  });
+      expect(outcome.exitCode).toBe(0);
+      expect(repository).toBe(SAVED_REPOSITORY);
+      expect(pullRequestArguments.includes("--draft")).toBe(draft);
+      expect(JSON.parse(outcome.stdout)).toMatchObject({
+        scanId: "scan-1",
+        pullRequest: { branch: "codex-security/patch-scan-1", url },
+      });
+    },
+  );
 
   test("redacts credentials when saved-finding pull request creation fails", async () => {
     const result = resultWithFindings(["high"]);
@@ -1046,19 +1097,22 @@ describe("scan and patch workflow", () => {
     expect(outcome.stderr).toContain("--patch-severity requires --patch");
   });
 
-  test("requires verified patching before creating a pull request", async () => {
-    const scan = await runWorkflow(["scan", "--create-pr"]);
-    expect(scan.exitCode).toBe(2);
-    expect(scan.stderr).toContain("--create-pr requires --patch");
+  test.each(["--create-pr", "--create-draft-pr"] as const)(
+    "requires verified patching before creating a pull request with %s",
+    async (pullRequestOption) => {
+      const scan = await runWorkflow(["scan", pullRequestOption]);
+      expect(scan.exitCode).toBe(2);
+      expect(scan.stderr).toContain(`${pullRequestOption} requires --patch`);
 
-    const literal = await runWorkflow([
-      "patch",
-      "Synthetic security issue",
-      "--create-pr",
-    ]);
-    expect(literal.exitCode).toBe(2);
-    expect(literal.stderr).toContain(
-      "--create-pr requires a saved finding identifier or --scan",
-    );
-  });
+      const literal = await runWorkflow([
+        "patch",
+        "Synthetic security issue",
+        pullRequestOption,
+      ]);
+      expect(literal.exitCode).toBe(2);
+      expect(literal.stderr).toContain(
+        `${pullRequestOption} requires a saved finding identifier or --scan`,
+      );
+    },
+  );
 });

--- a/sdk/typescript/tests-ts/cli-patch.test.ts
+++ b/sdk/typescript/tests-ts/cli-patch.test.ts
@@ -483,9 +483,9 @@ describe("scan and patch workflow", () => {
         const repeated = await runWorkflow(
           [
             "patch",
-            "--resume-pr",
-            branch,
-            ...(draft ? ["--create-draft-pr"] : []),
+            ...(draft
+              ? [`--resume-pr=${branch}`, "--create-draft-pr=true"]
+              : ["--resume-pr", branch]),
           ],
           fixtures,
         );
@@ -528,22 +528,24 @@ describe("scan and patch workflow", () => {
       ["--scan", "scan-1"],
       ["--linear-issue", "SEC-123"],
       ["--create-pr"],
+      ["--create-pr=true"],
       ["occ_1"],
     ]) {
       let commandStarted = false;
-      const outcome = await runWorkflow(
-        ["patch", "--resume-pr", "codex-security/patch-scan-1", ...input],
-        {
-          onCodex: () => {
-            commandStarted = true;
-            return 0;
-          },
-          onRepositoryCommand: () => {
-            commandStarted = true;
-            return "";
-          },
+      const resume =
+        input[0] === "--create-pr=true"
+          ? ["--resume-pr=codex-security/patch-scan-1"]
+          : ["--resume-pr", "codex-security/patch-scan-1"];
+      const outcome = await runWorkflow(["patch", ...resume, ...input], {
+        onCodex: () => {
+          commandStarted = true;
+          return 0;
         },
-      );
+        onRepositoryCommand: () => {
+          commandStarted = true;
+          return "";
+        },
+      });
       expect(outcome.exitCode).toBe(2);
       expect(outcome.stderr).toContain("--resume-pr cannot be combined");
       expect(commandStarted).toBe(false);
@@ -1113,6 +1115,89 @@ describe("scan and patch workflow", () => {
       expect(literal.stderr).toContain(
         `${pullRequestOption} requires a saved finding identifier or --scan`,
       );
+    },
+  );
+
+  test.each([
+    ["scan", ["scan", "--patch"], ["--create-pr", "--create-draft-pr"]],
+    [
+      "scan",
+      ["scan", "--patch"],
+      ["--create-pr=true", "--create-draft-pr=true"],
+    ],
+    [
+      "patch",
+      ["patch", "--scan", "scan-1"],
+      ["--create-pr", "--create-draft-pr"],
+    ],
+    [
+      "patch",
+      ["patch", "--scan", "scan-1"],
+      ["--create-pr=true", "--create-draft-pr=true"],
+    ],
+  ] as const)(
+    "rejects creating both a ready and draft pull request from %s",
+    async (_name, command, pullRequestOptions) => {
+      let started = false;
+      const outcome = await runWorkflow([...command, ...pullRequestOptions], {
+        onCodex: () => {
+          started = true;
+          return 0;
+        },
+        onRepositoryCommand: () => {
+          started = true;
+          return "";
+        },
+        onWorkbench: () => {
+          started = true;
+          return savedScan(resultWithFindings(["high"]));
+        },
+      });
+
+      expect(outcome.exitCode).toBe(2);
+      expect(outcome.stderr).toContain(
+        "--create-pr and --create-draft-pr are mutually exclusive",
+      );
+      expect(started).toBe(false);
+    },
+  );
+
+  test.each([
+    [
+      "ready creation is explicitly disabled",
+      ["--create-pr=false", "--create-draft-pr=true"],
+    ],
+    [
+      "draft creation is explicitly disabled",
+      ["--create-pr=true", "--create-draft-pr=false"],
+    ],
+    [
+      "ready creation is negated",
+      ["--create-pr", "--no-create-pr", "--create-draft-pr"],
+    ],
+    [
+      "draft creation is negated",
+      ["--create-pr", "--create-draft-pr", "--no-create-draft-pr"],
+    ],
+    [
+      "the final ready-creation value wins",
+      ["--create-pr", "--create-pr=false", "--create-draft-pr=true"],
+    ],
+    [
+      "the final draft-creation value wins",
+      ["--create-pr=true", "--create-draft-pr", "--create-draft-pr=false"],
+    ],
+  ] as const)(
+    "accepts pull request options when %s",
+    async (_description, pullRequestOptions) => {
+      const outcome = await runWorkflow([
+        "scan",
+        "--patch",
+        ...pullRequestOptions,
+      ]);
+
+      expect(outcome.exitCode).toBe(0);
+      expect(outcome.stderr).not.toContain("mutually exclusive");
     },
   );
 });

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -135,6 +135,7 @@ describe("CLI", () => {
           patch: { type: "boolean" },
           patchSeverity: { enum: ["critical", "high", "medium", "low"] },
           createPr: { type: "boolean" },
+          createDraftPr: { type: "boolean" },
           headless: { type: "boolean" },
         },
       },


### PR DESCRIPTION
## Summary

Add an opt-in `--create-draft-pr` flag so verified security patches can be reviewed and refined before requesting review.

## Changes

- Support draft pull requests from both `scan --patch` and saved-finding `patch` commands.
- Pass `--draft` to GitHub pull request creation while preserving existing `--create-pr` behavior.
- Reject conflicting pull request options and preserve draft intent when retrying publication.
- Extend CLI schemas, documentation, and regression coverage for draft and standard pull requests.

## Testing

- Full randomized SDK suite (`--seed 12345`): 1,467 passed, 21 platform-specific or optional integration tests skipped, 0 failed.
- Focused CLI suites: 173 passed.
- `pnpm run types`
- `pnpm run format`
- `pnpm run build`
- Built CLI smoke checks confirmed both pull request options and conflicting-option rejection.

## Risk and rollout

- Opt-in only; default patching and existing `--create-pr` behavior remain unchanged.
- Draft and ready-for-review pull request modes are mutually exclusive.
- Publication retry instructions retain draft mode to avoid accidentally opening a ready-for-review pull request.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.