### PR TITLE
release: bump Codex Security to 0.1.20

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -2,7 +2,7 @@
 
 ## Highlights
 
-- Bug fixes and reliability improvements for Linear publication, including
+- Bug fixes and reliability improvements for cloud publication, including
   access checks, recovery handling, and skipping findings that were already
   recorded.
 

--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,16 +1,9 @@
-<!-- release-version: 0.1.19 -->
+<!-- release-version: 0.1.20 -->
 
 ## Highlights
 
-- Publish one or more completed scans to Codex Security Cloud with
-  `publish scan --to cloud`. Choose saved scans interactively or with
-  repeatable `--scan` options, or use repeatable `--scan-dir` options for
-  external artifacts. `--dry-run` validates and previews findings without
-  uploading. Live uploads require a file-backed ChatGPT sign-in and an account
-  authorized for Cloud publication. See
-  [Cloud publication setup and behavior](https://github.com/openai/codex-security/blob/npm-v0.1.19/sdk/typescript/README.md#publish-multiple-completed-scans-to-cloud).
-- Select a saved scan for Linear publication by scan ID, unique ID prefix, or
-  `latest`; omitting the selector opens the interactive picker. See
-  [Linear publication](https://github.com/openai/codex-security/blob/npm-v0.1.19/sdk/typescript/README.md#publish-completed-scans-to-linear).
+- Bug fixes and reliability improvements for Linear publication, including
+  access checks, recovery handling, and skipping findings that were already
+  recorded.
 
 The categorized list below contains the individual changes.

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-security",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "TypeScript SDK and CLI for Codex Security",
   "license": "Apache-2.0",
   "author": "OpenAI",


### PR DESCRIPTION
## Summary

Prepare Codex Security 0.1.20 with the bug fixes and reliability improvements merged since 0.1.19.

## Changes

- Bump `@openai/codex-security` from 0.1.19 to 0.1.20.
- Replace the 0.1.19 highlights with a brief description of the Linear publication fixes included in this release.

## Testing

- `git diff --check`
- Confirmed exactly two changed files.
- `node sdk/typescript/scripts/release-automation.mjs version sdk/typescript/package.json`
- `node sdk/typescript/scripts/release-automation.mjs release-tag tag refs/tags/npm-v0.1.20 npm-v0.1.20 sdk/typescript/package.json`
- `node sdk/typescript/scripts/release-automation.mjs require-increase 0.1.20 0.1.19`
- `npm exec --yes --package=prettier@3.2.5 -- prettier --check .github/release-notes.md`

Package testing is left to the required pull-request CI because this pull request changes release metadata only.

## Risk and rollout

This pull request changes release metadata only. After merge, the existing protected release workflow handles package publication and GitHub release creation.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
