### PR TITLE
fix(plugin): read Git commit subjects as UTF-8

### DIFF
--- a/sdk/typescript/_bundled_plugin/scripts/workbench_target.py
+++ b/sdk/typescript/_bundled_plugin/scripts/workbench_target.py
@@ -135,7 +135,15 @@ def git_command(
         environment.pop(name, None)
     environment["GIT_LITERAL_PATHSPECS"] = "1"
     # Repository-local config is untrusted; fsmonitor may name an executable hook.
-    command = ["git", "-c", "core.fsmonitor=false", "-C", str(target)]
+    command = [
+        "git",
+        "-c",
+        "core.fsmonitor=false",
+        "-c",
+        "i18n.logOutputEncoding=UTF-8",
+        "-C",
+        str(target),
+    ]
     if git_dir is not None and work_tree is not None:
         command.extend(["--git-dir", str(git_dir), "--work-tree", str(work_tree)])
     full_command = [*command, *args]
@@ -548,9 +556,10 @@ def git_target_metadata(target: Path) -> dict[str, Any]:
     branch = git_output(target, "symbolic-ref", "--quiet", "--short", "HEAD")
     metadata.update({"branch": branch, "detachedHead": revision is not None and branch is None})
     if revision is not None:
+        subject = git_bytes(target, "show", "-s", "--format=%s", "HEAD")
         metadata.update(
             {
-                "commitSubject": git_output(target, "show", "-s", "--format=%s", "HEAD"),
+                "commitSubject": (subject or b"").decode("utf-8").strip() or None,
                 "revision": revision,
                 "shortRevision": revision[:7],
             }

--- a/sdk/typescript/tests-ts/workbench-canonical-paths.test.ts
+++ b/sdk/typescript/tests-ts/workbench-canonical-paths.test.ts
@@ -129,6 +129,34 @@ function runPythonProbe(
 }
 
 describe("bundled workbench canonical paths", () => {
+  test("reads Unicode commit subjects regardless of locale or Git log encoding", async () => {
+    const repository = await temporaryDirectory();
+    expect(
+      runPythonProbe(
+        [
+          "import json, subprocess, sys",
+          "from pathlib import Path",
+          "sys.path.insert(0, sys.argv[1])",
+          "import workbench_target as target",
+          "repository = Path(sys.argv[2])",
+          "def git(*args):",
+          "    subprocess.run(['git', '-C', str(repository), *args], check=True, capture_output=True)",
+          "git('init', '-q')",
+          "subjects = [('UTF-8', 'docs: \\u65e5\\u672c\\u8a9e \\ud55c\\uad6d\\uc5b4 \\U0001f527'), ('ISO-8859-1', 'docs: caf\\u00e9')]",
+          "for log_encoding, subject in subjects:",
+          "    git('-c', 'user.name=Test', '-c', 'user.email=test@example.invalid', '-c', 'commit.gpgsign=false', 'commit', '--allow-empty', '-qm', subject)",
+          "    git('config', 'i18n.logOutputEncoding', log_encoding)",
+          "    for encoding in ('cp932', 'cp949'):",
+          "        subprocess._text_encoding = lambda: encoding",
+          "        assert target.git_target_metadata(repository)['commitSubject'] == subject",
+          "        assert target.git_bytes(repository, 'show', '-s', '--format=%s', 'HEAD') == (subject + '\\n').encode('utf-8')",
+          "print(json.dumps({'subjects': len(subjects), 'locales': 2}))",
+        ].join("\n"),
+        repository,
+      ),
+    ).toEqual({ subjects: 2, locales: 2 });
+  });
+
   testPosix(
     "rejects private scan directories under insecure shared parents",
     async () => {


### PR DESCRIPTION
## Summary

Keep Unicode commit subjects readable when the system locale or repository Git configuration uses another encoding.

## Changes

- Request UTF-8 Git log output and decode commit subjects from bytes.
- Preserve native decoding for other text output and preserve binary output.
- Test Japanese and Korean locales and a repository with Latin-1 log output.

## Testing

- Full SDK suite on a local combination of all seven separate ports: 1,511 passed, 29 skipped, zero failures; randomized seed `1019194479`.
- Workbench canonical-path tests: 4 passed, 2 platform skips.
- Formatting and whitespace checks passed.

## Risk and rollout

No CLI or release-version changes. This is separate from #226, which sets the Windows decoder for general Git text output.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
