### PR TITLE
fix(plugin): Preserve recoverable root-cause evidence references

### DIFF
--- a/sdk/typescript/_bundled_plugin/scripts/finalize_scan_contract.py
+++ b/sdk/typescript/_bundled_plugin/scripts/finalize_scan_contract.py
@@ -1619,6 +1619,7 @@ def _legacy_sealed_findings_for_validation(findings: dict[str, Any]) -> dict[str
             and evidence["id"]
         }
         for section_name, list_fields in (
+            ("rootCause", ("evidenceRefs", "evidence_refs")),
             ("root_cause", ("evidenceRefs", "evidence_refs")),
             (
                 "validation",

--- a/sdk/typescript/tests-ts/plugin-finding-detail-contract.test.ts
+++ b/sdk/typescript/tests-ts/plugin-finding-detail-contract.test.ts
@@ -916,12 +916,22 @@ describe("bundled plugin finding detail contracts", () => {
       "findings = json.loads((plugin / 'examples' / 'completed-scan' / 'findings.json').read_text())",
       "finding = findings['findings'][0]",
       "finding['code_evidence'] = [{'id': 'legacy-source', 'code': 'legacy_source()'}]",
+      "finding['rootCause'] = {'summary': 'Canonical root cause.', 'evidenceRefs': ['legacy-source', 'missing-source']}",
       "finding['validation'] = {'evidenceRefs': [None, '', 42, 'legacy-source', 'missing-source']}",
       "finding['attackPath'] = {'dataflow': {'evidence_refs': [None, '', 42, 'legacy-source', 'missing-source']}}",
+      "original = json.dumps(findings, sort_keys=True)",
       "finalizer = runpy.run_path(str(plugin / 'scripts' / 'finalize_scan_contract.py'))",
       "compatible = finalizer['_legacy_sealed_findings_for_validation'](findings)",
       "finalizer['_validate_finding'](compatible['findings'][0], 'findings[0]')",
-      "print(json.dumps({'originalValidation': finding['validation']['evidenceRefs'], 'compatibleValidation': compatible['findings'][0]['validation']['evidenceRefs'], 'originalDataflow': finding['attackPath']['dataflow']['evidence_refs'], 'compatibleDataflow': compatible['findings'][0]['attackPath']['dataflow']['evidence_refs']}))",
+      "print(json.dumps({",
+      "    'originalUnchanged': json.dumps(findings, sort_keys=True) == original,",
+      "    'originalRootCause': finding['rootCause'],",
+      "    'compatibleRootCause': compatible['findings'][0]['rootCause'],",
+      "    'originalValidation': finding['validation']['evidenceRefs'],",
+      "    'compatibleValidation': compatible['findings'][0]['validation']['evidenceRefs'],",
+      "    'originalDataflow': finding['attackPath']['dataflow']['evidence_refs'],",
+      "    'compatibleDataflow': compatible['findings'][0]['attackPath']['dataflow']['evidence_refs'],",
+      "}))",
     ].join("\n");
     const result = Bun.spawnSync(
       [python!, "-I", "-B", "-c", script, PLUGIN_ROOT],
@@ -930,6 +940,15 @@ describe("bundled plugin finding detail contracts", () => {
 
     expect(result.exitCode, new TextDecoder().decode(result.stderr)).toBe(0);
     expect(JSON.parse(new TextDecoder().decode(result.stdout))).toEqual({
+      originalUnchanged: true,
+      originalRootCause: {
+        summary: "Canonical root cause.",
+        evidenceRefs: ["legacy-source", "missing-source"],
+      },
+      compatibleRootCause: {
+        summary: "Canonical root cause.",
+        evidenceRefs: ["legacy-source"],
+      },
       originalValidation: [null, "", 42, "legacy-source", "missing-source"],
       compatibleValidation: ["legacy-source"],
       originalDataflow: [null, "", 42, "legacy-source", "missing-source"],

--- a/sdk/typescript/tests-ts/scan-recovery.test.ts
+++ b/sdk/typescript/tests-ts/scan-recovery.test.ts
@@ -649,6 +649,81 @@ describe("malformed scan artifact recovery", () => {
     );
   });
 
+  test.each(
+    (["rootCause", "root_cause"] as const).flatMap((section) =>
+      (["evidenceRefs", "evidence_refs"] as const).flatMap((refsKey) =>
+        [true, false].map((includeEvidence) => ({
+          section,
+          refsKey,
+          includeEvidence,
+        })),
+      ),
+    ),
+  )(
+    "recovers $section refs $refsKey with evidence catalog: $includeEvidence",
+    async ({ section, refsKey, includeEvidence }) => {
+      const fixture = await startDraftScan();
+      const path = join(fixture.scanDir, "findings.json");
+      const document = await readJson<FindingsDocument>(path);
+      const finding = document.findings[0]!;
+      if (includeEvidence) {
+        finding.codeEvidence = [
+          {
+            id: "canonical-source",
+            label: "Synthetic source",
+            path: "src/extract.py",
+            startLine: 41,
+            code: "canonical_source()",
+            explanation: "Synthetic evidence for reference recovery.",
+          },
+        ];
+        finding["code_evidence"] = [
+          { id: "legacy-source", code: "legacy_source()" },
+        ];
+      }
+      finding[section] = {
+        summary: "The destination is not constrained to the extraction root.",
+        [refsKey]: ["legacy-source", "src/extract.py:41", "canonical-source"],
+      };
+      await writeJson(path, document);
+      const original = await readFile(path, "utf8");
+
+      const strict = spawnSync(
+        fixture.python,
+        [
+          "-I",
+          "-B",
+          join(PLUGIN_ROOT, "scripts", "finalize_scan_contract.py"),
+          "--scan-dir",
+          fixture.scanDir,
+        ],
+        { encoding: "utf8" },
+      );
+      expect(strict.status).not.toBe(0);
+      expect(strict.stderr).toContain("unknown code-evidence ids");
+      expect(await readFile(path, "utf8")).toBe(original);
+
+      const completed = await completeScan(fixture);
+
+      expect(completed.progress.status).toBe("complete");
+      expect(completed.findingCount).toBe(1);
+      expect(completed.warnings).toEqual([
+        "Recovered finding 1: normalized legacy finding details.",
+      ]);
+      const recovered = (await readJson<FindingsDocument>(path)).findings[0]!;
+      expect(recovered[section]).toEqual({
+        summary: "The destination is not constrained to the extraction root.",
+        [refsKey]: includeEvidence ? ["legacy-source", "canonical-source"] : [],
+      });
+      expect(recovered.codeEvidence).toEqual(finding.codeEvidence);
+      expect(recovered["code_evidence"]).toEqual(finding["code_evidence"]);
+      const coverage = await readJson<CoverageDocument>(
+        join(fixture.scanDir, "coverage.json"),
+      );
+      expect(coverage.completeness).toBe("complete");
+    },
+  );
+
   test("preserves recovery warnings across prepared scan completion", async () => {
     const fixture = await startDraftScan();
     const path = join(fixture.scanDir, "findings.json");
@@ -753,10 +828,27 @@ describe("malformed scan artifact recovery", () => {
     unsafeLocation.locations[0]!.path = "../outside.py";
     const missingIdentity = structuredClone(valid);
     delete (missingIdentity as Partial<Finding>).identity;
+    const invalidEvidenceId = structuredClone(valid);
+    invalidEvidenceId.identity.anchor = "invalid-evidence-id";
+    invalidEvidenceId.codeEvidence = [
+      {
+        id: "src/extract.py:41",
+        label: "Synthetic source",
+        path: "src/extract.py",
+        startLine: 41,
+        code: "synthetic_source()",
+        explanation: "The evidence identifier is intentionally malformed.",
+      },
+    ];
+    invalidEvidenceId["rootCause"] = {
+      summary: "Synthetic root cause.",
+      evidenceRefs: ["src/extract.py:41"],
+    };
     document.findings.push(
       missingSummary,
       unsafeLocation,
       missingIdentity,
+      invalidEvidenceId,
       structuredClone(valid),
       null,
     );
@@ -766,7 +858,7 @@ describe("malformed scan artifact recovery", () => {
 
     expect(completed.progress.status).toBe("complete");
     expect(completed.findingCount).toBe(1);
-    expect(completed.warnings).toHaveLength(5);
+    expect(completed.warnings).toHaveLength(6);
     expect(
       completed.warnings.every((warning) =>
         warning.startsWith("Skipped malformed finding"),
@@ -776,6 +868,7 @@ describe("malformed scan artifact recovery", () => {
       "summary",
       "safe repository-relative",
       "identity",
+      "codeEvidence[0].id",
       "duplicate logical finding",
       "expected an object",
     ]) {
@@ -791,7 +884,7 @@ describe("malformed scan artifact recovery", () => {
     expect((coverage.surfaces as CoverageSurface[])[0]?.disposition).toBe(
       "needs_follow_up",
     );
-    expect(coverage.deferred).toHaveLength(4);
+    expect(coverage.deferred).toHaveLength(5);
   });
 
   test.each([


### PR DESCRIPTION
## Summary

Keep otherwise-valid findings when optional `rootCause` evidence references do not resolve. The recovery pass already handles `root_cause`, but it omits the canonical field.

## Changes

- Add `rootCause` to the existing reference cleanup pass.
- Test both root-cause names, both reference names, and present or absent evidence catalogs through scan completion.
- Verify that valid evidence and prose remain, sealed input is unchanged, and malformed canonical evidence IDs are still rejected.

## Testing

- Before the fix, the eight-case regression produced four passes for `root_cause` and four failures for `rootCause` because the finding count fell from one to zero.
- After the fix, all 72 tests in `scan-recovery.test.ts` and `plugin-finding-detail-contract.test.ts` passed.
- The full suite passed with seeds `12345` and `1299782202`: 1,535 passed, 29 skipped, and zero failures in each run.
- Types and formatting passed.
- Build, `pnpm pack`, and installed-package validation passed from a clean source export. The package check verified the public import, CLI, 111 bundled plugin files, and nested worker startup without a global Codex executable.

## Risk and rollout

This is a narrow compatibility fix. It removes only unresolved optional references. Direct strict validation and fresh scan-draft validation are unchanged. It does not reconstruct missing evidence or change scan coverage policy. Package versions and runtime bundles are unchanged; the fix will ship in the next release.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
