### PR TITLE
[cli] Publish multiple scans to Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,15 +107,18 @@ incomplete or their original location was not reviewed.
 Publish every finding from a completed scan to a Linear team:
 
 ```bash
-npx @openai/codex-security publish scan /path/to/scan \
+npx @openai/codex-security publish scan --scan SCAN_ID \
   --to linear \
   --linear-team TEAM_ID
 ```
 
 Add `--linear-project PROJECT_ID` to place the issues in a Linear project, or
 omit it to create issues directly in the team. The existing `--project` flag
-remains an alias. Omit the scan directory to select a
-completed scan interactively. You can also set `CODEX_SECURITY_LINEAR_TEAM` and
+remains an alias. Omit `--scan` to select a completed scan interactively. Use
+`scans list --json` to find saved scan IDs, or pass `--scan latest` for the
+current repository's latest completed scan. External scan artifacts can still
+be supplied with `--scan-dir PATH` or a positional directory.
+You can also set `CODEX_SECURITY_LINEAR_TEAM` and
 the optional `CODEX_SECURITY_LINEAR_PROJECT` instead of passing the destination
 flags. Add `--dry-run` to preview the issues or `--json` to return
 machine-readable results.

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -588,8 +588,7 @@ same command to resume.
 
 ### Publish multiple completed scans to Cloud
 
-Repeat `--scan-dir` to publish multiple completed, sealed scan directories in
-one command:
+Repeat `--scan-dir` to publish findings from several completed scans:
 
 ```bash
 npx @openai/codex-security publish scan \
@@ -597,29 +596,38 @@ npx @openai/codex-security publish scan \
   --to cloud --dry-run --json
 ```
 
-The preview validates every scan without uploading or requiring credentials.
-Remove `--dry-run` to publish using a file-backed ChatGPT login. Scans are sent
-sequentially, with each scan's findings and provenance in its own request.
-Relative and home-relative (`~/...`) paths use the same resolution as other
-CLI commands. Repeated resolved paths are published only once per invocation.
+Pass a completed, sealed scan directory for each `--scan-dir`. Bulk-scan results
+directories and `results.jsonl` files are not accepted. Relative paths start at
+the current directory, and `~/...` starts at your home directory. The CLI
+processes each resolved path once.
 
-The existing `publish scan /path/to/scan --to cloud` form still works. You can
-combine that single positional directory with `--scan-dir` flags; additional
-bare positional directories are not accepted. With no directory, the existing
-interactive picker selects one saved scan. These inputs name individual scan
-directories, not a bulk-scan results directory or `results.jsonl` file.
+`--dry-run` validates the scans and prints their findings without uploading or
+requiring a login. Remove `--dry-run` to upload. Uploads require ChatGPT
+credentials stored in a file. The CLI sends one scan at a time, with each
+scan's findings and metadata in a separate request.
 
-Batch output contains `results` (one receipt or dry-run preview per successful
-scan, including its `scanDir`), `failed` (scan directories and errors), and
-`notAttempted` (directories left after cancellation). A failed scan does not
-stop the remaining scans; any failure produces exit code `2`. Ctrl-C and
-SIGTERM stop new requests, preserve completed receipts, and return `130` and
-`143`, respectively.
+A single directory can still be passed without `--scan-dir`. You can combine
+it with repeated flags. Omit all scan directories to choose one saved scan
+interactively. Linear accepts one scan directory, with or without `--scan-dir`.
 
-Requests are never retried automatically. An unconfirmed upload may already
-have been accepted: check acceptance before resubmitting, and do not rerun the
-whole batch blindly. Selecting one unique scan keeps the existing single-scan
-output shape. Linear accepts one scan, supplied positionally or by `--scan-dir`.
+For multiple distinct scan directories, output contains:
+
+- `results`: receipts or dry-run previews, each with its `scanDir`.
+- `failed`: errors, each paired with the scan directory.
+- `notAttempted`: scan directories the command did not reach before cancellation.
+
+For one distinct scan directory, the CLI returns the scan result directly,
+without the batch fields above.
+
+The CLI continues after a failed scan and exits with code `2` if any scan
+fails. Ctrl-C or SIGTERM stops new requests and returns the results collected
+so far. The exit code is `130` for Ctrl-C and `143` for SIGTERM. Cloud
+publication receipts appear in command output; the CLI does not save them to
+scan history.
+
+The CLI never retries an upload automatically. An upload with a missing or
+invalid receipt may already have been accepted. Check whether Cloud accepted
+that scan before retrying it. Do not resend scans with confirmed receipts.
 
 ### Publish completed scans to Linear
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -586,6 +586,32 @@ and scans stopped at their configured cost limit do not start another turn.
 invocation and defaults to `1`. Results remain under `--output-dir`; rerun the
 same command to resume.
 
+### Publish multiple completed scans to Cloud
+
+Pass multiple completed, sealed scan directories to publish them in one command:
+
+```bash
+npx @openai/codex-security publish scan /path/to/scan-a /path/to/scan-b \
+  --to cloud --dry-run --json
+```
+
+The preview validates every scan without uploading or requiring credentials.
+Remove `--dry-run` to publish using a file-backed ChatGPT login. Scans are sent
+sequentially, with each scan's findings and provenance in its own request.
+Repeated paths are resolved and published only once per invocation.
+
+Batch output contains `results` (one receipt or dry-run preview per successful
+scan, including its `scanDir`), `failed` (scan directories and errors), and
+`notAttempted` (directories left after cancellation). A failed scan does not
+stop the remaining scans; any failure produces exit code `2`. Ctrl-C and
+SIGTERM stop new requests, preserve completed receipts, and return `130` and
+`143`, respectively.
+
+Requests are never retried automatically. An unconfirmed upload may already
+have been accepted: check acceptance before resubmitting, and do not rerun the
+whole batch blindly. Single-scan publication keeps its existing output shape
+and interactive picker. Linear publication still accepts only one scan.
+
 ### Publish completed scans to Linear
 
 Publish every finding from a completed standard, deep, or scoped scan to one

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -588,17 +588,26 @@ same command to resume.
 
 ### Publish multiple completed scans to Cloud
 
-Pass multiple completed, sealed scan directories to publish them in one command:
+Repeat `--scan-dir` to publish multiple completed, sealed scan directories in
+one command:
 
 ```bash
-npx @openai/codex-security publish scan /path/to/scan-a /path/to/scan-b \
+npx @openai/codex-security publish scan \
+  --scan-dir /path/to/scan-a --scan-dir /path/to/scan-b \
   --to cloud --dry-run --json
 ```
 
 The preview validates every scan without uploading or requiring credentials.
 Remove `--dry-run` to publish using a file-backed ChatGPT login. Scans are sent
 sequentially, with each scan's findings and provenance in its own request.
-Repeated paths are resolved and published only once per invocation.
+Relative and home-relative (`~/...`) paths use the same resolution as other
+CLI commands. Repeated resolved paths are published only once per invocation.
+
+The existing `publish scan /path/to/scan --to cloud` form still works. You can
+combine that single positional directory with `--scan-dir` flags; additional
+bare positional directories are not accepted. With no directory, the existing
+interactive picker selects one saved scan. These inputs name individual scan
+directories, not a bulk-scan results directory or `results.jsonl` file.
 
 Batch output contains `results` (one receipt or dry-run preview per successful
 scan, including its `scanDir`), `failed` (scan directories and errors), and
@@ -609,8 +618,8 @@ SIGTERM stop new requests, preserve completed receipts, and return `130` and
 
 Requests are never retried automatically. An unconfirmed upload may already
 have been accepted: check acceptance before resubmitting, and do not rerun the
-whole batch blindly. Single-scan publication keeps its existing output shape
-and interactive picker. Linear publication still accepts only one scan.
+whole batch blindly. Selecting one unique scan keeps the existing single-scan
+output shape. Linear accepts one scan, supplied positionally or by `--scan-dir`.
 
 ### Publish completed scans to Linear
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -588,35 +588,50 @@ same command to resume.
 
 ### Publish multiple completed scans to Cloud
 
-Repeat `--scan-dir` to publish findings from several completed scans:
+Choose completed scans from your local history:
+
+```bash
+npx @openai/codex-security publish scan --to cloud --dry-run --json
+```
+
+The picker shows each scan's repository, finding count, age, and scan ID.
+Choose scans, then select **Done**. No scans are selected automatically.
+
+For scripts, repeat `--scan` with saved scan IDs or unique ID prefixes (at
+least eight characters):
 
 ```bash
 npx @openai/codex-security publish scan \
-  --scan-dir /path/to/scan-a --scan-dir /path/to/scan-b \
+  --scan SCAN_ID_A --scan SCAN_ID_B \
   --to cloud --dry-run --json
 ```
 
