### PR TITLE
fix(plugin): start MCP with managed Node

### DIFF
--- a/sdk/typescript/_bundled_plugin/.mcp.json
+++ b/sdk/typescript/_bundled_plugin/.mcp.json
@@ -1,14 +1,18 @@
 {
   "mcpServers": {
     "codex-security": {
-      "command": "node",
-      "args": ["./mcp/server.mjs", "--stdio"],
+      "command": "./scripts/launch_codex_security_mcp",
+      "args": ["--stdio"],
       "cwd": ".",
       "env_vars": [
         "CODEX_HOME",
         "CODEX_SQLITE_HOME",
         "CODEX_API_KEY",
+        "CODEX_BROWSER_USE_NODE_PATH",
         "CODEX_CLI_PATH",
+        "CODEX_ELECTRON_RESOURCES_PATH",
+        "CODEX_MANAGED_PACKAGE_ROOT",
+        "CODEX_MCP_NODE_PATH",
         "OPENROUTER_API_KEY",
         "FIREWORKS_API_KEY",
         "AWS_BEARER_TOKEN_BEDROCK",
@@ -39,7 +43,8 @@
         "NO_PROXY",
         "SSL_CERT_FILE",
         "REQUESTS_CA_BUNDLE",
-        "NODE_EXTRA_CA_CERTS"
+        "NODE_EXTRA_CA_CERTS",
+        "XDG_CACHE_HOME"
       ],
       "tool_timeout_sec": 349200
     }

--- a/sdk/typescript/_bundled_plugin/scripts/launch_codex_security_mcp
+++ b/sdk/typescript/_bundled_plugin/scripts/launch_codex_security_mcp
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -eu
+
+PATH="${PATH:-/usr/bin:/bin}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+export PATH
+
+launcher_dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
+server_path=$launcher_dir/../mcp/server.mjs
+cache_root=${XDG_CACHE_HOME:-${HOME:-}/.cache}
+codex_resources=
+case "${CODEX_CLI_PATH:-}" in
+  */*) codex_resources=${CODEX_CLI_PATH%/*} ;;
+esac
+
+for candidate in \
+  "${CODEX_MCP_NODE_PATH:-}" \
+  "${CODEX_BROWSER_USE_NODE_PATH:-}" \
+  "${CODEX_ELECTRON_RESOURCES_PATH:-}/cua_node/bin/node" \
+  "$codex_resources/cua_node/bin/node" \
+  "$cache_root/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node"
+do
+  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+    exec "$candidate" "$server_path" "$@"
+  fi
+done
+
+if command -v node >/dev/null 2>&1; then
+  exec node "$server_path" "$@"
+fi
+
+printf '%s\n' 'Codex Security could not find a Node runtime. Reinstall or update Codex, or set CODEX_MCP_NODE_PATH to an executable Node runtime.' >&2
+exit 127

--- a/sdk/typescript/_bundled_plugin/scripts/launch_codex_security_mcp.cmd
+++ b/sdk/typescript/_bundled_plugin/scripts/launch_codex_security_mcp.cmd
@@ -1,0 +1,27 @@
+@echo off
+setlocal DisableDelayedExpansion
+
+set "CODEX_SECURITY_MCP_SCRIPT=%~dp0..\mcp\server.mjs"
+
+rem This process waits for Node and must not keep the installed plugin directory locked.
+if "%~d0"=="" (cd /d "%SystemRoot%") else (cd /d "%~d0\")
+if errorlevel 1 (
+  echo Codex Security could not start: no safe Windows working directory. 1>&2
+  exit /b 1
+)
+
+rem WindowsApps can expose a Node path that exists but cannot be executed.
+rem Prefer relocated user-writable runtimes before probing packaged paths.
+if defined LOCALAPPDATA for /d %%D in ("%LOCALAPPDATA%\OpenAI\Codex\runtimes\cua_node\*") do if exist "%%~fD\bin\node.exe" ("%%~fD\bin\node.exe" "%CODEX_SECURITY_MCP_SCRIPT%" %* & exit)
+if defined XDG_CACHE_HOME if exist "%XDG_CACHE_HOME%\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe" ("%XDG_CACHE_HOME%\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe" "%CODEX_SECURITY_MCP_SCRIPT%" %* & exit)
+if defined USERPROFILE if exist "%USERPROFILE%\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe" ("%USERPROFILE%\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe" "%CODEX_SECURITY_MCP_SCRIPT%" %* & exit)
+if defined CODEX_MCP_NODE_PATH if exist "%CODEX_MCP_NODE_PATH%" ("%CODEX_MCP_NODE_PATH%" "%CODEX_SECURITY_MCP_SCRIPT%" %* & exit)
+if defined CODEX_BROWSER_USE_NODE_PATH if exist "%CODEX_BROWSER_USE_NODE_PATH%" ("%CODEX_BROWSER_USE_NODE_PATH%" "%CODEX_SECURITY_MCP_SCRIPT%" %* & exit)
+if defined CODEX_ELECTRON_RESOURCES_PATH if exist "%CODEX_ELECTRON_RESOURCES_PATH%\cua_node\bin\node.exe" ("%CODEX_ELECTRON_RESOURCES_PATH%\cua_node\bin\node.exe" "%CODEX_SECURITY_MCP_SCRIPT%" %* & exit)
+if defined CODEX_CLI_PATH for %%I in ("%CODEX_CLI_PATH%") do if exist "%%~dpIcua_node\bin\node.exe" ("%%~dpIcua_node\bin\node.exe" "%CODEX_SECURITY_MCP_SCRIPT%" %* & exit)
+
+where node >nul 2>&1
+if not errorlevel 1 (node "%CODEX_SECURITY_MCP_SCRIPT%" %* & exit)
+
+echo Codex Security could not find a Node runtime. Reinstall or update Codex, or set CODEX_MCP_NODE_PATH to an executable Node runtime. 1>&2
+exit /b 127

--- a/sdk/typescript/plugin-files.json
+++ b/sdk/typescript/plugin-files.json
@@ -47,6 +47,8 @@
     "scripts/finding_preview.py",
     "scripts/generate_in_scope_files.py",
     "scripts/generate_rank_input.py",
+    "scripts/launch_codex_security_mcp",
+    "scripts/launch_codex_security_mcp.cmd",
     "scripts/normalize_candidates.py",
     "scripts/rank_preview.py",
     "scripts/report_projection.py",

--- a/sdk/typescript/tests-ts/mcp-launcher.test.ts
+++ b/sdk/typescript/tests-ts/mcp-launcher.test.ts
@@ -44,7 +44,7 @@ test("starts the packaged MCP server with managed Node and an empty PATH", async
     const result = spawnSync(
       windows ? process.env["ComSpec"] ?? "cmd.exe" : launcher,
       windows
-        ? ["/d", "/s", "/c", `"${launcher}.cmd" ${config.args.join(" ")}`]
+        ? ["/d", "/s", "/c", `""${launcher}.cmd" ${config.args.join(" ")}"`]
         : config.args,
       {
         cwd: PLUGIN_ROOT,
@@ -62,6 +62,7 @@ test("starts the packaged MCP server with managed Node and an empty PATH", async
         encoding: "utf8",
         timeout: 10_000,
         windowsHide: true,
+        windowsVerbatimArguments: windows,
         input:
           JSON.stringify({
             jsonrpc: "2.0",

--- a/sdk/typescript/tests-ts/mcp-launcher.test.ts
+++ b/sdk/typescript/tests-ts/mcp-launcher.test.ts
@@ -1,0 +1,86 @@
+import { spawnSync } from "node:child_process";
+import {
+  chmod,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { PLUGIN_ROOT } from "./plugin-root.js";
+
+test("starts the packaged MCP server with managed Node and an empty PATH", async () => {
+  const node = Bun.which("node");
+  if (node === null)
+    throw new Error("Node is required for the MCP smoke test.");
+  const root = await realpath(
+    await mkdtemp(join(tmpdir(), "codex-security-node-")),
+  );
+  try {
+    const config = JSON.parse(
+      await readFile(join(PLUGIN_ROOT, ".mcp.json"), "utf8"),
+    ).mcpServers["codex-security"] as {
+      command: string;
+      args: string[];
+      env_vars: string[];
+    };
+    expect(config.env_vars).toContain("CODEX_MCP_NODE_PATH");
+    let managedNode = node;
+    const marker = join(root, "managed-node-used");
+    if (process.platform !== "win32") {
+      managedNode = join(root, "managed-node");
+      const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
+      await writeFile(
+        managedNode,
+        `#!/bin/sh\nprintf used > ${quote(marker)}\nexec ${quote(node)} "$@"\n`,
+      );
+      await chmod(managedNode, 0o700);
+    }
+    const launcher = join(PLUGIN_ROOT, config.command);
+    const windows = process.platform === "win32";
+    const result = spawnSync(
+      windows ? process.env["ComSpec"] ?? "cmd.exe" : launcher,
+      windows
+        ? ["/d", "/s", "/c", `"${launcher}.cmd" ${config.args.join(" ")}`]
+        : config.args,
+      {
+        cwd: PLUGIN_ROOT,
+        env: {
+          PATH: "",
+          HOME: root,
+          USERPROFILE: root,
+          LOCALAPPDATA: root,
+          XDG_CACHE_HOME: root,
+          ...(process.env["SystemRoot"] === undefined
+            ? {}
+            : { SystemRoot: process.env["SystemRoot"] }),
+          CODEX_MCP_NODE_PATH: managedNode,
+        },
+        encoding: "utf8",
+        timeout: 10_000,
+        windowsHide: true,
+        input:
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: {
+              protocolVersion: "2025-11-25",
+              capabilities: {},
+              clientInfo: { name: "launcher-test", version: "1.0.0" },
+            },
+          }) + "\n",
+      },
+    );
+    expect(result.status, result.stderr || result.error?.message).toBe(0);
+    expect(JSON.parse(result.stdout).result.serverInfo.name).toBe(
+      "codex-security",
+    );
+    if (!windows) expect(await readFile(marker, "utf8")).toBe("used");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Start the plugin with a Codex-managed Node runtime when Node is absent from PATH.

## Changes

- Add POSIX and Windows launchers with a system-Node fallback.
- Forward the existing managed-runtime settings and include both launchers in the package file list.
- Preserve the public plugin environment settings.

## Testing

- Full SDK suite on a local combination of all seven separate ports: 1,511 passed, 29 skipped, zero failures; randomized seed `1019194479`.
- Launcher and runtime tests: 125 passed, 10 platform skips.
- Initialized the real packaged MCP server with an empty PATH and verified use of the managed Node shim.
- Formatting and whitespace checks passed.
- The launcher test passed in Windows CI on Node 22 and Node 24 after correcting the batch-file quoting in the test.
- A local combination of the separate ports passed types, formatting, package build, and installed-package checks (111 plugin files and nested-worker startup).

## Risk and rollout

No new CLI flags or package-version changes. Native Windows startup was not run locally. The next release must refresh the bundled plugin version so cached installs receive the new launcher.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
