### PR TITLE
fix(plugin): avoid PATH lookup during MCP launch

### DIFF
--- a/sdk/typescript/_bundled_plugin/scripts/launch_codex_security_mcp
+++ b/sdk/typescript/_bundled_plugin/scripts/launch_codex_security_mcp
@@ -4,7 +4,11 @@ set -eu
 PATH="${PATH:-/usr/bin:/bin}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 export PATH
 
-launcher_dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
+case $0 in
+  */*) launcher_dir=${0%/*} ;;
+  *) launcher_dir=. ;;
+esac
+launcher_dir=$(CDPATH= cd "$launcher_dir" && pwd)
 server_path=$launcher_dir/../mcp/server.mjs
 cache_root=${XDG_CACHE_HOME:-${HOME:-}/.cache}
 codex_resources=

--- a/sdk/typescript/tests-ts/mcp-launcher.test.ts
+++ b/sdk/typescript/tests-ts/mcp-launcher.test.ts
@@ -12,7 +12,7 @@ import { join } from "node:path";
 import { expect, test } from "bun:test";
 import { PLUGIN_ROOT } from "./plugin-root.js";
 
-test("starts the packaged MCP server with managed Node and an empty PATH", async () => {
+test("starts the packaged MCP server without running PATH utilities", async () => {
   const node = Bun.which("node");
   if (node === null)
     throw new Error("Node is required for the MCP smoke test.");
@@ -30,6 +30,7 @@ test("starts the packaged MCP server with managed Node and an empty PATH", async
     expect(config.env_vars).toContain("CODEX_MCP_NODE_PATH");
     let managedNode = node;
     const marker = join(root, "managed-node-used");
+    const dirnameMarker = join(root, "dirname-used");
     if (process.platform !== "win32") {
       managedNode = join(root, "managed-node");
       const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
@@ -38,6 +39,12 @@ test("starts the packaged MCP server with managed Node and an empty PATH", async
         `#!/bin/sh\nprintf used > ${quote(marker)}\nexec ${quote(node)} "$@"\n`,
       );
       await chmod(managedNode, 0o700);
+      const dirname = join(root, "dirname");
+      await writeFile(
+        dirname,
+        `#!/bin/sh\nprintf used > ${quote(dirnameMarker)}\n`,
+      );
+      await chmod(dirname, 0o700);
     }
     const launcher = join(PLUGIN_ROOT, config.command);
     const windows = process.platform === "win32";
@@ -49,7 +56,7 @@ test("starts the packaged MCP server with managed Node and an empty PATH", async
       {
         cwd: PLUGIN_ROOT,
         env: {
-          PATH: "",
+          PATH: windows ? "" : root,
           HOME: root,
           USERPROFILE: root,
           LOCALAPPDATA: root,
@@ -80,7 +87,10 @@ test("starts the packaged MCP server with managed Node and an empty PATH", async
     expect(JSON.parse(result.stdout).result.serverInfo.name).toBe(
       "codex-security",
     );
-    if (!windows) expect(await readFile(marker, "utf8")).toBe("used");
+    if (!windows) {
+      expect(await readFile(marker, "utf8")).toBe("used");
+      expect(await Bun.file(dirnameMarker).exists()).toBe(false);
+    }
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
### Motivation

- The Unix MCP launcher used `$(dirname "$0")`, which performs an external `dirname` lookup via `PATH` and can run repository-controlled executables before the launcher selects a managed Node runtime.

### Description

- Replace the external `dirname` invocation with shell parameter expansion and the shell builtin `cd` to compute the launcher's directory in `sdk/typescript/_bundled_plugin/scripts/launch_codex_security_mcp`.
- Use a small `case` to preserve both slash-qualified and bare invocation paths and then canonicalize with `cd` and `pwd` so no external utilities are invoked.
- Add a regression test `sdk/typescript/tests-ts/mcp-launcher.test.ts` that places a synthetic `dirname` on `PATH`, starts the launcher, and asserts the synthetic executable is not executed.
- No functional change to Windows launcher behavior or to the managed Node selection logic beyond eliminating the unsafe lookup.

### Testing

- Ran `bun test --timeout 30000 tests-ts/mcp-launcher.test.ts`, and the new test passed.
- Ran the full package test suite with `pnpm run test -- --seed 12345`, and the tests passed.
- Ran `pnpm run types` and `pnpm run format`, and both checks passed.
- Ran `git diff --check` to verify formatting and whitespace, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_i_6a888422a4dc832494eddde10936504e)