### PR TITLE
test(scan): exercise large git output on Windows

### DIFF
--- a/sdk/typescript/src/targets.ts
+++ b/sdk/typescript/src/targets.ts
@@ -413,6 +413,7 @@ async function gitOutput(
       encoding: "utf8",
       signal,
       env: command.environment,
+      maxBuffer: Infinity,
     },
   );
   return stdout.trim();

--- a/sdk/typescript/tests-ts/targets-large-output.test.ts
+++ b/sdk/typescript/tests-ts/targets-large-output.test.ts
@@ -42,9 +42,9 @@ test("validates committed diffs with tracked-file output larger than 1 MB", asyn
   const trackedDirectory = join(repo, "tracked");
   await mkdir(trackedDirectory);
   // Exceed the byte limit without creating paths that are too long on Windows.
-  const utf8Stem = "界".repeat(120);
+  const utf8Stem = "界".repeat(60);
   await Promise.all(
-    Array.from({ length: 3_000 }, (_, index) =>
+    Array.from({ length: 6_000 }, (_, index) =>
       writeFile(
         join(
           trackedDirectory,

--- a/sdk/typescript/tests-ts/targets-large-output.test.ts
+++ b/sdk/typescript/tests-ts/targets-large-output.test.ts
@@ -70,5 +70,7 @@ test("validates committed diffs with tracked-file output larger than 1 MB", asyn
     repo,
     DiffTarget.refs({ base: "HEAD" }),
   );
-  await expect(validateCommittedDiffCheckout(repo, target)).resolves.toBeUndefined();
+  await expect(
+    validateCommittedDiffCheckout(repo, target),
+  ).resolves.toBeUndefined();
 });

--- a/sdk/typescript/tests-ts/targets-large-output.test.ts
+++ b/sdk/typescript/tests-ts/targets-large-output.test.ts
@@ -28,8 +28,6 @@ function git(repo: string, ...args: string[]): string {
 }
 
 test("validates committed diffs with tracked-file output larger than 1 MB", async () => {
-  if (process.platform === "win32") return;
-
   const root = await realpath(
     await mkdtemp(join(tmpdir(), "codex-security-large-targets-")),
   );
@@ -41,19 +39,16 @@ test("validates committed diffs with tracked-file output larger than 1 MB", asyn
   git(repo, "config", "user.email", "test@example.com");
   git(repo, "config", "user.name", "Test");
 
-  const longDirectory = join(
-    repo,
-    "a".repeat(200),
-    "b".repeat(200),
-    "c".repeat(200),
-  );
-  await mkdir(longDirectory, { recursive: true });
+  const trackedDirectory = join(repo, "tracked");
+  await mkdir(trackedDirectory);
+  // Exceed the byte limit without creating paths that are too long on Windows.
+  const utf8Stem = "界".repeat(120);
   await Promise.all(
-    Array.from({ length: 1_500 }, (_, index) =>
+    Array.from({ length: 3_000 }, (_, index) =>
       writeFile(
         join(
-          longDirectory,
-          `${index.toString().padStart(4, "0")}-${"x".repeat(180)}.ts`,
+          trackedDirectory,
+          `${index.toString().padStart(4, "0")}-${utf8Stem}.ts`,
         ),
         "",
       ),
@@ -66,10 +61,7 @@ test("validates committed diffs with tracked-file output larger than 1 MB", asyn
   const tracked = git(repo, "ls-files", "-t", "-z");
   expect(Buffer.byteLength(tracked, "utf8")).toBeGreaterThan(1024 * 1024);
 
-  const target = await normalizeTarget(
-    repo,
-    DiffTarget.refs({ base: "HEAD" }),
-  );
+  const target = await normalizeTarget(repo, DiffTarget.refs({ base: "HEAD" }));
   await expect(
     validateCommittedDiffCheckout(repo, target),
   ).resolves.toBeUndefined();

--- a/sdk/typescript/tests-ts/targets-large-output.test.ts
+++ b/sdk/typescript/tests-ts/targets-large-output.test.ts
@@ -1,0 +1,74 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, test } from "bun:test";
+import {
+  DiffTarget,
+  normalizeTarget,
+  validateCommittedDiffCheckout,
+} from "../src/targets.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+function git(repo: string, ...args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: repo,
+    encoding: "utf8",
+    maxBuffer: Infinity,
+  }).trim();
+}
+
+test("validates committed diffs with tracked-file output larger than 1 MB", async () => {
+  if (process.platform === "win32") return;
+
+  const root = await realpath(
+    await mkdtemp(join(tmpdir(), "codex-security-large-targets-")),
+  );
+  temporaryDirectories.push(root);
+  const repo = join(root, "repo");
+  await mkdir(repo);
+
+  git(repo, "init", "-b", "main");
+  git(repo, "config", "user.email", "test@example.com");
+  git(repo, "config", "user.name", "Test");
+
+  const longDirectory = join(
+    repo,
+    "a".repeat(200),
+    "b".repeat(200),
+    "c".repeat(200),
+  );
+  await mkdir(longDirectory, { recursive: true });
+  await Promise.all(
+    Array.from({ length: 1_500 }, (_, index) =>
+      writeFile(
+        join(
+          longDirectory,
+          `${index.toString().padStart(4, "0")}-${"x".repeat(180)}.ts`,
+        ),
+        "",
+      ),
+    ),
+  );
+
+  git(repo, "add", ".");
+  git(repo, "commit", "--quiet", "-m", "large tracked tree");
+
+  const tracked = git(repo, "ls-files", "-t", "-z");
+  expect(Buffer.byteLength(tracked, "utf8")).toBeGreaterThan(1024 * 1024);
+
+  const target = await normalizeTarget(
+    repo,
+    DiffTarget.refs({ base: "HEAD" }),
+  );
+  await expect(validateCommittedDiffCheckout(repo, target)).resolves.toBeUndefined();
+});


### PR DESCRIPTION
## Summary

Stacked follow-up to #572, which fixes committed-diff scan preparation when the tracked-file inventory exceeds Node's default subprocess buffer. This keeps its regression coverage active on Windows. Merge #572 first, then refresh this branch against `main`.

## Changes

- remove the Windows early return that made the regression report a pass without exercising the code
- use short multibyte filenames to produce more than 1 MiB of real `git ls-files -t -z` output without overlong Windows paths

## Testing

Run from `sdk/typescript` unless noted otherwise:

- `corepack pnpm dlx bun@1.3.14 test --timeout 30000 tests-ts/targets-large-output.test.ts --seed 12345` (1 passed)
- `corepack pnpm dlx bun@1.3.14 test --timeout 30000 ./tests-ts --seed 12345` (1,436 passed, 23 platform-specific skips; one unrelated concurrency assertion failed and passed on immediate isolated rerun)
- `corepack pnpm dlx bun@1.3.14 test --timeout 30000 tests-ts/api-credentials.test.ts --seed 12345 -t 'runs parallel ChatGPT scans with isolated mutable configuration'` (1 passed)
- exact-head GitHub Actions: all required checks passed; the regression passed on Windows with Node 22 and Node 24
- `corepack pnpm run types`, `corepack pnpm run format`, `corepack pnpm run build`, and `git diff --check` (passed)

## Risk and rollout

Test-only follow-up. The regression creates 6,000 temporary empty files and removes its temporary repository after each run. It does not change runtime behavior or public CLI surface. Until #572 merges, GitHub's comparison against `main` also includes the parent pull request's commits.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
