### PR TITLE
docs: require explicit requests for public CLI changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,21 @@ Codex Security is a thin wrapper around Codex and its security plugin.
   only after checking that it is public. If you cannot confirm its visibility,
   leave it out.
 
+## Public CLI changes
+
+Treat commands, arguments, flags, accepted values, public environment
+variables, and defaults as public API.
+
+- Do not add or change public CLI surface unless the task explicitly calls for
+  it. A request for new behavior is not permission to invent a command or flag.
+- Prefer existing commands, settings, and Codex behavior. Do not add flags for
+  implementation convenience or when a safe, compatible default is enough.
+- Before adding CLI surface, explain the user need, exact syntax and defaults,
+  why existing behavior is insufficient, and compatibility impact. Ask if those
+  choices are unclear.
+- Update relevant help, schemas, documentation, and tests in the same change.
+  Describe the public CLI change in the pull request.
+
 ## Public repository and pull requests
 
 Everything published in this repository is public. Review branch names before

--- a/sdk/typescript/AGENTS.md
+++ b/sdk/typescript/AGENTS.md
@@ -27,6 +27,21 @@ outside an approved path.
 - Support Windows as well as Unix. Use platform-aware path and process APIs, and test realistic Windows paths and directory links when relevant.
 - Favor direct flows and clear errors over defensive fallbacks for implausible cases.
 
+## Public CLI changes
+
+Treat commands, arguments, flags, accepted values, public environment
+variables, and defaults as public API.
+
+- Do not add or change public CLI surface unless the task explicitly calls for
+  it. A request for new behavior is not permission to invent a command or flag.
+- Prefer existing commands, settings, and Codex behavior. Do not add flags for
+  implementation convenience or when a safe, compatible default is enough.
+- Before adding CLI surface, explain the user need, exact syntax and defaults,
+  why existing behavior is insufficient, and compatibility impact. Ask if those
+  choices are unclear.
+- Update relevant help, schemas, documentation, and tests in the same change.
+  Describe the public CLI change in the pull request.
+
 ## Unit tests
 
 Add focused Bun tests in `tests-ts/<module>.test.ts`. Cover observable behavior,

--- a/sdk/typescript/AGENTS.md
+++ b/sdk/typescript/AGENTS.md
@@ -27,21 +27,6 @@ outside an approved path.
 - Support Windows as well as Unix. Use platform-aware path and process APIs, and test realistic Windows paths and directory links when relevant.
 - Favor direct flows and clear errors over defensive fallbacks for implausible cases.
 
-## Public CLI changes
-
-Treat commands, arguments, flags, accepted values, public environment
-variables, and defaults as public API.
-
-- Do not add or change public CLI surface unless the task explicitly calls for
-  it. A request for new behavior is not permission to invent a command or flag.
-- Prefer existing commands, settings, and Codex behavior. Do not add flags for
-  implementation convenience or when a safe, compatible default is enough.
-- Before adding CLI surface, explain the user need, exact syntax and defaults,
-  why existing behavior is insufficient, and compatibility impact. Ask if those
-  choices are unclear.
-- Update relevant help, schemas, documentation, and tests in the same change.
-  Describe the public CLI change in the pull request.
-
 ## Unit tests
 
 Add focused Bun tests in `tests-ts/<module>.test.ts`. Cover observable behavior,


### PR DESCRIPTION
## Summary

Keep the public CLI stable by requiring agents to justify changes to its user-facing interface.

## Changes

- Add root-level guidance that applies to every public CLI entrypoint.
- Treat commands, arguments, flags, accepted values, public environment variables, and defaults as public API.
- Require an explicit task request and a clear design; prefer existing commands, settings, and compatible defaults.
- Update relevant documentation and tests when a public CLI change is necessary.

## Testing

- `prettier --check AGENTS.md`
- `git diff --check origin/main...HEAD`
- Runtime tests are not applicable to this documentation-only change.

## Risk and rollout

Documentation only. No runtime behavior, configuration, or release process changes.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
