### PR TITLE
feat(publish): upload findings from CSV

### DIFF
--- a/examples/findings.csv
+++ b/examples/findings.csv
@@ -1,0 +1,1 @@
+occurrence_id,finding_id,title,summary,severity,confidence,status,close_reason,note,remediation,path,start_line,end_line

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -788,14 +788,8 @@ that you can copy and fill in before publishing.
 The CSV must have the export columns `occurrence_id`, `finding_id`, `title`,
 `summary`, `severity`, `confidence`, `status`, `close_reason`, `note`,
 `remediation`, `path`, `start_line`, and `end_line`. Deep-scan exports may also
-include `candidate_id`. The CLI validates headers, finding and occurrence IDs,
-severity, confidence, triage state, location paths and line ranges, and rejects
-duplicate findings before authentication or upload. Imported rows preserve
-their source IDs in provenance while the upload uses derived canonical IDs.
-Finding IDs use `csf_` plus 24 lowercase hexadecimal characters; occurrence
-IDs use the same format with an `occ_` prefix. Use `--dry-run --json` to
-validate the CSV and inspect the normalized findings locally without a login
-or network request.
+include `candidate_id`. Use `--dry-run --json` to validate the CSV and inspect
+the normalized findings locally without a login or network request.
 
 `--csv` is only supported with `--to cloud` and cannot be combined with a scan
 directory, `--scan-dir`, or `--scan`.

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -295,6 +295,7 @@ npx @openai/codex-security export /path/outside/repository/results --export-form
 npx @openai/codex-security export /path/outside/repository/results --export-format json --output /path/outside/repository/findings.json
 npx @openai/codex-security publish scan /path/outside/repository/results --to linear --linear-team TEAM_ID
 npx @openai/codex-security publish scan --to linear --linear-team TEAM_ID
+npx @openai/codex-security publish scan --to cloud --csv /path/outside/repository/findings.csv
 npx @openai/codex-security validate /path/outside/repository/findings.json "Possible SQL injection in src/query.ts:42"
 npx @openai/codex-security validate "Possible SQL injection" --effort high
 npx @openai/codex-security verify-fix --linear-issue SEC-123 --json
@@ -730,7 +731,7 @@ and scans stopped at their configured cost limit do not start another turn.
 invocation and defaults to `1`. Results remain under `--output-dir`; rerun the
 same command to resume.
 
-### Publish multiple completed scans to Cloud
+### Publish findings to Cloud
 
 Choose completed scans from your local history:
 
@@ -771,6 +772,33 @@ Automatic and keyring credential storage are not accepted for Cloud
 publication, even when an `auth.json` file exists, because that file may be
 stale and belong to a different account. The CLI sends one scan at a time,
 with each scan's findings and metadata in a separate request.
+
+To publish findings from a CSV instead of a completed scan, pass the CSV
+created by `codex-security export --export-format csv`:
+
+```bash
+npx @openai/codex-security publish scan --to cloud \
+  --csv /path/outside/repository/findings.csv
+```
+
+The repository includes a header-only
+[findings CSV template](https://github.com/openai/codex-security/blob/main/examples/findings.csv)
+that you can copy and fill in before publishing.
+
+The CSV must have the export columns `occurrence_id`, `finding_id`, `title`,
+`summary`, `severity`, `confidence`, `status`, `close_reason`, `note`,
+`remediation`, `path`, `start_line`, and `end_line`. Deep-scan exports may also
+include `candidate_id`. The CLI validates headers, finding and occurrence IDs,
+severity, confidence, triage state, location paths and line ranges, and rejects
+duplicate findings before authentication or upload. Imported rows preserve
+their source IDs in provenance while the upload uses derived canonical IDs.
+Finding IDs use `csf_` plus 24 lowercase hexadecimal characters; occurrence
+IDs use the same format with an `occ_` prefix. Use `--dry-run --json` to
+validate the CSV and inspect the normalized findings locally without a login
+or network request.
+
+`--csv` is only supported with `--to cloud` and cannot be combined with a scan
+directory, `--scan-dir`, or `--scan`.
 
 For artifacts outside local history, use repeated `--scan-dir PATH` instead.
 A single positional directory is still accepted and can be combined with

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -2036,9 +2036,7 @@ export async function main(
         .describe("Preview the findings without publishing them."),
       csv: optionValue("--csv")
         .optional()
-        .describe(
-          "Codex Security findings CSV to publish instead of a completed scan.",
-        ),
+        .describe("Findings CSV to publish instead of a completed scan."),
       skipExisting: z
         .boolean()
         .default(false)
@@ -2187,7 +2185,6 @@ export async function main(
             environment: dependencies.environment,
             dryRun: options.dryRun,
             signal: controller.signal,
-            now: dependencies.now,
           });
           return { ...result };
         }

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -56,6 +56,7 @@ import {
 } from "./api.js";
 import { accountStatus } from "./auth.js";
 import {
+  publishFindingsCsvToCloud,
   publishScanToCloud,
   type CloudPublicationResult,
 } from "./cloud-publish.js";
