### PR TITLE
fix(runtime): reclaim credential-home locks held by a reused PID

### DIFF
--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -24,6 +24,7 @@ import {
   rm,
   rmdir,
   stat,
+  utimes,
   writeFile,
 } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
@@ -74,6 +75,7 @@ const MAX_ZIP_EXPANDED_SIZE = 512 * 1024 * 1024;
 const MODEL_UNSAFE_PATH = /[\u0000-\u001f\u007f-\u009f\u2028\u2029]/u;
 const CREDENTIAL_LOCK_NAME = ".codex-security-scan.lock";
 const CREDENTIAL_LOGOUT_MARKER = ".codex-security-logged-out";
+const CREDENTIAL_LOCK_HEARTBEAT_MILLISECONDS = 5_000;
 const CREDENTIAL_LOCK_POLL_MILLISECONDS = 25;
 const INCOMPLETE_CREDENTIAL_LOCK_MILLISECONDS = 30_000;
 const MAX_PROCESS_ID = 2_147_483_647;
@@ -1065,7 +1067,7 @@ export async function acquireCodexSecurityCredentialHomeLock(
       throw error;
     });
     if (existingLock !== null) {
-      if (await recoverStaleCredentialHomeLock(lock)) continue;
+      if (await recoverStaleCredentialHomeLock(lock, signal)) continue;
       await delay(CREDENTIAL_LOCK_POLL_MILLISECONDS, undefined, { signal });
       continue;
     }
@@ -1078,7 +1080,7 @@ export async function acquireCodexSecurityCredentialHomeLock(
       await mkdir(lock, { mode: 0o700 });
     } catch (error) {
       if (nodeErrorCode(error) !== "EEXIST") throw error;
-      if (await recoverStaleCredentialHomeLock(lock)) continue;
+      if (await recoverStaleCredentialHomeLock(lock, signal)) continue;
       await delay(CREDENTIAL_LOCK_POLL_MILLISECONDS, undefined, { signal });
       continue;
     }
@@ -1094,9 +1096,18 @@ export async function acquireCodexSecurityCredentialHomeLock(
       throw error;
     }
 
