### PR TITLE
chore: include Linear comments in patch context

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -995,8 +995,9 @@ for a personal API key, or `LINEAR_ACCESS_TOKEN` for an OAuth access token.
 `LINEAR_API_KEY` is also accepted. `--linear-api-key KEY` overrides these
 environment settings; prefer the environment variable to keep keys out of shell
 history. Imported content is always literal, and issue URLs must match the
-selected workspace. Linear access is read-only, and its credentials are not
-passed to the patch subprocess.
+selected workspace. Each imported issue includes its title, description, and
+all comments with their source links. Linear access is read-only, and its
+credentials are not passed to the patch subprocess.
 
 Use `verify-fix` to check whether an existing security fix actually closes its
 original vulnerability without modifying the repository. Pass a finding

--- a/sdk/typescript/src/linear.ts
+++ b/sdk/typescript/src/linear.ts
@@ -112,12 +112,21 @@ export async function importLinearIssues(options: {
       }
     }
 
-    return issues.map(({ identifier, title, url, description }) => ({
-      source: "linear",
-      id: identifier,
-      url,
-      text: `Title: ${title}\n\n${description ?? ""}`,
-    }));
+    const imports: ImportedIssue[] = [];
+    for (const issue of issues) {
+      const comments = await issue.comments({ first: 50 });
+      while (comments.pageInfo.hasNextPage) await comments.fetchNext();
+      imports.push({
+        source: "linear",
+        id: issue.identifier,
+        url: issue.url,
+        text: [
+          `Title: ${issue.title}\n\n${issue.description ?? ""}`,
+          ...comments.nodes.map(({ url, body }) => `Comment: ${url}\n${body}`),
+        ].join("\n\n"),
+      });
+    }
+    return imports;
   } catch (error) {
     if (error instanceof CodexSecurityError) throw error;
     if (

--- a/sdk/typescript/src/linear.ts
+++ b/sdk/typescript/src/linear.ts
@@ -121,8 +121,11 @@ export async function importLinearIssues(options: {
         id: issue.identifier,
         url: issue.url,
         text: [
-          `Title: ${issue.title}\n\n${issue.description ?? ""}`,
-          ...comments.nodes.map(({ url, body }) => `Comment: ${url}\n${body}`),
+          `Title: ${issue.title}`,
+          `<description>\n${issue.description ?? ""}\n</description>`,
+          ...comments.nodes.map(
+            ({ url, body }) => `<comment>\nURL: ${url}\n\n${body}\n</comment>`,
+          ),
         ].join("\n\n"),
       });
     }

--- a/sdk/typescript/tests-ts/cli-skills.test.ts
+++ b/sdk/typescript/tests-ts/cli-skills.test.ts
@@ -141,7 +141,10 @@ describe("CLI skill commands", () => {
 
   test("imports selected Linear issues without exposing its credential to Codex", async () => {
     const requests: string[] = [];
-    const laterComment = "Duplicate report:\n\nCheck **both** paths.";
+    const description =
+      "# Report\n\n## Reproduction\n\n```ts\nreadRecord(id);\n```";
+    const laterComment =
+      "# Report\n\n## Extra evidence\n\n```ts\ncheckOwner(id);\n```\n\nCheck **both** paths.";
     let inputs: string[] = [];
     let environment: NodeJS.ProcessEnv | undefined;
 
@@ -171,10 +174,13 @@ describe("CLI skill commands", () => {
             return {
               issue: async (id: string) => {
                 requests.push(id);
-                return linearIssue(id, [
-                  `Additional evidence for ${id}`,
-                  laterComment,
-                ]);
+                return {
+                  ...linearIssue(id, [
+                    `Additional evidence for ${id}`,
+                    laterComment,
+                  ]),
+                  description,
+                };
               },
             } as ReturnType<LinearClientFactory>;
           },
@@ -190,13 +196,14 @@ describe("CLI skill commands", () => {
     expect(requests).toEqual(["SEC-123", "SEC-124"]);
     expect(inputs).toHaveLength(2);
     expect(inputs[0]).toContain("Issue: SEC-123");
-    expect(inputs[1]).toContain("Synthetic evidence for SEC-124");
+    expect(inputs[1]).toContain(
+      `<description>\n${description}\n</description>`,
+    );
     expect(inputs[0]).toContain("Additional evidence for SEC-123");
     expect(inputs[1]).toContain("Additional evidence for SEC-124");
-    expect(inputs[0]).toContain(laterComment);
     expect(inputs[1]).toContain(laterComment);
     expect(inputs[0]).toContain(
-      "https://linear.app/example/issue/SEC-123#comment-1",
+      `<comment>\nURL: https://linear.app/example/issue/SEC-123#comment-1\n\n${laterComment}\n</comment>`,
     );
     expect(environment).toEqual({
       OPENAI_API_KEY: "sk-proj-SYNTHETIC_MODEL_KEY",
@@ -226,7 +233,7 @@ describe("CLI skill commands", () => {
             `..${paths.sep}`.repeat(32) +
             paths.relative(paths.parse(target).root, target),
         };
-        const expected = `Source: linear\nIssue: SEC-123\nURL: ${issue.url}\n\nTitle: ${issue.title}\n\n${issue.description}`;
+        const expected = `Source: linear\nIssue: SEC-123\nURL: ${issue.url}\n\nTitle: ${issue.title}\n\n<description>\n${issue.description}\n</description>`;
         const forbiddenPath = resolve(repository, expected);
         const originalLstat = filesystem.lstat;
         let probed = false;

--- a/sdk/typescript/tests-ts/cli-skills.test.ts
+++ b/sdk/typescript/tests-ts/cli-skills.test.ts
@@ -15,12 +15,25 @@ import type { LinearClientFactory } from "../src/linear.js";
 import { capture, dependencies } from "./cli-fixtures.js";
 import { runTestInSubprocess } from "./support/test-subprocess.js";
 
-function linearIssue(identifier: string) {
+function linearIssue(identifier: string, comments: string[] = []) {
+  const nodes = comments.map((body, index) => ({
+    body,
+    url: `https://linear.app/example/issue/${identifier}#comment-${index}`,
+  }));
   return {
     identifier,
     title: `Fix ${identifier}`,
     description: `Synthetic evidence for ${identifier}`,
     url: `https://linear.app/example/issue/${identifier}`,
+    comments: async () => ({
+      nodes: nodes.slice(0, 1),
+      pageInfo: { hasNextPage: nodes.length > 1 },
+      async fetchNext() {
+        this.nodes.push(...nodes.slice(1));
+        this.pageInfo.hasNextPage = false;
+        return this;
+      },
+    }),
   };
 }
 
@@ -128,6 +141,7 @@ describe("CLI skill commands", () => {
 
   test("imports selected Linear issues without exposing its credential to Codex", async () => {
     const requests: string[] = [];
+    const laterComment = "Duplicate report:\n\nCheck **both** paths.";
     let inputs: string[] = [];
     let environment: NodeJS.ProcessEnv | undefined;
 
@@ -157,7 +171,10 @@ describe("CLI skill commands", () => {
             return {
               issue: async (id: string) => {
                 requests.push(id);
-                return linearIssue(id);
+                return linearIssue(id, [
+                  `Additional evidence for ${id}`,
+                  laterComment,
+                ]);
               },
             } as ReturnType<LinearClientFactory>;
           },
@@ -174,6 +191,13 @@ describe("CLI skill commands", () => {
     expect(inputs).toHaveLength(2);
     expect(inputs[0]).toContain("Issue: SEC-123");
     expect(inputs[1]).toContain("Synthetic evidence for SEC-124");
+    expect(inputs[0]).toContain("Additional evidence for SEC-123");
+    expect(inputs[1]).toContain("Additional evidence for SEC-124");
+    expect(inputs[0]).toContain(laterComment);
+    expect(inputs[1]).toContain(laterComment);
+    expect(inputs[0]).toContain(
+      "https://linear.app/example/issue/SEC-123#comment-1",
+    );
     expect(environment).toEqual({
       OPENAI_API_KEY: "sk-proj-SYNTHETIC_MODEL_KEY",
     });
@@ -269,11 +293,13 @@ describe("CLI skill commands", () => {
           linearClient: ({ accessToken }) => {
             expect(accessToken).toBe("SYNTHETIC_OAUTH_TOKEN");
             const page = {
-              nodes: [linearIssue("SEC-123")],
+              nodes: [linearIssue("SEC-123", ["First issue comment"])],
               pageInfo: { hasNextPage: true },
               async fetchNext() {
                 nextPages++;
-                this.nodes.push(linearIssue("SEC-124"));
+                this.nodes.push(
+                  linearIssue("SEC-124", ["Second issue comment"]),
+                );
                 this.pageInfo.hasNextPage = false;
                 return this;
               },
@@ -318,6 +344,8 @@ describe("CLI skill commands", () => {
     expect(inputs).toHaveLength(2);
     expect(inputs[0]).toContain("Issue: SEC-123");
     expect(inputs[1]).toContain("Issue: SEC-124");
+    expect(inputs[0]).toContain("First issue comment");
+    expect(inputs[1]).toContain("Second issue comment");
   });
 
   test("rejects invalid Linear selections before starting Codex", async () => {

--- a/sdk/typescript/tests-ts/cli-verify-fix.test.ts
+++ b/sdk/typescript/tests-ts/cli-verify-fix.test.ts
@@ -12,6 +12,15 @@ function linearIssue(identifier: string) {
     title: `Verify ${identifier}`,
     description: `Synthetic security evidence for ${identifier}`,
     url: `https://linear.app/example/issue/${identifier}`,
+    comments: async () => ({
+      nodes: [
+        {
+          body: `Additional verification evidence for ${identifier}`,
+          url: `https://linear.app/example/issue/${identifier}#comment-evidence`,
+        },
+      ],
+      pageInfo: { hasNextPage: false },
+    }),
   };
 }
 
@@ -79,6 +88,7 @@ describe("read-only finding verification", () => {
     expect(stderr.text()).not.toContain("lin_api_SYNTHETIC_SECRET");
     expect(prompt).toContain("standalone verification-only mode");
     expect(prompt).toContain("$codex-security:verify-fix");
+    expect(prompt).toContain("Additional verification evidence for SEC-123");
     expect(prompt).toContain(
       await readFile(
         new URL(

--- a/sdk/typescript/tests-ts/linear.test.ts
+++ b/sdk/typescript/tests-ts/linear.test.ts
@@ -74,6 +74,10 @@ describe("Linear issue intake", () => {
               title: "Recheck a completed issue",
               description: null,
               url: "https://linear.app/example/issue/SEC-123",
+              comments: async () => ({
+                nodes: [],
+                pageInfo: { hasNextPage: false },
+              }),
             },
           ],
           (value) => (filter = value),
@@ -108,6 +112,10 @@ describe("Linear issue intake", () => {
                 title: "Synthetic finding",
                 description: "Synthetic evidence",
                 url,
+                comments: async () => ({
+                  nodes: [],
+                  pageInfo: { hasNextPage: false },
+                }),
               };
             },
           }) as unknown as LinearImportClient,
@@ -165,9 +173,15 @@ describe("Linear issue intake", () => {
           },
           linearClient: () =>
             ({
-              issue: async () => {
-                throw error;
-              },
+              issue: async () => ({
+                comments: async () => ({
+                  nodes: [],
+                  pageInfo: { hasNextPage: true },
+                  fetchNext: async () => {
+                    throw error;
+                  },
+                }),
+              }),
             }) as unknown as LinearImportClient,
         }),
       ).rejects.toThrow(message);

--- a/sdk/typescript/tests-ts/linear.test.ts
+++ b/sdk/typescript/tests-ts/linear.test.ts
@@ -91,7 +91,7 @@ describe("Linear issue intake", () => {
         source: "linear",
         id: "SEC-123",
         url: "https://linear.app/example/issue/SEC-123",
-        text: "Title: Recheck a completed issue\n\n",
+        text: "Title: Recheck a completed issue\n\n<description>\n\n</description>",
       },
     ]);
   });
@@ -126,7 +126,7 @@ describe("Linear issue intake", () => {
             source: "linear",
             id: "SEC-123",
             url,
-            text: "Title: Synthetic finding\n\nSynthetic evidence",
+            text: "Title: Synthetic finding\n\n<description>\nSynthetic evidence\n</description>",
           },
         ]);
       } else {


### PR DESCRIPTION
## Summary

Linear issue imports contained only the title and description. The patch agent could miss supporting details in ticket comments.

## Changes

Read every comment page and append the comment text and source links to each imported issue. This applies to issue and project inputs for both `patch` and `verify-fix`. Wrap the description in `<description>...</description>` and each comment with its source link in `<comment>...</comment>`. Keep the original Markdown unchanged. Update the documentation and existing tests.

## Testing

- 48 focused Linear and CLI tests pass, covering pagination, headings, and fenced code.
- The full suite passes with fixed and random test order: 1,629 passed and 30 skipped in each run.
- The delimiter checks fail without the tags and pass with them.
- `pnpm run types`, `pnpm run format`, `pnpm run build`, and `git diff --check` pass.

Tests use synthetic Linear responses; no live tickets or model calls were needed.

## Risk and rollout

No command arguments or defaults change. Linear access stays read-only, and its credentials stay out of the patch subprocess. Imports make additional read requests for comment pages and use the existing error handling if a request fails.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
