### PR TITLE
docs(examples): add overview and clarify npm packaging

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,22 @@
+# Examples
+
+Examples and templates for using Codex Security:
+
+- [Findings CSV template](findings.csv): a header-only template for
+  `codex-security publish scan --to cloud --csv PATH`. Copy it and add your
+  findings before publishing. See the [CLI documentation](../sdk/typescript/README.md)
+  for the CSV format and dry-run options.
+- [Custom validation demo](custom-validation/README.md): run a scan with a custom
+  validation script against a deliberately vulnerable API using synthetic data.
+  Follow the demo's setup instructions, and do not deploy the example app.
+
+## npm package
+
+This top-level `examples/` directory is available in the repository only; it is
+not included in the `@openai/codex-security` npm package. The package is built
+from [`sdk/typescript`](../sdk/typescript/package.json), whose `files` list
+includes only the CLI launcher, compiled SDK, bundled plugin, license, and
+package README. The package check rejects files outside its expected contents.
+
+The bundled plugin's own example artifacts are separate and remain part of the
+package.


### PR DESCRIPTION
## Summary

Add an overview for the repository examples and document that they are not shipped in the npm package.

## Changes

- Add `examples/README.md` with links to the findings CSV template and custom validation demo.
- Explain that the top-level examples are repository-only, while the bundled plugin's own example artifacts remain packaged.
- Keep the existing package configuration unchanged: the package lives in `sdk/typescript`, its `files` list excludes the top-level examples, and the existing package checker rejects unexpected files.

## Testing

- Prettier check of `examples/README.md`: passed.
- Checked every relative link in the new README: passed.
- `pnpm pack --pack-destination ../../dist` (including the TypeScript build): passed.
- `node scripts/check-package.mjs ../../dist/openai-codex-security-0.1.20.tgz plugin-files.json`: passed, validating 269 archive entries.
- Inspected the generated tarball: no top-level repository examples or examples README; all four bundled plugin example artifacts remain present.
- `git diff --check origin/main...HEAD`: passed.
- Full unit tests and installed-package smoke tests were not run because this change only adds documentation.

## Risk and rollout

Low risk. Documentation only; no CLI, runtime, dependency, or package configuration changes. No rollout steps are required.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