+    const heartbeat = setInterval(async () => {
+      try {
+        const now = new Date();
+        await utimes(lock, now, now);
+      } catch {}
+    }, CREDENTIAL_LOCK_HEARTBEAT_MILLISECONDS);
+    heartbeat.unref();
+
     let released = false;
     return async () => {
       if (released) return;
+      clearInterval(heartbeat);
       await requireSecureCredentialHome(codexHome, {
         ...securityOptions,
         expectedDevice,
@@ -1116,7 +1127,10 @@ export async function acquireCodexSecurityCredentialHomeLock(
   }
 }
 
-async function recoverStaleCredentialHomeLock(lock: string): Promise<boolean> {
+async function recoverStaleCredentialHomeLock(
+  lock: string,
+  signal?: AbortSignal,
+): Promise<boolean> {
   const metadata = await lstat(lock).catch((error: unknown) => {
     if (nodeErrorCode(error) === "ENOENT") return null;
     throw error;
@@ -1135,17 +1149,13 @@ async function recoverStaleCredentialHomeLock(lock: string): Promise<boolean> {
     if (nodeErrorCode(error) !== "ENOENT" && !(error instanceof SyntaxError)) {
       throw error;
     }
-    if (
-      Date.now() - metadata.mtimeMs <
-      INCOMPLETE_CREDENTIAL_LOCK_MILLISECONDS
-    ) {
-      return false;
-    }
   }
 
   // Only positive signed-32-bit PIDs identify an owner. Other values can name
   // process groups or fail argument validation, so use the stale-age check.
   const ownerPid = isRecord(owner) ? owner["pid"] : undefined;
+  let ownerExited = false;
+  let ownerIsAlive = false;
   if (
     typeof ownerPid === "number" &&
     Number.isInteger(ownerPid) &&
@@ -1154,18 +1164,36 @@ async function recoverStaleCredentialHomeLock(lock: string): Promise<boolean> {
   ) {
     try {
       process.kill(ownerPid, 0);
-      return false;
+      ownerIsAlive = true;
     } catch (error) {
-      if (nodeErrorCode(error) !== "ESRCH") {
-        if (nodeErrorCode(error) === "EPERM") return false;
-        throw error;
-      }
+      if (nodeErrorCode(error) === "ESRCH") ownerExited = true;
+      else if (nodeErrorCode(error) === "EPERM") ownerIsAlive = true;
+      else throw error;
     }
-  } else if (
-    Date.now() - metadata.mtimeMs <
-    INCOMPLETE_CREDENTIAL_LOCK_MILLISECONDS
+  }
+  if (
+    !ownerExited &&
+    Date.now() - metadata.mtimeMs < INCOMPLETE_CREDENTIAL_LOCK_MILLISECONDS
   ) {
     return false;
+  }
+
+  if (ownerIsAlive) {
+    await delay(CREDENTIAL_LOCK_HEARTBEAT_MILLISECONDS, undefined, { signal });
+    const refreshedMetadata = await lstat(lock).catch((error: unknown) => {
+      if (nodeErrorCode(error) === "ENOENT") return null;
+      throw error;
+    });
+    if (refreshedMetadata === null) return true;
+    if (
+      !refreshedMetadata.isDirectory() ||
+      refreshedMetadata.isSymbolicLink()
+    ) {
+      throw new OutputDirectoryError(
+        `Codex Security credential-home lock is not a directory: ${lock}`,
+      );
+    }
+    if (refreshedMetadata.mtimeMs > metadata.mtimeMs) return false;
   }
 
   const quarantine = `${lock}.stale-${randomUUID()}`;

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -147,6 +147,55 @@ function abortCredentialLockWaitWhenOwnerIsInspected(
   }) as typeof process.kill);
 }
 
+function captureCredentialLockHeartbeatTimer() {
+  const realSetInterval = globalThis.setInterval.bind(globalThis);
+  const realClearInterval = globalThis.clearInterval.bind(globalThis);
+  const unref = mock(() => undefined);
+  const interval = { unref } as unknown as NodeJS.Timeout;
+  let callback: (() => Promise<void>) | undefined;
+  let milliseconds: number | undefined;
+  let cleared = false;
+  const setIntervalSpy = spyOn(globalThis, "setInterval").mockImplementation(((
+    candidate: (...args: unknown[]) => void,
+    delay?: number,
+    ...args: unknown[]
+  ) => {
+    if (delay === 5_000 && callback === undefined) {
+      callback = candidate as () => Promise<void>;
+      milliseconds = delay;
+      return interval;
+    }
+    return realSetInterval(candidate, delay, ...args);
+  }) as typeof setInterval);
+  const clearIntervalSpy = spyOn(
+    globalThis,
+    "clearInterval",
+  ).mockImplementation(((timer: NodeJS.Timeout) => {
+    if (timer === interval) {
+      cleared = true;
+      return;
+    }
+    realClearInterval(timer);
+  }) as typeof clearInterval);
+
+  return {
+    get callback() {
+      return callback;
+    },
+    get cleared() {
+      return cleared;
+    },
+    get milliseconds() {
+      return milliseconds;
+    },
+    restore() {
+      clearIntervalSpy.mockRestore();
+      setIntervalSpy.mockRestore();
+    },
+    unref,
+  };
+}
+
 async function plugin(root: string, version = "1.2.3"): Promise<string> {
   const path = join(root, "plugin");
   await mkdir(join(path, ".codex-plugin"), { recursive: true });
@@ -2362,35 +2411,19 @@ describe("runtime directories and plugin Python boundary", () => {
       CODEX_SECURITY_STATE_DIR: join(root, "state"),
     });
     const lock = join(home, ".codex-security-scan.lock");
-    let heartbeat: (() => Promise<void>) | undefined;
-    const unref = mock(() => undefined);
-    const interval = { unref } as unknown as NodeJS.Timeout;
-    let cleared = false;
-    const setHeartbeat = spyOn(globalThis, "setInterval").mockImplementation(((
-      callback: () => Promise<void>,
-      milliseconds: number,
-    ) => {
-      expect(milliseconds).toBe(5_000);
-      heartbeat = callback;
-      return interval;
-    }) as typeof setInterval);
-    const clearHeartbeat = spyOn(
-      globalThis,
-      "clearInterval",
-    ).mockImplementation(((timer: NodeJS.Timeout) => {
-      if (timer === interval) cleared = true;
-    }) as typeof clearInterval);
+    const heartbeatTimer = captureCredentialLockHeartbeatTimer();
     let release: (() => Promise<void>) | undefined;
     let inspectOwner: ReturnType<typeof spyOn> | undefined;
 
     try {
       release = await acquireCodexSecurityCredentialHomeLock(home);
-      expect(unref).toHaveBeenCalledTimes(1);
-      expect(heartbeat).toBeDefined();
+      expect(heartbeatTimer.milliseconds).toBe(5_000);
+      expect(heartbeatTimer.unref).toHaveBeenCalledTimes(1);
+      expect(heartbeatTimer.callback).toBeDefined();
 
       const stale = new Date(Date.now() - 60_000);
       await utimes(lock, stale, stale);
-      await heartbeat!();
+      await heartbeatTimer.callback!();
       expect(Date.now() - (await stat(lock)).mtimeMs).toBeLessThan(30_000);
 
       const controller = new AbortController();
@@ -2406,11 +2439,10 @@ describe("runtime directories and plugin Python boundary", () => {
       try {
         if (release !== undefined) await release();
       } finally {
-        clearHeartbeat.mockRestore();
-        setHeartbeat.mockRestore();
+        heartbeatTimer.restore();
       }
     }
-    expect(cleared).toBe(true);
+    expect(heartbeatTimer.cleared).toBe(true);
     expect(existsSync(lock)).toBe(false);
   });
 
@@ -2535,25 +2567,10 @@ describe("runtime directories and plugin Python boundary", () => {
     });
     const lock = join(home, ".codex-security-scan.lock");
     const controller = new AbortController();
-    let heartbeat: (() => Promise<void>) | undefined;
-    const interval = {
-      unref: mock(() => undefined),
-    } as unknown as NodeJS.Timeout;
-    const setHeartbeat = spyOn(globalThis, "setInterval").mockImplementation(((
-      callback: () => Promise<void>,
-      milliseconds: number,
-    ) => {
-      expect(milliseconds).toBe(5_000);
-      if (heartbeat === undefined) heartbeat = callback;
-      else controller.abort(new DOMException("lock stolen", "AbortError"));
-      return interval;
-    }) as typeof setInterval);
-    const clearHeartbeat = spyOn(
-      globalThis,
-      "clearInterval",
-    ).mockImplementation((() => undefined) as typeof clearInterval);
+    const heartbeatTimer = captureCredentialLockHeartbeatTimer();
     const realDelay = timersPromises.setTimeout;
     let waitedForHeartbeat = false;
+    let observedDelaySignal: AbortSignal | undefined;
     mock.module("node:timers/promises", () => ({
       ...timersPromises,
       setTimeout: (async (
@@ -2561,11 +2578,10 @@ describe("runtime directories and plugin Python boundary", () => {
         value?: unknown,
         options?: { signal?: AbortSignal },
       ) => {
-        expect(options?.signal).toBe(controller.signal);
+        observedDelaySignal = options?.signal;
         if (milliseconds === 5_000) {
           waitedForHeartbeat = true;
-          expect(heartbeat).toBeDefined();
-          await heartbeat!();
+          await heartbeatTimer.callback!();
           return value;
         }
         controller.abort(new DOMException("canceled", "AbortError"));
@@ -2576,6 +2592,9 @@ describe("runtime directories and plugin Python boundary", () => {
 
     try {
       release = await acquireCodexSecurityCredentialHomeLock(home);
+      expect(heartbeatTimer.milliseconds).toBe(5_000);
+      expect(heartbeatTimer.unref).toHaveBeenCalledTimes(1);
+      expect(heartbeatTimer.callback).toBeDefined();
       const stale = new Date(Date.now() - 10 * 60_000);
       await utimes(lock, stale, stale);
 
@@ -2585,6 +2604,7 @@ describe("runtime directories and plugin Python boundary", () => {
       );
       await expect(waiting).rejects.toMatchObject({ name: "AbortError" });
       expect(waitedForHeartbeat).toBe(true);
+      expect(observedDelaySignal).toBe(controller.signal);
       expect(Date.now() - (await stat(lock)).mtimeMs).toBeLessThan(30_000);
       expect(existsSync(lock)).toBe(true);
     } finally {
@@ -2595,8 +2615,7 @@ describe("runtime directories and plugin Python boundary", () => {
       try {
         if (release !== undefined) await release();
       } finally {
-        clearHeartbeat.mockRestore();
-        setHeartbeat.mockRestore();
+        heartbeatTimer.restore();
       }
     }
   });

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -29,6 +29,7 @@ import {
   sep,
 } from "node:path";
 import { promisify } from "node:util";
+import * as timersPromises from "node:timers/promises";
 import { brotliDecompressSync } from "node:zlib";
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { strToU8, zipSync } from "fflate";
@@ -95,6 +96,55 @@ async function temporaryDirectory(
   const path = await realpath(await mkdtemp(join(tmpdir(), prefix)));
   temporaryDirectories.push(path);
   return path;
+}
+
+async function plantCredentialHomeLock(
+  home: string,
+  pid: number,
+  modifiedAt?: Date,
+): Promise<string> {
+  const lock = join(home, ".codex-security-scan.lock");
+  await mkdir(lock, { mode: 0o700 });
+  await writeFile(
+    join(lock, "owner.json"),
+    `${JSON.stringify({ pid, token: "planted-owner" })}\n`,
+    { mode: 0o600 },
+  );
+  if (modifiedAt !== undefined) await utimes(lock, modifiedAt, modifiedAt);
+  return lock;
+}
+
+async function acquireCredentialHomeLockWithTimeout(
+  home: string,
+): Promise<() => Promise<void>> {
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(new DOMException("timed out", "AbortError")),
+    10_000,
+  );
+  timeout.unref();
+  try {
+    return await acquireCodexSecurityCredentialHomeLock(
+      home,
+      controller.signal,
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function abortCredentialLockWaitWhenOwnerIsInspected(
+  controller: AbortController,
+): ReturnType<typeof spyOn> {
+  const killProcess = process.kill.bind(process);
+  return spyOn(process, "kill").mockImplementation(((
+    pid: number,
+    signal: number,
+  ) => {
+    const result = killProcess(pid, signal);
+    controller.abort(new DOMException("canceled", "AbortError"));
+    return result;
+  }) as typeof process.kill);
 }
 
 async function plugin(root: string, version = "1.2.3"): Promise<string> {
@@ -2281,24 +2331,87 @@ describe("runtime directories and plugin Python boundary", () => {
     expect(existsSync(join(home, ".codex-security-scan.lock"))).toBe(false);
   });
 
-  test("cancels a scan waiting for the persistent credential-home lock", async () => {
+  test("keeps a fresh live credential-home lock and cancels the waiter", async () => {
     const root = await temporaryDirectory();
     const home = await prepareCodexSecurityCredentialHome({
       CODEX_SECURITY_STATE_DIR: join(root, "state"),
     });
     const release = await acquireCodexSecurityCredentialHomeLock(home);
     const controller = new AbortController();
-    const waiting = acquireCodexSecurityCredentialHomeLock(
-      home,
-      controller.signal,
-    );
-    controller.abort(new DOMException("canceled", "AbortError"));
+    const inspectOwner =
+      abortCredentialLockWaitWhenOwnerIsInspected(controller);
 
     try {
+      const waiting = acquireCodexSecurityCredentialHomeLock(
+        home,
+        controller.signal,
+      );
       await expect(waiting).rejects.toMatchObject({ name: "AbortError" });
+      expect(inspectOwner).toHaveBeenCalledWith(process.pid, 0);
+      expect(existsSync(join(home, ".codex-security-scan.lock"))).toBe(true);
     } finally {
+      inspectOwner.mockRestore();
       await release();
     }
+    expect(existsSync(join(home, ".codex-security-scan.lock"))).toBe(false);
+  });
+
+  test("heartbeats a held credential-home lock across the stale horizon", async () => {
+    const root = await temporaryDirectory();
+    const home = await prepareCodexSecurityCredentialHome({
+      CODEX_SECURITY_STATE_DIR: join(root, "state"),
+    });
+    const lock = join(home, ".codex-security-scan.lock");
+    let heartbeat: (() => Promise<void>) | undefined;
+    const unref = mock(() => undefined);
+    const interval = { unref } as unknown as NodeJS.Timeout;
+    let cleared = false;
+    const setHeartbeat = spyOn(globalThis, "setInterval").mockImplementation(((
+      callback: () => Promise<void>,
+      milliseconds: number,
+    ) => {
+      expect(milliseconds).toBe(5_000);
+      heartbeat = callback;
+      return interval;
+    }) as typeof setInterval);
+    const clearHeartbeat = spyOn(
+      globalThis,
+      "clearInterval",
+    ).mockImplementation(((timer: NodeJS.Timeout) => {
+      if (timer === interval) cleared = true;
+    }) as typeof clearInterval);
+    let release: (() => Promise<void>) | undefined;
+    let inspectOwner: ReturnType<typeof spyOn> | undefined;
+
+    try {
+      release = await acquireCodexSecurityCredentialHomeLock(home);
+      expect(unref).toHaveBeenCalledTimes(1);
+      expect(heartbeat).toBeDefined();
+
+      const stale = new Date(Date.now() - 60_000);
+      await utimes(lock, stale, stale);
+      await heartbeat!();
+      expect(Date.now() - (await stat(lock)).mtimeMs).toBeLessThan(30_000);
+
+      const controller = new AbortController();
+      inspectOwner = abortCredentialLockWaitWhenOwnerIsInspected(controller);
+      const waiting = acquireCodexSecurityCredentialHomeLock(
+        home,
+        controller.signal,
+      );
+      await expect(waiting).rejects.toMatchObject({ name: "AbortError" });
+      expect(existsSync(lock)).toBe(true);
+    } finally {
+      inspectOwner?.mockRestore();
+      try {
+        if (release !== undefined) await release();
+      } finally {
+        clearHeartbeat.mockRestore();
+        setHeartbeat.mockRestore();
+      }
+    }
+    expect(cleared).toBe(true);
+    expect(existsSync(lock)).toBe(false);
   });
 
   test("does not rewrite Windows credential ACLs while polling a held lock", async () => {
@@ -2363,6 +2476,131 @@ describe("runtime directories and plugin Python boundary", () => {
     expect(existsSync(lock)).toBe(false);
   });
 
+  test("recovers a stale credential-home lock naming a live process", async () => {
+    const root = await temporaryDirectory();
+    const home = await prepareCodexSecurityCredentialHome({
+      CODEX_SECURITY_STATE_DIR: join(root, "state"),
+    });
+    const stale = new Date(Date.now() - 10 * 60_000);
+    const lock = await plantCredentialHomeLock(home, process.pid, stale);
+    let release: (() => Promise<void>) | undefined;
+
+    try {
+      release = await acquireCredentialHomeLockWithTimeout(home);
+      expect(existsSync(lock)).toBe(true);
+    } finally {
+      if (release !== undefined) await release();
+    }
+    expect(existsSync(lock)).toBe(false);
+  });
+
+  test("recovers a stale credential-home lock when PID inspection is denied", async () => {
+    const root = await temporaryDirectory();
+    const home = await prepareCodexSecurityCredentialHome({
+      CODEX_SECURITY_STATE_DIR: join(root, "state"),
+    });
+    const stale = new Date(Date.now() - 10 * 60_000);
+    const lock = await plantCredentialHomeLock(home, process.pid, stale);
+    const inspectOwner = spyOn(process, "kill").mockImplementation((() => {
+      const error = new Error(
+        "operation not permitted",
+      ) as NodeJS.ErrnoException;
+      error.code = "EPERM";
+      throw error;
+    }) as typeof process.kill);
+    let release: (() => Promise<void>) | undefined;
+
+    try {
+      release = await acquireCredentialHomeLockWithTimeout(home);
+      expect(existsSync(lock)).toBe(true);
+    } finally {
+      inspectOwner.mockRestore();
+      if (release !== undefined) await release();
+    }
+    expect(existsSync(lock)).toBe(false);
+  });
+
+  test("abandons stale recovery when the owner heartbeat advances", async () => {
+    if (
+      runTestInSubprocess(
+        import.meta.path,
+        "abandons stale recovery when the owner heartbeat advances",
+      )
+    ) {
+      return;
+    }
+    const root = await temporaryDirectory();
+    const home = await prepareCodexSecurityCredentialHome({
+      CODEX_SECURITY_STATE_DIR: join(root, "state"),
+    });
+    const lock = join(home, ".codex-security-scan.lock");
+    const controller = new AbortController();
+    let heartbeat: (() => Promise<void>) | undefined;
+    const interval = {
+      unref: mock(() => undefined),
+    } as unknown as NodeJS.Timeout;
+    const setHeartbeat = spyOn(globalThis, "setInterval").mockImplementation(((
+      callback: () => Promise<void>,
+      milliseconds: number,
+    ) => {
+      expect(milliseconds).toBe(5_000);
+      if (heartbeat === undefined) heartbeat = callback;
+      else controller.abort(new DOMException("lock stolen", "AbortError"));
+      return interval;
+    }) as typeof setInterval);
+    const clearHeartbeat = spyOn(
+      globalThis,
+      "clearInterval",
+    ).mockImplementation((() => undefined) as typeof clearInterval);
+    const realDelay = timersPromises.setTimeout;
+    let waitedForHeartbeat = false;
+    mock.module("node:timers/promises", () => ({
+      ...timersPromises,
+      setTimeout: (async (
+        milliseconds: number,
+        value?: unknown,
+        options?: { signal?: AbortSignal },
+      ) => {
+        expect(options?.signal).toBe(controller.signal);
+        if (milliseconds === 5_000) {
+          waitedForHeartbeat = true;
+          expect(heartbeat).toBeDefined();
+          await heartbeat!();
+          return value;
+        }
+        controller.abort(new DOMException("canceled", "AbortError"));
+        return await realDelay(0, value, { signal: controller.signal });
+      }) as typeof timersPromises.setTimeout,
+    }));
+    let release: (() => Promise<void>) | undefined;
+
+    try {
+      release = await acquireCodexSecurityCredentialHomeLock(home);
+      const stale = new Date(Date.now() - 10 * 60_000);
+      await utimes(lock, stale, stale);
+
+      const waiting = acquireCodexSecurityCredentialHomeLock(
+        home,
+        controller.signal,
+      );
+      await expect(waiting).rejects.toMatchObject({ name: "AbortError" });
+      expect(waitedForHeartbeat).toBe(true);
+      expect(Date.now() - (await stat(lock)).mtimeMs).toBeLessThan(30_000);
+      expect(existsSync(lock)).toBe(true);
+    } finally {
+      mock.module("node:timers/promises", () => ({
+        ...timersPromises,
+        setTimeout: realDelay,
+      }));
+      try {
+        if (release !== undefined) await release();
+      } finally {
+        clearHeartbeat.mockRestore();
+        setHeartbeat.mockRestore();
+      }
+    }
+  });
+
   test("recovers credential-home locks whose owner names no process", async () => {
     const root = await temporaryDirectory();
     const home = await prepareCodexSecurityCredentialHome({
@@ -2379,19 +2617,9 @@ describe("runtime directories and plugin Python boundary", () => {
       const aged = new Date(Date.now() - 10 * 60_000);
       await utimes(lock, aged, aged);
 
-      // Bound acquisition so a false live-owner result cannot hang the test.
-      const abort = new AbortController();
-      const timer = setTimeout(() => abort.abort(), 5_000);
-      try {
-        const release = await acquireCodexSecurityCredentialHomeLock(
-          home,
-          abort.signal,
-        );
-        expect(existsSync(lock)).toBe(true);
-        await release();
-      } finally {
-        clearTimeout(timer);
-      }
+      const release = await acquireCredentialHomeLockWithTimeout(home);
+      expect(existsSync(lock)).toBe(true);
+      await release();
       expect(existsSync(lock)).toBe(false);
     }
   });


### PR DESCRIPTION
## Summary

Severity: P1. Fixes #228.

`recoverStaleCredentialHomeLock` decided whether a credential-home lock was stale from
`process.kill(owner.pid, 0)` alone, so a reused process ID was indistinguishable from the original
owner and the lock was never reclaimed. The 30 s stale-age escape hatch applied only in the `else`
branch of the process-ID check, which exempted a lock naming any accepted live process ID from
expiry no matter how old it was. Acquisition then polled every 25 ms with no timeout.

Merged PR #448 fixed the malformed-process-ID half of #228 and stated that recovery of a genuinely
reused live process ID remained separate work. This is that work.

The lock is held for a whole scan and outlives a killed process, so a leftover owner record can name
an unrelated live process on the next run. A persisted state directory combined with process IDs that
restart from a low number makes the collision easy to hit, and every later scan then waits forever.

## Changes

- Prove ownership by freshness instead of by process-ID liveness. A held lock refreshes its directory
  mtime on an unreferenced 5 s heartbeat, cleared when the lock is released. Heartbeat failures are
  swallowed so they cannot interrupt a scan.
- Apply one 30 s staleness horizon on every path, reusing the existing threshold rather than adding a
  second expiry. A lock whose heartbeat has lapsed is reclaimed regardless of who owns that process ID
  now. This replaces the age check that previously applied only to unidentifiable owners.
- Keep immediate recovery for a definitively exited owner, so an `ESRCH` result still reclaims at once.
- Keep waiting when a live owner is still heartbeating, so scans stay serialized.
- Guard the suspend/wake race: a machine that sleeps mid-scan wakes with a stale-looking mtime while
  its owner is still alive. Recovery of a lock whose process ID looks alive waits one heartbeat
  interval and abandons the reclaim if the mtime advanced. Owners that cannot be identified at all
  skip that wait, so exited and malformed owners recover as quickly as before. The wait honors the
  abort signal.
- Preserve the owner token check on release, the quarantine-then-remove sequence, the non-directory
  lock error, credential-home device and inode pinning, and cancellation.

No public CLI surface changes: no new commands, flags, accepted values, environment variables, or
defaults. The remaining half of #228, that the wait itself is silent, is left for a separate change to
keep this diff reviewable.

A second, test-only commit stops the heartbeat tests from replacing the global timer functions for
every caller. They now capture just the heartbeat registration, delegate all other timer calls to the
real implementation, and assert from the test body rather than from inside a mock. Previously an
unrelated `setInterval` call arriving while those spies were installed could fail an assertion
attributed to another test, or abort the lock wait under test.

## Testing

From `sdk/typescript/`, against this branch on `main` at `f222faf`:

- `pnpm run test` — four unseeded whole-suite runs, each 0 failures.
- `pnpm run test --seed 12345` — 1,576 passed, 29 skipped, 0 failed across 1,605 tests in 87 files.
- `pnpm run types` — passed.
- `pnpm run format` — passed, all matched files use Prettier style.
- `git diff --check` — passed.

New focused coverage in the existing credential-lock suite: a stale lock naming a live process is
reclaimed, a stale lock whose process inspection is denied is reclaimed, a fresh live owner still
blocks and still cancels on abort, a heartbeat keeps a held lock across the stale horizon, and
recovery is abandoned when the owner heartbeat advances. The heartbeat and race tests drive the
captured interval callback and `utimes` explicitly rather than sleeping, and the race test isolates
its module mock in a subprocess. The existing exited-process and malformed-owner tests still pass.

Behavior was also measured directly against the reproduction in #228, on this base before and after
the change:

| planted lock | before | after |
| --- | --- | --- |
| exited process ID, 24 h old | reclaimed in 3 ms | reclaimed in 2 ms |
| process ID `0` and `-1`, 24 h old | reclaimed in 2-4 ms | reclaimed in 2-3 ms |
| live process ID, 24 h old | never reclaimed | reclaimed in 5005 ms |
| live process ID, 30 days old | never reclaimed | reclaimed in 5007 ms |
| process ID `1`, permission denied, 24 h old | never reclaimed | reclaimed in 5004 ms |

Tests use synthetic fixtures and temporary directories. No live scan, network, or credentials were
required. Post-push GitHub Actions checks remain pending.

Two local check failures are unrelated to this branch and reproduce identically on unmodified `main`
in the same environment, which was verified by running them against a clean checkout:

- `audit:prod` reports one pre-existing high advisory. `package.json` and `pnpm-lock.yaml` are
  byte-identical to `main` on this branch, so no dependency changed here.
- `check:package` fails in its installed-package smoke because the packed tarball resolves
  `@openai/codex` at a prerelease version that the public registry does not serve.

Whole-suite runs on this machine also produce occasional 30-second timeouts in I/O-heavy plugin and
publication tests. Unmodified `main` produced the same class of timeout at a comparable rate, in
tests that do not touch credential locking, so it is a local resource limit rather than a regression
here.

## Risk and rollout

A lock whose owner has not heartbeated for 30 s is now reclaimable even when its recorded process ID
is live. That is the intended fix, and it is the only behavior change for a lock that is still being
heartbeated: a healthy owner is never displaced, because its heartbeat keeps the lock fresh and the
suspend/wake re-check backs off when the mtime advances. If two processes ever do overlap, release
still verifies the owner token and refuses to remove a lock it no longer owns.

Recovery of an unidentifiable or exited owner keeps its previous latency. Only the reused or
suspended live-owner case pays one heartbeat interval, replacing a wait that never ended. No
migration, configuration, schema, or public CLI change is required.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
