### PR TITLE
fix(publish): select scans and reuse credentials

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -739,7 +739,9 @@ npx @openai/codex-security publish scan --to cloud --dry-run --json
 ```
 
 The picker shows each scan's repository, finding count, age, and scan ID.
-Choose scans, then select **Done**. No scans are selected automatically.
+Press <kbd>Space</kbd> to select or deselect scans, then press
+<kbd>Enter</kbd> to submit. At least one scan is required, and no scans are
+selected automatically.
 
 For scripts, repeat `--scan` with saved scan IDs or unique ID prefixes (at
 least eight characters):
@@ -753,7 +755,8 @@ npx @openai/codex-security publish scan \
 Use `scans list --json` to find IDs for the current repository. `--scan latest`
 selects its latest completed scan. The CLI resolves IDs through saved history,
 processes each selected scan once, and checks that its sealed artifacts match
-the selected ID. The artifacts must still be available locally.
+the selected ID. Picker selections use the order shown; repeated `--scan`
+selections use argument order. The artifacts must still be available locally.
 
 `--dry-run` validates the scans and prints their findings without uploading or
 requiring a login. Remove `--dry-run` to upload. Live uploads require ChatGPT

--- a/sdk/typescript/src/bulk-scan-discovery.ts
+++ b/sdk/typescript/src/bulk-scan-discovery.ts
@@ -5,7 +5,7 @@ import { join, resolve } from "node:path";
 import { stdin } from "node:process";
 import { Writable } from "node:stream";
 import { promisify } from "node:util";
-import { confirm, input, search } from "@inquirer/prompts";
+import { checkbox, confirm, input, search, Separator } from "@inquirer/prompts";
 import { Octokit } from "@octokit/core";
 import Papa from "papaparse";
 import { expandHome } from "./runtime.js";
@@ -71,6 +71,12 @@ export interface BulkScanPrompt {
     presentation?: { header?: string },
     signal?: AbortSignal,
   ): Promise<Value>;
+  checkbox<Value extends string>(
+    question: string,
+    options: readonly { label: string; value: Value; short?: string }[],
+    presentation?: { header?: string; required?: boolean },
+    signal?: AbortSignal,
+  ): Promise<Value[]>;
 }
 
 export interface BulkScanDiscoveryDependencies {
@@ -361,6 +367,24 @@ function createTerminalPrompt(output: PromptOutput): BulkScanPrompt {
       confirm({ message, default: defaultValue }, context(signal)),
     input: (message, defaultValue, signal) =>
       input({ message, default: defaultValue }, context(signal)),
+    checkbox: (message, options, presentation, signal) =>
+      checkbox(
+        {
+          message,
+          choices: [
+            ...(presentation?.header === undefined
+              ? []
+              : [new Separator(presentation.header)]),
+            ...options.map(({ label, value, short }) => ({
+              name: label,
+              value,
+              ...(short === undefined ? {} : { short }),
+            })),
+          ],
+          required: presentation?.required,
+        },
+        context(signal),
+      ),
     select: (message, options, presentation, signal) =>
       search(
         {

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -1057,7 +1057,8 @@ interface CliDependencies {
   ) => Promise<string>;
   hasStoredChatGPTSignIn?: (signal?: AbortSignal) => Promise<boolean>;
   scanAuthenticationPrompt?: Pick<BulkScanPrompt, "isInteractive" | "select">;
-  publishPrompt?: Pick<BulkScanPrompt, "isInteractive" | "select">;
+  publishPrompt?: Pick<BulkScanPrompt, "isInteractive" | "select"> &
+    Partial<Pick<BulkScanPrompt, "checkbox">>;
   checkScanPublication?: typeof checkScanPublication;
   publishScan?: typeof publishScan;
   publishScanToCloud?: typeof publishScanToCloud;
@@ -2321,28 +2322,22 @@ export async function main(
             };
           });
           if (options.to === "cloud") {
-            let remaining = choices;
-            while (true) {
-              controller.signal.throwIfAborted();
-              const selected = await prompt.select(
-                "Which completed scans would you like to publish?",
-                selectedScans.length === 0
-                  ? remaining
-                  : [
-                      {
-                        label: `Done (${selectedScans.length} selected)`,
-                        value: "",
-                      },
-                      ...remaining,
-                    ],
-                { header },
-                controller.signal,
+            if (prompt.checkbox === undefined) {
+              throw new CodexSecurityError(
+                "Interactive scan selection is unavailable.",
               );
-              controller.signal.throwIfAborted();
-              if (selected === "") break;
-              selectedScans.push(scansById.get(selected)!);
-              remaining = remaining.filter(({ value }) => value !== selected);
             }
+            controller.signal.throwIfAborted();
+            const selected = await prompt.checkbox(
+              "Which completed scans would you like to publish?",
+              choices,
+              { header, required: true },
+              controller.signal,
+            );
+            controller.signal.throwIfAborted();
+            selectedScans.push(
+              ...selected.map((scanId) => scansById.get(scanId)!),
+            );
             scanDir = selectedScans[0]!.scanDir;
           } else {
             scanDir = await prompt.select(

--- a/sdk/typescript/src/cloud-publish.ts
+++ b/sdk/typescript/src/cloud-publish.ts
@@ -17,7 +17,7 @@ import {
 const CLOUD_PUBLISH_URL =
   "https://chatgpt.com/backend-api/aardvark/cli/findings";
 const CHATGPT_LOGIN_REQUIRED =
-  'Cloud publication requires ChatGPT credentials stored with cli_auth_credentials_store = "file". Automatic and keyring storage are not read because a stale auth.json may belong to another account. Configure file storage, sign in with ChatGPT again, then retry.';
+  "Cloud publication requires a ChatGPT login already available to Codex Security. Run a scan or sign in with ChatGPT using Codex file credential storage, then retry.";
 
 const credentialsSchema = z.object({
   auth_mode: z.literal("chatgpt").optional(),
@@ -149,6 +149,7 @@ async function readCloudCredentials(environment: NodeJS.ProcessEnv) {
     environment["CODEX_HOME"]?.trim() || "~/.codex",
     environment,
   );
+  let requireFileStorage = true;
   const dedicatedHome = codexSecurityCredentialHome(environment);
   if (existsSync(dedicatedHome)) {
     if (!(await codexSecurityCredentialAllowsAmbientImport(dedicatedHome))) {
@@ -156,23 +157,26 @@ async function readCloudCredentials(environment: NodeJS.ProcessEnv) {
     }
     if (await codexSecurityHasStoredFileCredentials(dedicatedHome)) {
       home = dedicatedHome;
+      requireFileStorage = false;
     } else if (existsSync(join(dedicatedHome, "config.toml"))) {
       // Do not silently switch accounts when the dedicated login may be in a keyring.
       throw new AuthenticationRequiredError(CHATGPT_LOGIN_REQUIRED);
     }
   }
-  let credentialStorage: unknown;
-  try {
-    credentialStorage = parseToml(
-      await readFile(join(home, "config.toml"), "utf8"),
-    )["cli_auth_credentials_store"];
-  } catch {
-    throw new AuthenticationRequiredError(CHATGPT_LOGIN_REQUIRED);
-  }
-  // File presence is not proof that it is the active login: automatic or
-  // keyring storage can leave an auth.json from a different account.
-  if (credentialStorage !== "file") {
-    throw new AuthenticationRequiredError(CHATGPT_LOGIN_REQUIRED);
+  if (requireFileStorage) {
+    let credentialStorage: unknown;
+    try {
+      credentialStorage = parseToml(
+        await readFile(join(home, "config.toml"), "utf8"),
+      )["cli_auth_credentials_store"];
+    } catch {
+      throw new AuthenticationRequiredError(CHATGPT_LOGIN_REQUIRED);
+    }
+    // File presence is not proof that it is the active ambient login:
+    // automatic or keyring storage can leave auth.json for another account.
+    if (credentialStorage !== "file") {
+      throw new AuthenticationRequiredError(CHATGPT_LOGIN_REQUIRED);
+    }
   }
   try {
     const credentials = credentialsSchema.safeParse(

--- a/sdk/typescript/tests-ts/bulk-scan-discovery.test.ts
+++ b/sdk/typescript/tests-ts/bulk-scan-discovery.test.ts
@@ -71,6 +71,10 @@ class FakePrompt implements BulkScanPrompt {
     return (options.find((option) => option.value === value) ?? options[0]!)
       .value;
   }
+
+  public async checkbox<Value extends string>(): Promise<Value[]> {
+    throw new Error("unexpected checkbox prompt");
+  }
 }
 
 interface Repository {

--- a/sdk/typescript/tests-ts/cli-cloud-publish.test.ts
+++ b/sdk/typescript/tests-ts/cli-cloud-publish.test.ts
@@ -173,9 +173,9 @@ describe("publish scan to Cloud", () => {
     expect(stderr.text()).toContain("Use --scan or scan directory inputs");
   });
 
-  test("selects several saved scans in one multi-select prompt", async () => {
+  test("publishes checked scans in display order from one multi-select prompt", async () => {
     const { scans, deps } = await savedScansFixture();
-    const picks = [scans[1]!.scanId, scans[0]!.scanId];
+    const picks = scans.slice(0, 2).map(({ scanId }) => scanId);
     let selections = 0;
     deps.publishPrompt = {
       isInteractive: () => true,
@@ -199,9 +199,7 @@ describe("publish scan to Cloud", () => {
         expect(choices.map(({ value }) => String(value))).toEqual(
           scans.map(({ scanId }) => scanId),
         );
-        return picks.map(
-          (pick) => choices.find(({ value }) => value === pick)!.value,
-        );
+        return choices.slice(0, 2).map(({ value }) => value);
       },
     };
     const calls: string[] = [];

--- a/sdk/typescript/tests-ts/cli-cloud-publish.test.ts
+++ b/sdk/typescript/tests-ts/cli-cloud-publish.test.ts
@@ -173,26 +173,40 @@ describe("publish scan to Cloud", () => {
     expect(stderr.text()).toContain("Use --scan or scan directory inputs");
   });
 
-  test("selects several saved scans by ID and stops at Done without selecting the rest", async () => {
+  test("selects several saved scans in one multi-select prompt", async () => {
     const { scans, deps } = await savedScansFixture();
-    const picks = [scans[1]!.scanId, scans[0]!.scanId, ""];
+    const picks = [scans[1]!.scanId, scans[0]!.scanId];
     let selections = 0;
     deps.publishPrompt = {
       isInteractive: () => true,
-      select: async (_question, choices, presentation, signal) => {
+      select: async () => {
+        throw new Error("unexpected single-select prompt");
+      },
+      checkbox: async <Value extends string>(
+        _question: string,
+        choices: readonly { label: string; value: Value }[],
+        presentation?: { header?: string; required?: boolean },
+        signal?: AbortSignal,
+      ): Promise<Value[]> => {
+        selections++;
         expect(signal).toBeInstanceOf(AbortSignal);
         expect(presentation?.header).toContain("SCAN ID");
-        expect(choices.some(({ value }) => value === "")).toBe(selections > 0);
+        expect(presentation?.required).toBe(true);
+        expect(choices.some(({ value }) => value === "")).toBe(false);
         expect(
           choices.some(({ label }) => label.includes(scans[0]!.scanDir)),
         ).toBe(false);
-        const pick = picks[selections++]!;
-        return choices.find(({ value }) => value === pick)!.value;
+        expect(choices.map(({ value }) => String(value))).toEqual(
+          scans.map(({ scanId }) => scanId),
+        );
+        return picks.map(
+          (pick) => choices.find(({ value }) => value === pick)!.value,
+        );
       },
     };
     const calls: string[] = [];
     deps.publishScanToCloud = async (_directory, options) => {
-      expect(selections).toBe(3);
+      expect(selections).toBe(1);
       calls.push(options!.expectedScanId!);
       return { ...receipt, scanId: options!.expectedScanId! };
     };
@@ -205,7 +219,7 @@ describe("publish scan to Cloud", () => {
         deps,
       ),
     ).toBe(0);
-    expect(calls).toEqual(picks.slice(0, 2));
+    expect(calls).toEqual(picks);
     expect(
       JSON.parse(stdout.text()).results.map(
         (result: { scanId: string }) => result.scanId,
@@ -220,15 +234,15 @@ describe("publish scan to Cloud", () => {
       signals.add(signal, listener);
     deps.removeSignalListener = (signal, listener) =>
       signals.remove(signal, listener);
-    let selections = 0;
     deps.publishPrompt = {
       isInteractive: () => true,
-      select: async (_question, choices, _presentation, signal) => {
-        if (selections++ > 0) {
-          signals.emit("SIGINT");
-          signal!.throwIfAborted();
-        }
-        return choices[0]!.value;
+      select: async () => {
+        throw new Error("unexpected single-select prompt");
+      },
+      checkbox: async (_question, _choices, _presentation, signal) => {
+        signals.emit("SIGINT");
+        signal!.throwIfAborted();
+        return [];
       },
     };
     let uploads = 0;
@@ -770,16 +784,15 @@ describe("publish scan to Cloud", () => {
       let selections = 0;
       deps.publishPrompt = {
         isInteractive: () => true,
-        select: async (_question, choices) => {
+        select: async () => {
+          throw new Error("unexpected single-select prompt");
+        },
+        checkbox: async (_question, choices, presentation) => {
           selections++;
           const directories: string[] = choices.map(({ value }) => value);
-          if (selections === 1) {
-            expect(directories).toEqual(["scan-1"]);
-            return choices[0]!.value;
-          }
-          expect(directories).toEqual([""]);
-          expect(choices[0]!.label).toBe("Done (1 selected)");
-          return choices[0]!.value;
+          expect(directories).toEqual(["scan-1"]);
+          expect(presentation?.required).toBe(true);
+          return [choices[0]!.value];
         },
       };
       deps.publishScanToCloud = async (directory, options) => {
@@ -796,7 +809,7 @@ describe("publish scan to Cloud", () => {
           deps,
         ),
       ).toBe(0);
-      expect(selections).toBe(2);
+      expect(selections).toBe(1);
       expect(JSON.parse(stdout.text())).toEqual(receipt);
     } finally {
       await rm(root, { recursive: true, force: true });

--- a/sdk/typescript/tests-ts/cloud-publish.test.ts
+++ b/sdk/typescript/tests-ts/cloud-publish.test.ts
@@ -265,7 +265,7 @@ describe("Cloud publication", () => {
     expect(requestedUrl).toBe(publishUrl);
   });
 
-  test("prefers the dedicated file login and honors an explicit logout", async () => {
+  test("reuses the dedicated Codex Security login and honors an explicit logout", async () => {
     const { scan, environment } = await fixture();
     const home = codexSecurityCredentialHome(environment);
     await mkdir(home, { recursive: true, mode: 0o700 });
@@ -277,6 +277,10 @@ describe("Cloud publication", () => {
       }),
       { mode: 0o600 },
     );
+    await writeFile(
+      join(home, "config.toml"),
+      'cli_auth_credentials_store = "auto"\n',
+    );
     let requests = 0;
     const send = async (_url: string, options: RequestInit) => {
       requests++;
@@ -285,19 +289,11 @@ describe("Cloud publication", () => {
       );
       return Response.json(receipt);
     };
-    await expect(
-      publishScanToCloud(scan, { environment, fetch: send }),
-    ).rejects.toThrow('cli_auth_credentials_store = "file"');
-    expect(requests).toBe(0);
-    await writeFile(
-      join(home, "config.toml"),
-      'cli_auth_credentials_store = "file"\n',
-    );
     await publishScanToCloud(scan, { environment, fetch: send });
     await setCodexSecurityCredentialLogout(home, true);
     await expect(
       publishScanToCloud(scan, { environment, fetch: send }),
-    ).rejects.toThrow('cli_auth_credentials_store = "file"');
+    ).rejects.toThrow("ChatGPT login already available to Codex Security");
     expect(requests).toBe(1);
   });
 
@@ -340,7 +336,7 @@ describe("Cloud publication", () => {
       }
       await expect(
         publishScanToCloud(scan, { environment, fetch: send }),
-      ).rejects.toThrow('cli_auth_credentials_store = "file"');
+      ).rejects.toThrow("ChatGPT login already available to Codex Security");
     }
     expect(requests).toBe(0);
   });
@@ -363,16 +359,16 @@ describe("Cloud publication", () => {
       });
       await expect(
         publishScanToCloud(scan, { environment, fetch: send }),
-      ).rejects.toThrow('cli_auth_credentials_store = "file"');
+      ).rejects.toThrow("ChatGPT login already available to Codex Security");
     }
     await writeFile(join(home, "auth.json"), "malformed-synthetic-secret");
     await expect(
       publishScanToCloud(scan, { environment, fetch: send }),
-    ).rejects.toThrow('cli_auth_credentials_store = "file"');
+    ).rejects.toThrow("ChatGPT login already available to Codex Security");
     await rm(join(home, "auth.json"));
     await expect(
       publishScanToCloud(scan, { environment, fetch: send }),
-    ).rejects.toThrow('cli_auth_credentials_store = "file"');
+    ).rejects.toThrow("ChatGPT login already available to Codex Security");
     expect(requests).toBe(0);
   });
 
@@ -394,9 +390,8 @@ describe("Cloud publication", () => {
         () => undefined,
         (failure: unknown) => failure,
       );
-      expect(String(error)).toContain('cli_auth_credentials_store = "file"');
       expect(String(error)).toContain(
-        "a stale auth.json may belong to another account",
+        "ChatGPT login already available to Codex Security",
       );
     }
     expect(requests).toBe(0);


### PR DESCRIPTION
## Summary

The interactive Cloud publication flow presented repeated single-choice prompts even though it asked users to select multiple completed scans. Selecting a scan immediately reopened the prompt, making the interaction appear ineffective.

Use one checkbox prompt for scan selection. Reuse the ChatGPT credentials already available in Codex Security's private managed runtime when publishing selected scans.

## Changes

- add checkbox support to the terminal prompt adapter
- select completed scans through one required multi-select prompt
- remove the synthetic `Done` choice and repeated prompt loop
- process interactive selections in their visible picker order
- document the Space-select and Enter-submit interaction
- reuse the private managed credential file already used by Codex Security scans
- preserve explicit logout and the file-storage requirement for ambient credentials
- add regression coverage for multi-selection, ordering, cancellation, and managed credential reuse

## Testing

- `bun test --timeout 30000 tests-ts/cloud-publish.test.ts`
  - 16 passed
- `bun test --timeout 30000 ./tests-ts --seed 12345`
  - 1,772 passed, 30 platform-specific skipped, 0 failed
- `pnpm run types`
- `pnpm run format`
- `pnpm run build`
- `git diff --check`

## Risk and rollout

Low-to-moderate risk. Explicit scan arguments and publication payloads are unchanged. Interactive selections are processed in the picker's visible order, while repeated `--scan` arguments retain argument order.

Credential reuse is limited to Codex Security's private managed credential home. Explicit logout still blocks publication, and ambient automatic or keyring-backed files remain rejected because they may be stale. The publisher still performs the HTTP request directly; a future Codex-owned authenticated transport can replace this interim path.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
