### PR TITLE
ci: use formatter-only checks for Markdown changes

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   validate-title:
-    name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}validate pull request
+    name: validate pull request
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
@@ -115,7 +115,7 @@ jobs:
           fi
 
   test:
-    name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}tests / ${{ matrix.os }} / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }}
+    name: tests / ${{ matrix.os }} / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }}
     needs: validate-title
     if: needs.validate-title.outputs.ci-mode == 'full'
     runs-on: ${{ matrix.os }}
@@ -208,9 +208,9 @@ jobs:
         run: pnpm run check:package ../../dist/*.tgz
 
   required-test:
-    name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}${{ matrix.os }} / node-22
+    name: ${{ matrix.os }} / node-22
     needs: [validate-title, test]
-    if: always() && !(github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null)
+    if: always()
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -219,11 +219,11 @@ jobs:
 
     steps:
       - name: Require every Unix coverage job
-        if: needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && needs.test.result != 'success') || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown')
+        if: needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && needs.test.result != 'success') || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown' && needs.validate-title.outputs.ci-mode != 'skip')
         run: exit 1
 
   windows-test:
-    name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}windows-latest / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }} / tests-${{ matrix.shard }}
+    name: windows-latest / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }} / tests-${{ matrix.shard }}
     needs: validate-title
     if: needs.validate-title.outputs.ci-mode == 'full'
     runs-on: windows-latest
@@ -283,7 +283,7 @@ jobs:
         run: bun test --timeout 120000 ./tests-ts/windows-machine-policy.test.ts
 
   windows-verify:
-    name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}windows-latest / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }} / verify
+    name: windows-latest / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }} / verify
     needs: validate-title
     if: needs.validate-title.outputs.ci-mode == 'full'
     runs-on: windows-latest
@@ -323,9 +323,9 @@ jobs:
         run: pnpm run check:package ../../dist/*.tgz
 
   windows:
-    name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}windows-latest / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }}
+    name: windows-latest / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }}
     runs-on: ubuntu-latest
-    if: always() && !(github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null)
+    if: always()
     needs: [validate-title, windows-test, windows-verify]
     strategy:
       fail-fast: false
@@ -334,5 +334,5 @@ jobs:
 
     steps:
       - name: Require every Windows coverage job
-        if: needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && (needs.windows-test.result != 'success' || needs.windows-verify.result != 'success')) || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown')
+        if: needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && (needs.windows-test.result != 'success' || needs.windows-verify.result != 'success')) || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown' && needs.validate-title.outputs.ci-mode != 'skip')
         run: exit 1

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -131,9 +131,10 @@ jobs:
         working-directory: sdk/typescript
         run: |
           bun test --timeout 30000 \
-            --test-name-pattern '(documents user-facing environment and deep-scan configuration|keeps documented runtime and deep-scan defaults accurate|renders only the discovery portion of the shipped workflows)$' \
+            --test-name-pattern '(documents a canonical historical-summary prefix block|documents user-facing environment and deep-scan configuration|keeps documented runtime and deep-scan defaults accurate|renders only the discovery portion of the shipped workflows)$' \
             ./tests-ts/cli.test.ts \
-            ./tests-ts/custom-validation.test.ts
+            ./tests-ts/custom-validation.test.ts \
+            ./tests-ts/release-automation.test.ts
 
       - name: Check package contents
         working-directory: sdk/typescript

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   validate-title:
-    name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}validate pull request title
+    name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}validate pull request
     runs-on: ubuntu-latest
     outputs:
       ci-mode: ${{ steps.scope.outputs.ci-mode }}
@@ -78,21 +78,8 @@ jobs:
             exit 1
           fi
 
-  markdown-checks:
-    name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}Markdown checks
-    needs: validate-title
-    if: needs.validate-title.outputs.ci-mode == 'markdown'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 2
-          persist-credentials: false
-
       - name: Set up pnpm
+        if: steps.scope.outputs.ci-mode == 'markdown'
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           package_json_file: sdk/typescript/package.json
@@ -100,21 +87,19 @@ jobs:
           cache_dependency_path: sdk/typescript/pnpm-lock.yaml
 
       - name: Set up Node.js
+        if: steps.scope.outputs.ci-mode == 'markdown'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "22.13.0"
           cache: npm
           cache-dependency-path: sdk/typescript/pnpm-lock.yaml
 
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: "1.3.14"
-
       - name: Install dependencies
+        if: steps.scope.outputs.ci-mode == 'markdown'
         run: pnpm --dir sdk/typescript install --frozen-lockfile
 
       - name: Check Markdown formatting
+        if: steps.scope.outputs.ci-mode == 'markdown'
         shell: bash
         run: |
           files=()
@@ -123,26 +108,11 @@ jobs:
                   ! -L "$GITHUB_WORKSPACE/$path" ]]; then
               files+=("$GITHUB_WORKSPACE/$path")
             fi
-          done < <(git diff --no-renames --name-only -z HEAD^1 HEAD -- '*.md')
+          done < <(git diff --no-renames --name-only -z HEAD^1 HEAD)
           if ((${#files[@]} > 0)); then
-            pnpm --dir sdk/typescript exec prettier --check "${files[@]}"
+            pnpm --dir sdk/typescript exec prettier \
+              --ignore-path /dev/null --check "${files[@]}"
           fi
-
-      - name: Check documentation consistency
-        working-directory: sdk/typescript
-        run: |
-          bun test --timeout 30000 \
-            --test-name-pattern '(documents a canonical historical-summary prefix block|documents user-facing environment and deep-scan configuration|keeps documented runtime and deep-scan defaults accurate|renders only the discovery portion of the shipped workflows)$' \
-            ./tests-ts/cli.test.ts \
-            ./tests-ts/custom-validation.test.ts \
-            ./tests-ts/release-automation.test.ts
-
-      - name: Check package contents
-        working-directory: sdk/typescript
-        shell: bash
-        run: |
-          pnpm pack --pack-destination ../../dist
-          pnpm run check:package ../../dist/*.tgz
 
   test:
     name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}tests / ${{ matrix.os }} / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }}
@@ -239,7 +209,7 @@ jobs:
 
   required-test:
     name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}${{ matrix.os }} / node-22
-    needs: [validate-title, markdown-checks, test]
+    needs: [validate-title, test]
     if: always() && !(github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null)
     runs-on: ubuntu-latest
     strategy:
@@ -249,7 +219,7 @@ jobs:
 
     steps:
       - name: Require every Unix coverage job
-        if: needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && needs.test.result != 'success') || (needs.validate-title.outputs.ci-mode == 'markdown' && needs.markdown-checks.result != 'success')
+        if: needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && needs.test.result != 'success') || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown')
         run: exit 1
 
   windows-test:
@@ -356,7 +326,7 @@ jobs:
     name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}windows-latest / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }}
     runs-on: ubuntu-latest
     if: always() && !(github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null)
-    needs: [validate-title, markdown-checks, windows-test, windows-verify]
+    needs: [validate-title, windows-test, windows-verify]
     strategy:
       fail-fast: false
       matrix:
@@ -364,5 +334,5 @@ jobs:
 
     steps:
       - name: Require every Windows coverage job
-        if: needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && (needs.windows-test.result != 'success' || needs.windows-verify.result != 'success')) || (needs.validate-title.outputs.ci-mode == 'markdown' && needs.markdown-checks.result != 'success')
+        if: needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && (needs.windows-test.result != 'success' || needs.windows-verify.result != 'success')) || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown')
         run: exit 1

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -18,9 +18,40 @@ jobs:
     name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}validate pull request title
     runs-on: ubuntu-latest
     outputs:
+      readme-only: ${{ steps.scope.outputs.readme-only }}
       run-full-ci: ${{ steps.scope.outputs.run-full-ci }}
 
     steps:
+      - name: Checkout pull request for change classification
+        if: github.event_name == 'pull_request' && github.event.changes.base == null && (github.event.action != 'edited' || github.event.changes.title != null)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+
+      - name: Detect README-only changes
+        id: changes
+        if: github.event_name == 'pull_request' && github.event.changes.base == null && (github.event.action != 'edited' || github.event.changes.title != null)
+        shell: bash
+        run: |
+          set -euo pipefail
+          changed_files="$(mktemp)"
+          trap 'rm -f "$changed_files"' EXIT
+          git diff --no-renames --name-only -z HEAD^1 HEAD > "$changed_files"
+
+          changed=false
+          readme_only=true
+          while IFS= read -r -d '' path; do
+            changed=true
+            if [[ "$path" != "README.md" && "$path" != */README.md ]]; then
+              readme_only=false
+            fi
+          done < "$changed_files"
+          if [[ "$changed" != "true" ]]; then
+            readme_only=false
+          fi
+          printf 'readme-only=%s\n' "$readme_only" >> "$GITHUB_OUTPUT"
+
       - name: Decide whether full CI is needed
         id: scope
         shell: bash
@@ -29,15 +60,23 @@ jobs:
           EVENT_ACTION: ${{ github.event.action }}
           TITLE_CHANGED: ${{ github.event.changes.title != null }}
           BASE_CHANGED: ${{ github.event.changes.base != null }}
+          README_ONLY: ${{ steps.changes.outputs.readme-only || 'false' }}
         run: |
           set -euo pipefail
           run_full_ci=true
+          readme_only=false
           if [[ "$EVENT_NAME" == "pull_request" &&
                 "$EVENT_ACTION" == "edited" &&
                 "$TITLE_CHANGED" != "true" &&
                 "$BASE_CHANGED" != "true" ]]; then
             run_full_ci=false
+          elif [[ "$EVENT_NAME" == "pull_request" &&
+                  "$BASE_CHANGED" != "true" &&
+                  "$README_ONLY" == "true" ]]; then
+            readme_only=true
+            run_full_ci=false
           fi
+          printf 'readme-only=%s\n' "$readme_only" >> "$GITHUB_OUTPUT"
           printf 'run-full-ci=%s\n' "$run_full_ci" >> "$GITHUB_OUTPUT"
 
       - name: Require a Conventional Commit pull request title
@@ -53,6 +92,60 @@ jobs:
             echo "Pull request title must follow <type>[optional scope][!]: <description>." >&2
             exit 1
           fi
