### PR TITLE
fix(plugin): make the security access app optional

### DIFF
--- a/sdk/typescript/_bundled_plugin/.app.json
+++ b/sdk/typescript/_bundled_plugin/.app.json
@@ -3,7 +3,7 @@
     "codex-security-access": {
       "id": "connector_openai_codex_security_access",
       "category": "Security",
-      "required": true
+      "required": false
     },
     "linear": {
       "id": "asdk_app_69a089a326dc8191b32a3f2553f5be2c",

--- a/sdk/typescript/tests-ts/plugin-apps.test.ts
+++ b/sdk/typescript/tests-ts/plugin-apps.test.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { expect, test } from "bun:test";
 import { PLUGIN_ROOT } from "./plugin-root.js";
 
-test("registers security access as a required hosted app, not a local MCP server", async () => {
+test("registers security access as an optional hosted app, not a local MCP server", async () => {
   const [appConfiguration, mcpConfiguration] = await Promise.all([
     readFile(join(PLUGIN_ROOT, ".app.json"), "utf8"),
     readFile(join(PLUGIN_ROOT, ".mcp.json"), "utf8"),
@@ -18,7 +18,7 @@ test("registers security access as a required hosted app, not a local MCP server
   expect(apps["codex-security-access"]).toEqual({
     id: "connector_openai_codex_security_access",
     category: "Security",
-    required: true,
+    required: false,
   });
   expect(mcpServers).not.toHaveProperty("codex-security-access");
 });


### PR DESCRIPTION
## Summary

Allow the plugin to start without connecting the security access app.

## Changes

- Mark the security access app as optional.
- Keep the app available and leave the other app entries unchanged.

## Testing

- Full SDK suite on a local combination of all seven separate ports: 1,511 passed, 29 skipped, zero failures; randomized seed `1019194479`.
- Parsed the manifest and checked the optional setting and unchanged app count.
- Updated and ran the existing hosted-app contract test: 1 passed.

## Risk and rollout

Manifest-only change. No CLI, credential, or release-version changes.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
