### PR TITLE
fix(cli): order update-notice prereleases by SemVer precedence

### DIFF
--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -159,12 +159,31 @@ function isNewerVersion(latest: string, current: string): boolean {
   if (candidate[4] === installed[4]) return false;
   if (candidate[4] === undefined) return true;
   if (installed[4] === undefined) return false;
-  return (
-    new Intl.Collator("en", { numeric: true }).compare(
-      candidate[4],
-      installed[4],
-    ) > 0
-  );
+  return comparePrerelease(candidate[4], installed[4]) > 0;
+}
+
+/** Compare two SemVer prerelease identifiers according to spec precedence. */
+function comparePrerelease(latest: string, current: string): number {
+  const candidate = latest.split(".");
+  const installed = current.split(".");
+  const length = Math.max(candidate.length, installed.length);
+  for (let index = 0; index < length; index += 1) {
+    const candidateId = candidate[index];
+    const installedId = installed[index];
+    if (candidateId === undefined) return -1;
+    if (installedId === undefined) return 1;
+    const candidateNumeric = /^\d+$/u.test(candidateId);
+    const installedNumeric = /^\d+$/u.test(installedId);
+    if (candidateNumeric && installedNumeric) {
+      const difference = Number(candidateId) - Number(installedId);
+      if (difference !== 0) return Math.sign(difference);
+    } else if (candidateNumeric !== installedNumeric) {
+      return candidateNumeric ? -1 : 1;
+    } else if (candidateId !== installedId) {
+      return candidateId < installedId ? -1 : 1;
+    }
+  }
+  return 0;
 }
 
 function packageVersions(url: URL): {

--- a/sdk/typescript/tests-ts/update-notice.test.ts
+++ b/sdk/typescript/tests-ts/update-notice.test.ts
@@ -148,6 +148,33 @@ describe("CLI update notice", () => {
     ).toBeUndefined();
   });
 
+  test("orders prerelease identifiers by SemVer precedence, not locale collation", async () => {
+    for (const [current, latest, available] of [
+      // ASCII case ordering: "a" (97) sorts after "A" (65) in SemVer.
+      ["1.0.0-A", "1.0.0-a", true],
+      ["1.0.0-a", "1.0.0-A", false],
+      // Numeric identifiers have lower precedence than non-numeric ones.
+      ["1.0.0-1", "1.0.0-alpha", true],
+      ["1.0.0-alpha", "1.0.0-1", false],
+      // When shared identifiers are equal, the longer list wins.
+      ["1.0.0-alpha", "1.0.0-alpha.1", true],
+      ["1.0.0-alpha.1", "1.0.0-alpha", false],
+      // Numeric identifiers compare numerically regardless of width.
+      ["1.0.0-alpha.9", "1.0.0-alpha.10", true],
+      ["1.0.0-alpha.10", "1.0.0-alpha.9", false],
+      // Mixed identifier lists follow pairwise precedence.
+      ["1.0.0-alpha.2", "1.0.0-alpha.10", true],
+      ["1.0.0-alpha.2", "1.0.0-alpha.beta", true],
+    ] as const) {
+      const notice = await checkForUpdate({
+        environment: {},
+        currentVersion: current,
+        fetch: registryResponse(latest),
+      });
+      expect(notice !== undefined).toBe(available);
+    }
+  });
+
   test("suppresses registry checks in CI or when disabled", async () => {
     let requests = 0;
     const fetchLatest = async () => {


### PR DESCRIPTION
## Summary

`isNewerVersion()` compared prerelease suffixes with `Intl.Collator("en", { numeric: true })`, which applies locale collation instead of the SemVer precedence rules the helper is meant to enforce. Non-numeric identifiers must compare by ASCII code points (case-sensitive), while numeric identifiers compare numerically and have lower precedence than non-numeric identifiers. The locale collator orders lowercase `a` before uppercase `A`, so a valid update such as `1.0.0-A` → `1.0.0-a` was suppressed, and the reverse pair produced a false update notice.

## Changes

- Replace the `Intl.Collator` comparison with a deterministic `comparePrerelease()` helper implementing SemVer §11.4 precedence: split on `.`, compare numeric identifiers numerically, give numeric identifiers lower precedence than non-numeric identifiers, compare non-numeric identifiers by ASCII code points, and let the longer identifier list win when shared identifiers are equal.
- Add a regression test covering ASCII case ordering, numeric-vs-text precedence, prefix-length ordering, and numeric width.

## Testing

- `bun test --timeout 30000 tests-ts/update-notice.test.ts` — 12 pass, 0 fail
- `pnpm run test` — 1504 pass, 28 skip, 0 fail
- `pnpm run types` — clean
- `pnpm run format` — clean

## Risk and rollout

Low risk. The change only affects update-notice detection for prerelease versions; stable version ordering is unchanged. No public CLI surface, schema, or default changes.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.

Fixes #534