+
+  readme-checks:
+    name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}README checks
+    needs: validate-title
+    if: needs.validate-title.outputs.readme-only == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          package_json_file: sdk/typescript/package.json
+          cache: true
+          cache_dependency_path: sdk/typescript/pnpm-lock.yaml
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: "22.13.0"
+          cache: npm
+          cache-dependency-path: sdk/typescript/pnpm-lock.yaml
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install dependencies
+        run: pnpm --dir sdk/typescript install --frozen-lockfile
+
+      - name: Check README formatting
+        run: pnpm --dir sdk/typescript run format
+
+      - name: Check README consistency
+        working-directory: sdk/typescript
+        run: |
+          bun test --timeout 30000 \
+            --test-name-pattern '(documents user-facing environment and deep-scan configuration|keeps documented runtime and deep-scan defaults accurate)$' \
+            ./tests-ts/cli.test.ts
+
+      - name: Pack
+        working-directory: sdk/typescript
+        run: pnpm pack --pack-destination ../../dist
+
+      - name: Inspect package
+        working-directory: sdk/typescript
+        shell: bash
+        run: pnpm run check:package ../../dist/*.tgz
 
   test:
     name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}tests / ${{ matrix.os }} / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }}
@@ -149,7 +242,7 @@ jobs:
 
   required-test:
     name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}${{ matrix.os }} / node-22
-    needs: [validate-title, test]
+    needs: [validate-title, readme-checks, test]
     if: always() && !(github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null)
     runs-on: ubuntu-latest
     strategy:
@@ -159,7 +252,7 @@ jobs:
 
     steps:
       - name: Require every Unix coverage job
-        if: needs.validate-title.result != 'success' || needs.test.result != 'success'
+        if: needs.validate-title.result != 'success' || (needs.validate-title.outputs.run-full-ci == 'true' && needs.test.result != 'success') || (needs.validate-title.outputs.readme-only == 'true' && needs.readme-checks.result != 'success') || (needs.validate-title.outputs.run-full-ci != 'true' && needs.validate-title.outputs.readme-only != 'true')
         run: exit 1
 
   windows-test:
@@ -266,7 +359,7 @@ jobs:
     name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}windows-latest / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }}
     runs-on: ubuntu-latest
     if: always() && !(github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null)
-    needs: [validate-title, windows-test, windows-verify]
+    needs: [validate-title, readme-checks, windows-test, windows-verify]
     strategy:
       fail-fast: false
       matrix:
@@ -274,5 +367,5 @@ jobs:
 
     steps:
       - name: Require every Windows coverage job
-        if: needs.validate-title.result != 'success' || needs.windows-test.result != 'success' || needs.windows-verify.result != 'success'
+        if: needs.validate-title.result != 'success' || (needs.validate-title.outputs.run-full-ci == 'true' && (needs.windows-test.result != 'success' || needs.windows-verify.result != 'success')) || (needs.validate-title.outputs.readme-only == 'true' && needs.readme-checks.result != 'success') || (needs.validate-title.outputs.run-full-ci != 'true' && needs.validate-title.outputs.readme-only != 'true')
         run: exit 1

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -119,7 +119,8 @@ jobs:
         run: |
           files=()
           while IFS= read -r -d '' path; do
-            if [[ -f "$GITHUB_WORKSPACE/$path" ]]; then
+            if [[ -f "$GITHUB_WORKSPACE/$path" &&
+                  ! -L "$GITHUB_WORKSPACE/$path" ]]; then
               files+=("$GITHUB_WORKSPACE/$path")
             fi
           done < <(git diff --no-renames --name-only -z HEAD^1 HEAD -- '*.md')

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -131,8 +131,9 @@ jobs:
         working-directory: sdk/typescript
         run: |
           bun test --timeout 30000 \
-            --test-name-pattern '(documents user-facing environment and deep-scan configuration|keeps documented runtime and deep-scan defaults accurate)$' \
-            ./tests-ts/cli.test.ts
+            --test-name-pattern '(documents user-facing environment and deep-scan configuration|keeps documented runtime and deep-scan defaults accurate|renders only the discovery portion of the shipped workflows)$' \
+            ./tests-ts/cli.test.ts \
+            ./tests-ts/custom-validation.test.ts
 
       - name: Check package contents
         working-directory: sdk/typescript

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -17,6 +17,7 @@ jobs:
   validate-title:
     name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}validate pull request
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       ci-mode: ${{ steps.scope.outputs.ci-mode }}
 

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -111,8 +111,7 @@ jobs:
             fi
           done < <(git diff --no-renames --name-only -z HEAD^1 HEAD)
           if ((${#files[@]} > 0)); then
-            pnpm --dir sdk/typescript exec prettier \
-              --ignore-path /dev/null --check "${files[@]}"
+            pnpm --dir sdk/typescript exec prettier --check "${files[@]}"
           fi
 
   test:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -10,8 +10,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}-${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only' || 'full' }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' && (github.event.action != 'edited' || github.event.changes.title != null || github.event.changes.base != null) }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   validate-title:
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout pull request for change classification
-        if: github.event_name == 'pull_request' && github.event.changes.base == null && (github.event.action != 'edited' || github.event.changes.title != null)
+        if: github.event_name == 'pull_request' && github.event.changes.base == null
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
@@ -34,19 +34,12 @@ jobs:
         shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
-          EVENT_ACTION: ${{ github.event.action }}
-          TITLE_CHANGED: ${{ github.event.changes.title != null }}
           BASE_CHANGED: ${{ github.event.changes.base != null }}
         run: |
           set -euo pipefail
           ci_mode=full
           if [[ "$EVENT_NAME" == "pull_request" &&
-                "$EVENT_ACTION" == "edited" &&
-                "$TITLE_CHANGED" != "true" &&
                 "$BASE_CHANGED" != "true" ]]; then
-            ci_mode=skip
-          elif [[ "$EVENT_NAME" == "pull_request" &&
-                  "$BASE_CHANGED" != "true" ]]; then
             changed_files="$(mktemp)"
             trap 'rm -f "$changed_files"' EXIT
             git diff --no-renames --name-only -z HEAD^1 HEAD > "$changed_files"
@@ -219,7 +212,7 @@ jobs:
 
     steps:
       - name: Require every Unix coverage job
-        if: needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && needs.test.result != 'success') || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown' && needs.validate-title.outputs.ci-mode != 'skip')
+        if: needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && needs.test.result != 'success') || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown')
         run: exit 1
 
   windows-test:
@@ -334,5 +327,5 @@ jobs:
 
     steps:
       - name: Require every Windows coverage job
-        if: needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && (needs.windows-test.result != 'success' || needs.windows-verify.result != 'success')) || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown' && needs.validate-title.outputs.ci-mode != 'skip')
+        if: needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && (needs.windows-test.result != 'success' || needs.windows-verify.result != 'success')) || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown')
         run: exit 1

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -18,8 +18,7 @@ jobs:
     name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}validate pull request title
     runs-on: ubuntu-latest
     outputs:
-      readme-only: ${{ steps.scope.outputs.readme-only }}
-      run-full-ci: ${{ steps.scope.outputs.run-full-ci }}
+      ci-mode: ${{ steps.scope.outputs.ci-mode }}
 
     steps:
       - name: Checkout pull request for change classification
@@ -29,30 +28,7 @@ jobs:
           fetch-depth: 2
           persist-credentials: false
 
-      - name: Detect README-only changes
-        id: changes
-        if: github.event_name == 'pull_request' && github.event.changes.base == null && (github.event.action != 'edited' || github.event.changes.title != null)
-        shell: bash
-        run: |
-          set -euo pipefail
-          changed_files="$(mktemp)"
-          trap 'rm -f "$changed_files"' EXIT
-          git diff --no-renames --name-only -z HEAD^1 HEAD > "$changed_files"
-
-          changed=false
-          readme_only=true
-          while IFS= read -r -d '' path; do
-            changed=true
-            if [[ "$path" != "README.md" && "$path" != */README.md ]]; then
-              readme_only=false
-            fi
-          done < "$changed_files"
-          if [[ "$changed" != "true" ]]; then
-            readme_only=false
-          fi
-          printf 'readme-only=%s\n' "$readme_only" >> "$GITHUB_OUTPUT"
-
-      - name: Decide whether full CI is needed
+      - name: Decide CI mode
         id: scope
         shell: bash
         env:
@@ -60,24 +36,33 @@ jobs:
           EVENT_ACTION: ${{ github.event.action }}
           TITLE_CHANGED: ${{ github.event.changes.title != null }}
           BASE_CHANGED: ${{ github.event.changes.base != null }}
-          README_ONLY: ${{ steps.changes.outputs.readme-only || 'false' }}
         run: |
           set -euo pipefail
-          run_full_ci=true
-          readme_only=false
+          ci_mode=full
           if [[ "$EVENT_NAME" == "pull_request" &&
                 "$EVENT_ACTION" == "edited" &&
                 "$TITLE_CHANGED" != "true" &&
                 "$BASE_CHANGED" != "true" ]]; then
-            run_full_ci=false
+            ci_mode=skip
           elif [[ "$EVENT_NAME" == "pull_request" &&
-                  "$BASE_CHANGED" != "true" &&
-                  "$README_ONLY" == "true" ]]; then
-            readme_only=true
-            run_full_ci=false
+                  "$BASE_CHANGED" != "true" ]]; then
+            changed_files="$(mktemp)"
+            trap 'rm -f "$changed_files"' EXIT
+            git diff --no-renames --name-only -z HEAD^1 HEAD > "$changed_files"
+
+            changed=false
+            markdown_only=true
+            while IFS= read -r -d '' path; do
+              changed=true
+              if [[ "$path" != *.md ]]; then
+                markdown_only=false
+              fi
+            done < "$changed_files"
+            if [[ "$changed" == "true" && "$markdown_only" == "true" ]]; then
+              ci_mode=markdown
+            fi
           fi
-          printf 'readme-only=%s\n' "$readme_only" >> "$GITHUB_OUTPUT"
-          printf 'run-full-ci=%s\n' "$run_full_ci" >> "$GITHUB_OUTPUT"
+          printf 'ci-mode=%s\n' "$ci_mode" >> "$GITHUB_OUTPUT"
 
       - name: Require a Conventional Commit pull request title
         if: github.event_name == 'pull_request'
@@ -93,10 +78,10 @@ jobs:
             exit 1
           fi
 
-  readme-checks:
-    name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}README checks
+  markdown-checks:
+    name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}Markdown checks
     needs: validate-title
-    if: needs.validate-title.outputs.readme-only == 'true'
+    if: needs.validate-title.outputs.ci-mode == 'markdown'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -104,6 +89,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          fetch-depth: 2
           persist-credentials: false
 
       - name: Set up pnpm
@@ -128,29 +114,37 @@ jobs:
       - name: Install dependencies
         run: pnpm --dir sdk/typescript install --frozen-lockfile
 
