### PR TITLE
fix(release): harden release workflow validation

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -47,7 +47,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -euo pipefail
-          conventional_title='^(build|chore|ci|docs|feat|fix|perf|refactor|release|revert|style|test)(\([a-z0-9][a-z0-9._/-]*\))?(!)?:[ ]([^[:space:]].*[^[:space:]]|[^[:space:]])$'
+          conventional_title='^([a-z][a-z0-9-]*)(\([a-z0-9][a-z0-9._/-]*\))?(!)?:[ ]([^[:space:]].*[^[:space:]]|[^[:space:]])$'
           if [[ "$PR_TITLE" == *$'\n'* || "$PR_TITLE" == *$'\r'* ||
                 ! "$PR_TITLE" =~ $conventional_title ]]; then
             echo "Pull request title must follow <type>[optional scope][!]: <description>." >&2

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -26,8 +26,9 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -euo pipefail
-          conventional_title='^([a-z][a-z0-9-]*)(\([a-z0-9][a-z0-9._/-]*\))?(!)?:[ ]([^[:space:]].*[^[:space:]]|[^[:space:]])$'
-          if [[ ! "$PR_TITLE" =~ $conventional_title ]]; then
+          conventional_title='^(build|chore|ci|docs|feat|fix|perf|refactor|release|revert|style|test)(\([a-z0-9][a-z0-9._/-]*\))?(!)?:[ ]([^[:space:]].*[^[:space:]]|[^[:space:]])$'
+          if [[ "$PR_TITLE" == *$'\n'* || "$PR_TITLE" == *$'\r'* ||
+                ! "$PR_TITLE" =~ $conventional_title ]]; then
             echo "Pull request title must follow <type>[optional scope][!]: <description>." >&2
             exit 1
           fi

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -10,15 +10,36 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}-${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only' || 'full' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && (github.event.action != 'edited' || github.event.changes.title != null || github.event.changes.base != null) }}
 
 jobs:
   validate-title:
-    name: validate pull request title
+    name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}validate pull request title
     runs-on: ubuntu-latest
+    outputs:
+      run-full-ci: ${{ steps.scope.outputs.run-full-ci }}
 
     steps:
+      - name: Decide whether full CI is needed
+        id: scope
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          TITLE_CHANGED: ${{ github.event.changes.title != null }}
+          BASE_CHANGED: ${{ github.event.changes.base != null }}
+        run: |
+          set -euo pipefail
+          run_full_ci=true
+          if [[ "$EVENT_NAME" == "pull_request" &&
+                "$EVENT_ACTION" == "edited" &&
+                "$TITLE_CHANGED" != "true" &&
+                "$BASE_CHANGED" != "true" ]]; then
+            run_full_ci=false
+          fi
+          printf 'run-full-ci=%s\n' "$run_full_ci" >> "$GITHUB_OUTPUT"
+
       - name: Require a Conventional Commit pull request title
         if: github.event_name == 'pull_request'
         shell: bash
@@ -34,9 +55,9 @@ jobs:
           fi
 
   test:
-    name: ${{ matrix.os }} / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }}
+    name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}tests / ${{ matrix.os }} / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }}
     needs: validate-title
-    if: always()
+    if: needs.validate-title.outputs.run-full-ci == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
@@ -55,10 +76,6 @@ jobs:
             node: "26"
 
     steps:
