### PR TITLE
release: bump Codex Security to 0.1.19

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,16 +1,8 @@
-<!-- release-version: 0.1.18 -->
+<!-- release-version: 0.1.19 -->
 
 ## Highlights
 
-- Attribute API-key scans to the originating end user with the CLI's
-  `--safety-identifier` option or the SDK's `safetyIdentifier` option. Use a
-  stable, privacy-preserving identifier rather than personal data. This
-  requires a Codex runtime with native safety identifier support; the bundled
-  runtime does not yet support it, so select a compatible build with
-  `CODEX_CLI_PATH`. See
-  [Safety ID setup and runtime requirements](https://github.com/openai/codex-security/blob/npm-v0.1.18/sdk/typescript/README.md#attribute-scans-to-end-users).
-- Preserve accepted findings and partial artifacts when Deep Scan fails, is
-  canceled, or is interrupted. Recovered results keep their terminal state and
-  incomplete coverage explicit rather than appearing complete.
+- Maintenance release with no additional user-facing behavior changes since
+  0.1.18.
 
 The categorized list below contains the individual changes.

--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -2,7 +2,15 @@
 
 ## Highlights
 
-- Maintenance release with no additional user-facing behavior changes since
-  0.1.18.
+- Publish one or more completed scans to Codex Security Cloud with
+  `publish scan --to cloud`. Choose saved scans interactively or with
+  repeatable `--scan` options, or use repeatable `--scan-dir` options for
+  external artifacts. `--dry-run` validates and previews findings without
+  uploading. Live uploads require a file-backed ChatGPT sign-in and an account
+  authorized for Cloud publication. See
+  [Cloud publication setup and behavior](https://github.com/openai/codex-security/blob/npm-v0.1.19/sdk/typescript/README.md#publish-multiple-completed-scans-to-cloud).
+- Select a saved scan for Linear publication by scan ID, unique ID prefix, or
+  `latest`; omitting the selector opens the interactive picker. See
+  [Linear publication](https://github.com/openai/codex-security/blob/npm-v0.1.19/sdk/typescript/README.md#publish-completed-scans-to-linear).
 
 The categorized list below contains the individual changes.

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-security",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "TypeScript SDK and CLI for Codex Security",
   "license": "Apache-2.0",
   "author": "OpenAI",


### PR DESCRIPTION
## Summary

Prepare Codex Security 0.1.19 after the Cloud publication feature landed in [#612](https://github.com/openai/codex-security/pull/612). This pull request advances the package version and replaces the maintenance placeholder with a reviewed summary of the user-facing changes since 0.1.18.

## Changes

- Bump `@openai/codex-security` from 0.1.18 to 0.1.19.
- Highlight publication of one or more completed scans to Codex Security Cloud, including interactive or explicit scan selection and upload-free `--dry-run` validation.
- Document the file-backed ChatGPT sign-in and authorized-account requirements for live Cloud uploads.
- Highlight saved-scan selection for Linear publication by scan ID, unique prefix, `latest`, or the interactive picker.
- Link both highlights to the version-matched public documentation used by the generated GitHub release.

## Testing

- `git diff --check`
- Release-note header matched `node sdk/typescript/scripts/release-automation.mjs version sdk/typescript/package.json`: `0.1.19`
- `node sdk/typescript/scripts/release-automation.mjs release-tag tag refs/tags/npm-v0.1.19 npm-v0.1.19 sdk/typescript/package.json`
- `node sdk/typescript/scripts/release-automation.mjs require-increase 0.1.19 0.1.18`
- `npm exec --yes --package=prettier@3.2.5 -- prettier --check .github/release-notes.md`
- Exact-head author/reviewer pass and two-pass prepublish review gate on `996c498e99bcb4638ac37e32984c0f2307f009e7`: no findings

The pushed head leaves package testing to the required pull-request CI. The merged feature PR completed its own implementation and cross-platform validation before landing on `main`.

## Risk and rollout

This pull request changes release metadata only. The 0.1.19 package includes the Cloud publication behavior already merged on `main`. Live uploads require explicit file-backed ChatGPT credentials and an account authorized for Cloud publication; `--dry-run` does not upload or require a login. Existing Linear publication gains saved-scan selectors without changing its destination or credential behavior.

After merge, successful `node-ci` on `main` triggers the release-cut workflow, followed by protected npm publication and GitHub release creation for 0.1.19. npm publication remains gated by the protected `npm` environment.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