-      - name: Check README formatting
-        run: pnpm --dir sdk/typescript run format
+      - name: Check Markdown formatting
+        shell: bash
+        run: |
+          files=()
+          while IFS= read -r -d '' path; do
+            if [[ -f "$GITHUB_WORKSPACE/$path" ]]; then
+              files+=("$GITHUB_WORKSPACE/$path")
+            fi
+          done < <(git diff --no-renames --name-only -z HEAD^1 HEAD -- '*.md')
+          if ((${#files[@]} > 0)); then
+            pnpm --dir sdk/typescript exec prettier --check "${files[@]}"
+          fi
 
-      - name: Check README consistency
+      - name: Check documentation consistency
         working-directory: sdk/typescript
         run: |
           bun test --timeout 30000 \
             --test-name-pattern '(documents user-facing environment and deep-scan configuration|keeps documented runtime and deep-scan defaults accurate)$' \
             ./tests-ts/cli.test.ts
 
-      - name: Pack
-        working-directory: sdk/typescript
-        run: pnpm pack --pack-destination ../../dist
-
-      - name: Inspect package
+      - name: Check package contents
         working-directory: sdk/typescript
         shell: bash
-        run: pnpm run check:package ../../dist/*.tgz
+        run: |
+          pnpm pack --pack-destination ../../dist
+          pnpm run check:package ../../dist/*.tgz
 
   test:
     name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}tests / ${{ matrix.os }} / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }}
     needs: validate-title
-    if: needs.validate-title.outputs.run-full-ci == 'true'
+    if: needs.validate-title.outputs.ci-mode == 'full'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
@@ -242,7 +236,7 @@ jobs:
 
   required-test:
     name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}${{ matrix.os }} / node-22
-    needs: [validate-title, readme-checks, test]
+    needs: [validate-title, markdown-checks, test]
     if: always() && !(github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null)
     runs-on: ubuntu-latest
     strategy:
@@ -252,13 +246,13 @@ jobs:
 
     steps:
       - name: Require every Unix coverage job
-        if: needs.validate-title.result != 'success' || (needs.validate-title.outputs.run-full-ci == 'true' && needs.test.result != 'success') || (needs.validate-title.outputs.readme-only == 'true' && needs.readme-checks.result != 'success') || (needs.validate-title.outputs.run-full-ci != 'true' && needs.validate-title.outputs.readme-only != 'true')
+        if: needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && needs.test.result != 'success') || (needs.validate-title.outputs.ci-mode == 'markdown' && needs.markdown-checks.result != 'success')
         run: exit 1
 
   windows-test:
     name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}windows-latest / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }} / tests-${{ matrix.shard }}
     needs: validate-title
-    if: needs.validate-title.outputs.run-full-ci == 'true'
+    if: needs.validate-title.outputs.ci-mode == 'full'
     runs-on: windows-latest
     timeout-minutes: 20
     strategy:
@@ -318,7 +312,7 @@ jobs:
   windows-verify:
     name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}windows-latest / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }} / verify
     needs: validate-title
-    if: needs.validate-title.outputs.run-full-ci == 'true'
+    if: needs.validate-title.outputs.ci-mode == 'full'
     runs-on: windows-latest
     timeout-minutes: 20
     strategy:
@@ -359,7 +353,7 @@ jobs:
     name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null && 'metadata-only / ' || '' }}windows-latest / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }}
     runs-on: ubuntu-latest
     if: always() && !(github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null)
-    needs: [validate-title, readme-checks, windows-test, windows-verify]
+    needs: [validate-title, markdown-checks, windows-test, windows-verify]
     strategy:
       fail-fast: false
       matrix:
@@ -367,5 +361,5 @@ jobs:
 
     steps:
       - name: Require every Windows coverage job
-        if: needs.validate-title.result != 'success' || (needs.validate-title.outputs.run-full-ci == 'true' && (needs.windows-test.result != 'success' || needs.windows-verify.result != 'success')) || (needs.validate-title.outputs.readme-only == 'true' && needs.readme-checks.result != 'success') || (needs.validate-title.outputs.run-full-ci != 'true' && needs.validate-title.outputs.readme-only != 'true')
+        if: needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && (needs.windows-test.result != 'success' || needs.windows-verify.result != 'success')) || (needs.validate-title.outputs.ci-mode == 'markdown' && needs.markdown-checks.result != 'success')
         run: exit 1

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Use the included Docker Compose configuration for scans of many repositories. Se
 
 ## Other providers
 
-
 To use another inference provider, set its API key and select a model:
 
 ```bash

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -3900,11 +3900,9 @@ describe("GitHub release workflow safeguards", () => {
     );
   });
 
-  test("isolates body-only edits from full CI names and concurrency", () => {
+  test("keeps required contexts for body-only edits without full CI", () => {
     const metadataOnly =
       "github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null";
-    const metadataPrefix =
-      "${{ " + metadataOnly + " && 'metadata-only / ' || '' }}";
     const workflow = Bun.YAML.parse(nodeCiWorkflow) as {
       concurrency: {
         group: string;
@@ -3934,9 +3932,6 @@ describe("GitHub release workflow safeguards", () => {
     expect(workflow.concurrency["cancel-in-progress"]).toBe(
       "${{ github.event_name == 'pull_request' && (github.event.action != 'edited' || github.event.changes.title != null || github.event.changes.base != null) }}",
     );
-    for (const job of Object.values(workflow.jobs)) {
-      expect(job.name.startsWith(metadataPrefix), job.name).toBe(true);
-    }
     expect(workflow.jobs["validate-title"]?.["timeout-minutes"]).toBe(10);
     expect(
       workflow.jobs["validate-title"]?.steps.find(
@@ -3972,20 +3967,22 @@ describe("GitHub release workflow safeguards", () => {
       "pnpm --dir sdk/typescript exec prettier --check",
     );
     expect(markdownCommand).not.toContain("--ignore-path");
-    const requiredJobCondition = `always() && !(${metadataOnly})`;
+    const requiredJobCondition = "always()";
     expect(workflow.jobs["required-test"]?.if).toBe(requiredJobCondition);
     expect(workflow.jobs["windows"]?.if).toBe(requiredJobCondition);
     expect(workflow.jobs["required-test"]?.steps[0]?.if).toBe(
-      "needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && needs.test.result != 'success') || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown')",
+      "needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && needs.test.result != 'success') || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown' && needs.validate-title.outputs.ci-mode != 'skip')",
     );
     expect(workflow.jobs["windows"]?.steps[0]?.if).toBe(
-      "needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && (needs.windows-test.result != 'success' || needs.windows-verify.result != 'success')) || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown')",
+      "needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && (needs.windows-test.result != 'success' || needs.windows-verify.result != 'success')) || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown' && needs.validate-title.outputs.ci-mode != 'skip')",
     );
     for (const [ciMode, validation, upstream, gateFailure] of [
       ["full", "success", "success", false],
       ["full", "success", "skipped", true],
       ["markdown", "success", "skipped", false],
       ["markdown", "failure", "skipped", true],
+      ["skip", "success", "skipped", false],
+      ["skip", "failure", "skipped", true],
       ["unknown", "success", "skipped", true],
     ] as const) {
       const values = {
@@ -4006,15 +4003,8 @@ describe("GitHub release workflow safeguards", () => {
       }
     }
 
-    const renderName = (
-      template: string,
-      values: Record<string, string>,
-      metadata: boolean,
-    ) => {
-      let name = template.replace(
-        metadataPrefix,
-        metadata ? "metadata-only / " : "",
-      );
+    const renderName = (template: string, values: Record<string, string>) => {
+      let name = template;
       for (const [key, value] of Object.entries(values)) {
         name = name.replaceAll("${{ matrix." + key + " }}", value);
       }
@@ -4027,18 +4017,10 @@ describe("GitHub release workflow safeguards", () => {
     const windowsJob = workflow.jobs["windows"];
     const fullNames = [
       ...(unixJob?.strategy?.matrix["os"] ?? []).map((os) =>
-        renderName(unixJob?.name ?? "", { os }, false),
+        renderName(unixJob?.name ?? "", { os }),
       ),
       ...(windowsJob?.strategy?.matrix["node"] ?? []).map((node) =>
-        renderName(windowsJob?.name ?? "", { node }, false),
-      ),
-    ];
-    const metadataNames = [
-      ...(unixJob?.strategy?.matrix["os"] ?? []).map((os) =>
-        renderName(unixJob?.name ?? "", { os }, true),
-      ),
-      ...(windowsJob?.strategy?.matrix["node"] ?? []).map((node) =>
-        renderName(windowsJob?.name ?? "", { node }, true),
+        renderName(windowsJob?.name ?? "", { node }),
       ),
     ];
     const requiredContexts = new Set([
@@ -4050,12 +4032,6 @@ describe("GitHub release workflow safeguards", () => {
     expect(
       fullNames.filter((name) => requiredContexts.has(name)).sort(),
     ).toEqual([...requiredContexts].sort());
-    expect(metadataNames.some((name) => requiredContexts.has(name))).toBe(
-      false,
-    );
-    expect(
-      metadataNames.every((name) => name.startsWith("metadata-only / ")),
-    ).toBe(true);
   });
 
   test.each([

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -3915,6 +3915,7 @@ describe("GitHub release workflow safeguards", () => {
         {
           name: string;
           if?: string;
+          "timeout-minutes"?: number;
           strategy?: { matrix: Record<string, string[]> };
           steps: Array<{
             if?: string;
@@ -3936,6 +3937,7 @@ describe("GitHub release workflow safeguards", () => {
     for (const job of Object.values(workflow.jobs)) {
       expect(job.name.startsWith(metadataPrefix), job.name).toBe(true);
     }
+    expect(workflow.jobs["validate-title"]?.["timeout-minutes"]).toBe(10);
     expect(
       workflow.jobs["validate-title"]?.steps.find(
         ({ name }) =>
@@ -3979,25 +3981,30 @@ describe("GitHub release workflow safeguards", () => {
     expect(workflow.jobs["windows"]?.steps[0]?.if).toBe(
       "needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && (needs.windows-test.result != 'success' || needs.windows-verify.result != 'success')) || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown')",
     );
-    const unknownMode = {
-      "needs.test.result": "skipped",
-      "needs.validate-title.outputs.ci-mode": "unknown",
-      "needs.validate-title.result": "success",
-      "needs.windows-test.result": "skipped",
-      "needs.windows-verify.result": "skipped",
-    };
-    expect(
-      evaluateWorkflowCondition(
-        workflow.jobs["required-test"]?.steps[0]?.if ?? "",
-        unknownMode,
-      ),
-    ).toBe(true);
-    expect(
-      evaluateWorkflowCondition(
-        workflow.jobs["windows"]?.steps[0]?.if ?? "",
-        unknownMode,
-      ),
-    ).toBe(true);
+    for (const [ciMode, validation, upstream, gateFailure] of [
+      ["full", "success", "success", false],
+      ["full", "success", "skipped", true],
+      ["markdown", "success", "skipped", false],
+      ["markdown", "failure", "skipped", true],
+      ["unknown", "success", "skipped", true],
+    ] as const) {
+      const values = {
+        "needs.test.result": upstream,
+        "needs.validate-title.outputs.ci-mode": ciMode,
+        "needs.validate-title.result": validation,
+        "needs.windows-test.result": upstream,
+        "needs.windows-verify.result": upstream,
+      };
+      for (const job of ["required-test", "windows"]) {
+        expect(
+          evaluateWorkflowCondition(
+            workflow.jobs[job]?.steps[0]?.if ?? "",
+            values,
+          ),
+          `${job}: ${ciMode}/${validation}/${upstream}`,
+        ).toBe(gateFailure);
+      }
+    }
 
     const renderName = (
       template: string,
@@ -4148,50 +4155,53 @@ describe("GitHub release workflow safeguards", () => {
     },
   );
 
-  test("formats every changed regular non-symlink Markdown file", () => {
-    const workspace = mkdtempSync(join(tmpdir(), "release-ci-markdown-"));
-    const argsFile = join(workspace, "prettier-args");
-    const guide = join(workspace, "docs", "guide with spaces.md");
-    const readme = join(workspace, "README.md");
-    mkdirSync(join(workspace, "docs"));
-    writeFileSync(guide, "# Guide\n");
-    writeFileSync(readme, "# Readme\n");
-    symlinkSync(readme, join(workspace, "docs", "link.md"));
-    const mocks = `git() {
+  test.skipIf(process.platform === "win32")(
+    "formats every changed regular non-symlink Markdown file",
+    () => {
+      const workspace = mkdtempSync(join(tmpdir(), "release-ci-markdown-"));
+      const argsFile = join(workspace, "prettier-args");
+      const guide = join(workspace, "docs", "guide with spaces.md");
+      const readme = join(workspace, "README.md");
+      mkdirSync(join(workspace, "docs"));
+      writeFileSync(guide, "# Guide\n");
+      writeFileSync(readme, "# Readme\n");
+      symlinkSync(readme, join(workspace, "docs", "link.md"));
+      const mocks = `git() {
       printf '%s\\0' README.md 'docs/guide with spaces.md' docs/link.md deleted.md
     }
     pnpm() { printf '%s\\n' "$@" > "$MOCK_PNPM_ARGS"; }`;
-    try {
-      const result = spawnSync(
-        bash,
-        [
-          "-c",
-          `${mocks}\n${workflowStepShell(nodeCiWorkflow, "Check Markdown formatting")}`,
-        ],
-        {
-          env: {
-            ...process.env,
-            GITHUB_WORKSPACE: workspace,
-            MOCK_PNPM_ARGS: argsFile,
+      try {
+        const result = spawnSync(
+          bash,
+          [
+            "-c",
+            `${mocks}\n${workflowStepShell(nodeCiWorkflow, "Check Markdown formatting")}`,
+          ],
+          {
+            env: {
+              ...process.env,
+              GITHUB_WORKSPACE: workspace,
+              MOCK_PNPM_ARGS: argsFile,
+            },
           },
-        },
-      );
-      expect(result.status).toBe(0);
-      expect(readFileSync(argsFile, "utf8").trim().split("\n")).toEqual([
-        "--dir",
-        "sdk/typescript",
-        "exec",
-        "prettier",
-        "--ignore-path",
-        "/dev/null",
-        "--check",
-        readme,
-        guide,
-      ]);
-    } finally {
-      rmSync(workspace, { recursive: true, force: true });
-    }
-  });
+        );
+        expect(result.status).toBe(0);
+        expect(readFileSync(argsFile, "utf8").trim().split("\n")).toEqual([
+          "--dir",
+          "sdk/typescript",
+          "exec",
+          "prettier",
+          "--ignore-path",
+          "/dev/null",
+          "--check",
+          readme,
+          guide,
+        ]);
+      } finally {
+        rmSync(workspace, { recursive: true, force: true });
+      }
+    },
+  );
 
   test("documents a canonical historical-summary prefix block", () => {
     const start = "<!-- codex-security-release-summary:start -->";

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -3954,6 +3954,7 @@ describe("GitHub release workflow safeguards", () => {
       .join("\n");
     for (const command of [
       "'*.md'",
+      "! -L",
       "prettier --check",
       "--test-name-pattern",
       "./tests-ts/cli.test.ts",

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -3958,6 +3958,7 @@ describe("GitHub release workflow safeguards", () => {
       "--test-name-pattern",
       "./tests-ts/cli.test.ts",
       "./tests-ts/custom-validation.test.ts",
+      "./tests-ts/release-automation.test.ts",
       "pnpm pack --pack-destination ../../dist",
       "pnpm run check:package ../../dist/*.tgz",
     ]) {

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -3900,9 +3900,7 @@ describe("GitHub release workflow safeguards", () => {
     );
   });
 
-  test("keeps required contexts for body-only edits without full CI", () => {
-    const metadataOnly =
-      "github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title == null && github.event.changes.base == null";
+  test("keeps required contexts stable across reduced CI", () => {
     const workflow = Bun.YAML.parse(nodeCiWorkflow) as {
       concurrency: {
         group: string;
@@ -3925,12 +3923,10 @@ describe("GitHub release workflow safeguards", () => {
     };
 
     expect(workflow.concurrency.group).toBe(
-      "${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}-${{ " +
-        metadataOnly +
-        " && 'metadata-only' || 'full' }}",
+      "${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}",
     );
     expect(workflow.concurrency["cancel-in-progress"]).toBe(
-      "${{ github.event_name == 'pull_request' && (github.event.action != 'edited' || github.event.changes.title != null || github.event.changes.base != null) }}",
+      "${{ github.event_name == 'pull_request' }}",
     );
     expect(workflow.jobs["validate-title"]?.["timeout-minutes"]).toBe(10);
     expect(
@@ -3971,18 +3967,17 @@ describe("GitHub release workflow safeguards", () => {
     expect(workflow.jobs["required-test"]?.if).toBe(requiredJobCondition);
     expect(workflow.jobs["windows"]?.if).toBe(requiredJobCondition);
     expect(workflow.jobs["required-test"]?.steps[0]?.if).toBe(
-      "needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && needs.test.result != 'success') || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown' && needs.validate-title.outputs.ci-mode != 'skip')",
+      "needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && needs.test.result != 'success') || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown')",
     );
     expect(workflow.jobs["windows"]?.steps[0]?.if).toBe(
-      "needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && (needs.windows-test.result != 'success' || needs.windows-verify.result != 'success')) || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown' && needs.validate-title.outputs.ci-mode != 'skip')",
+      "needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && (needs.windows-test.result != 'success' || needs.windows-verify.result != 'success')) || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown')",
     );
     for (const [ciMode, validation, upstream, gateFailure] of [
       ["full", "success", "success", false],
       ["full", "success", "skipped", true],
       ["markdown", "success", "skipped", false],
       ["markdown", "failure", "skipped", true],
-      ["skip", "success", "skipped", false],
-      ["skip", "failure", "skipped", true],
+      ["skip", "success", "skipped", true],
       ["unknown", "success", "skipped", true],
     ] as const) {
       const values = {
@@ -4035,73 +4030,27 @@ describe("GitHub release workflow safeguards", () => {
   });
 
   test.each([
-    ["body-only edit", "pull_request", "edited", false, false, [], "skip"],
     [
       "Markdown-only PR",
       "pull_request",
-      "synchronize",
-      false,
       false,
       ["README.md", "docs/guide.md"],
       "markdown",
     ],
-    [
-      "Markdown-only title edit",
-      "pull_request",
-      "edited",
-      true,
-      false,
-      ["README.md"],
-      "markdown",
-    ],
-    [
-      "base retarget",
-      "pull_request",
-      "edited",
-      false,
-      true,
-      ["README.md"],
-      "full",
-    ],
-    [
-      "mixed PR",
-      "pull_request",
-      "synchronize",
-      false,
-      false,
-      ["README.md", "src/index.ts"],
-      "full",
-    ],
+    ["base retarget", "pull_request", true, ["README.md"], "full"],
+    ["mixed PR", "pull_request", false, ["README.md", "src/index.ts"], "full"],
     [
       "source-to-Markdown rename",
       "pull_request",
-      "synchronize",
-      false,
       false,
       ["src/index.ts", "docs/index.md"],
       "full",
     ],
-    [
-      "empty merge diff",
-      "pull_request",
-      "synchronize",
-      false,
-      false,
-      [],
-      "full",
-    ],
-    ["push", "push", "", false, false, ["README.md"], "full"],
+    ["empty merge diff", "pull_request", false, [], "full"],
+    ["push", "push", false, ["README.md"], "full"],
   ] as const)(
     "selects the conservative CI mode for %s",
-    (
-      _name,
-      eventName,
-      action,
-      titleChanged,
-      baseChanged,
-      changedPaths,
-      ciMode,
-    ) => {
+    (_name, eventName, baseChanged, changedPaths, ciMode) => {
       const workspace = mkdtempSync(join(tmpdir(), "release-ci-scope-"));
       const output = join(workspace, "output");
       const script = workflowStepShell(nodeCiWorkflow, "Decide CI mode");
@@ -4116,11 +4065,9 @@ describe("GitHub release workflow safeguards", () => {
           env: {
             ...process.env,
             BASE_CHANGED: String(baseChanged),
-            EVENT_ACTION: action,
             EVENT_NAME: eventName,
             GITHUB_OUTPUT: output,
             MOCK_CHANGED_FILES: changedPaths.join("\n"),
-            TITLE_CHANGED: String(titleChanged),
           },
         });
         expect(result.status).toBe(0);

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -3957,6 +3957,7 @@ describe("GitHub release workflow safeguards", () => {
       "prettier --check",
       "--test-name-pattern",
       "./tests-ts/cli.test.ts",
+      "./tests-ts/custom-validation.test.ts",
       "pnpm pack --pack-destination ../../dist",
       "pnpm run check:package ../../dist/*.tgz",
     ]) {

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -3895,7 +3895,7 @@ describe("GitHub release workflow safeguards", () => {
     );
     expect(nodeCiWorkflow).toContain("needs: validate-title");
     expect(nodeCiWorkflow).toContain(
-      "needs: [validate-title, windows-test, windows-verify]",
+      "needs: [validate-title, readme-checks, windows-test, windows-verify]",
     );
   });
 
@@ -3915,7 +3915,12 @@ describe("GitHub release workflow safeguards", () => {
           name: string;
           if?: string;
           strategy?: { matrix: Record<string, string[]> };
-          steps: Array<{ if?: string }>;
+          steps: Array<{
+            if?: string;
+            name?: string;
+            run?: string;
+            "working-directory"?: string;
+          }>;
         }
       >;
     };
@@ -3931,20 +3936,56 @@ describe("GitHub release workflow safeguards", () => {
     for (const job of Object.values(workflow.jobs)) {
       expect(job.name.startsWith(metadataPrefix), job.name).toBe(true);
     }
+    for (const stepName of [
+      "Checkout pull request for change classification",
+      "Detect README-only changes",
+    ]) {
+      expect(
+        workflow.jobs["validate-title"]?.steps.find(
+          ({ name }) => name === stepName,
+        )?.if,
+      ).toContain("github.event.changes.base == null");
+    }
 
     const fullCiCondition =
       "needs.validate-title.outputs.run-full-ci == 'true'";
     for (const job of ["test", "windows-test", "windows-verify"]) {
       expect(workflow.jobs[job]?.if).toBe(fullCiCondition);
     }
+    expect(workflow.jobs["readme-checks"]?.if).toBe(
+      "needs.validate-title.outputs.readme-only == 'true'",
+    );
+    const readmeSteps = workflow.jobs["readme-checks"]?.steps ?? [];
+    expect(
+      readmeSteps.find(({ name }) => name === "Check README formatting")?.run,
+    ).toBe("pnpm --dir sdk/typescript run format");
+    const consistencyCommand =
+      readmeSteps.find(({ name }) => name === "Check README consistency")
+        ?.run ?? "";
+    expect(consistencyCommand).toContain("--test-name-pattern");
+    expect(consistencyCommand).toContain(
+      "documents user-facing environment and deep-scan configuration",
+    );
+    expect(consistencyCommand).toContain(
+      "keeps documented runtime and deep-scan defaults accurate",
+    );
+    expect(consistencyCommand).toContain("./tests-ts/cli.test.ts");
+    for (const [name, run] of [
+      ["Pack", "pnpm pack --pack-destination ../../dist"],
+      ["Inspect package", "pnpm run check:package ../../dist/*.tgz"],
+    ]) {
+      const step = readmeSteps.find((candidate) => candidate.name === name);
+      expect(step?.["working-directory"]).toBe("sdk/typescript");
+      expect(step?.run).toBe(run);
+    }
     const requiredJobCondition = `always() && !(${metadataOnly})`;
     expect(workflow.jobs["required-test"]?.if).toBe(requiredJobCondition);
     expect(workflow.jobs["windows"]?.if).toBe(requiredJobCondition);
     expect(workflow.jobs["required-test"]?.steps[0]?.if).toBe(
-      "needs.validate-title.result != 'success' || needs.test.result != 'success'",
+      "needs.validate-title.result != 'success' || (needs.validate-title.outputs.run-full-ci == 'true' && needs.test.result != 'success') || (needs.validate-title.outputs.readme-only == 'true' && needs.readme-checks.result != 'success') || (needs.validate-title.outputs.run-full-ci != 'true' && needs.validate-title.outputs.readme-only != 'true')",
     );
     expect(workflow.jobs["windows"]?.steps[0]?.if).toBe(
-      "needs.validate-title.result != 'success' || needs.windows-test.result != 'success' || needs.windows-verify.result != 'success'",
+      "needs.validate-title.result != 'success' || (needs.validate-title.outputs.run-full-ci == 'true' && (needs.windows-test.result != 'success' || needs.windows-verify.result != 'success')) || (needs.validate-title.outputs.readme-only == 'true' && needs.readme-checks.result != 'success') || (needs.validate-title.outputs.run-full-ci != 'true' && needs.validate-title.outputs.readme-only != 'true')",
     );
 
     const renderName = (
@@ -4001,14 +4042,85 @@ describe("GitHub release workflow safeguards", () => {
 
   test.each([
     {
+      name: "a root README",
+      paths: ["README.md"],
+      readmeOnly: true,
+    },
+    {
+      name: "nested READMEs",
+      paths: ["examples/README.md", "sdk/typescript/README.md"],
+      readmeOnly: true,
+    },
+    {
+      name: "another Markdown file",
+      paths: ["docs/guide.md"],
+      readmeOnly: false,
+    },
+    {
+      name: "a README and source code",
+      paths: ["README.md", "sdk/typescript/src/index.ts"],
+      readmeOnly: false,
+    },
+    {
+      name: "a source file renamed to README",
+      paths: ["sdk/typescript/src/index.ts", "README.md"],
+      readmeOnly: false,
+    },
+    {
+      name: "a differently cased readme",
+      paths: ["readme.md"],
+      readmeOnly: false,
+    },
+    {
+      name: "an empty diff",
+      paths: [],
+      readmeOnly: false,
+    },
+  ])("classifies $name without weakening full CI", ({ paths, readmeOnly }) => {
+    const script = workflowStepShell(
+      nodeCiWorkflow,
+      "Detect README-only changes",
+    );
+    const workspace = mkdtempSync(join(tmpdir(), "release-ci-readme-"));
+    const output = join(workspace, "output");
+    const mock = [
+      "git() {",
+      '  if [[ "$*" != "diff --no-renames --name-only -z HEAD^1 HEAD" ]]; then return 64; fi',
+      "  while IFS= read -r path; do",
+      '    if [[ -n "$path" ]]; then printf \'%s\\0\' "$path"; fi',
+      '  done <<< "$MOCK_CHANGED_FILES"',
+      "}",
+    ].join("\n");
+    try {
+      const result = spawnSync(bash, ["-c", `${mock}\n${script}`], {
+        env: {
+          ...process.env,
+          GITHUB_OUTPUT: output,
+          MOCK_CHANGED_FILES: paths.join("\n"),
+        },
+      });
+      expect(result.status).toBe(0);
+      expect(readFileSync(output, "utf8")).toBe(
+        `readme-only=${String(readmeOnly)}\n`,
+      );
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test.each([
+    {
       name: "body-only edit with a valid title",
       eventName: "pull_request",
       action: "edited",
       titleChanged: false,
       baseChanged: false,
       title: "docs: clarify release notes",
+      detectedReadmeOnly: false,
+      readmeOnly: false,
       fullCi: false,
       titleValid: true,
+      readmeChecks: "skipped",
       upstream: "skipped",
       gateFailure: false,
       cancellation: false,
@@ -4020,8 +4132,11 @@ describe("GitHub release workflow safeguards", () => {
       titleChanged: false,
       baseChanged: false,
       title: "Docs: invalid title ",
+      detectedReadmeOnly: false,
+      readmeOnly: false,
       fullCi: false,
       titleValid: false,
+      readmeChecks: "skipped",
       upstream: "skipped",
       gateFailure: false,
       cancellation: false,
@@ -4033,21 +4148,27 @@ describe("GitHub release workflow safeguards", () => {
       titleChanged: true,
       baseChanged: false,
       title: "ci: update title",
+      detectedReadmeOnly: false,
+      readmeOnly: false,
       fullCi: true,
       titleValid: true,
+      readmeChecks: "skipped",
       upstream: "success",
       gateFailure: false,
       cancellation: true,
     },
     {
-      name: "base edit",
+      name: "README-only base edit",
       eventName: "pull_request",
       action: "edited",
       titleChanged: false,
       baseChanged: true,
-      title: "ci: update base",
+      title: "docs: retarget README update",
+      detectedReadmeOnly: true,
+      readmeOnly: false,
       fullCi: true,
       titleValid: true,
+      readmeChecks: "skipped",
       upstream: "success",
       gateFailure: false,
       cancellation: true,
@@ -4059,10 +4180,45 @@ describe("GitHub release workflow safeguards", () => {
       titleChanged: false,
       baseChanged: false,
       title: "ci: update code",
+      detectedReadmeOnly: false,
+      readmeOnly: false,
       fullCi: true,
       titleValid: true,
+      readmeChecks: "skipped",
       upstream: "success",
       gateFailure: false,
+      cancellation: true,
+    },
+    {
+      name: "README-only synchronization",
+      eventName: "pull_request",
+      action: "synchronize",
+      titleChanged: false,
+      baseChanged: false,
+      title: "docs: clarify examples",
+      detectedReadmeOnly: true,
+      readmeOnly: true,
+      fullCi: false,
+      titleValid: true,
+      readmeChecks: "success",
+      upstream: "skipped",
+      gateFailure: false,
+      cancellation: true,
+    },
+    {
+      name: "README-only synchronization with failed formatting",
+      eventName: "pull_request",
+      action: "synchronize",
+      titleChanged: false,
+      baseChanged: false,
+      title: "docs: misformat examples",
+      detectedReadmeOnly: true,
+      readmeOnly: true,
+      fullCi: false,
+      titleValid: true,
+      readmeChecks: "failure",
+      upstream: "skipped",
+      gateFailure: true,
       cancellation: true,
     },
     {
@@ -4072,8 +4228,11 @@ describe("GitHub release workflow safeguards", () => {
       titleChanged: false,
       baseChanged: false,
       title: "",
+      detectedReadmeOnly: false,
+      readmeOnly: false,
       fullCi: true,
       titleValid: true,
+      readmeChecks: "skipped",
       upstream: "success",
       gateFailure: false,
       cancellation: false,
@@ -4085,8 +4244,11 @@ describe("GitHub release workflow safeguards", () => {
       titleChanged: false,
       baseChanged: false,
       title: "ci: update code",
+      detectedReadmeOnly: false,
+      readmeOnly: false,
       fullCi: true,
       titleValid: true,
+      readmeChecks: "skipped",
       upstream: "skipped",
       gateFailure: true,
       cancellation: true,
@@ -4099,8 +4261,11 @@ describe("GitHub release workflow safeguards", () => {
       titleChanged,
       baseChanged,
       title,
+      detectedReadmeOnly,
+      readmeOnly,
       fullCi,
       titleValid,
+      readmeChecks,
       upstream,
       gateFailure,
       cancellation,
@@ -4127,12 +4292,13 @@ describe("GitHub release workflow safeguards", () => {
             EVENT_ACTION: action === "none" ? "" : action,
             EVENT_NAME: eventName,
             GITHUB_OUTPUT: output,
+            README_ONLY: String(detectedReadmeOnly),
             TITLE_CHANGED: String(titleChanged),
           },
         });
         expect(scope.status).toBe(0);
         expect(readFileSync(output, "utf8")).toBe(
-          `run-full-ci=${String(fullCi)}\n`,
+          `readme-only=${String(readmeOnly)}\nrun-full-ci=${String(fullCi)}\n`,
         );
 
         const validation =
@@ -4146,14 +4312,17 @@ describe("GitHub release workflow safeguards", () => {
         expect(validation === "success").toBe(titleValid);
 
         const values = {
+          "needs.readme-checks.result": readmeChecks,
           "needs.test.result": upstream,
+          "needs.validate-title.outputs.readme-only": String(readmeOnly),
+          "needs.validate-title.outputs.run-full-ci": String(fullCi),
           "needs.validate-title.result": validation,
           "needs.windows-test.result": upstream,
           "needs.windows-verify.result": upstream,
         };
         const unixGate = workflow.jobs["required-test"]?.steps[0]?.if ?? "";
         const windowsGate = workflow.jobs["windows"]?.steps[0]?.if ?? "";
-        if (fullCi) {
+        if (fullCi || readmeOnly) {
           expect(evaluateWorkflowCondition(unixGate, values)).toBe(gateFailure);
           expect(evaluateWorkflowCondition(windowsGate, values)).toBe(
             gateFailure,

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -3895,7 +3895,7 @@ describe("GitHub release workflow safeguards", () => {
     );
     expect(nodeCiWorkflow).toContain("needs: validate-title");
     expect(nodeCiWorkflow).toContain(
-      "needs: [validate-title, readme-checks, windows-test, windows-verify]",
+      "needs: [validate-title, markdown-checks, windows-test, windows-verify]",
     );
   });
 
@@ -3919,7 +3919,6 @@ describe("GitHub release workflow safeguards", () => {
             if?: string;
             name?: string;
             run?: string;
-            "working-directory"?: string;
           }>;
         }
       >;
@@ -3936,56 +3935,41 @@ describe("GitHub release workflow safeguards", () => {
     for (const job of Object.values(workflow.jobs)) {
       expect(job.name.startsWith(metadataPrefix), job.name).toBe(true);
     }
-    for (const stepName of [
-      "Checkout pull request for change classification",
-      "Detect README-only changes",
-    ]) {
-      expect(
-        workflow.jobs["validate-title"]?.steps.find(
-          ({ name }) => name === stepName,
-        )?.if,
-      ).toContain("github.event.changes.base == null");
-    }
+    expect(
+      workflow.jobs["validate-title"]?.steps.find(
+        ({ name }) =>
+          name === "Checkout pull request for change classification",
+      )?.if,
+    ).toContain("github.event.changes.base == null");
 
-    const fullCiCondition =
-      "needs.validate-title.outputs.run-full-ci == 'true'";
+    const fullCiCondition = "needs.validate-title.outputs.ci-mode == 'full'";
     for (const job of ["test", "windows-test", "windows-verify"]) {
       expect(workflow.jobs[job]?.if).toBe(fullCiCondition);
     }
-    expect(workflow.jobs["readme-checks"]?.if).toBe(
-      "needs.validate-title.outputs.readme-only == 'true'",
+    expect(workflow.jobs["markdown-checks"]?.if).toBe(
+      "needs.validate-title.outputs.ci-mode == 'markdown'",
     );
-    const readmeSteps = workflow.jobs["readme-checks"]?.steps ?? [];
-    expect(
-      readmeSteps.find(({ name }) => name === "Check README formatting")?.run,
-    ).toBe("pnpm --dir sdk/typescript run format");
-    const consistencyCommand =
-      readmeSteps.find(({ name }) => name === "Check README consistency")
-        ?.run ?? "";
-    expect(consistencyCommand).toContain("--test-name-pattern");
-    expect(consistencyCommand).toContain(
-      "documents user-facing environment and deep-scan configuration",
-    );
-    expect(consistencyCommand).toContain(
-      "keeps documented runtime and deep-scan defaults accurate",
-    );
-    expect(consistencyCommand).toContain("./tests-ts/cli.test.ts");
-    for (const [name, run] of [
-      ["Pack", "pnpm pack --pack-destination ../../dist"],
-      ["Inspect package", "pnpm run check:package ../../dist/*.tgz"],
+    const markdownCommands = (workflow.jobs["markdown-checks"]?.steps ?? [])
+      .map(({ run }) => run ?? "")
+      .join("\n");
+    for (const command of [
+      "'*.md'",
+      "prettier --check",
+      "--test-name-pattern",
+      "./tests-ts/cli.test.ts",
+      "pnpm pack --pack-destination ../../dist",
+      "pnpm run check:package ../../dist/*.tgz",
     ]) {
-      const step = readmeSteps.find((candidate) => candidate.name === name);
-      expect(step?.["working-directory"]).toBe("sdk/typescript");
-      expect(step?.run).toBe(run);
+      expect(markdownCommands).toContain(command);
     }
     const requiredJobCondition = `always() && !(${metadataOnly})`;
     expect(workflow.jobs["required-test"]?.if).toBe(requiredJobCondition);
     expect(workflow.jobs["windows"]?.if).toBe(requiredJobCondition);
     expect(workflow.jobs["required-test"]?.steps[0]?.if).toBe(
-      "needs.validate-title.result != 'success' || (needs.validate-title.outputs.run-full-ci == 'true' && needs.test.result != 'success') || (needs.validate-title.outputs.readme-only == 'true' && needs.readme-checks.result != 'success') || (needs.validate-title.outputs.run-full-ci != 'true' && needs.validate-title.outputs.readme-only != 'true')",
+      "needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && needs.test.result != 'success') || (needs.validate-title.outputs.ci-mode == 'markdown' && needs.markdown-checks.result != 'success')",
     );
     expect(workflow.jobs["windows"]?.steps[0]?.if).toBe(
-      "needs.validate-title.result != 'success' || (needs.validate-title.outputs.run-full-ci == 'true' && (needs.windows-test.result != 'success' || needs.windows-verify.result != 'success')) || (needs.validate-title.outputs.readme-only == 'true' && needs.readme-checks.result != 'success') || (needs.validate-title.outputs.run-full-ci != 'true' && needs.validate-title.outputs.readme-only != 'true')",
+      "needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && (needs.windows-test.result != 'success' || needs.windows-verify.result != 'success')) || (needs.validate-title.outputs.ci-mode == 'markdown' && needs.markdown-checks.result != 'success')",
     );
 
     const renderName = (
@@ -4042,86 +4026,16 @@ describe("GitHub release workflow safeguards", () => {
 
   test.each([
     {
-      name: "a root README",
-      paths: ["README.md"],
-      readmeOnly: true,
-    },
-    {
-      name: "nested READMEs",
-      paths: ["examples/README.md", "sdk/typescript/README.md"],
-      readmeOnly: true,
-    },
-    {
-      name: "another Markdown file",
-      paths: ["docs/guide.md"],
-      readmeOnly: false,
-    },
-    {
-      name: "a README and source code",
-      paths: ["README.md", "sdk/typescript/src/index.ts"],
-      readmeOnly: false,
-    },
-    {
-      name: "a source file renamed to README",
-      paths: ["sdk/typescript/src/index.ts", "README.md"],
-      readmeOnly: false,
-    },
-    {
-      name: "a differently cased readme",
-      paths: ["readme.md"],
-      readmeOnly: false,
-    },
-    {
-      name: "an empty diff",
-      paths: [],
-      readmeOnly: false,
-    },
-  ])("classifies $name without weakening full CI", ({ paths, readmeOnly }) => {
-    const script = workflowStepShell(
-      nodeCiWorkflow,
-      "Detect README-only changes",
-    );
-    const workspace = mkdtempSync(join(tmpdir(), "release-ci-readme-"));
-    const output = join(workspace, "output");
-    const mock = [
-      "git() {",
-      '  if [[ "$*" != "diff --no-renames --name-only -z HEAD^1 HEAD" ]]; then return 64; fi',
-      "  while IFS= read -r path; do",
-      '    if [[ -n "$path" ]]; then printf \'%s\\0\' "$path"; fi',
-      '  done <<< "$MOCK_CHANGED_FILES"',
-      "}",
-    ].join("\n");
-    try {
-      const result = spawnSync(bash, ["-c", `${mock}\n${script}`], {
-        env: {
-          ...process.env,
-          GITHUB_OUTPUT: output,
-          MOCK_CHANGED_FILES: paths.join("\n"),
-        },
-      });
-      expect(result.status).toBe(0);
-      expect(readFileSync(output, "utf8")).toBe(
-        `readme-only=${String(readmeOnly)}\n`,
-      );
-    } finally {
-      rmSync(workspace, { recursive: true, force: true });
-    }
-  });
-
-  test.each([
-    {
       name: "body-only edit with a valid title",
       eventName: "pull_request",
       action: "edited",
       titleChanged: false,
       baseChanged: false,
       title: "docs: clarify release notes",
-      detectedReadmeOnly: false,
-      readmeOnly: false,
-      fullCi: false,
+      changedPaths: [],
+      ciMode: "skip",
       titleValid: true,
-      readmeChecks: "skipped",
-      upstream: "skipped",
+      activeResult: "skipped",
       gateFailure: false,
       cancellation: false,
     },
@@ -4132,93 +4046,113 @@ describe("GitHub release workflow safeguards", () => {
       titleChanged: false,
       baseChanged: false,
       title: "Docs: invalid title ",
-      detectedReadmeOnly: false,
-      readmeOnly: false,
-      fullCi: false,
+      changedPaths: [],
+      ciMode: "skip",
       titleValid: false,
-      readmeChecks: "skipped",
-      upstream: "skipped",
+      activeResult: "skipped",
       gateFailure: false,
       cancellation: false,
     },
     {
-      name: "title edit",
+      name: "Markdown-only title edit",
       eventName: "pull_request",
       action: "edited",
       titleChanged: true,
       baseChanged: false,
-      title: "ci: update title",
-      detectedReadmeOnly: false,
-      readmeOnly: false,
-      fullCi: true,
+      title: "docs: update title",
+      changedPaths: ["README.md", "examples/custom-validation/scan.md"],
+      ciMode: "markdown",
       titleValid: true,
-      readmeChecks: "skipped",
-      upstream: "success",
+      activeResult: "success",
       gateFailure: false,
       cancellation: true,
     },
     {
-      name: "README-only base edit",
+      name: "Markdown-only base edit",
       eventName: "pull_request",
       action: "edited",
       titleChanged: false,
       baseChanged: true,
-      title: "docs: retarget README update",
-      detectedReadmeOnly: true,
-      readmeOnly: false,
-      fullCi: true,
+      title: "docs: retarget documentation update",
+      changedPaths: ["README.md"],
+      ciMode: "full",
       titleValid: true,
-      readmeChecks: "skipped",
-      upstream: "success",
+      activeResult: "success",
       gateFailure: false,
       cancellation: true,
     },
     {
-      name: "code synchronization",
+      name: "mixed Markdown and code changes",
       eventName: "pull_request",
       action: "synchronize",
       titleChanged: false,
       baseChanged: false,
-      title: "ci: update code",
-      detectedReadmeOnly: false,
-      readmeOnly: false,
-      fullCi: true,
+      title: "ci: update code and guidance",
+      changedPaths: ["README.md", "sdk/typescript/src/index.ts"],
+      ciMode: "full",
       titleValid: true,
-      readmeChecks: "skipped",
-      upstream: "success",
+      activeResult: "success",
       gateFailure: false,
       cancellation: true,
     },
     {
-      name: "README-only synchronization",
+      name: "Markdown-only synchronization",
       eventName: "pull_request",
       action: "synchronize",
       titleChanged: false,
       baseChanged: false,
-      title: "docs: clarify examples",
-      detectedReadmeOnly: true,
-      readmeOnly: true,
-      fullCi: false,
+      title: "docs: clarify guidance",
+      changedPaths: [
+        "SECURITY.md",
+        "examples/custom-validation/validation.md",
+        "sdk/typescript/_bundled_plugin/skills/security-scan/SKILL.md",
+      ],
+      ciMode: "markdown",
       titleValid: true,
-      readmeChecks: "success",
-      upstream: "skipped",
+      activeResult: "success",
       gateFailure: false,
       cancellation: true,
     },
     {
-      name: "README-only synchronization with failed formatting",
+      name: "Markdown-only synchronization with failed checks",
       eventName: "pull_request",
       action: "synchronize",
       titleChanged: false,
       baseChanged: false,
-      title: "docs: misformat examples",
-      detectedReadmeOnly: true,
-      readmeOnly: true,
-      fullCi: false,
+      title: "docs: update guidance",
+      changedPaths: ["CONTRIBUTING.md"],
+      ciMode: "markdown",
       titleValid: true,
-      readmeChecks: "failure",
-      upstream: "skipped",
+      activeResult: "failure",
       gateFailure: true,
+      cancellation: true,
+    },
+    {
+      name: "source renamed to Markdown",
+      eventName: "pull_request",
+      action: "synchronize",
+      titleChanged: false,
+      baseChanged: false,
+      title: "ci: rename source file",
+      changedPaths: ["sdk/typescript/src/index.ts", "docs/index.md"],
+      ciMode: "full",
+      titleValid: true,
+      activeResult: "success",
+      gateFailure: false,
+      cancellation: true,
+    },
+    {
+      name: "empty synchronization",
+      eventName: "pull_request",
+      action: "synchronize",
+      titleChanged: false,
+      baseChanged: false,
+      title: "ci: refresh branch",
+      changedPaths: [],
+      ciMode: "full",
+      titleValid: true,
+      activeResult: "success",
+      gateFailure: false,
       cancellation: true,
     },
     {
@@ -4228,12 +4162,10 @@ describe("GitHub release workflow safeguards", () => {
       titleChanged: false,
       baseChanged: false,
       title: "",
-      detectedReadmeOnly: false,
-      readmeOnly: false,
-      fullCi: true,
+      changedPaths: ["README.md"],
+      ciMode: "full",
       titleValid: true,
-      readmeChecks: "skipped",
-      upstream: "success",
+      activeResult: "success",
       gateFailure: false,
       cancellation: false,
     },
@@ -4244,12 +4176,10 @@ describe("GitHub release workflow safeguards", () => {
       titleChanged: false,
       baseChanged: false,
       title: "ci: update code",
-      detectedReadmeOnly: false,
-      readmeOnly: false,
-      fullCi: true,
+      changedPaths: ["sdk/typescript/src/index.ts"],
+      ciMode: "full",
       titleValid: true,
-      readmeChecks: "skipped",
-      upstream: "skipped",
+      activeResult: "skipped",
       gateFailure: true,
       cancellation: true,
     },
@@ -4261,12 +4191,10 @@ describe("GitHub release workflow safeguards", () => {
       titleChanged,
       baseChanged,
       title,
-      detectedReadmeOnly,
-      readmeOnly,
-      fullCi,
+      changedPaths,
+      ciMode,
       titleValid,
-      readmeChecks,
-      upstream,
+      activeResult,
       gateFailure,
       cancellation,
     }) => {
@@ -4274,32 +4202,35 @@ describe("GitHub release workflow safeguards", () => {
         concurrency: { "cancel-in-progress": string };
         jobs: Record<string, { steps: Array<{ if?: string }> }>;
       };
-      const scopeScript = workflowStepShell(
-        nodeCiWorkflow,
-        "Decide whether full CI is needed",
-      );
+      const scopeScript = workflowStepShell(nodeCiWorkflow, "Decide CI mode");
       const titleScript = workflowStepShell(
         nodeCiWorkflow,
         "Require a Conventional Commit pull request title",
       );
       const workspace = mkdtempSync(join(tmpdir(), "release-ci-scope-"));
       const output = join(workspace, "output");
+      const gitMock = [
+        "git() {",
+        '  if [[ "$*" != "diff --no-renames --name-only -z HEAD^1 HEAD" ]]; then return 64; fi',
+        "  while IFS= read -r path; do",
+        '    if [[ -n "$path" ]]; then printf \'%s\\0\' "$path"; fi',
+        '  done <<< "$MOCK_CHANGED_FILES"',
+        "}",
+      ].join("\n");
       try {
-        const scope = spawnSync(bash, ["-c", scopeScript], {
+        const scope = spawnSync(bash, ["-c", `${gitMock}\n${scopeScript}`], {
           env: {
             ...process.env,
             BASE_CHANGED: String(baseChanged),
             EVENT_ACTION: action === "none" ? "" : action,
             EVENT_NAME: eventName,
             GITHUB_OUTPUT: output,
-            README_ONLY: String(detectedReadmeOnly),
+            MOCK_CHANGED_FILES: changedPaths.join("\n"),
             TITLE_CHANGED: String(titleChanged),
           },
         });
         expect(scope.status).toBe(0);
-        expect(readFileSync(output, "utf8")).toBe(
-          `readme-only=${String(readmeOnly)}\nrun-full-ci=${String(fullCi)}\n`,
-        );
+        expect(readFileSync(output, "utf8")).toBe(`ci-mode=${ciMode}\n`);
 
         const validation =
           eventName === "pull_request"
@@ -4311,18 +4242,19 @@ describe("GitHub release workflow safeguards", () => {
             : "success";
         expect(validation === "success").toBe(titleValid);
 
+        const markdownResult = ciMode === "markdown" ? activeResult : "skipped";
+        const upstreamResult = ciMode === "full" ? activeResult : "skipped";
         const values = {
-          "needs.readme-checks.result": readmeChecks,
-          "needs.test.result": upstream,
-          "needs.validate-title.outputs.readme-only": String(readmeOnly),
-          "needs.validate-title.outputs.run-full-ci": String(fullCi),
+          "needs.markdown-checks.result": markdownResult,
+          "needs.test.result": upstreamResult,
+          "needs.validate-title.outputs.ci-mode": ciMode,
           "needs.validate-title.result": validation,
-          "needs.windows-test.result": upstream,
-          "needs.windows-verify.result": upstream,
+          "needs.windows-test.result": upstreamResult,
+          "needs.windows-verify.result": upstreamResult,
         };
         const unixGate = workflow.jobs["required-test"]?.steps[0]?.if ?? "";
         const windowsGate = workflow.jobs["windows"]?.steps[0]?.if ?? "";
-        if (fullCi || readmeOnly) {
+        if (ciMode !== "skip") {
           expect(evaluateWorkflowCondition(unixGate, values)).toBe(gateFailure);
           expect(evaluateWorkflowCondition(windowsGate, values)).toBe(
             gateFailure,

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -3969,9 +3969,9 @@ describe("GitHub release workflow safeguards", () => {
     );
     expect(markdownCommand).toContain("! -L");
     expect(markdownCommand).toContain(
-      "pnpm --dir sdk/typescript exec prettier",
+      "pnpm --dir sdk/typescript exec prettier --check",
     );
-    expect(markdownCommand).toContain("--ignore-path /dev/null --check");
+    expect(markdownCommand).not.toContain("--ignore-path");
     const requiredJobCondition = `always() && !(${metadataOnly})`;
     expect(workflow.jobs["required-test"]?.if).toBe(requiredJobCondition);
     expect(workflow.jobs["windows"]?.if).toBe(requiredJobCondition);
@@ -4191,8 +4191,6 @@ describe("GitHub release workflow safeguards", () => {
           "sdk/typescript",
           "exec",
           "prettier",
-          "--ignore-path",
-          "/dev/null",
           "--check",
           readme,
           guide,

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -5,6 +5,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -3895,7 +3896,7 @@ describe("GitHub release workflow safeguards", () => {
     );
     expect(nodeCiWorkflow).toContain("needs: validate-title");
     expect(nodeCiWorkflow).toContain(
-      "needs: [validate-title, markdown-checks, windows-test, windows-verify]",
+      "needs: [validate-title, windows-test, windows-verify]",
     );
   });
 
@@ -3946,34 +3947,57 @@ describe("GitHub release workflow safeguards", () => {
     for (const job of ["test", "windows-test", "windows-verify"]) {
       expect(workflow.jobs[job]?.if).toBe(fullCiCondition);
     }
-    expect(workflow.jobs["markdown-checks"]?.if).toBe(
-      "needs.validate-title.outputs.ci-mode == 'markdown'",
-    );
-    const markdownCommands = (workflow.jobs["markdown-checks"]?.steps ?? [])
-      .map(({ run }) => run ?? "")
-      .join("\n");
-    for (const command of [
-      "'*.md'",
-      "! -L",
-      "prettier --check",
-      "--test-name-pattern",
-      "./tests-ts/cli.test.ts",
-      "./tests-ts/custom-validation.test.ts",
-      "./tests-ts/release-automation.test.ts",
-      "pnpm pack --pack-destination ../../dist",
-      "pnpm run check:package ../../dist/*.tgz",
+    expect(workflow.jobs["markdown-checks"]).toBeUndefined();
+    const validationSteps = workflow.jobs["validate-title"]?.steps ?? [];
+    for (const stepName of [
+      "Set up pnpm",
+      "Set up Node.js",
+      "Install dependencies",
+      "Check Markdown formatting",
     ]) {
-      expect(markdownCommands).toContain(command);
+      expect(validationSteps.find(({ name }) => name === stepName)?.if).toBe(
+        "steps.scope.outputs.ci-mode == 'markdown'",
+      );
     }
+    const markdownCommand =
+      validationSteps.find(({ name }) => name === "Check Markdown formatting")
+        ?.run ?? "";
+    expect(markdownCommand).toContain(
+      "git diff --no-renames --name-only -z HEAD^1 HEAD",
+    );
+    expect(markdownCommand).toContain("! -L");
+    expect(markdownCommand).toContain(
+      "pnpm --dir sdk/typescript exec prettier",
+    );
+    expect(markdownCommand).toContain("--ignore-path /dev/null --check");
     const requiredJobCondition = `always() && !(${metadataOnly})`;
     expect(workflow.jobs["required-test"]?.if).toBe(requiredJobCondition);
     expect(workflow.jobs["windows"]?.if).toBe(requiredJobCondition);
     expect(workflow.jobs["required-test"]?.steps[0]?.if).toBe(
-      "needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && needs.test.result != 'success') || (needs.validate-title.outputs.ci-mode == 'markdown' && needs.markdown-checks.result != 'success')",
+      "needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && needs.test.result != 'success') || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown')",
     );
     expect(workflow.jobs["windows"]?.steps[0]?.if).toBe(
-      "needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && (needs.windows-test.result != 'success' || needs.windows-verify.result != 'success')) || (needs.validate-title.outputs.ci-mode == 'markdown' && needs.markdown-checks.result != 'success')",
+      "needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && (needs.windows-test.result != 'success' || needs.windows-verify.result != 'success')) || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown')",
     );
+    const unknownMode = {
+      "needs.test.result": "skipped",
+      "needs.validate-title.outputs.ci-mode": "unknown",
+      "needs.validate-title.result": "success",
+      "needs.windows-test.result": "skipped",
+      "needs.windows-verify.result": "skipped",
+    };
+    expect(
+      evaluateWorkflowCondition(
+        workflow.jobs["required-test"]?.steps[0]?.if ?? "",
+        unknownMode,
+      ),
+    ).toBe(true);
+    expect(
+      evaluateWorkflowCondition(
+        workflow.jobs["windows"]?.steps[0]?.if ?? "",
+        unknownMode,
+      ),
+    ).toBe(true);
 
     const renderName = (
       template: string,
@@ -4028,261 +4052,146 @@ describe("GitHub release workflow safeguards", () => {
   });
 
   test.each([
-    {
-      name: "body-only edit with a valid title",
-      eventName: "pull_request",
-      action: "edited",
-      titleChanged: false,
-      baseChanged: false,
-      title: "docs: clarify release notes",
-      changedPaths: [],
-      ciMode: "skip",
-      titleValid: true,
-      activeResult: "skipped",
-      gateFailure: false,
-      cancellation: false,
-    },
-    {
-      name: "body-only edit with an invalid title",
-      eventName: "pull_request",
-      action: "edited",
-      titleChanged: false,
-      baseChanged: false,
-      title: "Docs: invalid title ",
-      changedPaths: [],
-      ciMode: "skip",
-      titleValid: false,
-      activeResult: "skipped",
-      gateFailure: false,
-      cancellation: false,
-    },
-    {
-      name: "Markdown-only title edit",
-      eventName: "pull_request",
-      action: "edited",
-      titleChanged: true,
-      baseChanged: false,
-      title: "docs: update title",
-      changedPaths: ["README.md", "examples/custom-validation/scan.md"],
-      ciMode: "markdown",
-      titleValid: true,
-      activeResult: "success",
-      gateFailure: false,
-      cancellation: true,
-    },
-    {
-      name: "Markdown-only base edit",
-      eventName: "pull_request",
-      action: "edited",
-      titleChanged: false,
-      baseChanged: true,
-      title: "docs: retarget documentation update",
-      changedPaths: ["README.md"],
-      ciMode: "full",
-      titleValid: true,
-      activeResult: "success",
-      gateFailure: false,
-      cancellation: true,
-    },
-    {
-      name: "mixed Markdown and code changes",
-      eventName: "pull_request",
-      action: "synchronize",
-      titleChanged: false,
-      baseChanged: false,
-      title: "ci: update code and guidance",
-      changedPaths: ["README.md", "sdk/typescript/src/index.ts"],
-      ciMode: "full",
-      titleValid: true,
-      activeResult: "success",
-      gateFailure: false,
-      cancellation: true,
-    },
-    {
-      name: "Markdown-only synchronization",
-      eventName: "pull_request",
-      action: "synchronize",
-      titleChanged: false,
-      baseChanged: false,
-      title: "docs: clarify guidance",
-      changedPaths: [
-        "SECURITY.md",
-        "examples/custom-validation/validation.md",
-        "sdk/typescript/_bundled_plugin/skills/security-scan/SKILL.md",
-      ],
-      ciMode: "markdown",
-      titleValid: true,
-      activeResult: "success",
-      gateFailure: false,
-      cancellation: true,
-    },
-    {
-      name: "Markdown-only synchronization with failed checks",
-      eventName: "pull_request",
-      action: "synchronize",
-      titleChanged: false,
-      baseChanged: false,
-      title: "docs: update guidance",
-      changedPaths: ["CONTRIBUTING.md"],
-      ciMode: "markdown",
-      titleValid: true,
-      activeResult: "failure",
-      gateFailure: true,
-      cancellation: true,
-    },
-    {
-      name: "source renamed to Markdown",
-      eventName: "pull_request",
-      action: "synchronize",
-      titleChanged: false,
-      baseChanged: false,
-      title: "ci: rename source file",
-      changedPaths: ["sdk/typescript/src/index.ts", "docs/index.md"],
-      ciMode: "full",
-      titleValid: true,
-      activeResult: "success",
-      gateFailure: false,
-      cancellation: true,
-    },
-    {
-      name: "empty synchronization",
-      eventName: "pull_request",
-      action: "synchronize",
-      titleChanged: false,
-      baseChanged: false,
-      title: "ci: refresh branch",
-      changedPaths: [],
-      ciMode: "full",
-      titleValid: true,
-      activeResult: "success",
-      gateFailure: false,
-      cancellation: true,
-    },
-    {
-      name: "push",
-      eventName: "push",
-      action: "none",
-      titleChanged: false,
-      baseChanged: false,
-      title: "",
-      changedPaths: ["README.md"],
-      ciMode: "full",
-      titleValid: true,
-      activeResult: "success",
-      gateFailure: false,
-      cancellation: false,
-    },
-    {
-      name: "full CI with skipped upstream jobs",
-      eventName: "pull_request",
-      action: "synchronize",
-      titleChanged: false,
-      baseChanged: false,
-      title: "ci: update code",
-      changedPaths: ["sdk/typescript/src/index.ts"],
-      ciMode: "full",
-      titleValid: true,
-      activeResult: "skipped",
-      gateFailure: true,
-      cancellation: true,
-    },
-  ])(
-    "keeps required contexts truthful for $name",
-    ({
+    ["body-only edit", "pull_request", "edited", false, false, [], "skip"],
+    [
+      "Markdown-only PR",
+      "pull_request",
+      "synchronize",
+      false,
+      false,
+      ["README.md", "docs/guide.md"],
+      "markdown",
+    ],
+    [
+      "Markdown-only title edit",
+      "pull_request",
+      "edited",
+      true,
+      false,
+      ["README.md"],
+      "markdown",
+    ],
+    [
+      "base retarget",
+      "pull_request",
+      "edited",
+      false,
+      true,
+      ["README.md"],
+      "full",
+    ],
+    [
+      "mixed PR",
+      "pull_request",
+      "synchronize",
+      false,
+      false,
+      ["README.md", "src/index.ts"],
+      "full",
+    ],
+    [
+      "source-to-Markdown rename",
+      "pull_request",
+      "synchronize",
+      false,
+      false,
+      ["src/index.ts", "docs/index.md"],
+      "full",
+    ],
+    [
+      "empty merge diff",
+      "pull_request",
+      "synchronize",
+      false,
+      false,
+      [],
+      "full",
+    ],
+    ["push", "push", "", false, false, ["README.md"], "full"],
+  ] as const)(
+    "selects the conservative CI mode for %s",
+    (
+      _name,
       eventName,
       action,
       titleChanged,
       baseChanged,
-      title,
       changedPaths,
       ciMode,
-      titleValid,
-      activeResult,
-      gateFailure,
-      cancellation,
-    }) => {
-      const workflow = Bun.YAML.parse(nodeCiWorkflow) as {
-        concurrency: { "cancel-in-progress": string };
-        jobs: Record<string, { steps: Array<{ if?: string }> }>;
-      };
-      const scopeScript = workflowStepShell(nodeCiWorkflow, "Decide CI mode");
-      const titleScript = workflowStepShell(
-        nodeCiWorkflow,
-        "Require a Conventional Commit pull request title",
-      );
+    ) => {
       const workspace = mkdtempSync(join(tmpdir(), "release-ci-scope-"));
       const output = join(workspace, "output");
-      const gitMock = [
-        "git() {",
-        '  if [[ "$*" != "diff --no-renames --name-only -z HEAD^1 HEAD" ]]; then return 64; fi',
-        "  while IFS= read -r path; do",
-        '    if [[ -n "$path" ]]; then printf \'%s\\0\' "$path"; fi',
-        '  done <<< "$MOCK_CHANGED_FILES"',
-        "}",
-      ].join("\n");
+      const script = workflowStepShell(nodeCiWorkflow, "Decide CI mode");
+      const gitMock = `git() {
+      [[ "$*" == "diff --no-renames --name-only -z HEAD^1 HEAD" ]] || return 64
+      while IFS= read -r path; do
+        [[ -z "$path" ]] || printf '%s\\0' "$path"
+      done <<< "$MOCK_CHANGED_FILES"
+    }`;
       try {
-        const scope = spawnSync(bash, ["-c", `${gitMock}\n${scopeScript}`], {
+        const result = spawnSync(bash, ["-c", `${gitMock}\n${script}`], {
           env: {
             ...process.env,
             BASE_CHANGED: String(baseChanged),
-            EVENT_ACTION: action === "none" ? "" : action,
+            EVENT_ACTION: action,
             EVENT_NAME: eventName,
             GITHUB_OUTPUT: output,
             MOCK_CHANGED_FILES: changedPaths.join("\n"),
             TITLE_CHANGED: String(titleChanged),
           },
         });
-        expect(scope.status).toBe(0);
+        expect(result.status).toBe(0);
         expect(readFileSync(output, "utf8")).toBe(`ci-mode=${ciMode}\n`);
-
-        const validation =
-          eventName === "pull_request"
-            ? spawnSync(bash, ["-c", titleScript], {
-                env: { ...process.env, PR_TITLE: title },
-              }).status === 0
-              ? "success"
-              : "failure"
-            : "success";
-        expect(validation === "success").toBe(titleValid);
-
-        const markdownResult = ciMode === "markdown" ? activeResult : "skipped";
-        const upstreamResult = ciMode === "full" ? activeResult : "skipped";
-        const values = {
-          "needs.markdown-checks.result": markdownResult,
-          "needs.test.result": upstreamResult,
-          "needs.validate-title.outputs.ci-mode": ciMode,
-          "needs.validate-title.result": validation,
-          "needs.windows-test.result": upstreamResult,
-          "needs.windows-verify.result": upstreamResult,
-        };
-        const unixGate = workflow.jobs["required-test"]?.steps[0]?.if ?? "";
-        const windowsGate = workflow.jobs["windows"]?.steps[0]?.if ?? "";
-        if (ciMode !== "skip") {
-          expect(evaluateWorkflowCondition(unixGate, values)).toBe(gateFailure);
-          expect(evaluateWorkflowCondition(windowsGate, values)).toBe(
-            gateFailure,
-          );
-        } else {
-          expect(unixGate).toBeDefined();
-          expect(windowsGate).toBeDefined();
-        }
-
-        expect(
-          evaluateWorkflowCondition(
-            workflow.concurrency["cancel-in-progress"],
-            {
-              "github.event.changes.base": baseChanged ? "changed" : "null",
-              "github.event.changes.title": titleChanged ? "changed" : "null",
-              "github.event.action": action,
-              "github.event_name": eventName,
-            },
-          ),
-        ).toBe(cancellation);
       } finally {
         rmSync(workspace, { recursive: true, force: true });
       }
     },
   );
+
+  test("formats every changed regular non-symlink Markdown file", () => {
+    const workspace = mkdtempSync(join(tmpdir(), "release-ci-markdown-"));
+    const argsFile = join(workspace, "prettier-args");
+    const guide = join(workspace, "docs", "guide with spaces.md");
+    const readme = join(workspace, "README.md");
+    mkdirSync(join(workspace, "docs"));
+    writeFileSync(guide, "# Guide\n");
+    writeFileSync(readme, "# Readme\n");
+    symlinkSync(readme, join(workspace, "docs", "link.md"));
+    const mocks = `git() {
+      printf '%s\\0' README.md 'docs/guide with spaces.md' docs/link.md deleted.md
+    }
+    pnpm() { printf '%s\\n' "$@" > "$MOCK_PNPM_ARGS"; }`;
+    try {
+      const result = spawnSync(
+        bash,
+        [
+          "-c",
+          `${mocks}\n${workflowStepShell(nodeCiWorkflow, "Check Markdown formatting")}`,
+        ],
+        {
+          env: {
+            ...process.env,
+            GITHUB_WORKSPACE: workspace,
+            MOCK_PNPM_ARGS: argsFile,
+          },
+        },
+      );
+      expect(result.status).toBe(0);
+      expect(readFileSync(argsFile, "utf8").trim().split("\n")).toEqual([
+        "--dir",
+        "sdk/typescript",
+        "exec",
+        "prettier",
+        "--ignore-path",
+        "/dev/null",
+        "--check",
+        readme,
+        guide,
+      ]);
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
 
   test("documents a canonical historical-summary prefix block", () => {
     const start = "<!-- codex-security-release-summary:start -->";

--- a/sdk/typescript/tests-ts/skeleton.test.ts
+++ b/sdk/typescript/tests-ts/skeleton.test.ts
@@ -123,7 +123,6 @@ describe("TypeScript package skeleton", () => {
     );
     expect(jobs["windows"]?.needs).toEqual([
       "validate-title",
-      "markdown-checks",
       "windows-test",
       "windows-verify",
     ]);

--- a/sdk/typescript/tests-ts/skeleton.test.ts
+++ b/sdk/typescript/tests-ts/skeleton.test.ts
@@ -123,7 +123,7 @@ describe("TypeScript package skeleton", () => {
     );
     expect(jobs["windows"]?.needs).toEqual([
       "validate-title",
-      "readme-checks",
+      "markdown-checks",
       "windows-test",
       "windows-verify",
     ]);

--- a/sdk/typescript/tests-ts/skeleton.test.ts
+++ b/sdk/typescript/tests-ts/skeleton.test.ts
@@ -123,6 +123,7 @@ describe("TypeScript package skeleton", () => {
     );
     expect(jobs["windows"]?.needs).toEqual([
       "validate-title",
+      "readme-checks",
       "windows-test",
       "windows-verify",
     ]);


### PR DESCRIPTION
## Summary

Use a formatter-only validation path when a pull request's nonempty merge diff contains only Markdown (`.md`) files. This avoids the full cross-platform matrix without creating a second mini-CI suite.

## Changes

- Classify pull requests as `full` or `markdown` using a NUL-safe merge diff.
- Run the repository's pinned Prettier on every changed existing regular non-symlink `.md` file, honoring the existing ignore policy.
- Reclassify edited pull requests from their unchanged merge diff, so Markdown-only pull requests stay reduced while mixed or code pull requests rerun full CI.
- Keep full CI for pushes to `main`, base retargets, mixed or non-Markdown changes, empty diffs, and source-to-Markdown renames.
- Preserve the existing required Linux, macOS, and Windows contexts, and fail them closed for unknown classification modes.
- Add focused coverage for classification, formatting arguments, and required-check behavior.
- Establish a clean Prettier baseline for the root README.

Earlier review threads describe a more expansive Markdown lane. This revision supersedes those iterations by intentionally removing bespoke documentation tests, Bun setup, and package inspection from the reduced path.

## Testing

- `bun test --timeout 30000 ./tests-ts/release-automation.test.ts ./tests-ts/skeleton.test.ts` — 289 passed
- `pnpm --dir sdk/typescript run types`
- `pnpm --dir sdk/typescript run format`
- `git diff --check origin/main...HEAD`
- Checked every tracked Markdown file with the repository's existing Prettier ignore policy.

This pull request changes the workflow itself, so its exact-head GitHub run exercises full CI. The reduced Markdown path is covered by the focused workflow tests above and will first run on a subsequent Markdown-only pull request.

## Risk and rollout

The reduced path is limited to pull requests whose nonempty merge diff contains only `.md` paths. Deleted files and symlinks are not passed to Prettier. It intentionally does not run semantic documentation, package-contract, or runtime-input compatibility tests; those remain part of full CI on `main`. Required status names remain stable, edited pull requests are reclassified instead of bypassing checks, and all pushes to `main` continue to run the full suite. The workflow change can be reverted if classification behaves unexpectedly.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