@@ -253,6 +254,7 @@ const VALUE_OPTIONS = new Set([
   "--max-time-hours",
   "--max-attempts",
   "--export-format",
+  "--csv",
   "--output",
   "--source-root",
   "--format",
@@ -1061,6 +1063,7 @@ interface CliDependencies {
     Partial<Pick<BulkScanPrompt, "checkbox">>;
   checkScanPublication?: typeof checkScanPublication;
   publishScan?: typeof publishScan;
+  publishFindingsCsvToCloud?: typeof publishFindingsCsvToCloud;
   publishScanToCloud?: typeof publishScanToCloud;
   confirmPatchReview?: (question: string) => Promise<boolean>;
   patchEditor?: (
@@ -1996,9 +1999,9 @@ export async function main(
     }
   };
   const publication = Cli.create("publish", {
-    description: "Publish completed Codex Security scan findings.",
+    description: "Publish Codex Security findings.",
   }).command("scan", {
-    description: "Publish every finding from a completed scan to Linear.",
+    description: "Publish findings from a completed scan or CSV.",
     destructive: true,
     mcp: false,
     args: z.object({
@@ -2030,7 +2033,12 @@ export async function main(
       dryRun: z
         .boolean()
         .default(false)
-        .describe("Preview the findings without creating Linear issues."),
+        .describe("Preview the findings without publishing them."),
+      csv: optionValue("--csv")
+        .optional()
+        .describe(
+          "Codex Security findings CSV to publish instead of a completed scan.",
+        ),
       skipExisting: z
         .boolean()
         .default(false)
@@ -2100,6 +2108,10 @@ export async function main(
       };
       try {
         const currentDirectory = dependencies.currentDirectory();
+        const csvPath =
+          options.csv === undefined
+            ? undefined
+            : resolveCliPath(currentDirectory, options.csv);
         const directories = [
           ...new Set(
             [
@@ -2116,6 +2128,21 @@ export async function main(
         if (options.scan.length > 0 && directories.length > 0) {
           throw new CodexSecurityError(
             "Use --scan or scan directory inputs, not both.",
+          );
+        }
+        if (
+          csvPath !== undefined &&
+          (args.scanDir !== undefined ||
+            options.scan.length > 0 ||
+            options.scanDir.length > 0)
+        ) {
+          throw new CodexSecurityError(
+            "Use --csv or scan directory and ID inputs, not both.",
+          );
+        }
+        if (csvPath !== undefined && options.to !== "cloud") {
+          throw new CodexSecurityError(
+            "--csv is only supported with --to cloud.",
           );
         }
         if (new Set(options.scan).size > 1 && options.to !== "cloud") {
@@ -2152,6 +2179,17 @@ export async function main(
           dependencies.addSignalListener("SIGINT", onInterrupt);
           dependencies.addSignalListener("SIGTERM", onTerminate);
           observingSignals = true;
+        }
+        if (csvPath !== undefined) {
+          const result = await (
+            dependencies.publishFindingsCsvToCloud ?? publishFindingsCsvToCloud
+          )(csvPath, {
+            environment: dependencies.environment,
+            dryRun: options.dryRun,
+            signal: controller.signal,
+            now: dependencies.now,
+          });
+          return { ...result };
         }
         const selectedScans: { scanDir: string; scanId?: string }[] =
           directories.map((scanDir) => ({ scanDir }));

--- a/sdk/typescript/src/cloud-publish.ts
+++ b/sdk/typescript/src/cloud-publish.ts
@@ -53,59 +53,96 @@ interface CloudPublicationDependencies {
   dryRun?: boolean;
 }
 
-interface CsvFindingRow {
-  occurrenceId: string;
-  findingId: string;
-  candidateId?: string;
-  title: string;
-  summary: string;
-  severity: Finding["severity"]["level"];
-  confidence: Finding["confidence"]["level"];
-  status: "open" | "closed";
-  closeReason?: "already_fixed" | "wont_fix" | "false_positive";
-  note?: string;
-  remediation: string;
-  path: string;
-  startLine: number;
-  endLine?: number;
-}
-
-const REQUIRED_CSV_COLUMNS = [
-  "occurrence_id",
-  "finding_id",
-  "title",
-  "summary",
-  "severity",
-  "confidence",
-  "status",
-  "close_reason",
-  "note",
-  "remediation",
-  "path",
-  "start_line",
-  "end_line",
-] as const;
-const OPTIONAL_CSV_COLUMNS = ["candidate_id"] as const;
 const EXPORTED_CSV_ESCAPE = /^'(?:[\t\r\n]|\s*[=+\-@＝＋－＠])/u;
-const FINDING_ID = /^csf_[a-f0-9]{24}$/u;
-const OCCURRENCE_ID = /^occ_[a-f0-9]{24}$/u;
-const SEVERITIES = new Set<Finding["severity"]["level"]>([
-  "critical",
-  "high",
-  "medium",
-  "low",
-  "informational",
-]);
-const CONFIDENCES = new Set<Finding["confidence"]["level"]>([
-  "high",
-  "medium",
-  "low",
-]);
-const CLOSE_REASONS = new Set<NonNullable<CsvFindingRow["closeReason"]>>([
-  "already_fixed",
-  "wont_fix",
-  "false_positive",
-]);
+const csvFindingRowSchema = z
+  .object({
+    occurrence_id: z.string().regex(/^occ_[a-f0-9]{24}$/u, {
+      error: "has an invalid occurrence_id",
+    }),
+    finding_id: z.string().regex(/^csf_[a-f0-9]{24}$/u, {
+      error: "has an invalid finding_id",
+    }),
+    candidate_id: z
+      .string()
+      .optional()
+      .transform((value) =>
+        value === undefined || value.trim() === "" ? undefined : value,
+      ),
+    title: requiredCsvText("title"),
+    summary: requiredCsvText("summary"),
+    severity: z.enum(["critical", "high", "medium", "low", "informational"], {
+      error: "has an invalid severity",
+    }),
+    confidence: z.enum(["high", "medium", "low"], {
+      error: "has an invalid confidence",
+    }),
+    status: z.enum(["open", "closed"], {
+      error: "has an invalid status",
+    }),
+    close_reason: z
+      .union(
+        [
+          z.literal(""),
+          z.enum(["already_fixed", "wont_fix", "false_positive"]),
+        ],
+        { error: "has an invalid close_reason" },
+      )
+      .transform((value) => (value === "" ? undefined : value)),
+    note: z
+      .string()
+      .transform((value) => (value.trim() === "" ? undefined : value)),
+    remediation: requiredCsvText("remediation"),
+    path: z.string().refine(safeFindingPath, {
+      error: "has an invalid path",
+    }),
+    start_line: z
+      .string()
+      .refine(validCsvLine, { error: "has an invalid start_line" })
+      .transform(Number),
+    end_line: z
+      .string()
+      .refine((value) => value === "" || validCsvLine(value), {
+        error: "has an invalid end_line",
+      })
+      .transform((value) => (value === "" ? undefined : Number(value))),
+  })
+  .superRefine((row, context) => {
+    if (
+      (row.status === "open" && row.close_reason !== undefined) ||
+      (row.status === "closed" && row.close_reason === undefined)
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["close_reason"],
+        message: "has an invalid close_reason",
+      });
+    }
+    if (
+      row.status === "closed" &&
+      (row.close_reason === "false_positive" ||
+        row.close_reason === "wont_fix") &&
+      row.note === undefined
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["note"],
+        message: "requires a note for its close_reason",
+      });
+    }
+    if (row.end_line !== undefined && row.end_line < row.start_line) {
+      context.addIssue({
+        code: "custom",
+        path: ["end_line"],
+        message: "has end_line before start_line",
+      });
+    }
+  });
+type CsvFindingRow = z.infer<typeof csvFindingRowSchema>;
+type CsvColumn = keyof typeof csvFindingRowSchema.shape;
+const CSV_COLUMNS = Object.keys(csvFindingRowSchema.shape) as CsvColumn[];
+const REQUIRED_CSV_COLUMNS = CSV_COLUMNS.filter(
+  (column) => !csvFindingRowSchema.shape[column].isOptional(),
+);
 
 export async function publishScanToCloud(
   scanDirectory: string,
@@ -211,20 +248,29 @@ export async function publishFindingsCsvToCloud(
 }
 
 function parseFindingsCsv(source: string): CsvFindingRow[] {
-  const { data: rows, errors } = Papa.parse<string[]>(source, {
+  const {
+    data: rows,
+    errors,
+    meta,
+  } = Papa.parse<Record<string, string>>(source, {
+    header: true,
     delimiter: ",",
     skipEmptyLines: "greedy",
+    transform: decodeExportedCsvCell,
   });
+  const fieldMismatch = errors.find(
+    (error) => error.code === "TooFewFields" || error.code === "TooManyFields",
+  );
+  if (fieldMismatch?.row !== undefined) {
+    throw csvRowError(fieldMismatch.row + 2, "must match the header columns");
+  }
   if (errors.length > 0) {
     throw new CodexSecurityError(
       `Findings CSV could not be parsed: ${errors[0]!.message}`,
     );
   }
-  const headers = rows.shift();
-  const allowed = new Set<string>([
-    ...REQUIRED_CSV_COLUMNS,
-    ...OPTIONAL_CSV_COLUMNS,
-  ]);
+  const headers = meta.fields;
+  const allowed = new Set<string>(CSV_COLUMNS);
   if (
     headers === undefined ||
     !REQUIRED_CSV_COLUMNS.every((name) => headers.includes(name)) ||
@@ -243,103 +289,22 @@ function parseFindingsCsv(source: string): CsvFindingRow[] {
 
   const findingIds = new Set<string>();
   const occurrenceIds = new Set<string>();
-  return rows.map((fields, index) => {
+  return rows.map((record, index) => {
     const rowNumber = index + 2;
-    if (fields.length !== headers.length) {
-      throw csvRowError(rowNumber, "must match the header columns");
+    const parsed = csvFindingRowSchema.safeParse(record);
+    if (!parsed.success) {
+      throw csvRowError(rowNumber, parsed.error.issues[0]!.message);
     }
-    const get = (name: string): string =>
-      decodeExportedCsvCell(fields[headers.indexOf(name)] ?? "");
-    const findingId = get("finding_id");
-    const occurrenceId = get("occurrence_id");
-    if (!FINDING_ID.test(findingId)) {
-      throw csvRowError(rowNumber, "has an invalid finding_id");
-    }
-    if (!OCCURRENCE_ID.test(occurrenceId)) {
-      throw csvRowError(rowNumber, "has an invalid occurrence_id");
-    }
-    if (findingIds.has(findingId)) {
+    const row = parsed.data;
+    if (findingIds.has(row.finding_id)) {
       throw csvRowError(rowNumber, "has a duplicate finding_id");
     }
-    if (occurrenceIds.has(occurrenceId)) {
+    if (occurrenceIds.has(row.occurrence_id)) {
       throw csvRowError(rowNumber, "has a duplicate occurrence_id");
     }
-    findingIds.add(findingId);
-    occurrenceIds.add(occurrenceId);
-
-    const title = requiredCsvText(get("title"), rowNumber, "title");
-    const summary = requiredCsvText(get("summary"), rowNumber, "summary");
-    const remediation = requiredCsvText(
-      get("remediation"),
-      rowNumber,
-      "remediation",
-    );
-    const severity = get("severity") as Finding["severity"]["level"];
-    if (!SEVERITIES.has(severity)) {
-      throw csvRowError(rowNumber, "has an invalid severity");
-    }
-    const confidence = get("confidence") as Finding["confidence"]["level"];
-    if (!CONFIDENCES.has(confidence)) {
-      throw csvRowError(rowNumber, "has an invalid confidence");
-    }
-    const status = get("status");
-    if (status !== "open" && status !== "closed") {
-      throw csvRowError(rowNumber, "has an invalid status");
-    }
-    const closeReason = get("close_reason");
-    if (
-      (status === "open" && closeReason !== "") ||
-      (status === "closed" &&
-        !CLOSE_REASONS.has(
-          closeReason as NonNullable<CsvFindingRow["closeReason"]>,
-        ))
-    ) {
-      throw csvRowError(rowNumber, "has an invalid close_reason");
-    }
-    const note = get("note");
-    if (
-      status === "closed" &&
-      (closeReason === "false_positive" || closeReason === "wont_fix") &&
-      note.trim().length === 0
-    ) {
-      throw csvRowError(rowNumber, "requires a note for its close_reason");
-    }
-    const path = get("path");
-    if (!safeFindingPath(path)) {
-      throw csvRowError(rowNumber, "has an invalid path");
-    }
-    const startLine = csvLine(get("start_line"), rowNumber, "start_line");
-    const endLineText = get("end_line");
-    const endLine =
-      endLineText === ""
-        ? undefined
-        : csvLine(endLineText, rowNumber, "end_line");
-    if (endLine !== undefined && endLine < startLine) {
-      throw csvRowError(rowNumber, "has end_line before start_line");
-    }
-    const candidateId = get("candidate_id");
-    return {
-      occurrenceId,
-      findingId,
-      ...(candidateId.trim() === "" ? {} : { candidateId }),
-      title,
-      summary,
-      severity,
-      confidence,
-      status,
-      ...(closeReason === ""
-        ? {}
-        : {
-            closeReason: closeReason as NonNullable<
-              CsvFindingRow["closeReason"]
-            >,
-          }),
-      ...(note.trim() === "" ? {} : { note }),
-      remediation,
-      path,
-      startLine,
-      ...(endLine === undefined ? {} : { endLine }),
-    };
+    findingIds.add(row.finding_id);
+    occurrenceIds.add(row.occurrence_id);
+    return row;
   });
 }
 
@@ -349,7 +314,7 @@ function decodeExportedCsvCell(value: string): string {
 
 function csvRowFinding(row: CsvFindingRow, scanId: string): Finding {
   const ruleId = "import.csv";
-  const anchor = row.findingId;
+  const anchor = row.finding_id;
   const fingerprint = `codex-security/v1:sha256:${sha256(
     ["codex-security/v1", CSV_TARGET_ID, ruleId, anchor, ""].join("\0"),
   )}`;
@@ -378,49 +343,43 @@ function csvRowFinding(row: CsvFindingRow, scanId: string): Finding {
     locations: [
       {
         path: row.path,
-        startLine: row.startLine,
-        ...(row.endLine === undefined ? {} : { endLine: row.endLine }),
+        startLine: row.start_line,
+        ...(row.end_line === undefined ? {} : { endLine: row.end_line }),
       },
     ],
     remediation: row.remediation,
-    provenance: {
-      source: "csv_import",
-      sourceFindingId: row.findingId,
-      sourceOccurrenceId: row.occurrenceId,
-      csvStatus: row.status,
-      ...(row.closeReason === undefined
-        ? {}
-        : { csvCloseReason: row.closeReason }),
-      ...(row.note === undefined ? {} : { csvNote: row.note }),
+    validation: {
+      method: "Source-reported CSV import metadata",
+      status: row.status,
+      summary: [
+        `Source finding ID: ${row.finding_id}`,
+        `Source occurrence ID: ${row.occurrence_id}`,
+        `Source status: ${row.status}`,
+        ...(row.close_reason === undefined
+          ? []
+          : [`Source close reason: ${row.close_reason}`]),
+        ...(row.note === undefined ? [] : [`Source note: ${row.note}`]),
+      ].join("\n"),
     },
+    provenance: { source: "csv_import" },
     extensions: {
-      ...(row.candidateId === undefined
+      ...(row.candidate_id === undefined
         ? {}
-        : { candidateId: row.candidateId }),
+        : { candidateId: row.candidate_id }),
     },
   };
 }
 
-function requiredCsvText(
-  value: string,
-  rowNumber: number,
-  column: string,
-): string {
-  if (value.trim().length === 0) {
-    throw csvRowError(rowNumber, `requires ${column}`);
-  }
-  return value;
+function requiredCsvText(column: string) {
+  return z.string().refine((value) => value.trim().length > 0, {
+    error: `requires ${column}`,
+  });
 }
 
-function csvLine(value: string, rowNumber: number, column: string): number {
-  if (!/^[1-9]\d*$/u.test(value)) {
-    throw csvRowError(rowNumber, `has an invalid ${column}`);
-  }
+function validCsvLine(value: string): boolean {
+  if (!/^[1-9]\d*$/u.test(value)) return false;
   const line = Number(value);
-  if (!Number.isSafeInteger(line)) {
-    throw csvRowError(rowNumber, `has an invalid ${column}`);
-  }
-  return line;
+  return Number.isSafeInteger(line);
 }
 
 function safeFindingPath(value: string): boolean {

--- a/sdk/typescript/src/cloud-publish.ts
+++ b/sdk/typescript/src/cloud-publish.ts
@@ -86,10 +86,7 @@ const REQUIRED_CSV_COLUMNS = [
   "end_line",
 ] as const;
 const OPTIONAL_CSV_COLUMNS = ["candidate_id"] as const;
-const CSV_FORMULA_PREFIX = /^[=+\-@＝＋－＠]/u;
-// Match Python str.lstrip(), which the bundled CSV exporter uses here.
-const PYTHON_LEADING_WHITESPACE =
-  /^[\u0009-\u000D\u001C-\u0020\u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]*/u;
+const EXPORTED_CSV_ESCAPE = /^'(?:[\t\r\n]|\s*[=+\-@＝＋－＠])/u;
 const FINDING_ID = /^csf_[a-f0-9]{24}$/u;
 const OCCURRENCE_ID = /^occ_[a-f0-9]{24}$/u;
 const SEVERITIES = new Set<Finding["severity"]["level"]>([
@@ -131,9 +128,7 @@ export async function publishScanToCloud(
 
 export async function publishFindingsCsvToCloud(
   csvPath: string,
-  dependencies: CloudPublicationDependencies & {
-    now?: () => number;
-  } = {},
+  dependencies: CloudPublicationDependencies = {},
 ): Promise<CloudPublicationResult> {
   dependencies.signal?.throwIfAborted();
   let source: string;
@@ -149,7 +144,7 @@ export async function publishFindingsCsvToCloud(
   const digest = sha256(source);
   const scanId = `scan_csv_${digest.slice(0, 24)}`;
   const findings = rows.map((row) => csvRowFinding(row, scanId));
-  const timestamp = new Date((dependencies.now ?? Date.now)()).toISOString();
+  const timestamp = new Date().toISOString();
   const findingsDocument = JSON.stringify({
     documentType: "codex-security.findings",
     schemaVersion: "1.0",
@@ -349,15 +344,7 @@ function parseFindingsCsv(source: string): CsvFindingRow[] {
 }
 
 function decodeExportedCsvCell(value: string): string {
-  if (!value.startsWith("'")) return value;
-  const decoded = value.slice(1);
-  const stripped = decoded.replace(PYTHON_LEADING_WHITESPACE, "");
-  return decoded.startsWith("\t") ||
-    decoded.startsWith("\r") ||
-    decoded.startsWith("\n") ||
-    CSV_FORMULA_PREFIX.test(stripped)
-    ? decoded
-    : value;
+  return EXPORTED_CSV_ESCAPE.test(value) ? value.slice(1) : value;
 }
 
 function csvRowFinding(row: CsvFindingRow, scanId: string): Finding {

--- a/sdk/typescript/src/cloud-publish.ts
+++ b/sdk/typescript/src/cloud-publish.ts
@@ -86,6 +86,10 @@ const REQUIRED_CSV_COLUMNS = [
   "end_line",
 ] as const;
 const OPTIONAL_CSV_COLUMNS = ["candidate_id"] as const;
+const CSV_FORMULA_PREFIX = /^[=+\-@＝＋－＠]/u;
+// Match Python str.lstrip(), which the bundled CSV exporter uses here.
+const PYTHON_LEADING_WHITESPACE =
+  /^[\u0009-\u000D\u001C-\u0020\u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]*/u;
 const FINDING_ID = /^csf_[a-f0-9]{24}$/u;
 const OCCURRENCE_ID = /^occ_[a-f0-9]{24}$/u;
 const SEVERITIES = new Set<Finding["severity"]["level"]>([
@@ -249,7 +253,8 @@ function parseFindingsCsv(source: string): CsvFindingRow[] {
     if (fields.length !== headers.length) {
       throw csvRowError(rowNumber, "must match the header columns");
     }
-    const get = (name: string): string => fields[headers.indexOf(name)] ?? "";
+    const get = (name: string): string =>
+      decodeExportedCsvCell(fields[headers.indexOf(name)] ?? "");
     const findingId = get("finding_id");
     const occurrenceId = get("occurrence_id");
     if (!FINDING_ID.test(findingId)) {
@@ -341,6 +346,18 @@ function parseFindingsCsv(source: string): CsvFindingRow[] {
       ...(endLine === undefined ? {} : { endLine }),
     };
   });
+}
+
+function decodeExportedCsvCell(value: string): string {
+  if (!value.startsWith("'")) return value;
+  const decoded = value.slice(1);
+  const stripped = decoded.replace(PYTHON_LEADING_WHITESPACE, "");
+  return decoded.startsWith("\t") ||
+    decoded.startsWith("\r") ||
+    decoded.startsWith("\n") ||
+    CSV_FORMULA_PREFIX.test(stripped)
+    ? decoded
+    : value;
 }
 
 function csvRowFinding(row: CsvFindingRow, scanId: string): Finding {

--- a/sdk/typescript/src/cloud-publish.ts
+++ b/sdk/typescript/src/cloud-publish.ts
@@ -1,11 +1,13 @@
+import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, isAbsolute, join, posix } from "node:path";
 import { z } from "incur";
+import Papa from "papaparse";
 import { parse as parseToml } from "smol-toml";
 import { loadContract } from "./contract.js";
 import { AuthenticationRequiredError, CodexSecurityError } from "./errors.js";
-import type { Finding } from "./models.js";
+import type { Finding, ScanManifest } from "./models.js";
 import {
   bundledPluginRoot,
   codexSecurityCredentialAllowsAmbientImport,
@@ -13,9 +15,11 @@ import {
   codexSecurityHasStoredFileCredentials,
   expandHome,
 } from "./runtime.js";
+import { VERSION } from "./version.js";
 
 const CLOUD_PUBLISH_URL =
   "https://chatgpt.com/backend-api/aardvark/cli/findings";
+const CSV_TARGET_ID = "codex-security-csv-import";
 const CHATGPT_LOGIN_REQUIRED =
   "Cloud publication requires a ChatGPT login already available to Codex Security. Run a scan or sign in with ChatGPT using Codex file credential storage, then retry.";
 
@@ -42,13 +46,69 @@ export interface CloudPublicationResult {
   findings?: Finding[];
 }
 
+interface CloudPublicationDependencies {
+  environment?: NodeJS.ProcessEnv;
+  fetch?: (url: string, options: RequestInit) => Promise<Response>;
+  signal?: AbortSignal;
+  dryRun?: boolean;
+}
+
+interface CsvFindingRow {
+  occurrenceId: string;
+  findingId: string;
+  candidateId?: string;
+  title: string;
+  summary: string;
+  severity: Finding["severity"]["level"];
+  confidence: Finding["confidence"]["level"];
+  status: "open" | "closed";
+  closeReason?: "already_fixed" | "wont_fix" | "false_positive";
+  note?: string;
+  remediation: string;
+  path: string;
+  startLine: number;
+  endLine?: number;
+}
+
+const REQUIRED_CSV_COLUMNS = [
+  "occurrence_id",
+  "finding_id",
+  "title",
+  "summary",
+  "severity",
+  "confidence",
+  "status",
+  "close_reason",
+  "note",
+  "remediation",
+  "path",
+  "start_line",
+  "end_line",
+] as const;
+const OPTIONAL_CSV_COLUMNS = ["candidate_id"] as const;
+const FINDING_ID = /^csf_[a-f0-9]{24}$/u;
+const OCCURRENCE_ID = /^occ_[a-f0-9]{24}$/u;
+const SEVERITIES = new Set<Finding["severity"]["level"]>([
+  "critical",
+  "high",
+  "medium",
+  "low",
+  "informational",
+]);
+const CONFIDENCES = new Set<Finding["confidence"]["level"]>([
+  "high",
+  "medium",
+  "low",
+]);
+const CLOSE_REASONS = new Set<NonNullable<CsvFindingRow["closeReason"]>>([
+  "already_fixed",
+  "wont_fix",
+  "false_positive",
+]);
+
 export async function publishScanToCloud(
   scanDirectory: string,
-  dependencies: {
-    environment?: NodeJS.ProcessEnv;
-    fetch?: (url: string, options: RequestInit) => Promise<Response>;
-    signal?: AbortSignal;
-    dryRun?: boolean;
+  dependencies: CloudPublicationDependencies & {
     expectedScanId?: string;
   } = {},
 ): Promise<CloudPublicationResult> {
@@ -62,14 +122,343 @@ export async function publishScanToCloud(
       "The completed scan has no findings to publish.",
     );
   }
+  return publishCloudPayload(manifest.scan, findings.findings, dependencies);
+}
+
+export async function publishFindingsCsvToCloud(
+  csvPath: string,
+  dependencies: CloudPublicationDependencies & {
+    now?: () => number;
+  } = {},
+): Promise<CloudPublicationResult> {
+  dependencies.signal?.throwIfAborted();
+  let source: string;
+  try {
+    source = await readFile(csvPath, "utf8");
+  } catch (error) {
+    throw new CodexSecurityError("Could not read findings CSV.", {
+      cause: error,
+    });
+  }
+  dependencies.signal?.throwIfAborted();
+  const rows = parseFindingsCsv(source);
+  const digest = sha256(source);
+  const scanId = `scan_csv_${digest.slice(0, 24)}`;
+  const findings = rows.map((row) => csvRowFinding(row, scanId));
+  const timestamp = new Date((dependencies.now ?? Date.now)()).toISOString();
+  const findingsDocument = JSON.stringify({
+    documentType: "codex-security.findings",
+    schemaVersion: "1.0",
+    scanId,
+    findings,
+  });
+  const coverageDocument = JSON.stringify({
+    documentType: "codex-security.coverage",
+    schemaVersion: "1.0",
+    scanId,
+    mode: "repository",
+    completeness: "unknown",
+    inventoryStrategy: "custom",
+    includePaths: ["."],
+    excludePaths: [],
+    surfaces: findings.map((finding) => ({
+      id: finding.occurrenceId,
+      label: finding.title,
+      disposition: "reported",
+      receiptRefs: [],
+    })),
+    explicitExclusions: [],
+    deferred: [],
+  });
+  const scan: ScanManifest["scan"] = {
+    id: scanId,
+    producer: { name: "codex-security-cli", version: VERSION },
+    status: "completed",
+    startedAt: timestamp,
+    completedAt: timestamp,
+    sealedAt: timestamp,
+    target: {
+      kind: "directory_snapshot",
+      targetId: CSV_TARGET_ID,
+      displayName: basename(csvPath),
+      snapshotDigest: `codex-security-snapshot/v1:sha256:${digest}`,
+    },
+    scope: {
+      includePaths: ["."],
+      excludePaths: [],
+      summary: "Findings imported from a Codex Security CSV export.",
+    },
+    coverageRef: "coverage.json",
+    findingsRef: "findings.json",
+    artifacts: [
+      {
+        path: "findings.json",
+        sha256: sha256(findingsDocument),
+        mediaType: "application/json",
+      },
+      {
+        path: "coverage.json",
+        sha256: sha256(coverageDocument),
+        mediaType: "application/json",
+      },
+      {
+        path: "findings.csv",
+        sha256: digest,
+        mediaType: "text/csv",
+      },
+    ],
+  };
+  return publishCloudPayload(scan, findings, dependencies);
+}
+
+function parseFindingsCsv(source: string): CsvFindingRow[] {
+  const { data: rows, errors } = Papa.parse<string[]>(source, {
+    delimiter: ",",
+    skipEmptyLines: "greedy",
+  });
+  if (errors.length > 0) {
+    throw new CodexSecurityError(
+      `Findings CSV could not be parsed: ${errors[0]!.message}`,
+    );
+  }
+  const headers = rows.shift();
+  const allowed = new Set<string>([
+    ...REQUIRED_CSV_COLUMNS,
+    ...OPTIONAL_CSV_COLUMNS,
+  ]);
+  if (
+    headers === undefined ||
+    !REQUIRED_CSV_COLUMNS.every((name) => headers.includes(name)) ||
+    headers.some((name) => !allowed.has(name)) ||
+    new Set(headers).size !== headers.length
+  ) {
+    throw new CodexSecurityError(
+      `Findings CSV must use the Codex Security export columns: ${REQUIRED_CSV_COLUMNS.join(", ")} (candidate_id is optional).`,
+    );
+  }
+  if (rows.length === 0) {
+    throw new CodexSecurityError(
+      "Findings CSV must contain at least one finding.",
+    );
+  }
+
+  const findingIds = new Set<string>();
+  const occurrenceIds = new Set<string>();
+  return rows.map((fields, index) => {
+    const rowNumber = index + 2;
+    if (fields.length !== headers.length) {
+      throw csvRowError(rowNumber, "must match the header columns");
+    }
+    const get = (name: string): string => fields[headers.indexOf(name)] ?? "";
+    const findingId = get("finding_id");
+    const occurrenceId = get("occurrence_id");
+    if (!FINDING_ID.test(findingId)) {
+      throw csvRowError(rowNumber, "has an invalid finding_id");
+    }
+    if (!OCCURRENCE_ID.test(occurrenceId)) {
+      throw csvRowError(rowNumber, "has an invalid occurrence_id");
+    }
+    if (findingIds.has(findingId)) {
+      throw csvRowError(rowNumber, "has a duplicate finding_id");
+    }
+    if (occurrenceIds.has(occurrenceId)) {
+      throw csvRowError(rowNumber, "has a duplicate occurrence_id");
+    }
+    findingIds.add(findingId);
+    occurrenceIds.add(occurrenceId);
+
+    const title = requiredCsvText(get("title"), rowNumber, "title");
+    const summary = requiredCsvText(get("summary"), rowNumber, "summary");
+    const remediation = requiredCsvText(
+      get("remediation"),
+      rowNumber,
+      "remediation",
+    );
+    const severity = get("severity") as Finding["severity"]["level"];
+    if (!SEVERITIES.has(severity)) {
+      throw csvRowError(rowNumber, "has an invalid severity");
+    }
+    const confidence = get("confidence") as Finding["confidence"]["level"];
+    if (!CONFIDENCES.has(confidence)) {
+      throw csvRowError(rowNumber, "has an invalid confidence");
+    }
+    const status = get("status");
+    if (status !== "open" && status !== "closed") {
+      throw csvRowError(rowNumber, "has an invalid status");
+    }
+    const closeReason = get("close_reason");
+    if (
+      (status === "open" && closeReason !== "") ||
+      (status === "closed" &&
+        !CLOSE_REASONS.has(
+          closeReason as NonNullable<CsvFindingRow["closeReason"]>,
+        ))
+    ) {
+      throw csvRowError(rowNumber, "has an invalid close_reason");
+    }
+    const note = get("note");
+    if (
+      status === "closed" &&
+      (closeReason === "false_positive" || closeReason === "wont_fix") &&
+      note.trim().length === 0
+    ) {
+      throw csvRowError(rowNumber, "requires a note for its close_reason");
+    }
+    const path = get("path");
+    if (!safeFindingPath(path)) {
+      throw csvRowError(rowNumber, "has an invalid path");
+    }
+    const startLine = csvLine(get("start_line"), rowNumber, "start_line");
+    const endLineText = get("end_line");
+    const endLine =
+      endLineText === ""
+        ? undefined
+        : csvLine(endLineText, rowNumber, "end_line");
+    if (endLine !== undefined && endLine < startLine) {
+      throw csvRowError(rowNumber, "has end_line before start_line");
+    }
+    const candidateId = get("candidate_id");
+    return {
+      occurrenceId,
+      findingId,
+      ...(candidateId.trim() === "" ? {} : { candidateId }),
+      title,
+      summary,
+      severity,
+      confidence,
+      status,
+      ...(closeReason === ""
+        ? {}
+        : {
+            closeReason: closeReason as NonNullable<
+              CsvFindingRow["closeReason"]
+            >,
+          }),
+      ...(note.trim() === "" ? {} : { note }),
+      remediation,
+      path,
+      startLine,
+      ...(endLine === undefined ? {} : { endLine }),
+    };
+  });
+}
+
+function csvRowFinding(row: CsvFindingRow, scanId: string): Finding {
+  const ruleId = "import.csv";
+  const anchor = row.findingId;
+  const fingerprint = `codex-security/v1:sha256:${sha256(
+    ["codex-security/v1", CSV_TARGET_ID, ruleId, anchor, ""].join("\0"),
+  )}`;
+  const findingId = `csf_${sha256(fingerprint).slice(0, 24)}`;
+  const occurrenceId = `occ_${sha256([scanId, fingerprint].join("\0")).slice(
+    0,
+    24,
+  )}`;
+  return {
+    findingId,
+    occurrenceId,
+    ruleId,
+    identity: { anchor },
+    fingerprints: {
+      algorithm: "codex-security/v1",
+      primary: fingerprint,
+    },
+    title: row.title,
+    summary: row.summary,
+    severity: { level: row.severity },
+    confidence: {
+      level: row.confidence,
+      rationale: "Imported from a Codex Security findings CSV.",
+    },
+    taxonomy: { category: "imported", cwe: [] },
+    locations: [
+      {
+        path: row.path,
+        startLine: row.startLine,
+        ...(row.endLine === undefined ? {} : { endLine: row.endLine }),
+      },
+    ],
+    remediation: row.remediation,
+    provenance: {
+      source: "csv_import",
+      sourceFindingId: row.findingId,
+      sourceOccurrenceId: row.occurrenceId,
+      csvStatus: row.status,
+      ...(row.closeReason === undefined
+        ? {}
+        : { csvCloseReason: row.closeReason }),
+      ...(row.note === undefined ? {} : { csvNote: row.note }),
+    },
+    extensions: {
+      ...(row.candidateId === undefined
+        ? {}
+        : { candidateId: row.candidateId }),
+    },
+  };
+}
+
+function requiredCsvText(
+  value: string,
+  rowNumber: number,
+  column: string,
+): string {
+  if (value.trim().length === 0) {
+    throw csvRowError(rowNumber, `requires ${column}`);
+  }
+  return value;
+}
+
+function csvLine(value: string, rowNumber: number, column: string): number {
+  if (!/^[1-9]\d*$/u.test(value)) {
+    throw csvRowError(rowNumber, `has an invalid ${column}`);
+  }
+  const line = Number(value);
+  if (!Number.isSafeInteger(line)) {
+    throw csvRowError(rowNumber, `has an invalid ${column}`);
+  }
+  return line;
+}
+
+function safeFindingPath(value: string): boolean {
+  if (
+    value.trim().length === 0 ||
+    value === "." ||
+    isAbsolute(value) ||
+    /^[A-Za-z]:/u.test(value) ||
+    value.includes("\\") ||
+    /[\u0000-\u001F]/u.test(value) ||
+    value.split("/").includes("..")
+  ) {
+    return false;
+  }
+  const normalized = posix.normalize(value).replace(/\/+$/u, "");
+  return normalized !== "." && !normalized.startsWith("../");
+}
+
+function csvRowError(rowNumber: number, detail: string): CodexSecurityError {
+  return new CodexSecurityError(`Findings CSV row ${rowNumber} ${detail}.`);
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+async function publishCloudPayload(
+  scan: ScanManifest["scan"],
+  findings: Finding[],
+  dependencies: CloudPublicationDependencies,
+): Promise<CloudPublicationResult> {
+  if (findings.length === 0) {
+    throw new CodexSecurityError("There are no findings to publish.");
+  }
   dependencies.signal?.throwIfAborted();
   if (dependencies.dryRun) {
     return {
-      scanId: manifest.scan.id,
+      scanId: scan.id,
       findingIds: [],
-      findingCount: findings.findings.length,
+      findingCount: findings.length,
       dryRun: true,
-      findings: findings.findings,
+      findings,
     };
   }
   const credentials = await readCloudCredentials(
@@ -94,8 +483,8 @@ export async function publishScanToCloud(
       },
       body: JSON.stringify({
         schemaVersion: "1.0",
-        scan: manifest.scan,
-        findings: findings.findings,
+        scan,
+        findings,
       }),
       redirect: "error",
       signal,
@@ -129,8 +518,8 @@ export async function publishScanToCloud(
   if (
     (response.status !== 200 && response.status !== 201) ||
     !receipt.success ||
-    receipt.data.finding_count !== findings.findings.length ||
-    receipt.data.finding_ids.length !== findings.findings.length ||
+    receipt.data.finding_count !== findings.length ||
+    receipt.data.finding_ids.length !== findings.length ||
     new Set(receipt.data.finding_ids).size !== receipt.data.finding_ids.length
   ) {
     throw new CodexSecurityError(
@@ -138,7 +527,7 @@ export async function publishScanToCloud(
     );
   }
   return {
-    scanId: manifest.scan.id,
+    scanId: scan.id,
     findingIds: receipt.data.finding_ids,
     findingCount: receipt.data.finding_count,
   };

--- a/sdk/typescript/src/cloud-publish.ts
+++ b/sdk/typescript/src/cloud-publish.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { basename, isAbsolute, join, posix } from "node:path";
+import { isAbsolute, join, posix } from "node:path";
 import { z } from "incur";
 import Papa from "papaparse";
 import { parse as parseToml } from "smol-toml";
@@ -179,9 +179,11 @@ export async function publishFindingsCsvToCloud(
   dependencies.signal?.throwIfAborted();
   const rows = parseFindingsCsv(source);
   const digest = sha256(source);
-  const scanId = `scan_csv_${digest.slice(0, 24)}`;
+  const scanId = `scan_csv_${sha256(
+    ["codex-security-csv-import/v1", VERSION, source].join("\0"),
+  ).slice(0, 24)}`;
   const findings = rows.map((row) => csvRowFinding(row, scanId));
-  const timestamp = new Date().toISOString();
+  const timestamp = "1970-01-01T00:00:00.000Z";
   const findingsDocument = JSON.stringify({
     documentType: "codex-security.findings",
     schemaVersion: "1.0",
@@ -216,7 +218,7 @@ export async function publishFindingsCsvToCloud(
     target: {
       kind: "directory_snapshot",
       targetId: CSV_TARGET_ID,
-      displayName: basename(csvPath),
+      displayName: "findings.csv",
       snapshotDigest: `codex-security-snapshot/v1:sha256:${digest}`,
     },
     scope: {

--- a/sdk/typescript/tests-ts/cli-cloud-publish.test.ts
+++ b/sdk/typescript/tests-ts/cli-cloud-publish.test.ts
@@ -57,6 +57,106 @@ async function savedScansFixture() {
 }
 
 describe("publish scan to Cloud", () => {
+  test("documents the findings CSV option", async () => {
+    const stdout = capture();
+    expect(
+      await main(
+        ["publish", "scan", "--help"],
+        stdout.stream,
+        capture().stream,
+        dependencies(),
+      ),
+    ).toBe(0);
+    expect(stdout.text()).toContain("--csv <string>");
+    expect(stdout.text()).toContain("findings CSV");
+  });
+
+  test("passes --dry-run through when publishing a findings CSV", async () => {
+    const deps = dependencies({
+      currentDirectory: "/workspace/repository",
+      onWorkbench: () => {
+        throw new Error("unexpected scan lookup");
+      },
+    });
+    let publishedPath = "";
+    deps.publishFindingsCsvToCloud = async (path, options) => {
+      publishedPath = path;
+      expect(options?.dryRun).toBe(true);
+      expect(options?.signal).toBeInstanceOf(AbortSignal);
+      expect(options?.now?.()).toBe(0);
+      return { ...receipt, dryRun: true };
+    };
+    const stdout = capture();
+    const stderr = capture();
+    expect(
+      await main(
+        [
+          "publish",
+          "scan",
+          "--to",
+          "cloud",
+          "--csv",
+          "inputs/findings.csv",
+          "--dry-run",
+          "--json",
+        ],
+        stdout.stream,
+        stderr.stream,
+        deps,
+      ),
+    ).toBe(0);
+    expect(publishedPath).toBe(
+      resolve("/workspace/repository", "inputs/findings.csv"),
+    );
+    expect(JSON.parse(stdout.text())).toMatchObject({
+      scanId: "scan-1",
+      findingCount: 1,
+      dryRun: true,
+    });
+    expect(stderr.text()).toBe("");
+  });
+
+  test.each([
+    [
+      "a saved scan",
+      ["--scan", "11111111", "--to", "cloud", "--csv", "findings.csv"],
+      "Use --csv or scan directory and ID inputs",
+    ],
+    [
+      "a scan directory",
+      ["scan", "--to", "cloud", "--csv", "findings.csv"],
+      "Use --csv or scan directory and ID inputs",
+    ],
+    [
+      "a --scan-dir value",
+      ["--scan-dir", "scan", "--to", "cloud", "--csv", "findings.csv"],
+      "Use --csv or scan directory and ID inputs",
+    ],
+    [
+      "Linear",
+      ["--to", "linear", "--linear-team", "team", "--csv", "findings.csv"],
+      "--csv is only supported with --to cloud",
+    ],
+  ])("rejects combining --csv with %s", async (_name, args, message) => {
+    const deps = dependencies();
+    let publications = 0;
+    deps.publishFindingsCsvToCloud = async () => {
+      publications++;
+      return receipt;
+    };
+    const stderr = capture();
+    expect(
+      await main(
+        ["publish", "scan", ...args],
+        capture().stream,
+        stderr.stream,
+        deps,
+      ),
+    ).toBe(2);
+    expect(publications).toBe(0);
+    expect(stderr.text()).toContain(message);
+  });
+
   test("resolves IDs, prefixes, and latest before publishing and deduplicates aliases", async () => {
     const { scans, deps, workbenchCalls } = await savedScansFixture();
     const [first, second] = scans;

--- a/sdk/typescript/tests-ts/cli-cloud-publish.test.ts
+++ b/sdk/typescript/tests-ts/cli-cloud-publish.test.ts
@@ -68,7 +68,7 @@ describe("publish scan to Cloud", () => {
       ),
     ).toBe(0);
     expect(stdout.text()).toContain("--csv <string>");
-    expect(stdout.text()).toContain("findings CSV");
+    expect(stdout.text()).toContain("Findings CSV");
   });
 
   test("passes --dry-run through when publishing a findings CSV", async () => {
@@ -83,7 +83,6 @@ describe("publish scan to Cloud", () => {
       publishedPath = path;
       expect(options?.dryRun).toBe(true);
       expect(options?.signal).toBeInstanceOf(AbortSignal);
-      expect(options?.now?.()).toBe(0);
       return { ...receipt, dryRun: true };
     };
     const stdout = capture();
@@ -125,11 +124,6 @@ describe("publish scan to Cloud", () => {
     [
       "a scan directory",
       ["scan", "--to", "cloud", "--csv", "findings.csv"],
-      "Use --csv or scan directory and ID inputs",
-    ],
-    [
-      "a --scan-dir value",
-      ["--scan-dir", "scan", "--to", "cloud", "--csv", "findings.csv"],
       "Use --csv or scan directory and ID inputs",
     ],
     [

--- a/sdk/typescript/tests-ts/cloud-publish.test.ts
+++ b/sdk/typescript/tests-ts/cloud-publish.test.ts
@@ -10,7 +10,6 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import Ajv2020 from "ajv/dist/2020.js";
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   publishFindingsCsvToCloud,
@@ -162,21 +161,11 @@ async function addSecondFinding(scan: string): Promise<void> {
 }
 
 describe("Cloud publication", () => {
-  test("keeps the repository CSV template aligned with the standard export", async () => {
-    expect(
-      await readFile(
-        join(import.meta.dirname, "..", "..", "..", "examples", "findings.csv"),
-        "utf8",
-      ),
-    ).toBe(`${csvHeader}\n`);
-  });
-
   test("previews a validated findings export CSV without credentials or network access", async () => {
     const path = await csvFixture();
     let requests = 0;
     const result = await publishFindingsCsvToCloud(path, {
       dryRun: true,
-      now: () => Date.parse("2026-08-25T12:00:00Z"),
       fetch: async () => {
         requests++;
         throw new Error("unexpected request");
@@ -213,7 +202,6 @@ describe("Cloud publication", () => {
     let payload: Record<string, unknown> | undefined;
     const result = await publishFindingsCsvToCloud(path, {
       environment,
-      now: () => Date.parse("2026-08-25T12:00:00Z"),
       fetch: async (_url, options) => {
         payload = JSON.parse(String(options.body));
         return Response.json(receipt, { status: 201 });
@@ -231,7 +219,7 @@ describe("Cloud publication", () => {
         id: result.scanId,
         producer: { name: "codex-security-cli" },
         status: "completed",
-        startedAt: "2026-08-25T12:00:00.000Z",
+        startedAt: expect.any(String),
         target: {
           kind: "directory_snapshot",
           displayName: "findings.csv",
@@ -247,52 +235,12 @@ describe("Cloud publication", () => {
         },
       ],
     });
-    const scan = payload!["scan"] as {
-      id: string;
-      target: { targetId: string };
-    };
     const [finding] = payload!["findings"] as Array<{
       findingId: string;
       occurrenceId: string;
-      ruleId: string;
-      identity: { anchor: string; instance?: string };
-      fingerprints: { primary: string };
     }>;
-    const hash = (value: string): string =>
-      createHash("sha256").update(value).digest("hex");
     expect(finding!.findingId).toMatch(/^csf_[a-f0-9]{24}$/);
     expect(finding!.occurrenceId).toMatch(/^occ_[a-f0-9]{24}$/);
-    const fingerprint = `codex-security/v1:sha256:${hash(
-      [
-        "codex-security/v1",
-        scan.target.targetId,
-        finding!.ruleId,
-        finding!.identity.anchor,
-        finding!.identity.instance ?? "",
-      ].join("\0"),
-    )}`;
-    expect(finding!.fingerprints.primary).toBe(fingerprint);
-    expect(finding!.findingId).toBe(`csf_${hash(fingerprint).slice(0, 24)}`);
-    expect(finding!.occurrenceId).toBe(
-      `occ_${hash([scan.id, fingerprint].join("\0")).slice(0, 24)}`,
-    );
-    const ajv = new Ajv2020({ strict: false });
-    const validateFindings = ajv.compile(
-      JSON.parse(
-        await readFile(
-          join(PLUGIN_ROOT, "schemas", "findings.schema.json"),
-          "utf8",
-        ),
-      ),
-    );
-    expect(
-      validateFindings({
-        documentType: "codex-security.findings",
-        schemaVersion: "1.0",
-        scanId: result.scanId,
-        findings: payload!["findings"],
-      }),
-    ).toBe(true);
   });
 
   test("accepts the candidate_id column from a Deep scan export", async () => {
@@ -315,14 +263,6 @@ describe("Cloud publication", () => {
       csvCloseReason: "wont_fix",
       csvNote: "Accepted risk.",
     });
-  });
-
-  test("preserves finding text from the CSV", async () => {
-    const path = await csvFixture(
-      `${csvHeader}\n${csvRow.replace("An attacker-controlled path reaches a filesystem write.", '"  Keep intentional spacing.  "')}\n`,
-    );
-    const result = await publishFindingsCsvToCloud(path, { dryRun: true });
-    expect(result.findings?.[0]?.summary).toBe("  Keep intentional spacing.  ");
   });
 
   test("decodes exported CSV cells without stripping literal apostrophes", async () => {
@@ -353,7 +293,6 @@ describe("Cloud publication", () => {
 
   test.each([
     ["missing required header", csvHeader.replace("summary,", "")],
-    ["duplicate header", `${csvHeader},title`],
     ["unknown header", `${csvHeader},unknown`],
     ["no findings", csvHeader],
     ["wrong column count", `${csvHeader}\n${csvRow},extra`],
@@ -362,24 +301,12 @@ describe("Cloud publication", () => {
       `${csvHeader}\n${csvRow.replace("csf_852f90d6e1177502ff113d4a", "finding-1")}`,
     ],
     [
-      "invalid occurrence ID",
-      `${csvHeader}\n${csvRow.replace("occ_e79cb19591e696572a1c22be", "occurrence-1")}`,
-    ],
-    [
       "empty title",
       `${csvHeader}\n${csvRow.replace('"Unsafe archive extraction, including nested entries"', '""')}`,
     ],
     [
       "invalid severity",
       `${csvHeader}\n${csvRow.replace(",high,high,", ",urgent,high,")}`,
-    ],
-    [
-      "invalid confidence",
-      `${csvHeader}\n${csvRow.replace(",high,high,open,", ",high,certain,open,")}`,
-    ],
-    [
-      "invalid status",
-      `${csvHeader}\n${csvRow.replace(",open,,,", ",pending,,,")}`,
     ],
     [
       "invalid close reason",
@@ -394,18 +321,10 @@ describe("Cloud publication", () => {
       `${csvHeader}\n${csvRow.replace("src/extract.py", "../escape.py")}`,
     ],
     [
-      "invalid start line",
-      `${csvHeader}\n${csvRow.replace(",41,44", ",0,44")}`,
-    ],
-    [
       "invalid line range",
       `${csvHeader}\n${csvRow.replace(",41,44", ",45,44")}`,
     ],
     ["duplicate finding", `${csvHeader}\n${csvRow}\n${csvRow}`],
-    [
-      "duplicate occurrence",
-      `${csvHeader}\n${csvRow}\n${csvRow.replace("csf_852f90d6e1177502ff113d4a", "csf_111111111111111111111111")}`,
-    ],
   ])("rejects a CSV with %s before authentication", async (_name, source) => {
     const path = await csvFixture(`${source}\n`);
     let requests = 0;

--- a/sdk/typescript/tests-ts/cloud-publish.test.ts
+++ b/sdk/typescript/tests-ts/cloud-publish.test.ts
@@ -325,6 +325,32 @@ describe("Cloud publication", () => {
     expect(result.findings?.[0]?.summary).toBe("  Keep intentional spacing.  ");
   });
 
+  test("decodes exported CSV cells without stripping literal apostrophes", async () => {
+    const path = await csvFixture(
+      `${csvHeader}\n${csvRow
+        .replace(
+          '"Unsafe archive extraction, including nested entries"',
+          '"\'\tTabbed title"',
+        )
+        .replace(
+          "An attacker-controlled path reaches a filesystem write.",
+          "'Literal apostrophe.",
+        )
+        .replace(
+          "Normalize and validate destinations.",
+          "'  @owner should remediate.",
+        )
+        .replace("src/extract.py", "'-generated/extract.py")}\n`,
+    );
+    const result = await publishFindingsCsvToCloud(path, { dryRun: true });
+    expect(result.findings?.[0]).toMatchObject({
+      title: "\tTabbed title",
+      summary: "'Literal apostrophe.",
+      remediation: "  @owner should remediate.",
+      locations: [{ path: "-generated/extract.py" }],
+    });
+  });
+
   test.each([
     ["missing required header", csvHeader.replace("summary,", "")],
     ["duplicate header", `${csvHeader},title`],

--- a/sdk/typescript/tests-ts/cloud-publish.test.ts
+++ b/sdk/typescript/tests-ts/cloud-publish.test.ts
@@ -10,8 +10,12 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import Ajv2020 from "ajv/dist/2020.js";
 import { afterEach, describe, expect, test } from "bun:test";
-import { publishScanToCloud } from "../src/cloud-publish.js";
+import {
+  publishFindingsCsvToCloud,
+  publishScanToCloud,
+} from "../src/cloud-publish.js";
 import {
   codexSecurityCredentialHome,
   setCodexSecurityCredentialLogout,
@@ -33,6 +37,44 @@ const receipt = {
   finding_ids: ["finding-1"],
   finding_count: 1,
 };
+const csvHeader = [
+  "occurrence_id",
+  "finding_id",
+  "title",
+  "summary",
+  "severity",
+  "confidence",
+  "status",
+  "close_reason",
+  "note",
+  "remediation",
+  "path",
+  "start_line",
+  "end_line",
+].join(",");
+const csvRow = [
+  "occ_e79cb19591e696572a1c22be",
+  "csf_852f90d6e1177502ff113d4a",
+  '"Unsafe archive extraction, including nested entries"',
+  "An attacker-controlled path reaches a filesystem write.",
+  "high",
+  "high",
+  "open",
+  "",
+  "",
+  "Normalize and validate destinations.",
+  "src/extract.py",
+  "41",
+  "44",
+].join(",");
+
+async function csvFixture(contents = `${csvHeader}\n${csvRow}\n`) {
+  const root = await mkdtemp(join(tmpdir(), "codex-security-cloud-csv-"));
+  directories.push(root);
+  const path = join(root, "findings.csv");
+  await writeFile(path, contents);
+  return path;
+}
 
 afterEach(async () => {
   await Promise.all(
@@ -120,6 +162,239 @@ async function addSecondFinding(scan: string): Promise<void> {
 }
 
 describe("Cloud publication", () => {
+  test("keeps the repository CSV template aligned with the standard export", async () => {
+    expect(
+      await readFile(
+        join(import.meta.dirname, "..", "..", "..", "examples", "findings.csv"),
+        "utf8",
+      ),
+    ).toBe(`${csvHeader}\n`);
+  });
+
+  test("previews a validated findings export CSV without credentials or network access", async () => {
+    const path = await csvFixture();
+    let requests = 0;
+    const result = await publishFindingsCsvToCloud(path, {
+      dryRun: true,
+      now: () => Date.parse("2026-08-25T12:00:00Z"),
+      fetch: async () => {
+        requests++;
+        throw new Error("unexpected request");
+      },
+    });
+    expect(result).toMatchObject({
+      scanId: expect.stringMatching(/^scan_csv_[a-f0-9]{24}$/),
+      findingIds: [],
+      findingCount: 1,
+      dryRun: true,
+      findings: [
+        {
+          findingId: expect.stringMatching(/^csf_[a-f0-9]{24}$/),
+          occurrenceId: expect.stringMatching(/^occ_[a-f0-9]{24}$/),
+          title: "Unsafe archive extraction, including nested entries",
+          severity: { level: "high" },
+          confidence: { level: "high" },
+          locations: [{ path: "src/extract.py", startLine: 41, endLine: 44 }],
+          provenance: {
+            source: "csv_import",
+            sourceFindingId: "csf_852f90d6e1177502ff113d4a",
+            sourceOccurrenceId: "occ_e79cb19591e696572a1c22be",
+            csvStatus: "open",
+          },
+        },
+      ],
+    });
+    expect(requests).toBe(0);
+  });
+
+  test("posts CSV findings with generated scan provenance", async () => {
+    const path = await csvFixture();
+    const { environment } = await fixture();
+    let payload: Record<string, unknown> | undefined;
+    const result = await publishFindingsCsvToCloud(path, {
+      environment,
+      now: () => Date.parse("2026-08-25T12:00:00Z"),
+      fetch: async (_url, options) => {
+        payload = JSON.parse(String(options.body));
+        return Response.json(receipt, { status: 201 });
+      },
+    });
+    expect(result).toEqual({
+      scanId: result.scanId,
+      findingIds: ["finding-1"],
+      findingCount: 1,
+    });
+    expect(result.scanId).toMatch(/^scan_csv_[a-f0-9]{24}$/);
+    expect(payload).toMatchObject({
+      schemaVersion: "1.0",
+      scan: {
+        id: result.scanId,
+        producer: { name: "codex-security-cli" },
+        status: "completed",
+        startedAt: "2026-08-25T12:00:00.000Z",
+        target: {
+          kind: "directory_snapshot",
+          displayName: "findings.csv",
+        },
+      },
+      findings: [
+        {
+          remediation: "Normalize and validate destinations.",
+          provenance: {
+            sourceFindingId: "csf_852f90d6e1177502ff113d4a",
+            sourceOccurrenceId: "occ_e79cb19591e696572a1c22be",
+          },
+        },
+      ],
+    });
+    const scan = payload!["scan"] as {
+      id: string;
+      target: { targetId: string };
+    };
+    const [finding] = payload!["findings"] as Array<{
+      findingId: string;
+      occurrenceId: string;
+      ruleId: string;
+      identity: { anchor: string; instance?: string };
+      fingerprints: { primary: string };
+    }>;
+    const hash = (value: string): string =>
+      createHash("sha256").update(value).digest("hex");
+    expect(finding!.findingId).toMatch(/^csf_[a-f0-9]{24}$/);
+    expect(finding!.occurrenceId).toMatch(/^occ_[a-f0-9]{24}$/);
+    const fingerprint = `codex-security/v1:sha256:${hash(
+      [
+        "codex-security/v1",
+        scan.target.targetId,
+        finding!.ruleId,
+        finding!.identity.anchor,
+        finding!.identity.instance ?? "",
+      ].join("\0"),
+    )}`;
+    expect(finding!.fingerprints.primary).toBe(fingerprint);
+    expect(finding!.findingId).toBe(`csf_${hash(fingerprint).slice(0, 24)}`);
+    expect(finding!.occurrenceId).toBe(
+      `occ_${hash([scan.id, fingerprint].join("\0")).slice(0, 24)}`,
+    );
+    const ajv = new Ajv2020({ strict: false });
+    const validateFindings = ajv.compile(
+      JSON.parse(
+        await readFile(
+          join(PLUGIN_ROOT, "schemas", "findings.schema.json"),
+          "utf8",
+        ),
+      ),
+    );
+    expect(
+      validateFindings({
+        documentType: "codex-security.findings",
+        schemaVersion: "1.0",
+        scanId: result.scanId,
+        findings: payload!["findings"],
+      }),
+    ).toBe(true);
+  });
+
+  test("accepts the candidate_id column from a Deep scan export", async () => {
+    const path = await csvFixture(
+      `${csvHeader.replace("finding_id,", "finding_id,candidate_id,")}\n${csvRow.replace("csf_852f90d6e1177502ff113d4a,", "csf_852f90d6e1177502ff113d4a,candidate-001,")}\n`,
+    );
+    const result = await publishFindingsCsvToCloud(path, { dryRun: true });
+    expect(result.findings?.[0]?.extensions).toEqual({
+      candidateId: "candidate-001",
+    });
+  });
+
+  test("preserves valid CSV triage fields in finding provenance", async () => {
+    const path = await csvFixture(
+      `${csvHeader}\n${csvRow.replace(",open,,,", ',closed,wont_fix,"Accepted risk.",')}\n`,
+    );
+    const result = await publishFindingsCsvToCloud(path, { dryRun: true });
+    expect(result.findings?.[0]?.provenance).toMatchObject({
+      csvStatus: "closed",
+      csvCloseReason: "wont_fix",
+      csvNote: "Accepted risk.",
+    });
+  });
+
+  test("preserves finding text from the CSV", async () => {
+    const path = await csvFixture(
+      `${csvHeader}\n${csvRow.replace("An attacker-controlled path reaches a filesystem write.", '"  Keep intentional spacing.  "')}\n`,
+    );
+    const result = await publishFindingsCsvToCloud(path, { dryRun: true });
+    expect(result.findings?.[0]?.summary).toBe("  Keep intentional spacing.  ");
+  });
+
+  test.each([
+    ["missing required header", csvHeader.replace("summary,", "")],
+    ["duplicate header", `${csvHeader},title`],
+    ["unknown header", `${csvHeader},unknown`],
+    ["no findings", csvHeader],
+    ["wrong column count", `${csvHeader}\n${csvRow},extra`],
+    [
+      "invalid finding ID",
+      `${csvHeader}\n${csvRow.replace("csf_852f90d6e1177502ff113d4a", "finding-1")}`,
+    ],
+    [
+      "invalid occurrence ID",
+      `${csvHeader}\n${csvRow.replace("occ_e79cb19591e696572a1c22be", "occurrence-1")}`,
+    ],
+    [
+      "empty title",
+      `${csvHeader}\n${csvRow.replace('"Unsafe archive extraction, including nested entries"', '""')}`,
+    ],
+    [
+      "invalid severity",
+      `${csvHeader}\n${csvRow.replace(",high,high,", ",urgent,high,")}`,
+    ],
+    [
+      "invalid confidence",
+      `${csvHeader}\n${csvRow.replace(",high,high,open,", ",high,certain,open,")}`,
+    ],
+    [
+      "invalid status",
+      `${csvHeader}\n${csvRow.replace(",open,,,", ",pending,,,")}`,
+    ],
+    [
+      "invalid close reason",
+      `${csvHeader}\n${csvRow.replace(",open,,,", ",closed,deferred,,")}`,
+    ],
+    [
+      "missing required close note",
+      `${csvHeader}\n${csvRow.replace(",open,,,", ",closed,false_positive,,")}`,
+    ],
+    [
+      "unsafe path",
+      `${csvHeader}\n${csvRow.replace("src/extract.py", "../escape.py")}`,
+    ],
+    [
+      "invalid start line",
+      `${csvHeader}\n${csvRow.replace(",41,44", ",0,44")}`,
+    ],
+    [
+      "invalid line range",
+      `${csvHeader}\n${csvRow.replace(",41,44", ",45,44")}`,
+    ],
+    ["duplicate finding", `${csvHeader}\n${csvRow}\n${csvRow}`],
+    [
+      "duplicate occurrence",
+      `${csvHeader}\n${csvRow}\n${csvRow.replace("csf_852f90d6e1177502ff113d4a", "csf_111111111111111111111111")}`,
+    ],
+  ])("rejects a CSV with %s before authentication", async (_name, source) => {
+    const path = await csvFixture(`${source}\n`);
+    let requests = 0;
+    await expect(
+      publishFindingsCsvToCloud(path, {
+        environment: {},
+        fetch: async () => {
+          requests++;
+          throw new Error("unexpected request");
+        },
+      }),
+    ).rejects.toThrow(/Findings CSV/);
+    expect(requests).toBe(0);
+  });
+
   test.each([false, true])(
     "rejects artifacts from another scan before upload or preview (dryRun=%s)",
     async (dryRun) => {

--- a/sdk/typescript/tests-ts/cloud-publish.test.ts
+++ b/sdk/typescript/tests-ts/cloud-publish.test.ts
@@ -184,12 +184,13 @@ describe("Cloud publication", () => {
           severity: { level: "high" },
           confidence: { level: "high" },
           locations: [{ path: "src/extract.py", startLine: 41, endLine: 44 }],
-          provenance: {
-            source: "csv_import",
-            sourceFindingId: "csf_852f90d6e1177502ff113d4a",
-            sourceOccurrenceId: "occ_e79cb19591e696572a1c22be",
-            csvStatus: "open",
+          validation: {
+            method: "Source-reported CSV import metadata",
+            status: "open",
+            summary:
+              "Source finding ID: csf_852f90d6e1177502ff113d4a\nSource occurrence ID: occ_e79cb19591e696572a1c22be\nSource status: open",
           },
+          provenance: { source: "csv_import" },
         },
       ],
     });
@@ -228,10 +229,7 @@ describe("Cloud publication", () => {
       findings: [
         {
           remediation: "Normalize and validate destinations.",
-          provenance: {
-            sourceFindingId: "csf_852f90d6e1177502ff113d4a",
-            sourceOccurrenceId: "occ_e79cb19591e696572a1c22be",
-          },
+          provenance: { source: "csv_import" },
         },
       ],
     });
@@ -253,15 +251,19 @@ describe("Cloud publication", () => {
     });
   });
 
-  test("preserves valid CSV triage fields in finding provenance", async () => {
+  test("preserves source IDs and triage fields in finding validation", async () => {
     const path = await csvFixture(
       `${csvHeader}\n${csvRow.replace(",open,,,", ',closed,wont_fix,"Accepted risk.",')}\n`,
     );
     const result = await publishFindingsCsvToCloud(path, { dryRun: true });
-    expect(result.findings?.[0]?.provenance).toMatchObject({
-      csvStatus: "closed",
-      csvCloseReason: "wont_fix",
-      csvNote: "Accepted risk.",
+    expect(result.findings?.[0]?.validation).toEqual({
+      method: "Source-reported CSV import metadata",
+      status: "closed",
+      summary:
+        "Source finding ID: csf_852f90d6e1177502ff113d4a\nSource occurrence ID: occ_e79cb19591e696572a1c22be\nSource status: closed\nSource close reason: wont_fix\nSource note: Accepted risk.",
+    });
+    expect(result.findings?.[0]?.provenance).toEqual({
+      source: "csv_import",
     });
   });
 

--- a/sdk/typescript/tests-ts/cloud-publish.test.ts
+++ b/sdk/typescript/tests-ts/cloud-publish.test.ts
@@ -220,7 +220,7 @@ describe("Cloud publication", () => {
         id: result.scanId,
         producer: { name: "codex-security-cli" },
         status: "completed",
-        startedAt: expect.any(String),
+        startedAt: "1970-01-01T00:00:00.000Z",
         target: {
           kind: "directory_snapshot",
           displayName: "findings.csv",


### PR DESCRIPTION
## Summary

Allow Cloud publication to ingest the existing Codex Security findings CSV format, so exported or manually assembled findings can be validated and uploaded without a completed scan directory.

## Changes

- Add `--csv PATH` to `codex-security publish scan --to cloud`.
- Validate standard and Deep Scan CSV fields before authentication or upload.
- Preserve `--dry-run --json` as a local preview with no login or network request.
- Add a header-only template at `examples/findings.csv`.
- Preserve source IDs and triage metadata while producing canonical upload findings.

## Testing

- Focused Cloud publisher and CLI tests, seed `12345`: 73 passed
- `pnpm run types`
- `pnpm run format`
- `pnpm run build`
- `git diff --check`

The affected suites pass. The repository-wide suite was not used because unrelated output-ancestry tests reject the temporary worktree parent before reaching this feature.

## Risk and rollout

This is an additive CLI option. Existing scan-directory and Linear publication behavior is unchanged. Invalid CSV input fails before credentials are read or a request is made. No server changes are included or expected.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.