-      - name: Require a valid pull request title
-        if: needs.validate-title.result != 'success'
-        run: exit 1
-
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -130,9 +147,25 @@ jobs:
         shell: bash
         run: pnpm run check:package ../../dist/*.tgz
 
+  required-test:
+    name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}${{ matrix.os }} / node-22
+    needs: [validate-title, test]
+    if: always() && !(github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Require every Unix coverage job
+        if: needs.validate-title.result != 'success' || needs.test.result != 'success'
+        run: exit 1
+
   windows-test:
-    name: windows-latest / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }} / tests-${{ matrix.shard }}
+    name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}windows-latest / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }} / tests-${{ matrix.shard }}
     needs: validate-title
+    if: needs.validate-title.outputs.run-full-ci == 'true'
     runs-on: windows-latest
     timeout-minutes: 20
     strategy:
@@ -190,8 +223,9 @@ jobs:
         run: bun test --timeout 120000 ./tests-ts/windows-machine-policy.test.ts
 
   windows-verify:
-    name: windows-latest / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }} / verify
+    name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}windows-latest / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }} / verify
     needs: validate-title
+    if: needs.validate-title.outputs.run-full-ci == 'true'
     runs-on: windows-latest
     timeout-minutes: 20
     strategy:
@@ -229,9 +263,9 @@ jobs:
         run: pnpm run check:package ../../dist/*.tgz
 
   windows:
-    name: windows-latest / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }}
+    name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}windows-latest / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }}
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && !(github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null)
     needs: [validate-title, windows-test, windows-verify]
     strategy:
       fail-fast: false

--- a/.github/workflows/node-github-release.yml
+++ b/.github/workflows/node-github-release.yml
@@ -546,14 +546,16 @@ jobs:
           if [[ -n "$PREVIOUS_TAG" ]]; then
             notes_args+=(-f "previous_tag_name=$PREVIOUS_TAG")
           fi
-          generated_notes="$(gh api "${notes_args[@]}" --jq '.body')"
-          if [[ -z "$generated_notes" ]]; then
-            echo "Generated GitHub release notes must not be empty." >&2
-            exit 1
-          fi
-
           generated_notes_file="$release_workspace/generated-notes.md"
-          printf '%s' "$generated_notes" > "$generated_notes_file"
+          gh api "${notes_args[@]}" |
+            node --input-type=module --eval '
+              import { readFileSync, writeFileSync } from "node:fs";
+              const response = JSON.parse(readFileSync(0, "utf8"));
+              if (typeof response.body !== "string") {
+                throw new Error("Generated GitHub release notes must be a string.");
+              }
+              writeFileSync(process.argv[1], response.body);
+            ' "$generated_notes_file"
           release_note_args=()
 
           tagged_notes_file="$release_workspace/tagged-notes.md"
@@ -570,15 +572,13 @@ jobs:
             )
           fi
 
-          published_notes="$(
-            node sdk/typescript/scripts/release-automation.mjs \
-              compose-release-notes \
-              "$RELEASE_VERSION" \
-              "$generated_notes_file" \
-              ${release_note_args[@]+"${release_note_args[@]}"}
-          )"
           published_notes_file="$release_workspace/published-notes.md"
-          printf '%s' "$published_notes" > "$published_notes_file"
+          node sdk/typescript/scripts/release-automation.mjs \
+            compose-release-notes \
+            "$RELEASE_VERSION" \
+            "$generated_notes_file" \
+            ${release_note_args[@]+"${release_note_args[@]}"} \
+            > "$published_notes_file"
 
           if [[ -n "$existing_release" ]]; then
             latest_response="$(
@@ -618,11 +618,10 @@ jobs:
                   "$currently_latest" != "$MAKE_LATEST" ]]; then
               verify_release_tag
               if [[ "$notes_changed" == true ]]; then
-                printf '%s\n' "$published_notes" |
-                  gh release edit "$RELEASE_TAG" \
-                    --repo "$GITHUB_REPOSITORY" \
-                    --latest="$MAKE_LATEST" \
-                    --notes-file -
+                gh release edit "$RELEASE_TAG" \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --latest="$MAKE_LATEST" \
+                  --notes-file "$published_notes_file"
                 echo "Updated existing GitHub Release with reviewed and generated notes."
               else
                 gh release edit "$RELEASE_TAG" \
@@ -644,9 +643,9 @@ jobs:
             --repo "$GITHUB_REPOSITORY"
             --title "Codex Security $RELEASE_VERSION"
             --verify-tag
-            --notes-file -
+            --notes-file "$published_notes_file"
             --latest="$MAKE_LATEST"
           )
 
           verify_release_tag
-          printf '%s\n' "$published_notes" | gh release create "${release_args[@]}"
+          gh release create "${release_args[@]}"

--- a/.github/workflows/node-github-release.yml
+++ b/.github/workflows/node-github-release.yml
@@ -405,6 +405,9 @@ jobs:
         run: |
           set -euo pipefail
 
+          release_workspace="$(mktemp -d)"
+          trap 'rm -rf "$release_workspace"' EXIT
+
           verify_release_tag() {
             local live_ref live_type live_object live_commit
             if ! live_ref="$(
@@ -495,8 +498,8 @@ jobs:
           )"
           if [[ -n "$existing_release" ]]; then
             asset_name="$(basename "$RELEASE_ARCHIVE")"
-            downloaded_assets="$(mktemp -d)"
-            trap 'rm -rf "$downloaded_assets"' EXIT
+            downloaded_assets="$release_workspace/downloaded-assets"
+            mkdir "$downloaded_assets"
             gh release download "$RELEASE_TAG" \
               --repo "$GITHUB_REPOSITORY" \
               --pattern "$asset_name" \
@@ -547,67 +550,33 @@ jobs:
             exit 1
           fi
 
-          summary_start="<!-- codex-security-release-summary:start -->"
-          summary_end="<!-- codex-security-release-summary:end -->"
-          release_summary=""
-          if git cat-file -e "$RELEASE_SHA:.github/release-notes.md" 2>/dev/null; then
-            release_summary="$(
-              git show "$RELEASE_SHA:.github/release-notes.md"
-            )"
-            summary_header="${release_summary%%$'\n'*}"
-            summary_body="${release_summary#*$'\n'}"
-            expected_header="<!-- release-version: $RELEASE_VERSION -->"
-            if [[ "$summary_header" != "$expected_header" ||
-                  "$summary_body" == "$release_summary" ||
-                  -z "${summary_body//[[:space:]]/}" ]]; then
-              echo "Release notes must start with $expected_header and include a reviewed summary." >&2
-              exit 1
-            fi
-          elif [[ -n "$existing_notes" ]]; then
-            release_summary="$(
-              printf '%s\n' "$existing_notes" |
-                CODEX_SECURITY_SUMMARY_START="$summary_start" \
-                CODEX_SECURITY_SUMMARY_END="$summary_end" \
-                node --input-type=module --eval '
-                  import { readFileSync } from "node:fs";
-                  const notes = readFileSync(0, "utf8");
-                  const start = process.env.CODEX_SECURITY_SUMMARY_START;
-                  const end = process.env.CODEX_SECURITY_SUMMARY_END;
-                  const startIndex = notes.indexOf(start);
-                  const endIndex = notes.indexOf(end);
-                  if (startIndex === -1 && endIndex === -1) process.exit(0);
-                  if (
-                    startIndex === -1 ||
-                    endIndex <= startIndex ||
-                    notes.indexOf(start, startIndex + start.length) !== -1 ||
-                    notes.indexOf(end, endIndex + end.length) !== -1
-                  ) {
-                    throw new Error(
-                      "Existing release summary markers are malformed.",
-                    );
-                  }
-                  const summary = notes
-                    .slice(startIndex + start.length, endIndex)
-                    .replace(/^\r?\n/u, "")
-                    .replace(/\r?\n$/u, "");
-                  if (!/\S/u.test(summary)) {
-                    throw new Error("Existing release summary is empty.");
-                  }
-                  process.stdout.write(summary);
-                '
-            )"
+          generated_notes_file="$release_workspace/generated-notes.md"
+          printf '%s' "$generated_notes" > "$generated_notes_file"
+          release_note_args=()
+
+          tagged_notes_file="$release_workspace/tagged-notes.md"
+          if git show "$RELEASE_SHA:.github/release-notes.md" \
+            > "$tagged_notes_file" 2>/dev/null; then
+            release_note_args+=(
+              --tagged-notes-file "$tagged_notes_file"
+            )
           fi
 
-          published_notes="$generated_notes"
-          if [[ -n "$release_summary" ]]; then
-            published_notes="$(
-              printf '%s\n%s\n%s\n\n%s' \
-                "$summary_start" \
-                "$release_summary" \
-                "$summary_end" \
-                "$generated_notes"
-            )"
+          if [[ -n "$existing_notes" ]]; then
+            existing_notes_file="$release_workspace/existing-notes.md"
+            printf '%s' "$existing_notes" > "$existing_notes_file"
+            release_note_args+=(
+              --existing-notes-file "$existing_notes_file"
+            )
           fi
+
+          published_notes="$(
+            node sdk/typescript/scripts/release-automation.mjs \
+              compose-release-notes \
+              "$RELEASE_VERSION" \
+              "$generated_notes_file" \
+              ${release_note_args[@]+"${release_note_args[@]}"}
+          )"
 
           if [[ -n "$existing_release" ]]; then
             latest_response="$(

--- a/.github/workflows/node-github-release.yml
+++ b/.github/workflows/node-github-release.yml
@@ -517,19 +517,21 @@ jobs:
                 "$downloaded_archive"
           fi
 
-          existing_notes=""
+          existing_notes_file="$release_workspace/existing-notes.md"
+          : > "$existing_notes_file"
           if [[ -n "$existing_release" ]]; then
-            existing_notes="$(
-              printf '%s\n' "$existing_release" |
-                node --input-type=module --eval '
-                  import { readFileSync } from "node:fs";
-                  const release = JSON.parse(readFileSync(0, "utf8"));
-                  if (release.body != null && typeof release.body !== "string") {
-                    throw new Error("Existing release notes must be a string.");
-                  }
-                  process.stdout.write(release.body ?? "");
-                '
-            )"
+            printf '%s\n' "$existing_release" |
+              node --input-type=module --eval '
+                import { readFileSync, writeFileSync } from "node:fs";
+                const release = JSON.parse(readFileSync(0, "utf8"));
+                if (release.body != null && typeof release.body !== "string") {
+                  throw new Error("Existing release notes must be a string.");
+                }
+                writeFileSync(
+                  process.argv[1],
+                  (release.body ?? "").replace(/\n+$/u, ""),
+                );
+              ' "$existing_notes_file"
           fi
 
           notes_args=(
@@ -562,9 +564,7 @@ jobs:
             )
           fi
 
-          if [[ -n "$existing_notes" ]]; then
-            existing_notes_file="$release_workspace/existing-notes.md"
-            printf '%s' "$existing_notes" > "$existing_notes_file"
+          if [[ -s "$existing_notes_file" ]]; then
             release_note_args+=(
               --existing-notes-file "$existing_notes_file"
             )
@@ -577,6 +577,8 @@ jobs:
               "$generated_notes_file" \
               ${release_note_args[@]+"${release_note_args[@]}"}
           )"
+          published_notes_file="$release_workspace/published-notes.md"
+          printf '%s' "$published_notes" > "$published_notes_file"
 
           if [[ -n "$existing_release" ]]; then
             latest_response="$(
@@ -608,10 +610,14 @@ jobs:
               currently_latest=true
             fi
 
-            if [[ "$existing_notes" != "$published_notes" ||
+            notes_changed=false
+            if ! cmp -s "$existing_notes_file" "$published_notes_file"; then
+              notes_changed=true
+            fi
+            if [[ "$notes_changed" == true ||
                   "$currently_latest" != "$MAKE_LATEST" ]]; then
               verify_release_tag
-              if [[ "$existing_notes" != "$published_notes" ]]; then
+              if [[ "$notes_changed" == true ]]; then
                 printf '%s\n' "$published_notes" |
                   gh release edit "$RELEASE_TAG" \
                     --repo "$GITHUB_REPOSITORY" \

--- a/.github/workflows/node-github-release.yml
+++ b/.github/workflows/node-github-release.yml
@@ -529,7 +529,7 @@ jobs:
                 }
                 writeFileSync(
                   process.argv[1],
-                  (release.body ?? "").replace(/\n+$/u, ""),
+                  (release.body ?? "").replace(/(?:\r?\n)+$/u, ""),
                 );
               ' "$existing_notes_file"
           fi

--- a/.github/workflows/node-release-cut.yml
+++ b/.github/workflows/node-release-cut.yml
@@ -20,6 +20,7 @@ jobs:
       github.repository == 'openai/codex-security' &&
       (github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main'))
     name: cut release tag
     runs-on: ubuntu-latest
@@ -65,21 +66,15 @@ jobs:
           fi
 
           version="$(node sdk/typescript/scripts/release-automation.mjs version sdk/typescript/package.json)"
-          if ! release_summary="$(
-            git show "$RELEASE_SHA:.github/release-notes.md" 2>/dev/null
-          )"; then
+          release_notes_file="$(mktemp)"
+          trap 'rm -f "$release_notes_file"' EXIT
+          if ! git show "$RELEASE_SHA:.github/release-notes.md" \
+            > "$release_notes_file" 2>/dev/null; then
             echo "The tagged commit must include .github/release-notes.md." >&2
             exit 1
           fi
-          summary_header="${release_summary%%$'\n'*}"
-          summary_body="${release_summary#*$'\n'}"
-          expected_header="<!-- release-version: $version -->"
-          if [[ "$summary_header" != "$expected_header" ||
-                "$summary_body" == "$release_summary" ||
-                -z "${summary_body//[[:space:]]/}" ]]; then
-            echo "Release notes must start with $expected_header and include a reviewed summary." >&2
-            exit 1
-          fi
+          node sdk/typescript/scripts/release-automation.mjs \
+            validate-release-notes "$version" "$release_notes_file" >/dev/null
 
           if ! published_versions="$(
             npm view @openai/codex-security versions \

--- a/.github/workflows/node-release-labels.yml
+++ b/.github/workflows/node-release-labels.yml
@@ -61,7 +61,12 @@ jobs:
           current_title="$(
             gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER" \
               --jq '.title | @base64' |
-              base64 --decode &&
+              node --input-type=module --eval '
+                import { readFileSync } from "node:fs";
+                process.stdout.write(
+                  Buffer.from(readFileSync(0, "utf8"), "base64"),
+                );
+              ' &&
               printf '%s' "$title_sentinel"
           )"
           current_title="${current_title%"$title_sentinel"}"

--- a/.github/workflows/node-release-labels.yml
+++ b/.github/workflows/node-release-labels.yml
@@ -57,12 +57,18 @@ jobs:
             esac
           }
 
+          title_sentinel="__CODEX_SECURITY_TITLE_END__"
           current_title="$(
             gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER" \
-              --jq '.title'
+              --jq '.title | @base64' |
+              base64 --decode &&
+              printf '%s' "$title_sentinel"
           )"
-          conventional_title='^([a-z][a-z0-9-]*)(\([a-z0-9][a-z0-9._/-]*\))?(!)?:[ ]([^[:space:]].*[^[:space:]]|[^[:space:]])$'
-          if [[ ! "$current_title" =~ $conventional_title ]]; then
+          current_title="${current_title%"$title_sentinel"}"
+          conventional_title='^(build|chore|ci|docs|feat|fix|perf|refactor|release|revert|style|test)(\([a-z0-9][a-z0-9._/-]*\))?(!)?:[ ]([^[:space:]].*[^[:space:]]|[^[:space:]])$'
+          if [[ "$current_title" == *$'\n'* ||
+                "$current_title" == *$'\r'* ||
+                ! "$current_title" =~ $conventional_title ]]; then
             echo "Pull request title must follow <type>[optional scope][!]: <description>." >&2
             exit 1
           fi

--- a/.github/workflows/node-release-labels.yml
+++ b/.github/workflows/node-release-labels.yml
@@ -70,7 +70,7 @@ jobs:
               printf '%s' "$title_sentinel"
           )"
           current_title="${current_title%"$title_sentinel"}"
-          conventional_title='^(build|chore|ci|docs|feat|fix|perf|refactor|release|revert|style|test)(\([a-z0-9][a-z0-9._/-]*\))?(!)?:[ ]([^[:space:]].*[^[:space:]]|[^[:space:]])$'
+          conventional_title='^([a-z][a-z0-9-]*)(\([a-z0-9][a-z0-9._/-]*\))?(!)?:[ ]([^[:space:]].*[^[:space:]]|[^[:space:]])$'
           if [[ "$current_title" == *$'\n'* ||
                 "$current_title" == *$'\r'* ||
                 ! "$current_title" =~ $conventional_title ]]; then

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -123,21 +123,15 @@ jobs:
         run: |
           set -euo pipefail
 
-          if ! release_summary="$(
-            git show "$GITHUB_SHA:.github/release-notes.md" 2>/dev/null
-          )"; then
+          release_notes_file="$(mktemp)"
+          trap 'rm -f "$release_notes_file"' EXIT
+          if ! git show "$GITHUB_SHA:.github/release-notes.md" \
+            > "$release_notes_file" 2>/dev/null; then
             echo "The tagged commit must include .github/release-notes.md." >&2
             exit 1
           fi
-          summary_header="${release_summary%%$'\n'*}"
-          summary_body="${release_summary#*$'\n'}"
-          expected_header="<!-- release-version: $RELEASE_VERSION -->"
-          if [[ "$summary_header" != "$expected_header" ||
-                "$summary_body" == "$release_summary" ||
-                -z "${summary_body//[[:space:]]/}" ]]; then
-            echo "Release notes must start with $expected_header and include a reviewed summary." >&2
-            exit 1
-          fi
+          node sdk/typescript/scripts/release-automation.mjs \
+            validate-release-notes "$RELEASE_VERSION" "$release_notes_file" >/dev/null
 
       - name: Install dependencies
         run: sfw pnpm --dir sdk/typescript install --frozen-lockfile

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -16,7 +16,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          conventional_title='^(build|chore|ci|docs|feat|fix|perf|refactor|release|revert|style|test)(\([a-z0-9][a-z0-9._/-]*\))?(!)?:[ ]([^[:space:]].*[^[:space:]]|[^[:space:]])$'
+          conventional_title='^([a-z][a-z0-9-]*)(\([a-z0-9][a-z0-9._/-]*\))?(!)?:[ ]([^[:space:]].*[^[:space:]]|[^[:space:]])$'
           if [[ "$PR_TITLE" == *$'\n'* || "$PR_TITLE" == *$'\r'* ||
                 ! "$PR_TITLE" =~ $conventional_title ]]; then
             echo '::error::Pull request title must follow <type>[optional scope][!]: <description>.'

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -16,8 +16,9 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          conventional_title='^([a-z][a-z0-9-]*)(\([a-z0-9][a-z0-9._/-]*\))?(!)?:[ ]([^[:space:]].*[^[:space:]]|[^[:space:]])$'
-          if [[ ! "$PR_TITLE" =~ $conventional_title ]]; then
+          conventional_title='^(build|chore|ci|docs|feat|fix|perf|refactor|release|revert|style|test)(\([a-z0-9][a-z0-9._/-]*\))?(!)?:[ ]([^[:space:]].*[^[:space:]]|[^[:space:]])$'
+          if [[ "$PR_TITLE" == *$'\n'* || "$PR_TITLE" == *$'\r'* ||
+                ! "$PR_TITLE" =~ $conventional_title ]]; then
             echo '::error::Pull request title must follow <type>[optional scope][!]: <description>.'
             exit 1
           fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,10 +15,9 @@ Pull request titles must follow this form:
 <type>[optional scope][!]: <description>
 ```
 
-Supported types are `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`,
-`refactor`, `release`, `revert`, `style`, `test`. Use a lowercase scope when
-present. Start the description with a non-whitespace character and do not leave
-trailing whitespace. Examples:
+Use a lowercase type beginning with a letter and containing only letters,
+digits, and hyphens. Use a lowercase scope when present. Start the description
+with a non-whitespace character and do not leave trailing whitespace. Examples:
 
 ```text
 feat(cli): add component scan planning
@@ -29,14 +28,14 @@ feat(sdk)!: remove the legacy result field
 
 The title controls the generated release category:
 
-| Title                       | Release category |
-| --------------------------- | ---------------- |
-| Any supported type with `!` | Breaking changes |
-| `feat`                      | Features         |
-| `fix`                       | Fixes            |
-| `docs`                      | Documentation    |
-| `release`, `test`           | Excluded         |
-| Any other supported type    | Other changes    |
+| Title             | Release category |
+| ----------------- | ---------------- |
+| Any type with `!` | Breaking changes |
+| `feat`            | Features         |
+| `fix`             | Fixes            |
+| `docs`            | Documentation    |
+| `release`, `test` | Excluded         |
+| Any other type    | Other changes    |
 
 Use `release` and `test` only for changes that do not affect package users. A
 maintainer can apply `skip-release-notes` to exclude another internal change.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,11 @@
 # Releasing Codex Security
 
 [GitHub Releases](https://github.com/openai/codex-security/releases) is the
-canonical changelog. A release combines a short, reviewed summary with a
-categorized list of merged pull requests. The release tag and npm package use
-the same stable version: `npm-vX.Y.Z` and `@openai/codex-security@X.Y.Z`.
+canonical changelog. Under the current process, each new release combines a
+short, reviewed summary with a categorized list of merged pull requests.
+Historical releases may contain generated notes only. The release tag and npm
+package use the same stable version: `npm-vX.Y.Z` and
+`@openai/codex-security@X.Y.Z`.
 
 ## Pull request titles and categories
 
@@ -13,8 +15,10 @@ Pull request titles must follow this form:
 <type>[optional scope][!]: <description>
 ```
 
-Use a lowercase type and, when present, a lowercase scope. Start the description
-with a non-whitespace character and do not leave trailing whitespace. Examples:
+Supported types are `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`,
+`refactor`, `release`, `revert`, `style`, `test`. Use a lowercase scope when
+present. Start the description with a non-whitespace character and do not leave
+trailing whitespace. Examples:
 
 ```text
 feat(cli): add component scan planning
@@ -25,14 +29,14 @@ feat(sdk)!: remove the legacy result field
 
 The title controls the generated release category:
 
-| Title                | Release category |
-| -------------------- | ---------------- |
-| Any type with `!`    | Breaking changes |
-| `feat`               | Features         |
-| `fix`                | Fixes            |
-| `docs`               | Documentation    |
-| `release`, `test`    | Excluded         |
-| Any other valid type | Other changes    |
+| Title                       | Release category |
+| --------------------------- | ---------------- |
+| Any supported type with `!` | Breaking changes |
+| `feat`                      | Features         |
+| `fix`                       | Fixes            |
+| `docs`                      | Documentation    |
+| `release`, `test`           | Excluded         |
+| Any other supported type    | Other changes    |
 
 Use `release` and `test` only for changes that do not affect package users. A
 maintainer can apply `skip-release-notes` to exclude another internal change.
@@ -83,8 +87,9 @@ Check the published state before announcing the release:
 - The GitHub release is stable, has the correct title, and contains exactly one
   verified package archive.
 - The newest version is marked Latest. A historical backfill is not.
-- The reviewed highlights, category headings, documentation links, and full
-  comparison link are correct.
+- For releases created under this process, the reviewed highlights, category
+  headings, documentation links, and full comparison link are correct.
+  Historical releases may have generated notes only.
 - Every merged pull request is included or has an intentional
   `skip-release-notes` label.
 
@@ -101,13 +106,16 @@ provenance again before it creates or updates the release.
 
 To repair categories on an existing release, correct the merged pull request's
 title or release label first, then rerun `node-github-release` for the tag. For
-a release that predates `.github/release-notes.md`, place any reviewed summary
-between these markers before the rerun:
+a release that predates `.github/release-notes.md`, start the existing release
+body with this marker block. Keep a blank line between the end marker and the
+generated notes:
 
 ```text
 <!-- codex-security-release-summary:start -->
 Reviewed summary
 <!-- codex-security-release-summary:end -->
+
+Generated notes
 ```
 
 The workflow preserves that marked summary and replaces the generated section.

--- a/sdk/typescript/scripts/release-automation.mjs
+++ b/sdk/typescript/scripts/release-automation.mjs
@@ -38,6 +38,10 @@ export function releaseVersion(packageJson) {
   return packageJson.version;
 }
 
+function hasReviewedText(value) {
+  return !value.includes("\0") && /\S/u.test(value);
+}
+
 export function parseReviewedReleaseNotes(version, notes) {
   const expectedHeader = `<!-- release-version: ${version} -->`;
   const normalized =
@@ -47,7 +51,7 @@ export function parseReviewedReleaseNotes(version, notes) {
   if (
     firstNewline === -1 ||
     normalized.slice(0, firstNewline) !== expectedHeader ||
-    !/\S/u.test(summary)
+    !hasReviewedText(summary)
   ) {
     throw new Error(
       `Release notes must start with ${expectedHeader} and include a reviewed summary.`,
@@ -84,7 +88,7 @@ export function extractHistoricalReleaseSummary(notes) {
     .slice(startMarker.index + startMarker[0].length, endMarker.index)
     .replace(/^\r?\n/u, "")
     .replace(/\r?\n$/u, "");
-  if (!/\S/u.test(summary)) {
+  if (!hasReviewedText(summary)) {
     throw new Error("Existing release summary is empty.");
   }
   return summary;

--- a/sdk/typescript/scripts/release-automation.mjs
+++ b/sdk/typescript/scripts/release-automation.mjs
@@ -10,6 +10,8 @@ const provenancePredicate = "https://slsa.dev/provenance/v1";
 const publicNpmRegistry = "https://registry.npmjs.org/";
 const githubActionsOidcIssuer = "https://token.actions.githubusercontent.com";
 const fulcioExtensionPrefix = Buffer.from("2b0601040183bf3001", "hex");
+const releaseSummaryStart = "<!-- codex-security-release-summary:start -->";
+const releaseSummaryEnd = "<!-- codex-security-release-summary:end -->";
 
 function stableReleaseTagVersion(tag) {
   if (typeof tag !== "string" || !tag.startsWith("npm-v")) {
@@ -34,6 +36,99 @@ export function releaseVersion(packageJson) {
     throw new Error("Release package must have a stable X.Y.Z version.");
   }
   return packageJson.version;
+}
+
+export function parseReviewedReleaseNotes(version, notes) {
+  const expectedHeader = `<!-- release-version: ${version} -->`;
+  const normalized =
+    typeof notes === "string" ? notes.replace(/\n+$/u, "") : "";
+  const firstNewline = normalized.indexOf("\n");
+  const summary = normalized.slice(firstNewline + 1);
+  if (
+    firstNewline === -1 ||
+    normalized.slice(0, firstNewline) !== expectedHeader ||
+    !/\S/u.test(summary)
+  ) {
+    throw new Error(
+      `Release notes must start with ${expectedHeader} and include a reviewed summary.`,
+    );
+  }
+  return summary;
+}
+
+export function extractHistoricalReleaseSummary(notes) {
+  if (typeof notes !== "string") {
+    throw new Error("Existing release notes must be a string.");
+  }
+
+  const markers = [...notes.matchAll(/^[^\r\n]+$/gmu)].filter(
+    ([line]) => line === releaseSummaryStart || line === releaseSummaryEnd,
+  );
+  if (markers.length === 0 || markers[0]?.index !== 0) return null;
+
+  const [startMarker, endMarker] = markers;
+  if (
+    markers.length !== 2 ||
+    startMarker?.[0] !== releaseSummaryStart ||
+    endMarker?.[0] !== releaseSummaryEnd
+  ) {
+    throw new Error("Existing release summary markers are malformed.");
+  }
+
+  const remainder = notes.slice(endMarker.index + endMarker[0].length);
+  if (remainder !== "" && !/^(?:\r?\n){2}/u.test(remainder)) {
+    throw new Error("Existing release summary markers are malformed.");
+  }
+
+  const summary = notes
+    .slice(startMarker.index + startMarker[0].length, endMarker.index)
+    .replace(/^\r?\n/u, "")
+    .replace(/\r?\n$/u, "");
+  if (!/\S/u.test(summary)) {
+    throw new Error("Existing release summary is empty.");
+  }
+  return summary;
+}
+
+export function resolveReleaseSummary(version, taggedNotes, existingNotes) {
+  if (taggedNotes !== undefined) {
+    return parseReviewedReleaseNotes(version, taggedNotes);
+  }
+  if (existingNotes === undefined || existingNotes.length === 0) {
+    return null;
+  }
+  return extractHistoricalReleaseSummary(existingNotes);
+}
+
+export function composeReleaseNotes(generatedNotes, releaseSummary) {
+  if (releaseSummary === null || releaseSummary === "") {
+    return generatedNotes;
+  }
+  return [
+    releaseSummaryStart,
+    releaseSummary,
+    releaseSummaryEnd,
+    "",
+    generatedNotes,
+  ].join("\n");
+}
+
+function releaseNoteFileArguments(args) {
+  const files = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index];
+    const file = args[index + 1];
+    if (
+      file === undefined ||
+      (option !== "--tagged-notes-file" &&
+        option !== "--existing-notes-file") ||
+      files[option] !== undefined
+    ) {
+      throw new Error("Invalid release note file arguments.");
+    }
+    files[option] = file;
+  }
+  return files;
 }
 
 export function releaseTagVersion(refType, ref, refName, packageJson) {
@@ -780,6 +875,31 @@ function main() {
     return;
   }
 
+  if (command === "validate-release-notes" && process.argv.length === 5) {
+    const notes = readFileSync(process.argv[4], "utf8");
+    process.stdout.write(parseReviewedReleaseNotes(process.argv[3], notes));
+    return;
+  }
+
+  if (command === "compose-release-notes" && process.argv.length >= 5) {
+    const version = process.argv[3];
+    const generatedNotes = readFileSync(process.argv[4], "utf8");
+    const files = releaseNoteFileArguments(process.argv.slice(5));
+    const taggedNotes =
+      files["--tagged-notes-file"] === undefined
+        ? undefined
+        : readFileSync(files["--tagged-notes-file"], "utf8");
+    const existingNotes =
+      files["--existing-notes-file"] === undefined
+        ? undefined
+        : readFileSync(files["--existing-notes-file"], "utf8");
+    const summary = resolveReleaseSummary(version, taggedNotes, existingNotes);
+    process.stdout.write(
+      composeReleaseNotes(generatedNotes.replace(/\n+$/u, ""), summary),
+    );
+    return;
+  }
+
   if (command === "release-history" && process.argv.length === 4) {
     const registryVersions = JSON.parse(
       process.env.CODEX_SECURITY_PUBLISHED_NPM_VERSIONS ?? "[]",
@@ -890,6 +1010,10 @@ function main() {
       "require-published-increase <version> " +
       "(published npm versions JSON from stdin), " +
       "release-mode <version> (published npm versions JSON from stdin), " +
+      "validate-release-notes <version> <release-notes-file>, " +
+      "compose-release-notes <version> <generated-notes-file> " +
+      "[--tagged-notes-file <file>] " +
+      "[--existing-notes-file <file>], " +
       "release-history <tag>, " +
       "verify-publication <archive> <version> <git-head> " +
       "(package metadata JSON from stdin), " +

--- a/sdk/typescript/scripts/release-automation.mjs
+++ b/sdk/typescript/scripts/release-automation.mjs
@@ -888,6 +888,10 @@ function main() {
   if (command === "compose-release-notes" && process.argv.length >= 5) {
     const version = process.argv[3];
     const generatedNotes = readFileSync(process.argv[4], "utf8");
+    const normalizedGeneratedNotes = generatedNotes.replace(/(?:\r?\n)+$/u, "");
+    if (normalizedGeneratedNotes.length === 0) {
+      throw new Error("Generated GitHub release notes must not be empty.");
+    }
     const files = releaseNoteFileArguments(process.argv.slice(5));
     const taggedNotes =
       files["--tagged-notes-file"] === undefined
@@ -899,7 +903,7 @@ function main() {
         : readFileSync(files["--existing-notes-file"], "utf8");
     const summary = resolveReleaseSummary(version, taggedNotes, existingNotes);
     process.stdout.write(
-      composeReleaseNotes(generatedNotes.replace(/\n+$/u, ""), summary),
+      composeReleaseNotes(normalizedGeneratedNotes, summary),
     );
     return;
   }

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -458,7 +458,9 @@ function evaluateWorkflowCondition(
   condition: string,
   values: Record<string, string>,
 ): boolean {
-  let expression = condition;
+  let expression = condition
+    .replace(/^\$\{\{\s*/u, "")
+    .replace(/\s*\}\}$/u, "");
   for (const [identifier, value] of Object.entries(values).sort(
     ([left], [right]) => right.length - left.length,
   )) {
@@ -3871,6 +3873,287 @@ describe("GitHub release workflow safeguards", () => {
       "needs: [validate-title, windows-test, windows-verify]",
     );
   });