-Pass a completed, sealed scan directory for each `--scan-dir`. Bulk-scan results
-directories and `results.jsonl` files are not accepted. Relative paths start at
-the current directory, and `~/...` starts at your home directory. The CLI
-processes each resolved path once.
+Use `scans list --json` to find IDs for the current repository. `--scan latest`
+selects its latest completed scan. The CLI resolves IDs through saved history,
+processes each selected scan once, and checks that its sealed artifacts match
+the selected ID. The artifacts must still be available locally.
 
 `--dry-run` validates the scans and prints their findings without uploading or
 requiring a login. Remove `--dry-run` to upload. Uploads require ChatGPT
 credentials stored in a file. The CLI sends one scan at a time, with each
 scan's findings and metadata in a separate request.
 
-A single directory can still be passed without `--scan-dir`. You can combine
-it with repeated flags. Omit all scan directories to choose one saved scan
-interactively. Linear accepts one scan directory, with or without `--scan-dir`.
+For artifacts outside local history, use repeated `--scan-dir PATH` instead.
+A single positional directory is still accepted and can be combined with
+`--scan-dir`. Do not combine directory inputs with `--scan`. Each directory
+must contain one completed, sealed scan; bulk-run directories and
+`results.jsonl` files are not accepted. Relative paths start at the current
+directory, and `~/...` starts at your home directory. Each resolved directory
+is processed once.
 
-For multiple distinct scan directories, output contains:
+For multiple distinct scans, output contains:
 
-- `results`: receipts or dry-run previews, each with its `scanDir`.
-- `failed`: errors, each paired with the scan directory.
-- `notAttempted`: scan directories the command did not reach before cancellation.
+- `results`: receipts or dry-run previews, each with its `scanId` and `scanDir`.
+- `failed`: errors with `scanDir` and, for saved selections, `scanId`.
+- `notAttempted`: saved scan IDs, or paths for directory inputs, that the command
+  did not reach before cancellation.
 
-For one distinct scan directory, the CLI returns the scan result directly,
+For one distinct scan, the CLI returns the scan result directly,
 without the batch fields above.
 
 The CLI continues after a failed scan and exits with code `2` if any scan
@@ -635,17 +650,21 @@ Publish every finding from a completed standard, deep, or scoped scan to one
 Linear team:
 
 ```bash
-npx @openai/codex-security publish scan /path/to/completed-scan \
+npx @openai/codex-security publish scan --scan SCAN_ID \
   --to linear \
   --linear-team TEAM_ID
 ```
+
+Linear accepts one scan. Use a saved scan ID, a unique ID prefix, or `latest`.
+For external artifacts, a positional directory or `--scan-dir PATH` is also
+accepted.
 
 Add `--linear-project PROJECT_ID` to place the issues in a Linear project.
 The existing `--project` flag remains an alias. Without a project, issues are
 created directly in the selected team.
 
 To choose from all completed scans saved in your local scan history, omit the
-scan directory. The selector highlights each repository and shows its finding
+scan selector. The selector highlights each repository and shows its finding
 count, relative run time, and abbreviated scan ID:
 
 ```bash

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -1849,11 +1849,17 @@ export async function main(
         .describe("Completed scan directory; omit to select a saved scan."),
     }),
     options: z.object({
+      scan: z
+        .array(optionValue("--scan"))
+        .default([])
+        .describe(
+          "Saved scan ID, unique prefix, or latest; repeat for multiple scans (Linear accepts one).",
+        ),
       scanDir: z
         .array(optionValue("--scan-dir"))
         .default([])
         .describe(
-          "Completed scan directory; repeat for multiple scans (Linear accepts one).",
+          "External completed scan directory; repeat for multiple scans (Linear accepts one).",
         ),
       // Cloud remains an internal destination, omitted from public discovery.
       to: z
@@ -1892,7 +1898,7 @@ export async function main(
       let cloudBatch:
         | {
             results: (CloudPublicationResult & { scanDir: string })[];
-            failed: { scanDir: string; error: string }[];
+            failed: { scanDir: string; scanId?: string; error: string }[];
             notAttempted: string[];
           }
         | undefined;
@@ -1916,6 +1922,16 @@ export async function main(
         if (directories.length > 1 && options.to !== "cloud") {
           throw new CodexSecurityError(
             "Multiple scan directories are only supported with --to cloud.",
+          );
+        }
+        if (options.scan.length > 0 && directories.length > 0) {
+          throw new CodexSecurityError(
+            "Use --scan or scan directory inputs, not both.",
+          );
+        }
+        if (new Set(options.scan).size > 1 && options.to !== "cloud") {
+          throw new CodexSecurityError(
+            "Multiple scans are only supported with --to cloud.",
           );
         }
         if (
@@ -1978,7 +1994,21 @@ export async function main(
           dependencies.environment["CODEX_SECURITY_LINEAR_PROJECT"]?.trim() ||
           undefined;
 
-        let scanDir = directories[0];
+        if (options.to === "cloud") {
+          dependencies.addSignalListener("SIGINT", onInterrupt);
+          dependencies.addSignalListener("SIGTERM", onTerminate);
+          observingSignals = true;
+        }
+        const selectedScans: { scanDir: string; scanId?: string }[] =
+          directories.map((scanDir) => ({ scanDir }));
+        for (const requestedId of new Set(options.scan)) {
+          controller.signal.throwIfAborted();
+          const scan = await resolvePublicationScan(requestedId, dependencies);
+          if (!selectedScans.some(({ scanId }) => scanId === scan.scanId)) {
+            selectedScans.push(scan);
+          }
+        }
+        let scanDir = selectedScans[0]?.scanDir;
         let publicationRepository =
           scanDir === undefined ? "scan" : basename(scanDir);
         if (scanDir === undefined) {
@@ -1991,7 +2021,7 @@ export async function main(
             }).prompt;
           if (!prompt.isInteractive()) {
             throw new CodexSecurityError(
-              `Interactive scan selection requires a terminal. Provide a completed scan directory: codex-security publish scan /path/to/sealed-scan --to ${options.to}${options.to === "linear" ? " --linear-team TEAM_ID" : ""}.`,
+              `Interactive scan selection requires a terminal. Select a saved scan: codex-security publish scan --scan SCAN_ID --to ${options.to}${options.to === "linear" ? " --linear-team TEAM_ID" : ""}.`,
             );
           }
           const saved = await dependencies.runWorkbench([
@@ -2029,6 +2059,10 @@ export async function main(
             dependencies.environment["NO_COLOR"] === undefined &&
             dependencies.environment["TERM"] !== "dumb";
           const repositories = new Map<string, string>();
+          const scansById = new Map<
+            string,
+            { scanId: string; scanDir: string }
+          >();
           const rows = scans.flatMap((scan) => {
             if (!isJsonObject(scan)) return [];
             const progress = scan["progress"];
@@ -2078,13 +2112,17 @@ export async function main(
               .replace(/\s+/gu, " ")
               .slice(-6)}`;
             repositories.set(directory, repository);
+            scansById.set(scanId, {
+              scanId,
+              scanDir: resolveCliPath(currentDirectory, directory),
+            });
             return [
               {
                 repository,
                 findings,
                 age: publicationScanAge(timestamp, now),
                 scanId: shortScanId,
-                value: directory,
+                value: options.to === "cloud" ? scanId : directory,
               },
             ];
           });
@@ -2129,28 +2167,55 @@ export async function main(
               value: row.value,
             };
           });
