### PR TITLE
fix(sdk): align scan cost session attribution with log inclusion

### DIFF
--- a/sdk/typescript/src/cost.ts
+++ b/sdk/typescript/src/cost.ts
@@ -1,5 +1,5 @@
 import { open, readdir } from "node:fs/promises";
-import { join, relative, sep } from "node:path";
+import { isAbsolute, join, relative, sep } from "node:path";
 import {
   scanActivityFromSessionEvent,
   type ScanActivity,
@@ -248,13 +248,18 @@ export class ScanCostTracker {
           this.#options.scanDirectory,
           "artifacts",
         );
-        const workerDirectory = relative(
-          join(artifactsDirectory, "deep_discovery", "workers"),
-          session.workingDirectory,
-        ).split(sep);
+        const workers = join(artifactsDirectory, "deep_discovery", "workers");
+        const workerDirectory = relative(workers, session.workingDirectory);
+        const components = workerDirectory.split(sep);
         if (
-          session.workingDirectory === artifactsDirectory ||
-          (workerDirectory.length === 2 && workerDirectory[1] === "output")
+          relative(artifactsDirectory, session.workingDirectory) === "" ||
+          (!isAbsolute(workerDirectory) &&
+            components.length === 2 &&
+            components[0] !== ".." &&
+            relative(
+              join(workers, components[0]!, "output"),
+              session.workingDirectory,
+            ) === "")
         ) {
           included.add(session.threadId);
         }

--- a/sdk/typescript/tests-ts/cost.test.ts
+++ b/sdk/typescript/tests-ts/cost.test.ts
@@ -692,6 +692,55 @@ describe("live scan cost tracking", () => {
     ).toEqual([1, 2, 3]);
   });
 
+  test("excludes sessions beside the deep worker output directories", async () => {
+    const home = await codexHome();
+    const scanDirectory = join(home, "scans", "current");
+    await writeSession(
+      home,
+      "scan-thread",
+      { input_tokens: 1_000, output_tokens: 10 },
+      undefined,
+      scanDirectory,
+      "2026-07-26T12:00:00Z",
+    );
+    await writeSession(
+      home,
+      "deep-worker",
+      { input_tokens: 250, output_tokens: 2 },
+      undefined,
+      join(
+        scanDirectory,
+        "artifacts",
+        "deep_discovery",
+        "workers",
+        "worker",
+        "output",
+      ),
+      "2026-07-26T12:01:00Z",
+    );
+    // A session running in a directory that sits beside workers/ under
+    // deep_discovery is not a worker output directory and must not be counted.
+    await writeSession(
+      home,
+      "bystander",
+      { input_tokens: 1_000_000, output_tokens: 1_000_000 },
+      undefined,
+      join(scanDirectory, "artifacts", "deep_discovery", "output"),
+      "2026-07-26T12:02:00Z",
+    );
+    const tracker = new ScanCostTracker({
+      codexHome: home,
+      model: "gpt-5.6-sol",
+      scanDirectory,
+    });
+    tracker.start("scan-thread");
+
+    expect((await tracker.stop()).usage).toMatchObject({
+      input_tokens: 1_250,
+      output_tokens: 12,
+    });
+  });
+
   test("ignores replayed parent history in forked worker sessions", async () => {
     const home = await codexHome();
     const inherited = {


### PR DESCRIPTION
## Summary

`ScanCostTracker.#readSessions` (`sdk/typescript/src/cost.ts`) and `belongsToScan` in `readScanLogs` (`sdk/typescript/src/scan-logs.ts`) both decide whether a Codex session belongs to a scan from the deep-worker output directory layout, but the cost-side check is weaker and disagrees with the log-side one. It matches any working directory whose path relative to `<scanDir>/artifacts/deep_discovery/workers` splits into two components ending in `"output"`, without `belongsToScan`'s guards. Two directories the log path deliberately rejects are therefore counted toward scan cost:

- a sibling such as `<scanDir>/artifacts/deep_discovery/output` relativizes to `../output`; and
- on Windows a directory like `D:\output` on a different drive than the scan relativizes to the absolute `D:\output`.

Both inflate reported cost/token totals, and because `ScanCostTracker` gates `--max-cost`, a scan can abort early against its budget on tokens it never spent.

## Changes

- `cost.ts`: reuse `belongsToScan`'s guarded, exact-path worker-output check — require a non-absolute relative path, reject a `..` first component, and confirm the directory is exactly `workers/<id>/output` — so cost attribution matches log attribution. Adds the `isAbsolute` import.
- `cost.test.ts`: add a regression test (`"excludes sessions beside the deep worker output directories"`) asserting a 1,000,000/1,000,000-token bystander session in `<scanDir>/artifacts/deep_discovery/output` is not counted; expected usage stays `input_tokens: 1_250, output_tokens: 12`.

## Testing

- Compared the two predicates' expressions on identical inputs under both `path.win32` and `path.posix`; after the change they agree on every case — real `workers/<id>/output` and `artifacts` directories are still included, and the sibling / cross-drive directories are excluded.
- Added the regression test above (fails on `main`, passes with this change).
- Note: I did not run the full `bun test` suite locally; the new test follows the existing `cost.test.ts` harness.

## Risk and rollout

Low. The change strictly narrows over-inclusion in scan cost attribution — legitimate worker, artifacts, and child-thread sessions are unaffected. No CLI, API, schema, or output-format changes.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.