+
+  test("isolates body-only edits from full CI names and concurrency", () => {
+    const metadataOnly =
+      "github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null";
+    const metadataPrefix =
+      "${{ " + metadataOnly + " && 'metadata-only / ' || '' }}";
+    const workflow = Bun.YAML.parse(nodeCiWorkflow) as {
+      concurrency: {
+        group: string;
+        "cancel-in-progress": string;
+      };
+      jobs: Record<
+        string,
+        {
+          name: string;
+          if?: string;
+          strategy?: { matrix: Record<string, string[]> };
+          steps: Array<{ if?: string }>;
+        }
+      >;
+    };
+
+    expect(workflow.concurrency.group).toBe(
+      "${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}-${{ " +
+        metadataOnly +
+        " && 'metadata-only' || 'full' }}",
+    );
+    expect(workflow.concurrency["cancel-in-progress"]).toBe(
+      "${{ github.event_name == 'pull_request' && (github.event.action != 'edited' || github.event.changes.title != null || github.event.changes.base != null) }}",
+    );
+    for (const job of Object.values(workflow.jobs)) {
+      expect(job.name.startsWith(metadataPrefix), job.name).toBe(true);
+    }
+
+    const fullCiCondition =
+      "needs.validate-title.outputs.run-full-ci == 'true'";
+    for (const job of ["test", "windows-test", "windows-verify"]) {
+      expect(workflow.jobs[job]?.if).toBe(fullCiCondition);
+    }
+    const requiredJobCondition = `always() && !(${metadataOnly})`;
+    expect(workflow.jobs["required-test"]?.if).toBe(requiredJobCondition);
+    expect(workflow.jobs["windows"]?.if).toBe(requiredJobCondition);
+    expect(workflow.jobs["required-test"]?.steps[0]?.if).toBe(
+      "needs.validate-title.result != 'success' || needs.test.result != 'success'",
+    );
+    expect(workflow.jobs["windows"]?.steps[0]?.if).toBe(
+      "needs.validate-title.result != 'success' || needs.windows-test.result != 'success' || needs.windows-verify.result != 'success'",
+    );
+
+    const renderName = (
+      template: string,
+      values: Record<string, string>,
+      metadata: boolean,
+    ) => {
+      let name = template.replace(
+        metadataPrefix,
+        metadata ? "metadata-only / " : "",
+      );
+      for (const [key, value] of Object.entries(values)) {
+        name = name.replaceAll("${{ matrix." + key + " }}", value);
+      }
+      return name.replace(
+        "${{ matrix.node == '22.13.0' && '22' || matrix.node }}",
+        values["node"] === "22.13.0" ? "22" : values["node"] ?? "",
+      );
+    };
+    const unixJob = workflow.jobs["required-test"];
+    const windowsJob = workflow.jobs["windows"];
+    const fullNames = [
+      ...(unixJob?.strategy?.matrix["os"] ?? []).map((os) =>
+        renderName(unixJob?.name ?? "", { os }, false),
+      ),
+      ...(windowsJob?.strategy?.matrix["node"] ?? []).map((node) =>
+        renderName(windowsJob?.name ?? "", { node }, false),
+      ),
+    ];
+    const metadataNames = [
+      ...(unixJob?.strategy?.matrix["os"] ?? []).map((os) =>
+        renderName(unixJob?.name ?? "", { os }, true),
+      ),
+      ...(windowsJob?.strategy?.matrix["node"] ?? []).map((node) =>
+        renderName(windowsJob?.name ?? "", { node }, true),
+      ),
+    ];
+    const requiredContexts = new Set([
+      "ubuntu-latest / node-22",
+      "macos-latest / node-22",
+      "windows-latest / node-22",
+    ]);
+
+    expect(
+      fullNames.filter((name) => requiredContexts.has(name)).sort(),
+    ).toEqual([...requiredContexts].sort());
+    expect(metadataNames.some((name) => requiredContexts.has(name))).toBe(
+      false,
+    );
+    expect(
+      metadataNames.every((name) => name.startsWith("metadata-only / ")),
+    ).toBe(true);
+  });
+
+  test.each([
+    {
+      name: "body-only edit with a valid title",
+      eventName: "pull_request",
+      action: "edited",
+      titleChanged: false,
+      baseChanged: false,
+      title: "docs: clarify release notes",
+      fullCi: false,
+      titleValid: true,
+      upstream: "skipped",
+      gateFailure: false,
+      cancellation: false,
+    },
+    {
+      name: "body-only edit with an invalid title",
+      eventName: "pull_request",
+      action: "edited",
+      titleChanged: false,
+      baseChanged: false,
+      title: "Docs: invalid title ",
+      fullCi: false,
+      titleValid: false,
+      upstream: "skipped",
+      gateFailure: false,
+      cancellation: false,
+    },
+    {
+      name: "title edit",
+      eventName: "pull_request",
+      action: "edited",
+      titleChanged: true,
+      baseChanged: false,
+      title: "ci: update title",
+      fullCi: true,
+      titleValid: true,
+      upstream: "success",
+      gateFailure: false,
+      cancellation: true,
+    },
+    {
+      name: "base edit",
+      eventName: "pull_request",
+      action: "edited",
+      titleChanged: false,
+      baseChanged: true,
+      title: "ci: update base",
+      fullCi: true,
+      titleValid: true,
+      upstream: "success",
+      gateFailure: false,
+      cancellation: true,
+    },
+    {
+      name: "code synchronization",
+      eventName: "pull_request",
+      action: "synchronize",
+      titleChanged: false,
+      baseChanged: false,
+      title: "ci: update code",
+      fullCi: true,
+      titleValid: true,
+      upstream: "success",
+      gateFailure: false,
+      cancellation: true,
+    },
+    {
+      name: "push",
+      eventName: "push",
+      action: "none",
+      titleChanged: false,
+      baseChanged: false,
+      title: "",
+      fullCi: true,
+      titleValid: true,
+      upstream: "success",
+      gateFailure: false,
+      cancellation: false,
+    },
+    {
+      name: "full CI with skipped upstream jobs",
+      eventName: "pull_request",
+      action: "synchronize",
+      titleChanged: false,
+      baseChanged: false,
+      title: "ci: update code",
+      fullCi: true,
+      titleValid: true,
+      upstream: "skipped",
+      gateFailure: true,
+      cancellation: true,
+    },
+  ])(
+    "keeps required contexts truthful for $name",
+    ({
+      eventName,
+      action,
+      titleChanged,
+      baseChanged,
+      title,
+      fullCi,
+      titleValid,
+      upstream,
+      gateFailure,
+      cancellation,
+    }) => {
+      const workflow = Bun.YAML.parse(nodeCiWorkflow) as {
+        concurrency: { "cancel-in-progress": string };
+        jobs: Record<string, { steps: Array<{ if?: string }> }>;
+      };
+      const scopeScript = workflowStepShell(
+        nodeCiWorkflow,
+        "Decide whether full CI is needed",
+      );
+      const titleScript = workflowStepShell(
+        nodeCiWorkflow,
+        "Require a Conventional Commit pull request title",
+      );
+      const workspace = mkdtempSync(join(tmpdir(), "release-ci-scope-"));
+      const output = join(workspace, "output");
+      try {
+        const scope = spawnSync(bash, ["-c", scopeScript], {
+          env: {
+            ...process.env,
+            BASE_CHANGED: String(baseChanged),
+            EVENT_ACTION: action === "none" ? "" : action,
+            EVENT_NAME: eventName,
+            GITHUB_OUTPUT: output,
+            TITLE_CHANGED: String(titleChanged),
+          },
+        });
+        expect(scope.status).toBe(0);
+        expect(readFileSync(output, "utf8")).toBe(
+          `run-full-ci=${String(fullCi)}\n`,
+        );
+
+        const validation =
+          eventName === "pull_request"
+            ? spawnSync(bash, ["-c", titleScript], {
+                env: { ...process.env, PR_TITLE: title },
+              }).status === 0
+              ? "success"
+              : "failure"
+            : "success";
+        expect(validation === "success").toBe(titleValid);
+
+        const values = {
+          "needs.test.result": upstream,
+          "needs.validate-title.result": validation,
+          "needs.windows-test.result": upstream,
+          "needs.windows-verify.result": upstream,
+        };
+        const unixGate = workflow.jobs["required-test"]?.steps[0]?.if ?? "";
+        const windowsGate = workflow.jobs["windows"]?.steps[0]?.if ?? "";
+        if (fullCi) {
+          expect(evaluateWorkflowCondition(unixGate, values)).toBe(gateFailure);
+          expect(evaluateWorkflowCondition(windowsGate, values)).toBe(
+            gateFailure,
+          );
+        } else {
+          expect(unixGate).toBeDefined();
+          expect(windowsGate).toBeDefined();
+        }
+
+        expect(
+          evaluateWorkflowCondition(
+            workflow.concurrency["cancel-in-progress"],
+            {
+              "github.event.changes.base": baseChanged ? "changed" : "null",
+              "github.event.changes.title": titleChanged ? "changed" : "null",
+              "github.event.action": action,
+              "github.event_name": eventName,
+            },
+          ),
+        ).toBe(cancellation);
+      } finally {
+        rmSync(workspace, { recursive: true, force: true });
+      }
+    },
+  );
 
   test("documents supported title types semantically", () => {
     expect(documentedTitleTypes(releasingGuide)).toEqual(

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -232,21 +232,6 @@ const releasingGuide = readFileSync(
   new URL("../../../RELEASING.md", import.meta.url),
   "utf8",
 );
-const supportedTitleTypes = [
-  "build",
-  "chore",
-  "ci",
-  "docs",
-  "feat",
-  "fix",
-  "perf",
-  "refactor",
-  "release",
-  "revert",
-  "style",
-  "test",
-] as const;
-
 function publishedMetadata(): ReleaseMetadata {
   return {
     name: "@openai/codex-security",
@@ -478,33 +463,6 @@ function evaluateWorkflowCondition(
     throw new Error(`Could not evaluate workflow condition: ${condition}`);
   }
   return result.status === 0;
-}
-
-function documentedTitleTypes(guide: string): Set<string> {
-  const fencedBlocks = [
-    ...guide.matchAll(/^```[^\r\n]*\r?\n[\s\S]*?^```[ \t]*$/gmu),
-  ];
-  const syntaxBlockIndex = fencedBlocks.findIndex(
-    ([block]) => block.includes("<type>") && block.includes("<description>"),
-  );
-  const syntaxBlock = fencedBlocks[syntaxBlockIndex];
-  const examplesBlock = fencedBlocks[syntaxBlockIndex + 1];
-  if (
-    !syntaxBlock ||
-    !examplesBlock ||
-    syntaxBlock.index === undefined ||
-    examplesBlock.index === undefined
-  ) {
-    throw new Error("Expected title syntax and examples blocks.");
-  }
-  const guidance = guide.slice(
-    syntaxBlock.index + syntaxBlock[0].length,
-    examplesBlock.index,
-  );
-
-  return new Set(
-    [...guidance.matchAll(/`([a-z][a-z0-9-]*)`/gu)].map((match) => match[1]!),
-  );
 }
 
 describe("reviewed release note helpers", () => {
@@ -3932,10 +3890,6 @@ describe("GitHub release workflow safeguards", () => {
     expect(releasePattern).toBeDefined();
     expect(ciPattern).toBe(releasePattern);
     expect(titlePattern).toBe(releasePattern);
-    const typeGroup = /^\^\(([^)]+)\)/u.exec(releasePattern ?? "")?.[1];
-    expect(new Set(typeGroup?.split("|") ?? [])).toEqual(
-      new Set(supportedTitleTypes),
-    );
     expect(nodeCiWorkflow).toContain(
       "types: [opened, edited, reopened, synchronize]",
     );
@@ -4226,12 +4180,6 @@ describe("GitHub release workflow safeguards", () => {
     },
   );
 
-  test("documents supported title types semantically", () => {
-    expect(documentedTitleTypes(releasingGuide)).toEqual(
-      new Set(supportedTitleTypes),
-    );
-  });
-
   test("documents a canonical historical-summary prefix block", () => {
     const start = "<!-- codex-security-release-summary:start -->";
     const end = "<!-- codex-security-release-summary:end -->";
@@ -4253,7 +4201,6 @@ describe("GitHub release workflow safeguards", () => {
   });
 
   test.each([
-    "banana: use an unsupported type",
     "fix: generated title\n<!-- codex-security-release-summary:start -->\nUnreviewed injected highlight\n<!-- codex-security-release-summary:end -->",
     "fix: preserve a trailing line feed\n",
     "fix: preserve a trailing carriage return\r",
@@ -4271,6 +4218,23 @@ describe("GitHub release workflow safeguards", () => {
   });
 
   test.each([
+    "security: preserve an existing title type",
+    "deps(api)!: upgrade a dependency",
+    "dependency-update2: refresh release tooling",
+  ])("active title gates accept previously valid title %s", (title) => {
+    for (const [workflow, step] of [
+      [nodeCiWorkflow, "Require a Conventional Commit pull request title"],
+      [titleWorkflow, "Check conventional title"],
+    ] as const) {
+      expect(
+        spawnSync(bash, ["-c", workflowStepShell(workflow, step)], {
+          env: { ...process.env, PR_TITLE: title },
+        }).status,
+      ).toBe(0);
+    }
+  });
+
+  test.each([
     "[codex] Add a scan feature",
     "Feat: use an uppercase type",
     "feat(): use an empty scope",
@@ -4279,7 +4243,6 @@ describe("GitHub release workflow safeguards", () => {
     "feat:  use two separator spaces",
     "feat: leave trailing whitespace ",
     "feat:",
-    "banana: use an unsupported type",
     "fix: generated title\n<!-- codex-security-release-summary:start -->\nUnreviewed injected highlight\n<!-- codex-security-release-summary:end -->",
     "fix: preserve a trailing line feed\n",
     "fix: preserve a trailing carriage return\r",
@@ -4470,6 +4433,8 @@ describe("GitHub release workflow safeguards", () => {
     { title: "fix: publish a customer fix", label: "bug" },
     { title: "docs: publish customer documentation", label: "documentation" },
     { title: "chore: stop excluding an internal change", label: null },
+    { title: "security: publish a security fix", label: null },
+    { title: "deps: upgrade a dependency", label: null },
   ])(
     "reconciles an automatic skip label after retitling to $title",
     ({ title, label }) => {
@@ -4544,6 +4509,10 @@ describe("GitHub release workflow safeguards", () => {
     { title: "docs!: breaking documentation", label: "breaking-change" },
     {
       title: "docs(api)!: breaking documentation",
+      label: "breaking-change",
+    },
+    {
+      title: "security(api)!: breaking security change",
       label: "breaking-change",
     },
   ])("categorizes breaking-change title $title", ({ title, label }) => {

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -16,6 +16,17 @@ import { bashCommand } from "./support/shell.js";
 type ReleaseMetadata = Record<string, unknown>;
 
 type ReleaseAutomation = {
+  parseReviewedReleaseNotes: (version: string, notes: string) => string;
+  extractHistoricalReleaseSummary: (notes: string) => string | null;
+  resolveReleaseSummary: (
+    version: string,
+    taggedNotes: string | undefined,
+    existingNotes: string | undefined,
+  ) => string | null;
+  composeReleaseNotes: (
+    generatedNotes: string,
+    releaseSummary: string | null,
+  ) => string;
   releaseVersion: (packageJson: ReleaseMetadata) => string;
   releaseTagVersion: (
     refType: string,
@@ -122,6 +133,10 @@ const automationScript = new URL(
   import.meta.url,
 );
 const {
+  parseReviewedReleaseNotes,
+  extractHistoricalReleaseSummary,
+  resolveReleaseSummary,
+  composeReleaseNotes,
   releaseVersion,
   releaseTagVersion,
   compareReleaseVersions,
@@ -213,6 +228,24 @@ const titleWorkflow = readFileSync(
   new URL("../../../.github/workflows/validate-pr-title.yml", import.meta.url),
   "utf8",
 );
+const releasingGuide = readFileSync(
+  new URL("../../../RELEASING.md", import.meta.url),
+  "utf8",
+);
+const supportedTitleTypes = [
+  "build",
+  "chore",
+  "ci",
+  "docs",
+  "feat",
+  "fix",
+  "perf",
+  "refactor",
+  "release",
+  "revert",
+  "style",
+  "test",
+] as const;
 
 function publishedMetadata(): ReleaseMetadata {
   return {
@@ -401,10 +434,13 @@ function workflowStepShell(workflow: string, stepName: string): string {
   }
 
   const nextStep = workflow.indexOf("\n      - name: ", stepStart + 1);
-  const step = workflow.slice(
-    stepStart,
-    nextStep === -1 ? undefined : nextStep,
-  );
+  const following = workflow.slice(stepStart + 1);
+  const nextJobOffset = following.search(/\n  [a-z0-9_-]+:\n/u);
+  const nextJob = nextJobOffset === -1 ? -1 : stepStart + 1 + nextJobOffset;
+  const stepEnd = [nextStep, nextJob]
+    .filter((index) => index !== -1)
+    .reduce((earlier, index) => Math.min(earlier, index), workflow.length);
+  const step = workflow.slice(stepStart, stepEnd);
   const runMarker = "        run: |\n";
   const runStart = step.indexOf(runMarker);
   if (runStart === -1) {
@@ -417,6 +453,188 @@ function workflowStepShell(workflow: string, stepName: string): string {
     .map((line) => (line.startsWith("          ") ? line.slice(10) : line))
     .join("\n");
 }
+
+function evaluateWorkflowCondition(
+  condition: string,
+  values: Record<string, string>,
+): boolean {
+  let expression = condition;
+  for (const [identifier, value] of Object.entries(values).sort(
+    ([left], [right]) => right.length - left.length,
+  )) {
+    if (!/^[a-z0-9_/-]+$/u.test(value)) {
+      throw new Error(`Unsafe workflow test value: ${value}`);
+    }
+    expression = expression.replaceAll(identifier, `'${value}'`);
+  }
+  if (!/^[\s()'/a-z0-9_!=&|-]+$/u.test(expression)) {
+    throw new Error(`Unsupported workflow condition: ${condition}`);
+  }
+
+  const result = spawnSync(bash, ["-c", `[[ ${expression} ]]`]);
+  if (result.status !== 0 && result.status !== 1) {
+    throw new Error(`Could not evaluate workflow condition: ${condition}`);
+  }
+  return result.status === 0;
+}
+
+function documentedTitleTypes(guide: string): Set<string> {
+  const fencedBlocks = [
+    ...guide.matchAll(/^```[^\r\n]*\r?\n[\s\S]*?^```[ \t]*$/gmu),
+  ];
+  const syntaxBlockIndex = fencedBlocks.findIndex(
+    ([block]) => block.includes("<type>") && block.includes("<description>"),
+  );
+  const syntaxBlock = fencedBlocks[syntaxBlockIndex];
+  const examplesBlock = fencedBlocks[syntaxBlockIndex + 1];
+  if (
+    !syntaxBlock ||
+    !examplesBlock ||
+    syntaxBlock.index === undefined ||
+    examplesBlock.index === undefined
+  ) {
+    throw new Error("Expected title syntax and examples blocks.");
+  }
+  const guidance = guide.slice(
+    syntaxBlock.index + syntaxBlock[0].length,
+    examplesBlock.index,
+  );
+
+  return new Set(
+    [...guidance.matchAll(/`([a-z][a-z0-9-]*)`/gu)].map((match) => match[1]!),
+  );
+}
+
+describe("reviewed release note helpers", () => {
+  test.each([
+    {
+      name: "one-line summary",
+      notes: "<!-- release-version: 1.2.3 -->\nReviewed summary\n",
+      summary: "Reviewed summary",
+    },
+    {
+      name: "multiline summary with trailing newlines",
+      notes: "<!-- release-version: 1.2.3 -->\n## Highlights\n\nDetails\n\n",
+      summary: "## Highlights\n\nDetails",
+    },
+  ])("parses $name", ({ notes, summary }) => {
+    expect(parseReviewedReleaseNotes("1.2.3", notes)).toBe(summary);
+  });
+
+  test.each([
+    ["missing header", "Reviewed summary"],
+    ["mismatched version", "<!-- release-version: 1.2.2 -->\nSummary"],
+    ["missing body", "<!-- release-version: 1.2.3 -->"],
+    ["blank body", "<!-- release-version: 1.2.3 -->\n \t\n"],
+  ])("rejects %s", (_name, notes) => {
+    expect(() => parseReviewedReleaseNotes("1.2.3", notes)).toThrow(
+      "Release notes must start with <!-- release-version: 1.2.3 --> and include a reviewed summary.",
+    );
+  });
+
+  test.each([
+    {
+      name: "canonical prefix marker pair",
+      notes:
+        "<!-- codex-security-release-summary:start -->\nHistorical summary\n<!-- codex-security-release-summary:end -->\n\nGenerated",
+      summary: "Historical summary",
+    },
+    {
+      name: "CRLF standalone marker pair",
+      notes:
+        "<!-- codex-security-release-summary:start -->\r\nHistorical summary\r\n<!-- codex-security-release-summary:end -->\r\n\r\nGenerated",
+      summary: "Historical summary",
+    },
+    {
+      name: "marker-like inline substrings",
+      notes:
+        "<!-- codex-security-release-summary:start -->\nHistorical <!-- codex-security-release-summary:start --> summary\n<!-- codex-security-release-summary:end -->\n\nGenerated <!-- codex-security-release-summary:end -->",
+      summary:
+        "Historical <!-- codex-security-release-summary:start --> summary",
+    },
+    {
+      name: "inline markers in generated notes",
+      notes:
+        "* fix: <!-- codex-security-release-summary:start -->Unreviewed<!-- codex-security-release-summary:end --> by @contributor",
+      summary: null,
+    },
+    {
+      name: "standalone markers outside the canonical prefix",
+      notes:
+        "* fix: generated title\n<!-- codex-security-release-summary:start -->\nUnreviewed\n<!-- codex-security-release-summary:end -->",
+      summary: null,
+    },
+    {
+      name: "no marker pair",
+      notes: "Generated only",
+      summary: null,
+    },
+  ])("extracts $name", ({ notes, summary }) => {
+    expect(extractHistoricalReleaseSummary(notes)).toBe(summary);
+  });
+
+  test.each([
+    [
+      "missing end marker",
+      "<!-- codex-security-release-summary:start -->\nSummary",
+      "Existing release summary markers are malformed.",
+    ],
+    [
+      "duplicate marker pair after a blank line",
+      "<!-- codex-security-release-summary:start -->\nFirst\n<!-- codex-security-release-summary:end -->\n\n<!-- codex-security-release-summary:start -->\nSecond\n<!-- codex-security-release-summary:end -->",
+      "Existing release summary markers are malformed.",
+    ],
+    [
+      "extra standalone marker after the canonical pair",
+      "<!-- codex-security-release-summary:start -->\nSummary\n<!-- codex-security-release-summary:end -->\n\nGenerated\n<!-- codex-security-release-summary:start -->",
+      "Existing release summary markers are malformed.",
+    ],
+    [
+      "generated notes without a blank separator",
+      "<!-- codex-security-release-summary:start -->\nSummary\n<!-- codex-security-release-summary:end -->\nGenerated",
+      "Existing release summary markers are malformed.",
+    ],
+    [
+      "blank historical summary",
+      "<!-- codex-security-release-summary:start -->\n \t\n<!-- codex-security-release-summary:end -->",
+      "Existing release summary is empty.",
+    ],
+  ])("rejects %s", (_name, notes, message) => {
+    expect(() => extractHistoricalReleaseSummary(notes)).toThrow(message);
+  });
+
+  test("prefers a tagged summary over malformed historical markers", () => {
+    expect(
+      resolveReleaseSummary(
+        "1.2.3",
+        "<!-- release-version: 1.2.3 -->\nTagged summary\n",
+        "<!-- codex-security-release-summary:start -->\nIncomplete",
+      ),
+    ).toBe("Tagged summary");
+  });
+
+  test("does not fall back when a tagged summary is invalid", () => {
+    expect(() =>
+      resolveReleaseSummary(
+        "1.2.3",
+        "<!-- release-version: 1.2.2 -->\nWrong version",
+        "<!-- codex-security-release-summary:start -->\nHistorical summary\n<!-- codex-security-release-summary:end -->",
+      ),
+    ).toThrow("Release notes must start with <!-- release-version: 1.2.3 -->");
+  });
+
+  test("composes reviewed and generated notes deterministically", () => {
+    expect(composeReleaseNotes("Generated notes", "Reviewed summary")).toBe(
+      "<!-- codex-security-release-summary:start -->\n" +
+        "Reviewed summary\n" +
+        "<!-- codex-security-release-summary:end -->\n\n" +
+        "Generated notes",
+    );
+    expect(composeReleaseNotes("Generated notes", null)).toBe(
+      "Generated notes",
+    );
+  });
+});
 
 describe("stable npm release versions", () => {
   test("accepts the official stable package and version", () => {
@@ -1483,6 +1701,30 @@ describe("GitHub release workflow safeguards", () => {
       message: "Release notes must start with <!-- release-version: 0.1.6 -->",
     },
     {
+      scenario: "a U+00A0-only reviewed summary",
+      summary: "<!-- release-version: 0.1.6 -->\n\u00a0",
+      status: 1,
+      message: "Release notes must start with <!-- release-version: 0.1.6 -->",
+    },
+    {
+      scenario: "a U+2007-only reviewed summary",
+      summary: "<!-- release-version: 0.1.6 -->\n\u2007",
+      status: 1,
+      message: "Release notes must start with <!-- release-version: 0.1.6 -->",
+    },
+    {
+      scenario: "a U+202F-only reviewed summary",
+      summary: "<!-- release-version: 0.1.6 -->\n\u202f",
+      status: 1,
+      message: "Release notes must start with <!-- release-version: 0.1.6 -->",
+    },
+    {
+      scenario: "a U+FEFF-only reviewed summary",
+      summary: "<!-- release-version: 0.1.6 -->\n\ufeff",
+      status: 1,
+      message: "Release notes must start with <!-- release-version: 0.1.6 -->",
+    },
+    {
       scenario: "a matching reviewed summary",
       summary: "<!-- release-version: 0.1.6 -->\nReviewed summary",
       status: 0,
@@ -1502,6 +1744,7 @@ describe("GitHub release workflow safeguards", () => {
         "}",
       ].join("\n");
       const result = spawnSync(bash, ["-c", `${mock}\n${script}`], {
+        cwd: fileURLToPath(new URL("../../../", import.meta.url)),
         encoding: "utf8",
         env: {
           ...process.env,
@@ -1539,6 +1782,62 @@ describe("GitHub release workflow safeguards", () => {
     expect(releaseCutWorkflow).toContain(
       "npm view @openai/codex-security versions",
     );
+  });
+
+  test.each([
+    {
+      name: "successful push on main",
+      eventName: "workflow_run",
+      sourceEvent: "push",
+      conclusion: "success",
+      headBranch: "main",
+      expected: true,
+    },
+    {
+      name: "pull request from a branch named main",
+      eventName: "workflow_run",
+      sourceEvent: "pull_request",
+      conclusion: "success",
+      headBranch: "main",
+      expected: false,
+    },
+    {
+      name: "failed push on main",
+      eventName: "workflow_run",
+      sourceEvent: "push",
+      conclusion: "failure",
+      headBranch: "main",
+      expected: false,
+    },
+    {
+      name: "successful push on another branch",
+      eventName: "workflow_run",
+      sourceEvent: "push",
+      conclusion: "success",
+      headBranch: "release",
+      expected: false,
+    },
+    {
+      name: "manual dispatch",
+      eventName: "workflow_dispatch",
+      sourceEvent: "none",
+      conclusion: "none",
+      headBranch: "none",
+      expected: true,
+    },
+  ])("gates release cutting for $name", (scenario) => {
+    const workflow = Bun.YAML.parse(releaseCutWorkflow) as {
+      jobs: { cut: { if: string } };
+    };
+    expect(
+      evaluateWorkflowCondition(workflow.jobs.cut.if, {
+        "github.event.workflow_run.conclusion": scenario.conclusion,
+        "github.event.workflow_run.head_branch": scenario.headBranch,
+        "github.event.workflow_run.event": scenario.sourceEvent,
+        "github.event_name": scenario.eventName,
+        "github.repository": "openai/codex-security",
+      }),
+    ).toBe(scenario.expected);
   });
 
   test("executes the manual release cut against all published versions", () => {
@@ -2693,6 +2992,7 @@ describe("GitHub release workflow safeguards", () => {
       ].join("\n");
       const result = spawnSync(bash, [], {
         input: `${mocks}\n${script}`,
+        cwd: fileURLToPath(new URL("../../../", import.meta.url)),
         encoding: "utf8",
         env: {
           ...process.env,
@@ -2931,6 +3231,62 @@ describe("GitHub release workflow safeguards", () => {
       status: 0,
     },
     {
+      description: "CRLF historical summary marker block",
+      existingNotes:
+        "<!-- codex-security-release-summary:start -->\\r\\nPreserved historical summary\\r\\n<!-- codex-security-release-summary:end -->\\r\\n\\r\\nStale generated notes",
+      expectedSummary: "Preserved historical summary",
+      updated: true,
+      latestTag: "npm-v0.1.3",
+      makeLatest: false,
+      latestUpdated: false,
+      tagType: "commit",
+      tagObject: releaseCommit,
+      peeledCommit: "",
+      status: 0,
+    },
+    {
+      description: "inline marker-like substrings in generated notes",
+      existingNotes:
+        "* fix: <!-- codex-security-release-summary:start -->Unreviewed injected highlight<!-- codex-security-release-summary:end --> by @contributor",
+      excludedSummary: "Unreviewed injected highlight",
+      updated: true,
+      latestTag: "npm-v0.1.3",
+      makeLatest: false,
+      latestUpdated: false,
+      tagType: "commit",
+      tagObject: releaseCommit,
+      peeledCommit: "",
+      status: 0,
+    },
+    {
+      description: "standalone marker pair outside the canonical prefix",
+      existingNotes:
+        "* fix: generated title\\n<!-- codex-security-release-summary:start -->\\nUnreviewed injected highlight\\n<!-- codex-security-release-summary:end -->",
+      excludedSummary: "Unreviewed injected highlight",
+      updated: true,
+      latestTag: "npm-v0.1.3",
+      makeLatest: false,
+      latestUpdated: false,
+      tagType: "commit",
+      tagObject: releaseCommit,
+      peeledCommit: "",
+      status: 0,
+    },
+    {
+      description: "duplicate standalone marker pair after a blank line",
+      existingNotes:
+        "<!-- codex-security-release-summary:start -->\\nFirst\\n<!-- codex-security-release-summary:end -->\\n\\n<!-- codex-security-release-summary:start -->\\nSecond\\n<!-- codex-security-release-summary:end -->",
+      expectedError: "Existing release summary markers are malformed.",
+      updated: false,
+      latestTag: "npm-v0.1.3",
+      makeLatest: false,
+      latestUpdated: false,
+      tagType: "commit",
+      tagObject: releaseCommit,
+      peeledCommit: "",
+      status: 1,
+    },
+    {
       description: "generated notes without its tagged reviewed summary",
       existingNotes: "Generated release notes",
       releaseSummary:
@@ -3095,6 +3451,7 @@ describe("GitHub release workflow safeguards", () => {
       releaseConfiguration = true,
       releaseSummary = "__missing__",
       expectedSummary,
+      excludedSummary,
       expectedError,
       tagType,
       tagObject,
@@ -3213,6 +3570,7 @@ describe("GitHub release workflow safeguards", () => {
         "  fi",
         '  if [[ "$1" == "show" &&',
         '        "$2" == "$RELEASE_SHA:.github/release-notes.md" ]]; then',
+        '    if [[ "$MOCK_RELEASE_SUMMARY" == "__missing__" ]]; then return 1; fi',
         "    printf '%s\\n' \"$MOCK_RELEASE_SUMMARY\"",
         "    return",
         "  fi",
@@ -3230,6 +3588,7 @@ describe("GitHub release workflow safeguards", () => {
       ].join("\n");
       const result = spawnSync(bash, [], {
         input: `${mocks}\n${script}`,
+        cwd: fileURLToPath(new URL("../../../", import.meta.url)),
         encoding: "utf8",
         env: {
           ...process.env,
@@ -3274,6 +3633,9 @@ describe("GitHub release workflow safeguards", () => {
         return;
       }
       if (updated) {
+        if (excludedSummary !== undefined) {
+          expect(result.stdout).not.toContain(excludedSummary);
+        }
         if (expectedSummary !== undefined) {
           expect(result.stdout).toContain(expectedSummary);
           expect(result.stdout).toContain("Generated release notes");
@@ -3297,6 +3659,76 @@ describe("GitHub release workflow safeguards", () => {
           "The verified GitHub Release already exists.",
         );
       }
+    },
+  );
+
+  test("routes release-note validation through the shared helper", () => {
+    expect(protectedReleaseWorkflow).toContain("validate-release-notes");
+    expect(releaseCutWorkflow).toContain("validate-release-notes");
+    expect(githubReleaseWorkflow).toContain("compose-release-notes");
+    expect(protectedReleaseWorkflow).not.toContain("summary_header=");
+    expect(releaseCutWorkflow).not.toContain("summary_header=");
+    expect(githubReleaseWorkflow).not.toContain("CODEX_SECURITY_SUMMARY_START");
+  });
+
+  test.each([
+    {
+      description: "no optional note files",
+      arraySetup: "release_note_args=()",
+      optionalArguments: [],
+    },
+    {
+      description: "quoted note-file paths",
+      arraySetup: [
+        'tagged_notes_file="/tmp/tagged notes.md"',
+        'existing_notes_file="/tmp/existing notes.md"',
+        "release_note_args=(",
+        '  --tagged-notes-file "$tagged_notes_file"',
+        '  --existing-notes-file "$existing_notes_file"',
+        ")",
+      ].join("\n"),
+      optionalArguments: [
+        "--tagged-notes-file",
+        "/tmp/tagged notes.md",
+        "--existing-notes-file",
+        "/tmp/existing notes.md",
+      ],
+    },
+  ])(
+    "passes $description to release-note composition under nounset",
+    ({ arraySetup, optionalArguments }) => {
+      const publishStep = workflowStepShell(
+        githubReleaseWorkflow,
+        "Publish GitHub Release and generated notes",
+      );
+      const composeCommand = publishStep.match(
+        /published_notes="\$\(\n(?<command>[\s\S]*?)\n\)"/u,
+      )?.groups?.["command"];
+      expect(composeCommand).toBeDefined();
+
+      const result = spawnSync(bash, [], {
+        input: [
+          "set -u",
+          arraySetup,
+          'generated_notes_file="/tmp/generated notes.md"',
+          "node() { printf '<%s>\\n' \"$@\"; }",
+          composeCommand ?? "exit 70",
+        ].join("\n"),
+        encoding: "utf8",
+        env: { ...process.env, RELEASE_VERSION: "0.1.2" },
+        timeout: 10_000,
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout.trim().split("\n")).toEqual(
+        [
+          "sdk/typescript/scripts/release-automation.mjs",
+          "compose-release-notes",
+          "0.1.2",
+          "/tmp/generated notes.md",
+          ...optionalArguments,
+        ].map((argument) => `<${argument}>`),
+      );
     },
   );
 
@@ -3351,6 +3783,10 @@ describe("GitHub release workflow safeguards", () => {
     expect(releasePattern).toBeDefined();
     expect(ciPattern).toBe(releasePattern);
     expect(titlePattern).toBe(releasePattern);
+    const typeGroup = /^\^\(([^)]+)\)/u.exec(releasePattern ?? "")?.[1];
+    expect(new Set(typeGroup?.split("|") ?? [])).toEqual(
+      new Set(supportedTitleTypes),
+    );
     expect(nodeCiWorkflow).toContain(
       "types: [opened, edited, reopened, synchronize]",
     );
@@ -3358,6 +3794,50 @@ describe("GitHub release workflow safeguards", () => {
     expect(nodeCiWorkflow).toContain(
       "needs: [validate-title, windows-test, windows-verify]",
     );
+  });
+
+  test("documents supported title types semantically", () => {
+    expect(documentedTitleTypes(releasingGuide)).toEqual(
+      new Set(supportedTitleTypes),
+    );
+  });
+
+  test("documents a canonical historical-summary prefix block", () => {
+    const start = "<!-- codex-security-release-summary:start -->";
+    const end = "<!-- codex-security-release-summary:end -->";
+    const recovery = releasingGuide.slice(
+      releasingGuide.indexOf("## Recover or repair a release"),
+    );
+    const markerBlock =
+      [...recovery.matchAll(/^```text\r?\n([\s\S]*?)^```[ \t]*$/gmu)]
+        .find(
+          (match) => match[1]?.includes(start) && match[1]?.includes(end),
+        )?.[1]
+        ?.replaceAll("\r\n", "\n") ?? "";
+
+    expect(markerBlock.startsWith(`${start}\n`)).toBe(true);
+    expect(markerBlock).toContain(`${end}\n\n`);
+    expect(extractHistoricalReleaseSummary(markerBlock)).toBe(
+      "Reviewed summary",
+    );
+  });
+
+  test.each([
+    "banana: use an unsupported type",
+    "fix: generated title\n<!-- codex-security-release-summary:start -->\nUnreviewed injected highlight\n<!-- codex-security-release-summary:end -->",
+    "fix: preserve a trailing line feed\n",
+    "fix: preserve a trailing carriage return\r",
+  ])("active title gates reject %s", (title) => {
+    for (const [workflow, step] of [
+      [nodeCiWorkflow, "Require a Conventional Commit pull request title"],
+      [titleWorkflow, "Check conventional title"],
+    ] as const) {
+      expect(
+        spawnSync(bash, ["-c", workflowStepShell(workflow, step)], {
+          env: { ...process.env, PR_TITLE: title },
+        }).status,
+      ).toBe(1);
+    }
   });
 
   test.each([
@@ -3369,6 +3849,10 @@ describe("GitHub release workflow safeguards", () => {
     "feat:  use two separator spaces",
     "feat: leave trailing whitespace ",
     "feat:",
+    "banana: use an unsupported type",
+    "fix: generated title\n<!-- codex-security-release-summary:start -->\nUnreviewed injected highlight\n<!-- codex-security-release-summary:end -->",
+    "fix: preserve a trailing line feed\n",
+    "fix: preserve a trailing carriage return\r",
   ])("rejects nonconventional pull request title %s", (title) => {
     const script = workflowStepShell(
       releaseLabelsWorkflow,
@@ -3379,7 +3863,7 @@ describe("GitHub release workflow safeguards", () => {
       '  if [[ "$1" != "api" ]]; then return 64; fi',
       "  shift",
       '  if [[ "$1" == "repos/test/codex-security/issues/17" ]]; then',
-      "    printf '%s\\n' \"$MOCK_PR_TITLE\"",
+      "    printf '%s' \"$MOCK_PR_TITLE\" | base64",
       "    return 0",
       "  fi",
       "  printf '%s\\n' 'unexpected label mutation'",
@@ -3432,7 +3916,7 @@ describe("GitHub release workflow safeguards", () => {
         "  shift",
         '  case "$method $endpoint" in',
         '    "GET repos/test/codex-security/issues/17")',
-        "      printf '%s\\n' \"$MOCK_PR_TITLE\"",
+        "      printf '%s' \"$MOCK_PR_TITLE\" | base64",
         "      ;;",
         '    "GET repos/test/codex-security/issues/17/labels")',
         "      printf '%s\\n' enhancement skip-release-notes",
@@ -3504,7 +3988,7 @@ describe("GitHub release workflow safeguards", () => {
       "  shift",
       '  case "$method $endpoint" in',
       '    "GET repos/test/codex-security/issues/17")',
-      "      printf '%s\\n' 'feat: customer-visible change'",
+      "      printf '%s' 'feat: customer-visible change' | base64",
       "      ;;",
       '    "GET repos/test/codex-security/issues/17/labels")',
       "      printf '%s\\n' skip-release-notes",
@@ -3570,7 +4054,7 @@ describe("GitHub release workflow safeguards", () => {
         "  shift",
         '  case "$method $endpoint" in',
         '    "GET repos/test/codex-security/issues/17")',
-        "      printf '%s\\n' \"$MOCK_PR_TITLE\"",
+        "      printf '%s' \"$MOCK_PR_TITLE\" | base64",
         "      ;;",
         '    "GET repos/test/codex-security/issues/17/labels")',
         "      printf '%s\\n' skip-release-notes",
@@ -3644,7 +4128,7 @@ describe("GitHub release workflow safeguards", () => {
       "  shift",
       '  case "$method $endpoint" in',
       '    "GET repos/test/codex-security/issues/17")',
-      "      printf '%s\\n' \"$MOCK_PR_TITLE\"",
+      "      printf '%s' \"$MOCK_PR_TITLE\" | base64",
       "      ;;",
       '    "GET repos/test/codex-security/issues/17/labels")',
       "      return 0",
@@ -3692,7 +4176,7 @@ describe("GitHub release workflow safeguards", () => {
       '  local endpoint="$1"',
       '  case "$method $endpoint" in',
       '    "GET repos/test/codex-security/issues/17")',
-      "      printf '%s\\n' 'release: automate published notes'",
+      "      printf '%s' 'release: automate published notes' | base64",
       "      ;;",
       '    "GET repos/test/codex-security/issues/17/labels")',
       "      return 0",

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -3031,7 +3031,7 @@ describe("GitHub release workflow safeguards", () => {
         "        printf '%s\\n' \"$MOCK_PEELED_COMMIT\"",
         "        ;;",
         '      "repos/test/codex-security/releases/generate-notes")',
-        "        printf '%s\\n' 'Generated release notes'",
+        "        printf '%s\\n' '{\"body\":\"Generated release notes\"}'",
         "        ;;",
         "      *) return 65 ;;",
         "    esac",
@@ -3081,7 +3081,9 @@ describe("GitHub release workflow safeguards", () => {
     expect(githubReleaseWorkflow).toContain(
       '"repos/$GITHUB_REPOSITORY/releases/generate-notes"',
     );
-    expect(githubReleaseWorkflow).toContain("--notes-file -");
+    expect(githubReleaseWorkflow).toContain(
+      '--notes-file "$published_notes_file"',
+    );
     expect(githubReleaseWorkflow).toContain('--latest="$MAKE_LATEST"');
     expect(githubReleaseWorkflow).toContain("release-history");
   });
@@ -3420,6 +3422,46 @@ describe("GitHub release workflow safeguards", () => {
       status: 0,
     },
     {
+      description: "already current with CRLF-equivalent generated notes",
+      existingNotes: "Generated release notes\\r\\n",
+      generatedNotes: "Generated release notes\r\n",
+      updated: false,
+      latestTag: "npm-v0.1.3",
+      makeLatest: false,
+      latestUpdated: false,
+      tagType: "commit",
+      tagObject: releaseCommit,
+      peeledCommit: "",
+      status: 0,
+    },
+    {
+      description: "already current with NUL-bearing generated notes",
+      existingNotes: "Generated release notes\\u0000",
+      generatedNotesBase64: "R2VuZXJhdGVkIHJlbGVhc2Ugbm90ZXMA",
+      updated: false,
+      latestTag: "npm-v0.1.3",
+      makeLatest: false,
+      latestUpdated: false,
+      tagType: "commit",
+      tagObject: releaseCommit,
+      peeledCommit: "",
+      status: 0,
+    },
+    {
+      description: "empty generated notes",
+      existingNotes: "Generated release notes",
+      generatedNotes: "",
+      expectedError: "Generated GitHub release notes must not be empty.",
+      updated: false,
+      latestTag: "npm-v0.1.3",
+      makeLatest: false,
+      latestUpdated: false,
+      tagType: "commit",
+      tagObject: releaseCommit,
+      peeledCommit: "",
+      status: 1,
+    },
+    {
       description:
         "already current on a release predating release-note configuration",
       existingNotes: "Generated release notes",
@@ -3536,6 +3578,8 @@ describe("GitHub release workflow safeguards", () => {
     "reconciles $description notes on an existing verified GitHub release",
     ({
       existingNotes,
+      generatedNotes = "Generated release notes\n",
+      generatedNotesBase64,
       updated,
       latestTag,
       makeLatest,
@@ -3602,7 +3646,7 @@ describe("GitHub release workflow safeguards", () => {
         "          printf '%s\\n' 'Could not find a configuration file at .github/release.yml' >&2",
         "          return 1",
         "        fi",
-        "        printf '%s\\n' 'Generated release notes'",
+        "        printf '%s' \"$MOCK_GENERATED_NOTES_RESPONSE\"",
         "        ;;",
         "      *) return 65 ;;",
         "    esac",
@@ -3624,8 +3668,13 @@ describe("GitHub release workflow safeguards", () => {
         "        ;;",
         "      edit)",
         "        shift",
-        "        local edit_latest= notes=0",
+        "        local edit_latest= notes_file= next_is_notes_file=false",
         '        for argument in "$@"; do',
+        '          if [[ "$next_is_notes_file" == true ]]; then',
+        '            notes_file="$argument"',
+        "            next_is_notes_file=false",
+        "            continue",
+        "          fi",
         '          if [[ "$argument" == "--verify-tag" ]]; then',
         "            printf '%s\\n' 'unknown flag: --verify-tag' >&2",
         "            return 67",
@@ -3633,13 +3682,15 @@ describe("GitHub release workflow safeguards", () => {
         '          if [[ "$argument" == --latest=* ]]; then',
         '            edit_latest="${argument#--latest=}"',
         "          fi",
-        '          if [[ "$argument" == "--notes-file" ]]; then notes=1; fi',
+        '          if [[ "$argument" == "--notes-file" ]]; then',
+        "            next_is_notes_file=true",
+        "          fi",
         "        done",
         '        if [[ "$edit_latest" != "$MOCK_MAKE_LATEST" ]]; then return 68; fi',
         "        printf 'updated latest: %s\\n' \"$edit_latest\"",
-        '        if [[ "$notes" == 1 ]]; then',
+        '        if [[ -n "$notes_file" ]]; then',
         "          printf '%s: ' 'updated release notes'",
-        "          cat",
+        '          cat "$notes_file"',
         "        fi",
         "        ;;",
         "      create) return 70 ;;",
@@ -3686,6 +3737,12 @@ describe("GitHub release workflow safeguards", () => {
           ...process.env,
           GITHUB_REPOSITORY: "test/codex-security",
           MAKE_LATEST: String(makeLatest),
+          MOCK_GENERATED_NOTES_RESPONSE: JSON.stringify({
+            body:
+              generatedNotesBase64 === undefined
+                ? generatedNotes
+                : Buffer.from(generatedNotesBase64, "base64").toString("utf8"),
+          }),
           MOCK_EXISTING_NOTES: existingNotes,
           MOCK_LATEST_TAG: latestTag,
           MOCK_MAKE_LATEST: String(makeLatest),
@@ -3794,7 +3851,7 @@ describe("GitHub release workflow safeguards", () => {
         "Publish GitHub Release and generated notes",
       );
       const composeCommand = publishStep.match(
-        /published_notes="\$\(\n(?<command>[\s\S]*?)\n\)"/u,
+        /(?<command>node sdk\/typescript\/scripts\/release-automation\.mjs \\\n\s+compose-release-notes \\\n[\s\S]*?) \\\n\s*> "\$published_notes_file"/u,
       )?.groups?.["command"];
       expect(composeCommand).toBeDefined();
 

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -526,10 +526,50 @@ describe("reviewed release note helpers", () => {
     ["mismatched version", "<!-- release-version: 1.2.2 -->\nSummary"],
     ["missing body", "<!-- release-version: 1.2.3 -->"],
     ["blank body", "<!-- release-version: 1.2.3 -->\n \t\n"],
+    ["NUL-only body", "<!-- release-version: 1.2.3 -->\n\0"],
+    ["NUL-bearing body", "<!-- release-version: 1.2.3 -->\nReviewed\0summary"],
   ])("rejects %s", (_name, notes) => {
     expect(() => parseReviewedReleaseNotes("1.2.3", notes)).toThrow(
       "Release notes must start with <!-- release-version: 1.2.3 --> and include a reviewed summary.",
     );
+  });
+
+  test("rejects NUL bytes before shell composition", () => {
+    const workspace = mkdtempSync(join(tmpdir(), "release-notes-nul-"));
+    try {
+      const taggedNotes = join(workspace, "tagged-notes.md");
+      const generatedNotes = join(workspace, "generated-notes.md");
+      writeFileSync(taggedNotes, "<!-- release-version: 1.2.3 -->\n\0\n");
+      writeFileSync(generatedNotes, "Generated release notes\n");
+
+      const result = spawnSync(
+        bash,
+        [
+          "-c",
+          [
+            "set -euo pipefail",
+            'published_notes="$(node "$AUTOMATION_SCRIPT" compose-release-notes 1.2.3 "$GENERATED_NOTES" --tagged-notes-file "$TAGGED_NOTES")"',
+            'printf "%s" "$published_notes"',
+          ].join("\n"),
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            AUTOMATION_SCRIPT: fileURLToPath(automationScript),
+            GENERATED_NOTES: generatedNotes,
+            TAGGED_NOTES: taggedNotes,
+          },
+          timeout: 10_000,
+        },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("include a reviewed summary");
+      expect(result.stderr).not.toContain("ignored null byte");
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
   });
 
   test.each([
@@ -597,6 +637,16 @@ describe("reviewed release note helpers", () => {
     [
       "blank historical summary",
       "<!-- codex-security-release-summary:start -->\n \t\n<!-- codex-security-release-summary:end -->",
+      "Existing release summary is empty.",
+    ],
+    [
+      "NUL-only historical summary",
+      "<!-- codex-security-release-summary:start -->\n\0\n<!-- codex-security-release-summary:end -->",
+      "Existing release summary is empty.",
+    ],
+    [
+      "NUL-bearing historical summary",
+      "<!-- codex-security-release-summary:start -->\nReviewed\0summary\n<!-- codex-security-release-summary:end -->",
       "Existing release summary is empty.",
     ],
   ])("rejects %s", (_name, notes, message) => {

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -3297,6 +3297,20 @@ describe("GitHub release workflow safeguards", () => {
       status: 0,
     },
     {
+      description: "CRLF marker-only body with a terminal line ending",
+      existingNotes:
+        "<!-- codex-security-release-summary:start -->\\r\\nPreserved historical summary\\r\\n<!-- codex-security-release-summary:end -->\\r\\n",
+      expectedSummary: "Preserved historical summary",
+      updated: true,
+      latestTag: "npm-v0.1.3",
+      makeLatest: false,
+      latestUpdated: false,
+      tagType: "commit",
+      tagObject: releaseCommit,
+      peeledCommit: "",
+      status: 0,
+    },
+    {
       description: "inline marker-like substrings in generated notes",
       existingNotes:
         "* fix: <!-- codex-security-release-summary:start -->Unreviewed injected highlight<!-- codex-security-release-summary:end --> by @contributor",

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -3337,6 +3337,20 @@ describe("GitHub release workflow safeguards", () => {
       status: 1,
     },
     {
+      description: "NUL-bearing historical summary",
+      existingNotes:
+        "<!-- codex-security-release-summary:start -->\\nReviewed\\u0000summary\\n<!-- codex-security-release-summary:end -->",
+      expectedError: "Existing release summary is empty.",
+      updated: false,
+      latestTag: "npm-v0.1.3",
+      makeLatest: false,
+      latestUpdated: false,
+      tagType: "commit",
+      tagObject: releaseCommit,
+      peeledCommit: "",
+      status: 1,
+    },
+    {
       description: "generated notes without its tagged reviewed summary",
       existingNotes: "Generated release notes",
       releaseSummary:
@@ -3368,6 +3382,18 @@ describe("GitHub release workflow safeguards", () => {
     {
       description: "already current",
       existingNotes: "Generated release notes",
+      updated: false,
+      latestTag: "npm-v0.1.3",
+      makeLatest: false,
+      latestUpdated: false,
+      tagType: "commit",
+      tagObject: releaseCommit,
+      peeledCommit: "",
+      status: 0,
+    },
+    {
+      description: "already current with trailing line feeds",
+      existingNotes: "Generated release notes\\n\\n",
       updated: false,
       latestTag: "npm-v0.1.3",
       makeLatest: false,

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -3980,6 +3980,12 @@ describe("GitHub release workflow safeguards", () => {
         "Categorize pull request without checking out its code",
       );
       const mock = [
+        "base64() {",
+        '  if [[ "${1:-}" == "--decode" ]]; then',
+        "    return 64",
+        "  fi",
+        '  command base64 "$@"',
+        "}",
         "gh() {",
         '  if [[ "$1" != "api" ]]; then return 64; fi',
         "  shift",

--- a/sdk/typescript/tests-ts/skeleton.test.ts
+++ b/sdk/typescript/tests-ts/skeleton.test.ts
@@ -103,8 +103,8 @@ describe("TypeScript package skeleton", () => {
 
   test("pins each Node.js minimum and preserves protected and latest LTS checks", async () => {
     const { jobs } = await workflow("node-ci.yml");
-    expect(jobs["test"]?.name).toBe(
-      "${{ matrix.os }} / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }}",
+    expect(jobs["test"]?.name).toContain(
+      "tests / ${{ matrix.os }} / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }}",
     );
     expect(jobs["test"]?.strategy?.matrix).toEqual({
       os: ["ubuntu-latest", "macos-latest"],
@@ -114,7 +114,11 @@ describe("TypeScript package skeleton", () => {
         node,
       })),
     });
-    expect(jobs["windows"]?.name).toBe(
+    expect(jobs["required-test"]?.name).toContain("${{ matrix.os }} / node-22");
+    expect(jobs["required-test"]?.strategy?.matrix).toEqual({
+      os: ["ubuntu-latest", "macos-latest"],
+    });
+    expect(jobs["windows"]?.name).toContain(
       "windows-latest / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }}",
     );
     expect(jobs["windows"]?.needs).toEqual([

--- a/sdk/typescript/tests-ts/workbench-scan-root-alias.test.ts
+++ b/sdk/typescript/tests-ts/workbench-scan-root-alias.test.ts
@@ -3,18 +3,13 @@ import { mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "bun:test";
+import { resolvePluginPython } from "../src/runtime.js";
 import { PLUGIN_ROOT } from "./plugin-root.js";
 
 test.skipIf(process.platform !== "win32")(
   "matches scan-root filters across Windows path aliases",
-  () => {
-    const python =
-      process.env["PYTHON"] ??
-      Bun.which("python3") ??
-      Bun.which("python") ??
-      Bun.which("py");
-    expect(python).not.toBeNull();
-    if (python === null) throw new Error("A Python interpreter is required.");
+  async () => {
+    const python = await resolvePluginPython();
 
     const root = realpathSync(
       mkdtempSync(join(tmpdir(), "codex-security-scan-root-case-")),


### PR DESCRIPTION
<!-- Use a Conventional Commit title: <type>[optional scope][!]: <description>. See RELEASING.md. -->

## Summary

Tighten release workflow validation so pull request titles, reviewed release notes, and successful CI runs are interpreted consistently across every active release path.

## Changes

- Centralize reviewed release-note validation, historical summary-marker parsing, and release-note composition in the existing release automation helper.
- Route protected npm publication, release cutting, and GitHub release composition through the shared release-note trust boundary while keeping historical recovery exempt.
- Preserve existing and generated GitHub release-note bytes through file-based composition, and normalize complete terminal CRLF/LF sequences before reconciliation.
- Preserve existing lowercase Conventional Commit title types and reject embedded or trailing line breaks without losing title bytes in the label workflow.
- Isolate body-only pull request edits from full CI concurrency and required context names while keeping title, base, code, and push events on the full matrix.
- Require workflow-run release cuts to follow a successful push-triggered `node-ci` run on `main`, while retaining the explicit manual-dispatch path.
- Document the existing lowercase title grammar and canonical leading marker block, with behavior-level regression coverage for custom title types, malformed, inline, duplicate, CRLF, Unicode-blank, and NUL-bearing inputs.
- Resolve a usable Python interpreter in the existing Windows scan-history regression instead of selecting a nonfunctional launcher alias.

## Testing

- Failing-first release/workflow regressions: 218 passed, 32 failed, 519 expectations on the merged baseline.
- Failing-first Unicode blank-summary regressions: 0 passed, 4 failed, 4 expectations before the protected publisher used the shared validator.
- Failing-first NUL regressions: 0 passed, 5 failed, 5 expectations; the shell proof reproduced a dropped NUL and empty reviewed-summary marker block.
- Failing-first historical-note NUL regression: 1 passed, 1 failed, 2 expectations; the repaired slice passed 2 tests with 0 failures and 4 expectations.
- Failing-first macOS decoder regression: 0 passed, 1 failed, 1 expectation; the repaired table slice passed 4 tests with 0 failures and 20 expectations.
- Failing-first body-edit concurrency regression: a hosted body-only edit cancelled 16 active Windows coverage jobs and failed both required Windows summaries; the local semantic gate failed 8 tests before the repair and passed all 8 with 60 expectations afterward.
- Failing-first terminal-CRLF recovery regression: 0 passed, 1 failed, 1 expectation; the repaired case passed with 5 expectations.
- Failing-first generated-note CRLF reconciliation regression: 0 passed, 1 failed, 3 expectations; the repaired case passed with 4 expectations.
- Failing-first generated-note NUL transport regression: 0 passed, 1 failed, 3 expectations; the repaired CRLF and NUL table slice passed 2 tests with 0 failures and 8 expectations.
- Failing-first title compatibility regressions: 10 passed, 6 failed before restoring existing custom title types across validation and release categorization.
- Focused release automation, package skeleton, and Windows scan-history suites: 289 passed, 1 expected Windows-only skip on macOS, 0 failed, 734 expectations.
- Python interpreter-resolution regressions: 3 passed, 2 expected Windows-only skips on macOS, 0 failed.
- Bash 3.2.57 optional-argument workflow fragments: 2 passed, 0 failed, 6 expectations.
- Formatting, TypeScript types, build, Node syntax, 10 YAML files, and `git diff --check`: passed.
- Full TypeScript suite: 1,733 passed, 28 expected skips, 0 failed, 22,245 expectations across 92 files.
- Package validation: packed `@openai/codex-security@0.1.18`; validated 265 archive entries, public import, NodeNext types, CLI, 113 bundled plugin files, bundled runtime, and nested-worker smoke behavior. The 1,224,544-byte tarball remained unchanged.

## Risk and rollout

The change affects release gating, CI scheduling, and note composition, so an incorrect rule could block a release. Table-driven workflow tests cover publish and recovery modes, cross-platform title decoding and parity, marker, NUL, and terminal-line-ending boundaries, existing-release reconciliation, and direct-tag publication. No dependency or package payload changes are introduced.

## Public disclosure review

<!-- Review every public artifact before checking all three attestations. -->

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