-          scanDir = await prompt.select(
-            "Which completed scan would you like to publish?",
-            choices,
-            { header },
-          );
+          if (options.to === "cloud") {
+            let remaining = choices;
+            while (remaining.length > 0) {
+              controller.signal.throwIfAborted();
+              const selected = await prompt.select(
+                "Which completed scans would you like to publish?",
+                selectedScans.length === 0
+                  ? remaining
+                  : [
+                      {
+                        label: `Done (${selectedScans.length} selected)`,
+                        value: "",
+                      },
+                      ...remaining,
+                    ],
+                { header },
+                controller.signal,
+              );
+              controller.signal.throwIfAborted();
+              if (selected === "") break;
+              selectedScans.push(scansById.get(selected)!);
+              remaining = remaining.filter(({ value }) => value !== selected);
+            }
+            scanDir = selectedScans[0]!.scanDir;
+          } else {
+            scanDir = await prompt.select(
+              "Which completed scan would you like to publish?",
+              choices,
+              { header },
+            );
+            selectedScans.push({ scanDir });
+          }
           publicationRepository =
             repositories.get(scanDir) ?? basename(scanDir);
         }
 
         if (options.to === "cloud") {
-          dependencies.addSignalListener("SIGINT", onInterrupt);
-          dependencies.addSignalListener("SIGTERM", onTerminate);
-          observingSignals = true;
-          if (directories.length > 1) {
+          controller.signal.throwIfAborted();
+          if (selectedScans.length > 1) {
             cloudBatch = {
               results: [],
               failed: [],
-              notAttempted: [...directories],
+              notAttempted: selectedScans.map(
+                ({ scanId, scanDir }) => scanId ?? scanDir,
+              ),
             };
             // Keep each scan's provenance and acceptance receipt separate. Never
             // retry a failed POST: a lost response may still have been accepted.
-            for (const directory of directories) {
+            for (const { scanDir: directory, scanId } of selectedScans) {
               controller.signal.throwIfAborted();
               cloudBatch.notAttempted.shift();
               try {
@@ -2160,15 +2225,20 @@ export async function main(
                   environment: dependencies.environment,
                   dryRun: options.dryRun,
                   signal: controller.signal,
+                  ...(scanId === undefined ? {} : { expectedScanId: scanId }),
                 });
                 cloudBatch.results.push({ scanDir: directory, ...result });
               } catch (error) {
                 const message = safeErrorMessage(error);
-                cloudBatch.failed.push({ scanDir: directory, error: message });
+                cloudBatch.failed.push({
+                  scanDir: directory,
+                  ...(scanId === undefined ? {} : { scanId }),
+                  error: message,
+                });
                 if (controller.signal.aborted) throw error;
                 exitCode = 2;
                 errorOutput.write(
-                  `codex-security: ${diagnosticValue(safeErrorMessage(directory))}: ${diagnosticValue(message)}\n`,
+                  `codex-security: ${diagnosticValue(safeErrorMessage(scanId ?? directory))}: ${diagnosticValue(message)}\n`,
                 );
               }
             }
@@ -2181,6 +2251,9 @@ export async function main(
             environment: dependencies.environment,
             dryRun: options.dryRun,
             signal: controller.signal,
+            ...(selectedScans[0]?.scanId === undefined
+              ? {}
+              : { expectedScanId: selectedScans[0].scanId }),
           });
           controller.signal.throwIfAborted();
           return { ...result };
@@ -2204,6 +2277,9 @@ export async function main(
             resolveCliPath(currentDirectory, scanDir),
             {
               destination: "linear",
+              ...(selectedScans[0]?.scanId === undefined
+                ? {}
+                : { expectedScanId: selectedScans[0].scanId }),
               teamId,
               ...(projectId === undefined ? {} : { projectId }),
               dryRun: options.dryRun,
@@ -3954,6 +4030,71 @@ async function* workbenchFindings(
     yield* page.findings;
     offset = typeof page.nextOffset === "number" ? page.nextOffset : undefined;
   } while (offset !== undefined);
+}
+
+async function resolvePublicationScan(
+  requestedId: string,
+  dependencies: CliDependencies,
+): Promise<SavedScan> {
+  let scanId = requestedId;
+  if (scanId === "latest") {
+    const history = await dependencies.runWorkbench([
+      "list-scans",
+      "--repository",
+      resolve(dependencies.currentDirectory()),
+      "--status",
+      "complete",
+    ]);
+    const scans = history["scans"];
+    const latest = Array.isArray(scans) ? scans[0] : undefined;
+    if (
+      latest === undefined ||
+      !isJsonObject(latest) ||
+      typeof latest["scanId"] !== "string"
+    ) {
+      throw new CodexSecurityError(
+        "No completed saved scan was found for this repository.",
+      );
+    }
+    scanId = latest["scanId"];
+  }
+  const context = await dependencies.runWorkbench([
+    "get-scan",
+    "--scan-id",
+    scanId,
+  ]);
+  const scan = context["scan"];
+  if (
+    scan === undefined ||
+    !isJsonObject(scan) ||
+    typeof scan["scanId"] !== "string"
+  ) {
+    throw new CodexSecurityError(`Could not read saved scan ${scanId}.`);
+  }
+  scanId = scan["scanId"];
+  const progress = scan["progress"];
+  if (
+    progress === undefined ||
+    !isJsonObject(progress) ||
+    progress["status"] !== "complete"
+  ) {
+    throw new CodexSecurityError(`Scan ${scanId} is not complete.`);
+  }
+  const storedDirectory = scan["scanDir"];
+  const scanDir =
+    typeof storedDirectory === "string" && storedDirectory.length > 0
+      ? resolveCliPath(dependencies.currentDirectory(), storedDirectory)
+      : undefined;
+  const metadata =
+    scanDir === undefined
+      ? undefined
+      : await lstat(scanDir).catch(() => undefined);
+  if (scanDir === undefined || metadata?.isDirectory() !== true) {
+    throw new CodexSecurityError(
+      `Artifacts for scan ${scanId} are unavailable. Restore the completed scan artifacts or run a new scan.`,
+    );
+  }
+  return { ...scan, scanId, scanDir };
 }
 
 async function selectSavedFindings(

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -55,7 +55,10 @@ import {
   type ScanPreflight,
 } from "./api.js";
 import { accountStatus } from "./auth.js";
-import { publishScanToCloud } from "./cloud-publish.js";
+import {
+  publishScanToCloud,
+  type CloudPublicationResult,
+} from "./cloud-publish.js";
 import {
   createBulkScanDiscoveryDependencies,
   runBulkScanWizard,
@@ -1843,6 +1846,12 @@ export async function main(
         .string()
         .optional()
         .describe("Completed scan directory; omit to select a saved scan."),
+      "additionalScanDirs...": z
+        .string()
+        .optional()
+        .describe(
+          "Additional completed scan directories; not supported by Linear.",
+        ),
     }),
     options: z.object({
       // Cloud remains an internal destination, omitted from public discovery.
@@ -1879,6 +1888,13 @@ export async function main(
     async run({ args, format, formatExplicit, options }) {
       const controller = new AbortController();
       let presentation: PublicationProgressPresenter | undefined;
+      let cloudBatch:
+        | {
+            results: (CloudPublicationResult & { scanDir: string })[];
+            failed: { scanDir: string; error: string }[];
+            notAttempted: string[];
+          }
+        | undefined;
       const cancel = (signal: SignalName): void => {
         presentation?.stop();
         controller.abort(signal);
@@ -1887,6 +1903,11 @@ export async function main(
       const onTerminate = (): void => cancel("SIGTERM");
       let observingSignals = false;
       try {
+        if (positionals.length > 1 && options.to !== "cloud") {
+          throw new CodexSecurityError(
+            "Multiple scan directories are only supported with --to cloud.",
+          );
+        }
         if (
           options.to === "cloud" &&
           [
@@ -2111,6 +2132,46 @@ export async function main(
           dependencies.addSignalListener("SIGINT", onInterrupt);
           dependencies.addSignalListener("SIGTERM", onTerminate);
           observingSignals = true;
+          if (positionals.length > 1) {
+            const directories = [
+              ...new Set(
+                positionals.map((directory) =>
+                  resolve(dependencies.currentDirectory(), directory),
+                ),
+              ),
+            ];
+            cloudBatch = {
+              results: [],
+              failed: [],
+              notAttempted: [...directories],
+            };
+            // Keep each scan's provenance and acceptance receipt separate. Never
+            // retry a failed POST: a lost response may still have been accepted.
+            for (const directory of directories) {
+              controller.signal.throwIfAborted();
+              cloudBatch.notAttempted.shift();
+              try {
+                const result = await (
+                  dependencies.publishScanToCloud ?? publishScanToCloud
+                )(directory, {
+                  environment: dependencies.environment,
+                  dryRun: options.dryRun,
+                  signal: controller.signal,
+                });
+                cloudBatch.results.push({ scanDir: directory, ...result });
+              } catch (error) {
+                const message = safeErrorMessage(error);
+                cloudBatch.failed.push({ scanDir: directory, error: message });
+                if (controller.signal.aborted) throw error;
+                exitCode = 2;
+                errorOutput.write(
+                  `codex-security: ${diagnosticValue(safeErrorMessage(directory))}: ${diagnosticValue(message)}\n`,
+                );
+              }
+            }
+            controller.signal.throwIfAborted();
+            return cloudBatch;
+          }
           const result = await (
             dependencies.publishScanToCloud ?? publishScanToCloud
           )(resolve(dependencies.currentDirectory(), scanDir), {
@@ -2200,7 +2261,7 @@ export async function main(
           );
           exitCode = 2;
         }
-        return undefined;
+        return cloudBatch;
       } finally {
         if (observingSignals) {
           dependencies.removeSignalListener("SIGINT", onInterrupt);
@@ -3755,6 +3816,7 @@ function validateCliArguments(
     command !== "validate" &&
     command !== "verify-fix" &&
     command !== "patch" &&
+    !(command === "publish" && subcommand === "scan") &&
     positionals.length >
       (command === "logout" || command === "info"
         ? 0

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -235,6 +235,7 @@ const VALUE_OPTIONS = new Set([
   "--patch-severity",
   "--resume-pr",
   "--scan",
+  "--scan-dir",
   "--severity",
   "--max-cost",
   "--workers",
@@ -1846,14 +1847,14 @@ export async function main(
         .string()
         .optional()
         .describe("Completed scan directory; omit to select a saved scan."),
-      "additionalScanDirs...": z
-        .string()
-        .optional()
-        .describe(
-          "Additional completed scan directories; not supported by Linear.",
-        ),
     }),
     options: z.object({
+      scanDir: z
+        .array(optionValue("--scan-dir"))
+        .default([])
+        .describe(
+          "Completed scan directory; repeat for multiple scans (Linear accepts one).",
+        ),
       // Cloud remains an internal destination, omitted from public discovery.
       to: z
         .string()
@@ -1903,7 +1904,16 @@ export async function main(
       const onTerminate = (): void => cancel("SIGTERM");
       let observingSignals = false;
       try {
-        if (positionals.length > 1 && options.to !== "cloud") {
+        const currentDirectory = dependencies.currentDirectory();
+        const directories = [
+          ...new Set(
+            [
+              ...(args.scanDir === undefined ? [] : [args.scanDir]),
+              ...options.scanDir,
+            ].map((directory) => resolveCliPath(currentDirectory, directory)),
+          ),
+        ];
+        if (directories.length > 1 && options.to !== "cloud") {
           throw new CodexSecurityError(
             "Multiple scan directories are only supported with --to cloud.",
           );
@@ -1968,7 +1978,7 @@ export async function main(
           dependencies.environment["CODEX_SECURITY_LINEAR_PROJECT"]?.trim() ||
           undefined;
 
-        let scanDir = args.scanDir;
+        let scanDir = directories[0];
         let publicationRepository =
           scanDir === undefined ? "scan" : basename(scanDir);
         if (scanDir === undefined) {
@@ -2004,7 +2014,7 @@ export async function main(
                   return undefined;
                 }
                 const metadata = await lstat(
-                  resolve(dependencies.currentDirectory(), directory),
+                  resolveCliPath(currentDirectory, directory),
                 ).catch(() => undefined);
                 return metadata?.isDirectory() === true &&
                   !metadata.isSymbolicLink()
@@ -2132,14 +2142,7 @@ export async function main(
           dependencies.addSignalListener("SIGINT", onInterrupt);
           dependencies.addSignalListener("SIGTERM", onTerminate);
           observingSignals = true;
-          if (positionals.length > 1) {
-            const directories = [
-              ...new Set(
-                positionals.map((directory) =>
-                  resolve(dependencies.currentDirectory(), directory),
-                ),
-              ),
-            ];
+          if (directories.length > 1) {
             cloudBatch = {
               results: [],
               failed: [],
@@ -2174,7 +2177,7 @@ export async function main(
           }
           const result = await (
             dependencies.publishScanToCloud ?? publishScanToCloud
-          )(resolve(dependencies.currentDirectory(), scanDir), {
+          )(resolveCliPath(currentDirectory, scanDir), {
             environment: dependencies.environment,
             dryRun: options.dryRun,
             signal: controller.signal,
@@ -2198,7 +2201,7 @@ export async function main(
         let result;
         try {
           result = await (dependencies.publishScan ?? publishScan)(
-            resolve(dependencies.currentDirectory(), scanDir),
+            resolveCliPath(currentDirectory, scanDir),
             {
               destination: "linear",
               teamId,
@@ -3816,7 +3819,6 @@ function validateCliArguments(
     command !== "validate" &&
     command !== "verify-fix" &&
     command !== "patch" &&
-    !(command === "publish" && subcommand === "scan") &&
     positionals.length >
       (command === "logout" || command === "info"
         ? 0

--- a/sdk/typescript/src/cloud-publish.ts
+++ b/sdk/typescript/src/cloud-publish.ts
@@ -49,11 +49,13 @@ export async function publishScanToCloud(
     fetch?: (url: string, options: RequestInit) => Promise<Response>;
     signal?: AbortSignal;
     dryRun?: boolean;
+    expectedScanId?: string;
   } = {},
 ): Promise<CloudPublicationResult> {
   const { manifest, findings } = await loadContract(scanDirectory, {
     pluginRoot: await bundledPluginRoot(),
     signal: dependencies.signal,
+    expectedScanId: dependencies.expectedScanId,
   });
   if (findings.findings.length === 0) {
     throw new CodexSecurityError(

--- a/sdk/typescript/src/contract.ts
+++ b/sdk/typescript/src/contract.ts
@@ -66,6 +66,7 @@ export interface LoadedContract {
 
 type LoadContractOptions = {
   pluginRoot: string;
+  expectedScanId?: string;
   expectation?: ScanExpectation;
   workbenchValidated?: boolean;
   signal?: AbortSignal;
@@ -154,6 +155,14 @@ export async function loadContractWithScanDirectory(
   const manifest = payloads["scan-manifest.json"] as unknown as ScanManifest;
   const findings = findingsPayload as FindingsDocument;
   const coverage = payloads["coverage.json"] as unknown as CoverageDocument;
+  if (
+    options.expectedScanId !== undefined &&
+    manifest.scan.id !== options.expectedScanId
+  ) {
+    throw new ContractValidationError(
+      `Scan artifacts do not match selected scan ${options.expectedScanId}.`,
+    );
+  }
   if (
     findings.scanId !== manifest.scan.id ||
     coverage.scanId !== manifest.scan.id

--- a/sdk/typescript/src/publication.ts
+++ b/sdk/typescript/src/publication.ts
@@ -22,6 +22,7 @@ export interface PrepareScanPublicationOptions {
   teamId: string;
   projectId?: string;
   uploadedAt?: string;
+  expectedScanId?: string;
 }
 
 export interface PreparedPublicationIssue {
@@ -55,6 +56,7 @@ export async function prepareScanPublication(
   const { contract, scanDirectory: canonicalScanDirectory } =
     await loadContractWithScanDirectory(scanDirectory, {
       pluginRoot: await bundledPluginRoot(),
+      expectedScanId: options.expectedScanId,
     });
   const uploadedAt = options.uploadedAt ?? new Date().toISOString();
   const scanId = contract.manifest.scan.id;

--- a/sdk/typescript/src/publish.ts
+++ b/sdk/typescript/src/publish.ts
@@ -41,6 +41,7 @@ import {
 } from "./runtime.js";
 
 export interface PublishScanOptions {
+  expectedScanId?: string;
   destination: "linear";
   teamId: string;
   projectId?: string;

--- a/sdk/typescript/tests-ts/cli-cloud-publish.test.ts
+++ b/sdk/typescript/tests-ts/cli-cloud-publish.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { describe, expect, test } from "bun:test";
 import { main } from "../src/cli.js";
 import {
@@ -17,6 +17,212 @@ const receipt = {
 };
 
 describe("publish scan to Cloud", () => {
+  test("publishes multiple explicit scans in order and deduplicates resolved paths", async () => {
+    for (const dryRun of [false, true]) {
+      const deps = dependencies({
+        onWorkbench: () => {
+          throw new Error("must not inspect scan history");
+        },
+      });
+      deps.createSecurity = () => {
+        throw new Error("must not initialize Codex");
+      };
+      deps.publishScan = async () => {
+        throw new Error("must not publish to Linear");
+      };
+      const directories = ["scan one", "scan-two"].map((path) =>
+        resolve(deps.currentDirectory(), path),
+      );
+      const calls: string[] = [];
+      let publishing = false;
+      const results = directories.map((scanDir, index) => ({
+        scanDir,
+        scanId: `scan-${index + 1}`,
+        findingIds: dryRun ? [] : [`finding-${index + 1}`],
+        findingCount: 1,
+        ...(dryRun ? { dryRun: true as const, findings: [] } : {}),
+      }));
+      deps.publishScanToCloud = async (directory, options) => {
+        expect(publishing).toBe(false);
+        publishing = true;
+        expect(directory).toBe(directories[calls.length]!);
+        expect(options).toEqual({
+          environment: deps.environment,
+          dryRun,
+          signal: expect.any(AbortSignal),
+        });
+        const { scanDir: _, ...result } = results[calls.length]!;
+        calls.push(directory);
+        await Promise.resolve();
+        publishing = false;
+        return result;
+      };
+      const stdout = capture();
+      const stderr = capture();
+      expect(
+        await main(
+          [
+            "publish",
+            "scan",
+            "scan one",
+            "--to=cloud",
+            "scan-two",
+            "./scan one",
+            "--json",
+            ...(dryRun ? ["--dry-run"] : []),
+          ],
+          stdout.stream,
+          stderr.stream,
+          deps,
+        ),
+      ).toBe(0);
+      expect(calls).toEqual(directories);
+      expect(JSON.parse(stdout.text())).toEqual({
+        results,
+        failed: [],
+        notAttempted: [],
+      });
+      expect(stderr.text()).toBe("");
+    }
+  });
+
+  test("keeps receipts and continues after a failed scan without retrying", async () => {
+    const deps = dependencies();
+    const directories = ["scan-one", "scan-two", "scan-three"].map((path) =>
+      resolve(deps.currentDirectory(), path),
+    );
+    const calls: string[] = [];
+    deps.publishScanToCloud = async (directory) => {
+      calls.push(directory);
+      if (directory === directories[1]) {
+        throw new Error(`Cloud failed: ${SYNTHETIC_CREDENTIALS}`);
+      }
+      return {
+        ...receipt,
+        scanId: directory === directories[0] ? "scan-1" : "scan-3",
+      };
+    };
+    const stdout = capture();
+    const stderr = capture();
+    expect(
+      await main(
+        ["publish", "scan", ...directories, "--to", "cloud", "--json"],
+        stdout.stream,
+        stderr.stream,
+        deps,
+      ),
+    ).toBe(2);
+    expect(calls).toEqual(directories);
+    expect(JSON.parse(stdout.text())).toEqual({
+      results: [
+        { scanDir: directories[0], ...receipt },
+        { scanDir: directories[2], ...receipt, scanId: "scan-3" },
+      ],
+      failed: [{ scanDir: directories[1], error: "[redacted]" }],
+      notAttempted: [],
+    });
+    expect(stderr.text()).toContain("[redacted]");
+    expect(stderr.text()).not.toContain(SYNTHETIC_CREDENTIALS);
+  });
+
+  test.each([false, true])(
+    "preserves batch receipts on cancellation with a confirmed response: %s",
+    async (confirmed) => {
+      for (const [signal, code] of [
+        ["SIGINT", 130],
+        ["SIGTERM", 143],
+      ] as const) {
+        const signals = new FakeSignals();
+        const deps = dependencies({ signals });
+        const directories = ["scan-one", "scan-two", "scan-three"].map((path) =>
+          resolve(deps.currentDirectory(), path),
+        );
+        const calls: string[] = [];
+        deps.publishScanToCloud = async (directory, options) => {
+          calls.push(directory);
+          if (directory === directories[1]) {
+            signals.emit(signal);
+            expect(options?.signal?.aborted).toBe(true);
+            if (confirmed) return { ...receipt, scanId: "scan-2" };
+            throw new Error(
+              "Cloud publication was not confirmed. Check acceptance before resubmitting.",
+            );
+          }
+          return receipt;
+        };
+        const stdout = capture();
+        const stderr = capture();
+        expect(
+          await main(
+            ["publish", "scan", ...directories, "--to", "cloud", "--json"],
+            stdout.stream,
+            stderr.stream,
+            deps,
+          ),
+        ).toBe(code);
+        expect(calls).toEqual(directories.slice(0, 2));
+        expect(JSON.parse(stdout.text())).toEqual({
+          results: [
+            { scanDir: directories[0], ...receipt },
+            ...(confirmed
+              ? [{ scanDir: directories[1], ...receipt, scanId: "scan-2" }]
+              : []),
+          ],
+          failed: confirmed
+            ? []
+            : [
+                {
+                  scanDir: directories[1],
+                  error:
+                    "Cloud publication was not confirmed. Check acceptance before resubmitting.",
+                },
+              ],
+          notAttempted: [directories[2]],
+        });
+        expect(stderr.text()).toContain(
+          signal === "SIGINT" ? "canceled" : "terminated",
+        );
+        expect(
+          [...signals.listeners.values()].every(
+            (listeners) => listeners.size === 0,
+          ),
+        ).toBe(true);
+      }
+    },
+  );
+
+  test("rejects multiple scans for Linear before publishing any findings", async () => {
+    const deps = dependencies();
+    let calls = 0;
+    deps.publishScan = async () => {
+      calls++;
+      throw new Error("unexpected publication");
+    };
+    const stdout = capture();
+    const stderr = capture();
+    expect(
+      await main(
+        [
+          "publish",
+          "scan",
+          "scan-one",
+          "scan-two",
+          "--to",
+          "linear",
+          "--linear-team",
+          "synthetic-team",
+          "--json",
+        ],
+        stdout.stream,
+        stderr.stream,
+        deps,
+      ),
+    ).toBe(2);
+    expect(calls).toBe(0);
+    expect(stdout.text()).toBe("");
+    expect(stderr.text()).toContain("Multiple scan directories");
+  });
+
   test("routes explicit scans to Cloud without initializing Codex or Linear", async () => {
     for (const destination of [["--to=cloud"], ["--to", "cloud"]]) {
       for (const dryRun of [false, true]) {

--- a/sdk/typescript/tests-ts/cli-cloud-publish.test.ts
+++ b/sdk/typescript/tests-ts/cli-cloud-publish.test.ts
@@ -1,5 +1,5 @@
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, test } from "bun:test";
 import { main } from "../src/cli.js";
@@ -64,9 +64,11 @@ describe("publish scan to Cloud", () => {
           [
             "publish",
             "scan",
+            "--scan-dir",
             "scan one",
             "--to=cloud",
-            "scan-two",
+            "--scan-dir=scan-two",
+            "--scan-dir",
             "./scan one",
             "--json",
             ...(dryRun ? ["--dry-run"] : []),
@@ -106,7 +108,14 @@ describe("publish scan to Cloud", () => {
     const stderr = capture();
     expect(
       await main(
-        ["publish", "scan", ...directories, "--to", "cloud", "--json"],
+        [
+          "publish",
+          "scan",
+          ...directories.flatMap((directory) => ["--scan-dir", directory]),
+          "--to",
+          "cloud",
+          "--json",
+        ],
         stdout.stream,
         stderr.stream,
         deps,
@@ -154,7 +163,14 @@ describe("publish scan to Cloud", () => {
         const stderr = capture();
         expect(
           await main(
-            ["publish", "scan", ...directories, "--to", "cloud", "--json"],
+            [
+              "publish",
+              "scan",
+              ...directories.flatMap((directory) => ["--scan-dir", directory]),
+              "--to",
+              "cloud",
+              "--json",
+            ],
             stdout.stream,
             stderr.stream,
             deps,
@@ -206,6 +222,7 @@ describe("publish scan to Cloud", () => {
           "publish",
           "scan",
           "scan-one",
+          "--scan-dir",
           "scan-two",
           "--to",
           "linear",
@@ -223,58 +240,143 @@ describe("publish scan to Cloud", () => {
     expect(stderr.text()).toContain("Multiple scan directories");
   });
 
-  test("routes explicit scans to Cloud without initializing Codex or Linear", async () => {
-    for (const destination of [["--to=cloud"], ["--to", "cloud"]]) {
-      for (const dryRun of [false, true]) {
-        const currentDirectory = join(tmpdir(), "cloud-publish-current");
-        const deps = dependencies({
-          currentDirectory,
-          environment: { CODEX_SECURITY_LINEAR_API_KEY: " " },
-          onWorkbench: () => {
-            throw new Error("must not inspect scan history");
-          },
-        });
-        deps.createSecurity = () => {
-          throw new Error("must not initialize Codex");
-        };
-        deps.publishScan = async () => {
-          throw new Error("must not publish to Linear");
-        };
-        let calls = 0;
-        const result = dryRun
-          ? { ...receipt, findingIds: [], dryRun: true as const, findings: [] }
-          : receipt;
-        deps.publishScanToCloud = async (directory, options) => {
-          calls++;
-          expect(directory).toBe(join(currentDirectory, "completed-scan"));
-          expect(options).toEqual({
-            environment: deps.environment,
-            dryRun,
-            signal: expect.any(AbortSignal),
+  test.each(["positional", "flag"])(
+    "routes an explicit %s scan to Cloud without initializing Codex or Linear",
+    async (syntax) => {
+      for (const destination of [["--to=cloud"], ["--to", "cloud"]]) {
+        for (const dryRun of [false, true]) {
+          const currentDirectory = join(tmpdir(), "cloud-publish-current");
+          const deps = dependencies({
+            currentDirectory,
+            environment: { CODEX_SECURITY_LINEAR_API_KEY: " " },
+            onWorkbench: () => {
+              throw new Error("must not inspect scan history");
+            },
           });
-          return result;
-        };
-        const stdout = capture();
-        const stderr = capture();
-        expect(
-          await main(
-            [
-              "publish",
-              "scan",
-              "completed-scan",
-              ...destination,
-              "--json",
-              ...(dryRun ? ["--dry-run"] : []),
-            ],
-            stdout.stream,
-            stderr.stream,
-            deps,
-          ),
-        ).toBe(0);
-        expect(calls).toBe(1);
-        expect(JSON.parse(stdout.text())).toEqual(result);
-        expect(stderr.text()).toBe("");
+          deps.createSecurity = () => {
+            throw new Error("must not initialize Codex");
+          };
+          deps.publishScan = async () => {
+            throw new Error("must not publish to Linear");
+          };
+          let calls = 0;
+          const result = dryRun
+            ? {
+                ...receipt,
+                findingIds: [],
+                dryRun: true as const,
+                findings: [],
+              }
+            : receipt;
+          deps.publishScanToCloud = async (directory, options) => {
+            calls++;
+            expect(directory).toBe(join(currentDirectory, "completed-scan"));
+            expect(options).toEqual({
+              environment: deps.environment,
+              dryRun,
+              signal: expect.any(AbortSignal),
+            });
+            return result;
+          };
+          const stdout = capture();
+          const stderr = capture();
+          expect(
+            await main(
+              [
+                "publish",
+                "scan",
+                ...(syntax === "flag"
+                  ? ["--scan-dir", "completed-scan"]
+                  : ["completed-scan"]),
+                ...destination,
+                "--json",
+                ...(dryRun ? ["--dry-run"] : []),
+              ],
+              stdout.stream,
+              stderr.stream,
+              deps,
+            ),
+          ).toBe(0);
+          expect(calls).toBe(1);
+          expect(JSON.parse(stdout.text())).toEqual(result);
+          expect(stderr.text()).toBe("");
+        }
       }
+    },
+  );
+
+  test("expands home-relative scan inputs and deduplicates mixed positional and flag paths", async () => {
+    const first = join(homedir(), "scan-one");
+    const second = join(homedir(), "scan-two");
+    for (const { inputs, expected } of [
+      { inputs: ["~/scan-one"], expected: [first] },
+      {
+        inputs: ["--scan-dir", "~/scan-one", "--scan-dir", first],
+        expected: [first],
+      },
+      {
+        inputs: ["~/scan-one", "--scan-dir", first, "--scan-dir", "~/scan-two"],
+        expected: [first, second],
+      },
+    ]) {
+      const deps = dependencies({
+        onWorkbench: () => {
+          throw new Error("must not inspect scan history");
+        },
+      });
+      const calls: string[] = [];
+      deps.publishScanToCloud = async (directory) => {
+        calls.push(directory);
+        return receipt;
+      };
+      const stdout = capture();
+      expect(
+        await main(
+          ["publish", "scan", ...inputs, "--to", "cloud", "--json"],
+          stdout.stream,
+          capture().stream,
+          deps,
+        ),
+      ).toBe(0);
+      expect(calls).toEqual(expected);
+      expect(JSON.parse(stdout.text())).toEqual(
+        expected.length === 1
+          ? receipt
+          : {
+              results: expected.map((scanDir) => ({ scanDir, ...receipt })),
+              failed: [],
+              notAttempted: [],
+            },
+      );
+    }
+  });
+
+  test("rejects missing or empty scan flags and extra positionals before publishing", async () => {
+    for (const inputs of [
+      ["--scan-dir"],
+      ["--scan-dir="],
+      ["--scan-dir", "--json"],
+      ["scan-one", "scan-two"],
+    ]) {
+      const deps = dependencies();
+      let calls = 0;
+      deps.publishScanToCloud = async () => {
+        calls++;
+        return receipt;
+      };
+      const stdout = capture();
+      const stderr = capture();
+      expect(
+        await main(
+          ["publish", "scan", ...inputs, "--to", "cloud"],
+          stdout.stream,
+          stderr.stream,
+          deps,
+        ),
+      ).toBe(2);
+      expect(calls).toBe(0);
+      expect(stdout.text()).toBe("");
+      expect(stderr.text()).not.toBe("");
     }
   });
 

--- a/sdk/typescript/tests-ts/cli-cloud-publish.test.ts
+++ b/sdk/typescript/tests-ts/cli-cloud-publish.test.ts
@@ -1,8 +1,9 @@
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { main } from "../src/cli.js";
+import type { JsonObject } from "../src/index.js";
 import {
   capture,
   dependencies,
@@ -16,7 +17,280 @@ const receipt = {
   findingCount: 1,
 };
 
+const temporaryDirectories: string[] = [];
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+async function savedScansFixture() {
+  const root = await mkdtemp(join(tmpdir(), "cloud-saved-scans-"));
+  temporaryDirectories.push(root);
+  const scans = await Promise.all(
+    [1, 2, 3].map(async (index) => {
+      const scanDir = join(root, `scan ${index}`);
+      await mkdir(scanDir);
+      return {
+        scanId: `${String(index).repeat(8)}-1111-4111-8111-111111111111`,
+        scanDir,
+        targetSummary: `example/repo-${index}`,
+        progress: { status: "complete" },
+        findingCount: index,
+      };
+    }),
+  );
+  const workbenchCalls: string[][] = [];
+  const deps = dependencies({
+    onWorkbench: (args): JsonObject => {
+      workbenchCalls.push([...args]);
+      if (args[0] === "list-scans") return { scans };
+      expect(args.slice(0, 2)).toEqual(["get-scan", "--scan-id"]);
+      const scan = scans.find(({ scanId }) => scanId.startsWith(args[2]!));
+      if (!scan) throw new Error("Codex Security scan not found.");
+      return { scan };
+    },
+  });
+  return { scans, deps, workbenchCalls };
+}
+
 describe("publish scan to Cloud", () => {
+  test("resolves IDs, prefixes, and latest before publishing and deduplicates aliases", async () => {
+    const { scans, deps, workbenchCalls } = await savedScansFixture();
+    const [first, second] = scans;
+    const calls: string[] = [];
+    deps.publishScanToCloud = async (directory, options) => {
+      expect(workbenchCalls).toHaveLength(4);
+      const scan = scans[calls.length]!;
+      expect(directory).toBe(scan.scanDir);
+      expect(options?.expectedScanId).toBe(scan.scanId);
+      expect(options?.dryRun).toBe(true);
+      calls.push(scan.scanId);
+      return { ...receipt, scanId: scan.scanId, dryRun: true };
+    };
+    const stdout = capture();
+    const stderr = capture();
+    expect(
+      await main(
+        [
+          "publish",
+          "scan",
+          "--scan",
+          first!.scanId,
+          `--scan=${second!.scanId.slice(0, 8)}`,
+          "--scan",
+          "latest",
+          "--to",
+          "cloud",
+          "--dry-run",
+          "--json",
+        ],
+        stdout.stream,
+        stderr.stream,
+        deps,
+      ),
+    ).toBe(0);
+    expect(workbenchCalls).toContainEqual([
+      "list-scans",
+      "--repository",
+      resolve(deps.currentDirectory()),
+      "--status",
+      "complete",
+    ]);
+    expect(calls).toEqual([first!.scanId, second!.scanId]);
+    expect(JSON.parse(stdout.text()).results).toHaveLength(2);
+    expect(stderr.text()).toBe("");
+  });
+
+  test.each(["missing", "incomplete", "unavailable"])(
+    "rejects a %s saved scan before uploading any selected scan",
+    async (failure) => {
+      const { scans, deps } = await savedScansFixture();
+      const [first, second] = scans;
+      let requestedId = second!.scanId;
+      if (failure === "missing") requestedId = "99999999";
+      if (failure === "incomplete") second!.progress.status = "running";
+      if (failure === "unavailable")
+        await rm(second!.scanDir, { recursive: true });
+      let uploads = 0;
+      deps.publishScanToCloud = async () => {
+        uploads++;
+        return receipt;
+      };
+      const stderr = capture();
+      expect(
+        await main(
+          [
+            "publish",
+            "scan",
+            "--scan",
+            first!.scanId,
+            "--scan",
+            requestedId,
+            "--to",
+            "cloud",
+          ],
+          capture().stream,
+          stderr.stream,
+          deps,
+        ),
+      ).toBe(2);
+      expect(uploads).toBe(0);
+      expect(stderr.text()).toMatch(
+        /not found|not complete|artifacts or run a new scan/,
+      );
+      if (failure !== "missing")
+        expect(stderr.text()).toContain(second!.scanId);
+    },
+  );
+
+  test("rejects mixed ID and directory selectors before reading history", async () => {
+    const deps = dependencies({
+      onWorkbench: () => {
+        throw new Error("unexpected lookup");
+      },
+    });
+    const stderr = capture();
+    expect(
+      await main(
+        [
+          "publish",
+          "scan",
+          "--scan",
+          "11111111",
+          "--scan-dir",
+          "external-scan",
+          "--to",
+          "cloud",
+        ],
+        capture().stream,
+        stderr.stream,
+        deps,
+      ),
+    ).toBe(2);
+    expect(stderr.text()).toContain("Use --scan or scan directory inputs");
+  });
+
+  test("selects several saved scans by ID and stops at Done without selecting the rest", async () => {
+    const { scans, deps } = await savedScansFixture();
+    const picks = [scans[1]!.scanId, scans[0]!.scanId, ""];
+    let selections = 0;
+    deps.publishPrompt = {
+      isInteractive: () => true,
+      select: async (_question, choices, presentation, signal) => {
+        expect(signal).toBeInstanceOf(AbortSignal);
+        expect(presentation?.header).toContain("SCAN ID");
+        expect(choices.some(({ value }) => value === "")).toBe(selections > 0);
+        expect(
+          choices.some(({ label }) => label.includes(scans[0]!.scanDir)),
+        ).toBe(false);
+        const pick = picks[selections++]!;
+        return choices.find(({ value }) => value === pick)!.value;
+      },
+    };
+    const calls: string[] = [];
+    deps.publishScanToCloud = async (_directory, options) => {
+      expect(selections).toBe(3);
+      calls.push(options!.expectedScanId!);
+      return { ...receipt, scanId: options!.expectedScanId! };
+    };
+    const stdout = capture();
+    expect(
+      await main(
+        ["publish", "scan", "--to", "cloud", "--json"],
+        stdout.stream,
+        capture().stream,
+        deps,
+      ),
+    ).toBe(0);
+    expect(calls).toEqual(picks.slice(0, 2));
+    expect(
+      JSON.parse(stdout.text()).results.map(
+        (result: { scanId: string }) => result.scanId,
+      ),
+    ).toEqual(calls);
+  });
+
+  test("cancels in the picker without uploading already selected scans", async () => {
+    const { deps } = await savedScansFixture();
+    const signals = new FakeSignals();
+    deps.addSignalListener = (signal, listener) =>
+      signals.add(signal, listener);
+    deps.removeSignalListener = (signal, listener) =>
+      signals.remove(signal, listener);
+    let selections = 0;
+    deps.publishPrompt = {
+      isInteractive: () => true,
+      select: async (_question, choices, _presentation, signal) => {
+        if (selections++ > 0) {
+          signals.emit("SIGINT");
+          signal!.throwIfAborted();
+        }
+        return choices[0]!.value;
+      },
+    };
+    let uploads = 0;
+    deps.publishScanToCloud = async () => {
+      uploads++;
+      return receipt;
+    };
+    expect(
+      await main(
+        ["publish", "scan", "--to", "cloud"],
+        capture().stream,
+        capture().stream,
+        deps,
+      ),
+    ).toBe(130);
+    expect(uploads).toBe(0);
+    expect(
+      [...signals.listeners.values()].every(
+        (listeners) => listeners.size === 0,
+      ),
+    ).toBe(true);
+  });
+
+  test("identifies failed and unattempted saved scans by ID on cancellation", async () => {
+    const { scans, deps } = await savedScansFixture();
+    const signals = new FakeSignals();
+    deps.addSignalListener = (signal, listener) =>
+      signals.add(signal, listener);
+    deps.removeSignalListener = (signal, listener) =>
+      signals.remove(signal, listener);
+    deps.publishScanToCloud = async (_directory, options) => {
+      if (options!.expectedScanId === scans[1]!.scanId) {
+        signals.emit("SIGTERM");
+        throw new Error("Publication was not confirmed.");
+      }
+      return { ...receipt, scanId: options!.expectedScanId! };
+    };
+    const stdout = capture();
+    expect(
+      await main(
+        [
+          "publish",
+          "scan",
+          ...scans.flatMap(({ scanId }) => ["--scan", scanId]),
+          "--to",
+          "cloud",
+          "--json",
+        ],
+        stdout.stream,
+        capture().stream,
+        deps,
+      ),
+    ).toBe(143);
+    expect(JSON.parse(stdout.text())).toMatchObject({
+      results: [{ scanId: scans[0]!.scanId }],
+      failed: [
+        { scanId: scans[1]!.scanId, error: "Publication was not confirmed." },
+      ],
+      notAttempted: [scans[2]!.scanId],
+    });
+  });
+
   test("publishes multiple explicit scans in order and deduplicates resolved paths", async () => {
     for (const dryRun of [false, true]) {
       const deps = dependencies({
@@ -353,6 +627,9 @@ describe("publish scan to Cloud", () => {
 
   test("rejects missing or empty scan flags and extra positionals before publishing", async () => {
     for (const inputs of [
+      ["--scan"],
+      ["--scan="],
+      ["--scan", "--json"],
       ["--scan-dir"],
       ["--scan-dir="],
       ["--scan-dir", "--json"],
@@ -406,12 +683,13 @@ describe("publish scan to Cloud", () => {
         select: async (_question, choices) => {
           selections++;
           const directories: string[] = choices.map(({ value }) => value);
-          expect(directories).toEqual([scanDir]);
+          expect(directories).toEqual(["scan-1"]);
           return choices[0]!.value;
         },
       };
-      deps.publishScanToCloud = async (directory) => {
+      deps.publishScanToCloud = async (directory, options) => {
         expect(directory).toBe(scanDir);
+        expect(options?.expectedScanId).toBe("scan-1");
         return receipt;
       };
       const stdout = capture();
@@ -450,7 +728,7 @@ describe("publish scan to Cloud", () => {
         deps,
       ),
     ).toBe(2);
-    expect(stderr.text()).toContain("/path/to/sealed-scan --to cloud");
+    expect(stderr.text()).toContain("--scan SCAN_ID --to cloud");
     expect(stderr.text()).not.toContain("--linear-team");
   });
 

--- a/sdk/typescript/tests-ts/cli-publish.test.ts
+++ b/sdk/typescript/tests-ts/cli-publish.test.ts
@@ -74,6 +74,45 @@ function publicationResult(
 }
 
 describe("publish scan", () => {
+  test("resolves a saved scan ID for Linear publication", async () => {
+    const scanDir = await publicationDirectory();
+    const deps = dependencies({
+      onWorkbench: (args) => {
+        expect(args).toEqual(["get-scan", "--scan-id", "scan-123"]);
+        return {
+          scan: {
+            scanId: "scan-123",
+            scanDir,
+            progress: { status: "complete" },
+          },
+        };
+      },
+    });
+    let calls = 0;
+    deps.publishScan = async (directory, options) => {
+      calls++;
+      expect(directory).toBe(scanDir);
+      expect(options.expectedScanId).toBe("scan-123");
+      return publicationResult();
+    };
+    expect(
+      await main(
+        [
+          "publish",
+          "scan",
+          "--scan",
+          "scan-123",
+          ...DESTINATION_OPTIONS,
+          "--json",
+        ],
+        capture().stream,
+        capture().stream,
+        deps,
+      ),
+    ).toBe(0);
+    expect(calls).toBe(1);
+  });
+
   test("accepts the Linear project flag and its published alias", async () => {
     for (const flag of ["--linear-project", "--project"]) {
       let projectId: string | undefined;

--- a/sdk/typescript/tests-ts/cli-publish.test.ts
+++ b/sdk/typescript/tests-ts/cli-publish.test.ts
@@ -125,49 +125,60 @@ describe("publish scan", () => {
     );
   });
 
-  test("publishes an explicit scan directory without inspecting scan history", async () => {
-    const currentDirectory = join(tmpdir(), "codex-security-publish-current");
-    const stdout = capture();
-    const stderr = capture();
-    let invocation:
-      | { scanDirectory: string; options: Record<string, unknown> }
-      | undefined;
-    const deps = dependencies({
-      currentDirectory,
-      onWorkbench: () => {
-        throw new Error("scan history must not be inspected");
-      },
-    });
-    deps.createSecurity = () => {
-      throw new Error("a new security scan must not be started");
-    };
-    deps.publishScan = async (scanDirectory, options) => {
-      invocation = { scanDirectory, options: { ...options } };
-      return publicationResult();
-    };
+  test.each(["positional", "flag"])(
+    "publishes an explicit %s scan directory without inspecting scan history",
+    async (syntax) => {
+      const currentDirectory = join(tmpdir(), "codex-security-publish-current");
+      const stdout = capture();
+      const stderr = capture();
+      let invocation:
+        | { scanDirectory: string; options: Record<string, unknown> }
+        | undefined;
+      const deps = dependencies({
+        currentDirectory,
+        onWorkbench: () => {
+          throw new Error("scan history must not be inspected");
+        },
+      });
+      deps.createSecurity = () => {
+        throw new Error("a new security scan must not be started");
+      };
+      deps.publishScan = async (scanDirectory, options) => {
+        invocation = { scanDirectory, options: { ...options } };
+        return publicationResult();
+      };
 
-    expect(
-      await main(
-        ["publish", "scan", "completed-scan", ...DESTINATION_OPTIONS, "--json"],
-        stdout.stream,
-        stderr.stream,
-        deps,
-      ),
-    ).toBe(0);
-    expect(invocation).toEqual({
-      scanDirectory: resolve(currentDirectory, "completed-scan"),
-      options: {
-        destination: "linear",
-        teamId: "team-from-flags",
-        projectId: "project-from-flags",
-        dryRun: false,
-        signal: expect.any(AbortSignal),
-        onProgress: expect.any(Function),
-      },
-    });
-    expect(JSON.parse(stdout.text())).toEqual(publicationResult());
-    expect(stderr.text()).toBe("");
-  });
+      expect(
+        await main(
+          [
+            "publish",
+            "scan",
+            ...(syntax === "flag"
+              ? ["--scan-dir", "completed-scan"]
+              : ["completed-scan"]),
+            ...DESTINATION_OPTIONS,
+            "--json",
+          ],
+          stdout.stream,
+          stderr.stream,
+          deps,
+        ),
+      ).toBe(0);
+      expect(invocation).toEqual({
+        scanDirectory: resolve(currentDirectory, "completed-scan"),
+        options: {
+          destination: "linear",
+          teamId: "team-from-flags",
+          projectId: "project-from-flags",
+          dryRun: false,
+          signal: expect.any(AbortSignal),
+          onProgress: expect.any(Function),
+        },
+      });
+      expect(JSON.parse(stdout.text())).toEqual(publicationResult());
+      expect(stderr.text()).toBe("");
+    },
+  );
 
   test("selects direct Linear publication and forwards the requested assignee", async () => {
     for (const scenario of [

--- a/sdk/typescript/tests-ts/cloud-publish.test.ts
+++ b/sdk/typescript/tests-ts/cloud-publish.test.ts
@@ -65,6 +65,28 @@ async function fixture() {
 }
 
 describe("Cloud publication", () => {
+  test.each([false, true])(
+    "rejects artifacts from another scan before upload or preview (dryRun=%s)",
+    async (dryRun) => {
+      const { scan, environment } = await fixture();
+      let requests = 0;
+      await expect(
+        publishScanToCloud(scan, {
+          environment,
+          dryRun,
+          expectedScanId: "another-scan",
+          fetch: async () => {
+            requests++;
+            throw new Error("unexpected request");
+          },
+        }),
+      ).rejects.toThrow(
+        "Scan artifacts do not match selected scan another-scan.",
+      );
+      expect(requests).toBe(0);
+    },
+  );
+
   test("previews validated findings without credentials or network access", async () => {
     const { scan, home, environment } = await fixture();
     await rm(join(home, "auth.json"));
@@ -79,6 +101,7 @@ describe("Cloud publication", () => {
       await publishScanToCloud(scan, {
         environment,
         dryRun: true,
+        expectedScanId: manifest.scan.id,
         fetch: async () => {
           requests++;
           throw new Error("unexpected request");

--- a/sdk/typescript/tests-ts/publication.test.ts
+++ b/sdk/typescript/tests-ts/publication.test.ts
@@ -68,6 +68,26 @@ async function reseal(scanDirectory: string): Promise<void> {
 }
 
 describe("scan publication preparation", () => {
+  test("requires artifacts to match the selected saved scan", async () => {
+    const scanDirectory = await copyExample();
+    await expect(
+      prepareScanPublication(scanDirectory, {
+        ...DESTINATION,
+        expectedScanId: "another-scan",
+      }),
+    ).rejects.toThrow(
+      "Scan artifacts do not match selected scan another-scan.",
+    );
+    expect(
+      (
+        await prepareScanPublication(scanDirectory, {
+          ...DESTINATION,
+          expectedScanId: "scan_example_001",
+        })
+      ).scanId,
+    ).toBe("scan_example_001");
+  });
+
   test("prepares sealed findings with scan-based upload IDs and full traceability", async () => {
     const scanDirectory = await copyExample();
     const publication = await prepareScanPublication(


### PR DESCRIPTION
## Summary

Publishes several saved scans in one command, using scan IDs or an interactive picker. The CLI looks up the artifact directories so users do not need to find them. Depends on #612.

```bash
codex-security publish scan --to cloud \
  --scan SCAN_ID_A --scan SCAN_ID_B --dry-run --json
```

Omit `--scan` to choose completed scans interactively. Select scans, then choose **Done**. Remove `--dry-run` to publish.

## Changes

- Reuse saved history for `--scan` IDs, unique prefixes, and `latest`. Resolve all requested IDs before uploading and publish each selected scan once.
- Reuse the existing picker pattern for multiple Cloud selections. Nothing is selected automatically, and canceling selection uploads nothing.
- Require completed scans with available artifacts. Check that the sealed artifact ID matches the selected saved scan before publication.
- Keep repeated `--scan-dir` and the single positional directory for external artifacts, using `resolveCliPath`. Reject mixed ID and directory inputs. Linear accepts one scan, including `--scan`.
- Upload one scan per request. Keep each acceptance receipt with its scan result.
- Continue after per-scan errors. On cancellation, return received receipts and list the scans that were not attempted.

## Testing

- Focused Cloud and Linear publication tests: 97 passed.
- Full test suite (seed `12345` and randomized), with `umask 022`: 1,568 passed, 27 skipped, 0 failed in each run.
- `pnpm run types`, `pnpm run format`, and `pnpm run build`: passed.
- Built CLI test with two synthetic scans in a real local history database: ID/prefix deduplication, `latest`, and directory previews passed. A localhost mock server returned two accepted receipts. Nothing was uploaded to Cloud.

## Risk and rollout

No server changes are needed. Each request uses the existing format. Saved scan selection still requires local artifacts; history alone is not enough to publish.

Some scans can succeed even if others fail. The CLI never retries requests automatically. A missing or invalid receipt does not prove an upload failed; check whether Cloud accepted the scan before resubmitting it.

Receipts are returned in command output and are not saved to publication history. Selecting an entire bulk-scan run is not part of this PR.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
