### PR TITLE
fix(cli): create draft patch pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ threshold, select individual findings, and add patch instructions for each one.
 Each selected finding runs in its own saved Codex desktop task.
 Use `--patch --patch-severity high` to fix high and critical findings. Add
 `--create-pr`, or enable the pull request option during review, to commit the
-verified files and open a GitHub pull request. Ordinary scans do not change
-repository files.
+verified files and open a draft GitHub pull request. Ordinary scans do not
+change repository files.
 
 Deep-scan discovery stops after 96 hours by default. Set `--max-time-hours` to
 any positive number of hours, including fractional hours, up to 96. Completed
@@ -88,8 +88,8 @@ and identifies findings not confirmed in its latest scan.
 
 Use `patch OCCURRENCE_ID` to fix one saved finding, or
 `patch --scan SCAN_ID --severity high` to fix selected findings from a saved
-scan. Add `--json` for structured results or `--create-pr` to open a GitHub pull
-request after verification. If publication fails, use the printed
+scan. Add `--json` for structured results or `--create-pr` to open a draft
+GitHub pull request after verification. If publication fails, use the printed
 `patch --resume-pr BRANCH` command to retry without running Codex again.
 
 Use `patch --linear-issue SEC-123` to import and fix a Linear issue, or

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -352,11 +352,11 @@ ask whether to open a color-coded finding browser with complete finding details
 and a separate patch-instructions panel. Use the arrow keys to
 browse, `Tab` to inspect details, `Space` to select individual findings, `i` to
 edit instructions for the focused finding, `1`–`4` to select by severity, and
-`r` to optionally create a GitHub pull request after patching. Press `Enter` to
-patch or `q` to keep the checkout unchanged. Each selected finding runs in its
-own saved Codex desktop task. Add `--create-pr` to `scan --patch` or a
+`r` to optionally create a draft GitHub pull request after patching. Press
+`Enter` to patch or `q` to keep the checkout unchanged. Each selected finding
+runs in its own saved Codex desktop task. Add `--create-pr` to `scan --patch` or a
 saved-finding `patch` command to commit only verified patch files and open a
-pull request with `gh`. If the push or pull request fails, run the printed
+draft pull request with `gh`. If the push or pull request fails, run the printed
 `patch --resume-pr BRANCH` command from the same repository. It uses the saved
 commit without running Codex again and refuses to publish if the branch changed.
 JSON scan results include `patchSeverity`. Scan and

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -261,7 +261,7 @@ const PROVIDER_OPTION = z
 const CREATE_PR_OPTION = z
   .boolean()
   .default(false)
-  .describe("Create a GitHub pull request after verified patches.");
+  .describe("Create a draft GitHub pull request after verified patches.");
 
 function optionValue(flag: string) {
   return z.string().min(1, `${flag} must not be empty.`);
@@ -4010,6 +4010,7 @@ async function publishPatchBranch(
       url = await run("gh", [
         "pr",
         "create",
+        "--draft",
         "--head",
         branch,
         "--title",
@@ -4090,7 +4091,9 @@ async function createPatchPullRequest(
   const branch = `codex-security/patch-${selected.scanId.replaceAll(/[^a-z\d._-]/giu, "-")}`;
   const run = (command: "git" | "gh", args: string[]) =>
     dependencies.runRepositoryCommand(command, args, selected.repository);
-  stderr.write("Creating a GitHub pull request for verified patches...\n");
+  stderr.write(
+    "Creating a draft GitHub pull request for verified patches...\n",
+  );
   await run("git", ["switch", "-c", branch]);
   await run("git", ["--literal-pathspecs", "add", "--", ...files]);
   await run("git", [

--- a/sdk/typescript/src/patch-tui.tsx
+++ b/sdk/typescript/src/patch-tui.tsx
@@ -652,7 +652,7 @@ export function PatchTui({
         <Text color={createPullRequest ? success : muted}>
           {createPullRequest ? "[✓]" : "[ ]"}
         </Text>
-        {" Create GitHub pull request after patching "}
+        {" Create draft GitHub pull request after patching "}
         <Text dimColor>(r toggle)</Text>
       </Text>
 

--- a/sdk/typescript/tests-ts/cli-patch.test.ts
+++ b/sdk/typescript/tests-ts/cli-patch.test.ts
@@ -322,6 +322,7 @@ describe("scan and patch workflow", () => {
       expect(pullRequestArguments).toEqual([
         "pr",
         "create",
+        "--draft",
         "--head",
         "codex-security/patch-scan",
         "--title",
@@ -839,7 +840,7 @@ describe("scan and patch workflow", () => {
     expect(patched[0]).not.toHaveProperty("instructions");
   });
 
-  test("creates a pull request when selected in the interactive review", async () => {
+  test("creates a draft pull request when selected in the interactive review", async () => {
     let published = false;
     const url = "https://github.example.test/example/repository/pull/13";
     const outcome = await runWorkflow(
@@ -896,7 +897,7 @@ describe("scan and patch workflow", () => {
     });
   });
 
-  test("creates a pull request for verified saved-finding patches", async () => {
+  test("creates a draft pull request for verified saved-finding patches", async () => {
     const result = resultWithFindings(["high"]);
     const url = "https://github.example.test/example/repository/pull/14";
     let repository = "";

--- a/sdk/typescript/tests-ts/patch-tui.test.ts
+++ b/sdk/typescript/tests-ts/patch-tui.test.ts
@@ -101,7 +101,7 @@ describe("interactive patch finding browser", () => {
     expect(app.lastFrame()).toContain("PATCH INSTRUCTIONS");
     expect(app.lastFrame()).toContain("Add instructions for this finding.");
     expect(app.lastFrame()).toContain(
-      "[ ] Create GitHub pull request after patching",
+      "[ ] Create draft GitHub pull request after patching",
     );
     expect(app.lastFrame()).toContain("3/3 selected");
     expect(app.lastFrame()).toContain("SUMMARY");
@@ -304,7 +304,7 @@ describe("interactive patch finding browser", () => {
     ]);
   });
 
-  test("optionally creates a pull request after selected patches", async () => {
+  test("optionally creates a draft pull request after selected patches", async () => {
     const selected: (PatchSelection | null)[] = [];
     const app = render(
       createElement(PatchTui, {
@@ -316,12 +316,12 @@ describe("interactive patch finding browser", () => {
     );
 
     expect(app.lastFrame()).toContain(
-      "[ ] Create GitHub pull request after patching",
+      "[ ] Create draft GitHub pull request after patching",
     );
     app.stdin.write("r");
     await settle();
     expect(app.lastFrame()).toContain(
-      "[✓] Create GitHub pull request after patching",
+      "[✓] Create draft GitHub pull request after patching",
     );
     app.stdin.write("\r");
     await settle();


### PR DESCRIPTION
## Summary

Patch-generated pull requests currently open as ready for review. This change opens them as drafts so maintainers can review the generated fixes before normal review starts.

## Changes

- Add the draft option to the GitHub pull request command.
- Update CLI help, interactive text, and documentation.
- Test the exact pull request command and interactive text.

## Testing

- pnpm dlx bun@1.3.13 test --timeout 30000 --seed 12345 ./tests-ts: 1,482 passed, 29 skipped, 0 failed.
- pnpm run types: passed.
- pnpm run format: passed.
- pnpm run build: passed.

## Risk and rollout

This change only changes the initial pull request state. Patch verification, commits, pushes, and publication retries are unchanged.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.