### PR TITLE
refactor(cli): use semver for update notices

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -68,6 +68,7 @@
     "papaparse": "5.5.3",
     "pdfjs-dist": "6.2.108",
     "react": "19.2.4",
+    "semver": "7.8.5",
     "smol-toml": "1.6.1"
   },
   "devDependencies": {
@@ -76,6 +77,7 @@
     "@types/node": "22.19.17",
     "@types/papaparse": "5.3.15",
     "@types/react": "19.2.14",
+    "@types/semver": "7.8.0",
     "fast-check": "4.9.0",
     "ink-testing-library": "4.0.0",
     "json-schema-to-typescript": "15.0.4",

--- a/sdk/typescript/pnpm-lock.yaml
+++ b/sdk/typescript/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       react:
         specifier: 19.2.4
         version: 19.2.4
+      semver:
+        specifier: 7.8.5
+        version: 7.8.5
       smol-toml:
         specifier: 1.6.1
         version: 1.6.1
@@ -69,6 +72,9 @@ importers:
       '@types/react':
         specifier: 19.2.14
         version: 19.2.14
+      '@types/semver':
+        specifier: 7.8.0
+        version: 7.8.0
       fast-check:
         specifier: 4.9.0
         version: 4.9.0
@@ -618,6 +624,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/semver@7.8.0':
+    resolution: {integrity: sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==}
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
@@ -1927,6 +1936,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/semver@7.8.0': {}
 
   '@types/yauzl@2.10.3':
     dependencies:

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import semverGt from "semver/functions/gt.js";
 
 const PACKAGE_VERSIONS = packageVersions(
   new URL("../package.json", import.meta.url),
@@ -11,8 +12,6 @@ export const CODEX_EXECUTABLE_VERSION = PACKAGE_VERSIONS.executable;
 export const BUNDLED_PLUGIN_VERSION = "0.1.22" as const;
 
 const PACKAGE_NAME = "@openai/codex-security";
-const VERSION_PATTERN =
-  /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/u;
 
 export interface UpdateNotice {
   readonly currentVersion: string;
@@ -116,7 +115,7 @@ export async function checkForUpdate({
       manifest === null ||
       !("version" in manifest) ||
       typeof manifest.version !== "string" ||
-      !isNewerVersion(manifest.version, currentVersion)
+      !semverGt(manifest.version, currentVersion)
     ) {
       return undefined;
     }
@@ -144,46 +143,6 @@ export function formatUpdateNotice(notice: UpdateNotice): string {
     `╰${"─".repeat(width + 2)}╯`,
     "",
   ].join("\n");
-}
-
-function isNewerVersion(latest: string, current: string): boolean {
-  const candidate = VERSION_PATTERN.exec(latest);
-  const installed = VERSION_PATTERN.exec(current);
-  if (candidate === null || installed === null) return false;
-
-  for (let index = 1; index <= 3; index += 1) {
-    const difference = Number(candidate[index]) - Number(installed[index]);
-    if (difference !== 0) return difference > 0;
-  }
-
-  if (candidate[4] === installed[4]) return false;
-  if (candidate[4] === undefined) return true;
-  if (installed[4] === undefined) return false;
-  return comparePrerelease(candidate[4], installed[4]) > 0;
-}
-
-/** Compare two SemVer prerelease identifiers according to spec precedence. */
-function comparePrerelease(latest: string, current: string): number {
-  const candidate = latest.split(".");
-  const installed = current.split(".");
-  const length = Math.max(candidate.length, installed.length);
-  for (let index = 0; index < length; index += 1) {
-    const candidateId = candidate[index];
-    const installedId = installed[index];
-    if (candidateId === undefined) return -1;
-    if (installedId === undefined) return 1;
-    const candidateNumeric = /^\d+$/u.test(candidateId);
-    const installedNumeric = /^\d+$/u.test(installedId);
-    if (candidateNumeric && installedNumeric) {
-      const difference = Number(candidateId) - Number(installedId);
-      if (difference !== 0) return Math.sign(difference);
-    } else if (candidateNumeric !== installedNumeric) {
-      return candidateNumeric ? -1 : 1;
-    } else if (candidateId !== installedId) {
-      return candidateId < installedId ? -1 : 1;
-    }
-  }
-  return 0;
 }
 
 function packageVersions(url: URL): {

--- a/sdk/typescript/tests-ts/update-notice.test.ts
+++ b/sdk/typescript/tests-ts/update-notice.test.ts
@@ -123,8 +123,10 @@ describe("CLI update notice", () => {
   test("ignores current, older, invalid, and lower prerelease versions", async () => {
     for (const [current, latest, available] of [
       ["0.1.0", "0.1.0", false],
+      ["0.1.0+local", "0.1.0+registry", false],
       ["0.2.0", "0.1.0", false],
       ["0.2.0", "not-a-version", false],
+      ["not-a-version", "0.2.0", false],
       ["0.2.0", "0.2.0-beta.1", false],
       ["0.2.0-beta.2", "0.2.0-beta.1", false],
       ["0.2.0-beta.1", "0.2.0-beta.2", true],


### PR DESCRIPTION
## Summary

This builds on the prerelease-ordering fix in #598 and keeps its regression coverage. The update notice now uses npm's `semver` package instead of maintaining its own version parser and precedence rules.

## Changes

- Add `semver` as a direct runtime dependency and `@types/semver` as a development dependency.
- Replace the version regex and both comparison helpers with `semver`'s `gt` function inside the existing update-check flow.
- Keep the prerelease regression tests from #598 and cover invalid installed versions and build-metadata-only differences.

## Testing

- `bun test --timeout 30000 tests-ts/update-notice.test.ts`: 12 passed.
- `pnpm run test --seed 12345`: 1,528 passed, 28 skipped, zero failures.
- `pnpm run test`: 1,528 passed, 28 skipped, zero failures (seed `193876316`).
- `pnpm run types` and `pnpm run format`: passed.
- `pnpm pack` and `pnpm run check:package` on the generated tarball: passed, including the installed public import, CLI, bundled plugin files, and nested-worker startup.
- Built Node update-notice smoke check: six version-comparison cases passed.
- `git diff --check`: passed.

## Risk and rollout

Low risk, limited to optional update notices. Comparisons now use npm-compatible parsing; malformed versions accepted by the previous permissive regex may now be ignored. The existing error handling continues to suppress notices when versions are invalid or the registry is unavailable. No new CLI flags, environment variables, or schemas.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
