### PR TITLE
fix(sdk): reject reversed finding line ranges

### DIFF
--- a/sdk/typescript/src/contract.ts
+++ b/sdk/typescript/src/contract.ts
@@ -480,6 +480,14 @@ function validateCanonicalContract(
           { cause: error },
         );
       }
+      if (
+        location.endLine !== undefined &&
+        location.endLine < location.startLine
+      ) {
+        throw new ContractValidationError(
+          `${locationContext}.endLine: must be greater than or equal to startLine.`,
+        );
+      }
     }
 
     const fingerprint = `codex-security/v1:sha256:${sha256Text(

--- a/sdk/typescript/tests-ts/contract.test.ts
+++ b/sdk/typescript/tests-ts/contract.test.ts
@@ -1092,6 +1092,21 @@ describe("canonical scan contract", () => {
     }
   });
 
+  test("rejects finding locations with reversed line ranges", async () => {
+    const scanDir = await copyExample();
+    const findingsPath = join(scanDir, "findings.json");
+    const findings = await readJson(findingsPath);
+    findings["findings"][0]["locations"][0]["endLine"] = 40;
+    await writeJson(findingsPath, findings);
+    await reseal(scanDir);
+
+    await expect(
+      loadContract(scanDir, { pluginRoot: PLUGIN_ROOT }),
+    ).rejects.toThrow(
+      "findings.findings[0].locations[0].endLine: must be greater than or equal to startLine.",
+    );
+  });
+
   test.skipIf(process.platform === "win32")(
     "rejects missing or symlinked derived writeup and hardening files",
     async () => {


### PR DESCRIPTION
## Summary

Reject finding locations whose `endLine` is less than `startLine` during canonical contract validation. This keeps the TypeScript loader aligned with the bundled Python producer, which already rejects reversed ranges.

## Changes

- Validate the relational `endLine >= startLine` invariant for ordinary finding locations.
- Add a regression that mutates and reseals the bundled completed-scan fixture with a reversed range and verifies `loadContract()` rejects it.

Fixes #560

## Testing

- `bun test --timeout 30000 tests-ts/contract.test.ts` — 44 passed
- `pnpm exec prettier --check src/contract.ts tests-ts/contract.test.ts` — passed
- `pnpm run types` — passed
- `git diff --check` — passed
