### PR TITLE
chore: clarify scan sign-in recovery

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -164,7 +164,8 @@ when the dedicated home does not already contain stored credentials. Logging
 out prevents later scans from automatically reimporting that ambient sign-in
 until you explicitly log in again.
 
-An environment API key takes precedence over a stored sign-in by default.
+By default, an environment API key takes precedence over a stored sign-in for
+model requests.
 When both a stored ChatGPT sign-in and an environment API key are available, an
 interactive scan asks which credential to use. JSON output, dry runs, CI, and
 other noninteractive scans never prompt and retain automatic API-key
@@ -190,6 +191,13 @@ unset OPENAI_API_KEY CODEX_API_KEY
 ```
 
 The interactive choice applies only to the current scan and is not persisted.
+
+If Codex cannot refresh a saved ChatGPT sign-in, run
+`npx @openai/codex-security logout`, then `npx @openai/codex-security login`.
+Signing in to the normal Codex CLI does not update an existing Codex Security
+sign-in. This error can also occur when you select an API key: Codex can still
+use the saved ChatGPT sign-in to load workspace settings before sending model
+requests with the key.
 
 When an environment key is configured, ChatGPT login and
 `codex-security login status` identify the effective scan credential source

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -5719,6 +5719,20 @@ function scanFailureMessage(
   // errors can name the organization or project, which must not reach stderr or
   // the JSON error field.
   if (isLocalScanFailure(error)) return diagnosticValue(error);
+  if (
+    /\b(?:access token|authentication session) could not be refreshed\b/iu.test(
+      errorMessage(error),
+    )
+  ) {
+    return (
+      "Codex could not refresh the saved ChatGPT sign-in. " +
+      (authentication?.method === "api_key"
+        ? "An API key was selected, but Codex can still use the saved ChatGPT sign-in to load workspace settings. "
+        : "") +
+      "Run Codex Security's 'logout' command, then 'login', and retry. " +
+      "Codex Security stores its sign-in separately from your normal Codex login."
+    );
+  }
   switch (classifyConnectionFailure(error)) {
     case "unauthorized":
       if (authentication?.method === "aws_credentials") {
@@ -5729,7 +5743,6 @@ function scanFailureMessage(
       }
       return authentication?.method === "api_key"
         ? `Authentication failed using ${authentication.source}. ` +
-            "Your ChatGPT sign-in was not used. " +
             "Retry with '--auth chatgpt' or provide a valid API key."
         : "Authentication failed using stored ChatGPT credentials. " +
             "Sign in again with 'codex-security login' or provide a valid API key.";

--- a/sdk/typescript/tests-ts/cli-authentication.test.ts
+++ b/sdk/typescript/tests-ts/cli-authentication.test.ts
@@ -884,6 +884,58 @@ describe("CLI authentication", () => {
     }
   });
 
+  test("explains how to recover the scanner login after token refresh fails", async () => {
+    for (const environment of [
+      {},
+      { OPENAI_API_KEY: "synthetic-api-key" },
+      { OPENAI_API_KEY: "synthetic-api-key", npm_command: "exec" },
+    ]) {
+      for (const detail of [
+        "Codex Exec exited with code 1: Error: Your access token could not be refreshed. Please log out and sign in again.",
+        "Your access token could not be refreshed because your refresh token was already used.",
+        "Your authentication session could not be refreshed automatically. 401 for org-private.",
+      ]) {
+        for (const json of [false, true]) {
+          const stdout = capture();
+          const stderr = capture(false);
+          const deps = dependencies({ environment });
+          deps.createSecurity = () => ({
+            run: async () => {
+              throw new CodexSecurityError(detail);
+            },
+            preflight: async () => fakePreflight(),
+            close: async () => {},
+          });
+
+          expect(
+            await main(
+              ["scan", ...(json ? ["--json"] : [])],
+              stdout.stream,
+              stderr.stream,
+              deps,
+            ),
+          ).toBe(2);
+          expect(stdout.text()).toBe("");
+          expect(stderr.text()).toContain("Codex Security's 'logout' command");
+          expect(stderr.text()).toContain("then 'login'");
+          expect(stderr.text()).not.toContain("npx");
+          expect(stderr.text()).toContain(
+            "separately from your normal Codex login",
+          );
+          expect(stderr.text().includes("load workspace settings")).toBe(
+            "OPENAI_API_KEY" in environment,
+          );
+          expect(stderr.text()).not.toContain("provide a valid API key");
+          expect(stderr.text()).not.toContain(
+            "Your ChatGPT sign-in was not used",
+          );
+          expect(stderr.text()).not.toContain("org-private");
+          expect(stderr.text()).not.toContain("synthetic-api-key");
+        }
+      }
+    }
+  });
+
   test("prints the ChatGPT recovery hint on noninteractive scan output", async () => {
     const stdout = capture();
     const stderr = capture(false);


### PR DESCRIPTION
## Summary

Explain how to recover when Codex cannot refresh a saved ChatGPT sign-in. The previous error did not explain that Codex Security keeps a separate sign-in, or why that sign-in can still affect a scan that uses an API key.

## Changes

- Suggest the Codex Security `logout` and `login` commands without assuming npx or an installed binary.
- Explain that Codex can use the saved ChatGPT sign-in to load workspace settings even when model requests use an API key.
- Remove the incorrect claim that an API-key scan did not use the ChatGPT sign-in.
- Update the documentation and test recovery advice for stored credentials, API keys, npx, and JSON output. Keep private error details out of the message.

## Testing

- `bun test --timeout 30000 tests-ts/cli-authentication.test.ts tests-ts/update-notice.test.ts`: 37 passed.
- `pnpm run types`: passed.
- `pnpm run format`: passed.
- `pnpm run build`: passed.
- `git diff --check`: passed.

## Risk and rollout

Low risk. This change updates error text, documentation, and tests. It does not change credential selection, saved credentials, workspace policies, commands, flags, or defaults. It does not fix the API-key startup failure itself.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
