### PR TITLE
refactor(auth): share scan authentication modes

### DIFF
--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -226,7 +226,8 @@ export interface ScanOptions extends DeepScanOptions {
   signal?: AbortSignal;
 }
 
-export type ScanAuthMode = "auto" | "chatgpt" | "api-key";
+export const SCAN_AUTH_MODES = ["auto", "chatgpt", "api-key"] as const;
+export type ScanAuthMode = (typeof SCAN_AUTH_MODES)[number];
 
 export type ScanAuthentication =
   | {
@@ -2770,7 +2771,7 @@ export function scanAuthentication(
   auth: ScanAuthMode = "auto",
   modelProvider?: unknown,
 ): ScanAuthentication {
-  if (auth !== "auto" && auth !== "chatgpt" && auth !== "api-key") {
+  if (!SCAN_AUTH_MODES.includes(auth)) {
     throw new TypeError(
       "Scan authentication mode must be auto, chatgpt, or api-key.",
     );

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -46,6 +46,7 @@ import {
   CodexSecurity,
   createSecurityInternal,
   listRepositoryFindings,
+  SCAN_AUTH_MODES,
   scanAuthentication,
   type DeepScanOptions,
   type ScanAuthMode,
@@ -2183,7 +2184,7 @@ export async function main(
       options: z
         .object({
           auth: z
-            .enum(["auto", "chatgpt", "api-key"])
+            .enum(SCAN_AUTH_MODES)
             .default("auto")
             .describe(
               "Select ChatGPT, OPENAI_API_KEY/CODEX_API_KEY, or automatic authentication.",


### PR DESCRIPTION
## Summary

Keep the SDK type, runtime validation, and CLI schema aligned by defining the supported scan authentication modes once. This is a behavior-preserving cleanup following #172.

## Changes

- Define `SCAN_AUTH_MODES` as the shared readonly tuple in the SDK API module.
- Derive `ScanAuthMode` from that tuple.
- Reuse the tuple for SDK runtime validation and the CLI enum schema.

## Testing

- `pnpm dlx bun test --timeout 30000 ./tests-ts --seed 12345` (1,461 passed, 23 skipped, 0 failed)
- `pnpm run types` (passed)
- `pnpm run format` (passed)
- `pnpm dlx bun test --timeout 30000 ./tests-ts` (1,461 passed, 23 skipped, 0 failed; seed `3938820364`)
- Native Codex prepublication review gate (three independent passes plus independent verification; no findings)

The package's `pnpm run test --seed 12345` wrapper could not start because `bun` is not installed globally in this environment, so the same test command was run through `pnpm dlx bun` instead.

## Risk and rollout

Low risk. The accepted values, validation error, and CLI behavior are unchanged. No rollout steps are required.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
