### PR TITLE
release: bump Codex Security to 0.1.21

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,9 +1,36 @@
-<!-- release-version: 0.1.20 -->
+<!-- release-version: 0.1.21 -->
 
 ## Highlights
 
-- Bug fixes and reliability improvements for cloud publication, including
-  access checks, recovery handling, and skipping findings that were already
-  recorded.
+- Request an advisory assessment of a completed patch with
+  `patch --assess-patch-risk`. Add `--create-pr` to include its concise summary
+  in the draft pull request. The assessment is opt-in and does not approve or
+  merge changes. See
+  [patching and risk assessment](https://github.com/openai/codex-security/blob/npm-v0.1.21/sdk/typescript/README.md#validate-and-patch-findings).
+- Import GitHub code scanning alerts through the CLI or SDK for validation
+  against a local checkout. Imports are read-only and preserve the upstream
+  alert context. See
+  [GitHub alert imports](https://github.com/openai/codex-security/blob/npm-v0.1.21/sdk/typescript/README.md#import-github-code-scanning-alerts).
+- Publish findings from CSV with `publish scan --to cloud --csv PATH`, or
+  preview the upload without signing in or sending data with `--dry-run`.
+  See
+  [Cloud publication](https://github.com/openai/codex-security/blob/npm-v0.1.21/sdk/typescript/README.md#publish-findings-to-cloud).
+- Improve repeated-scan credential handling on Windows, sign-in recovery
+  messages, cleanup after interrupted publication, and refreshes of changed
+  bundled plugins.
+
+## Upgrade notes
+
+- Finish operations using older versions before upgrading; credential-home
+  locks now follow the owning process's lifetime. See
+  [authentication](https://github.com/openai/codex-security/blob/npm-v0.1.21/sdk/typescript/README.md#authentication).
+- The bundled Codex runtime and SDK are now `0.149.1`. Custom executables
+  selected with `CODEX_CLI_PATH` need thread-source attribution support for
+  both `exec` and `app-server` (Codex `0.149.1+`). See
+  [runtime configuration](https://github.com/openai/codex-security/blob/npm-v0.1.21/sdk/typescript/README.md#environment-variables).
+- Existing Windows state with invalid ancestor permissions is not repaired
+  automatically. Keep the old reports and select a new private state
+  directory as described in
+  [scan history and recovery](https://github.com/openai/codex-security/blob/npm-v0.1.21/sdk/typescript/README.md#scan-history-and-reruns).
 
 The categorized list below contains the individual changes.

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-security",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "TypeScript SDK and CLI for Codex Security",
   "license": "Apache-2.0",
   "author": "OpenAI",

--- a/sdk/typescript/tests-ts/test-reports.test.ts
+++ b/sdk/typescript/tests-ts/test-reports.test.ts
@@ -1,4 +1,3 @@
-import { spawnSync } from "node:child_process";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -96,21 +95,24 @@ describe("JUnit inventory comparison", () => {
     const summary = join(fixture.root, "summary.md");
     for (const failedReport of ["", expected[0]!]) {
       await writeFile(summary, "");
-      const result = spawnSync(
-        bash,
-        ["-e", "-o", "pipefail", "-c", `${mock}\n${script}`],
-        {
-          cwd: fixture.root,
-          encoding: "utf8",
-          env: {
-            ...process.env,
-            GITHUB_STEP_SUMMARY: "summary.md",
-            CODEX_SECURITY_TEST_FAIL_REPORT: failedReport,
-          },
-          timeout: 10_000,
+      const child = Bun.spawn({
+        cmd: [bash, "-e", "-o", "pipefail", "-c", `${mock}\n${script}`],
+        cwd: fixture.root,
+        stdin: "ignore",
+        stdout: "ignore",
+        stderr: "pipe",
+        env: {
+          ...process.env,
+          GITHUB_STEP_SUMMARY: "summary.md",
+          CODEX_SECURITY_TEST_FAIL_REPORT: failedReport,
         },
-      );
-      expect(result.status, result.stderr).toBe(failedReport === "" ? 0 : 1);
+        timeout: 10_000,
+      });
+      const [status, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stderr).text(),
+      ]);
+      expect(status, stderr).toBe(failedReport === "" ? 0 : 1);
       expect((await readFile(summary, "utf8")).trim().split(/\r?\n/u)).toEqual(
         expected,
       );


### PR DESCRIPTION
## Summary

Prepare Codex Security 0.1.21 with version-matched release notes for the changes already on main.

## Changes

- Bump the package from 0.1.20 to 0.1.21; no lockfile change is needed for the root package version.
- Cover opt-in advisory patch-risk assessment, GitHub alert imports, CSV publication, and runtime reliability improvements, with upgrade notes and versioned documentation links.
- Fix the Windows JUnit-comparison test's null synchronous Bash status by awaiting the subprocess and stderr. Keep both exit-status cases and the assertion that every report is compared.

The release notes and package version are unchanged by this cleanup. Main is already included; the extra change is confined to the failing test fixture.

## Testing

- 296 release-automation, release-cut workflow, JUnit-report and package-skeleton tests passed (seed 672).
- Stable version, increase over main, manifest-only version change and matching reviewed-note checks passed. A read-only npm registry check confirmed 0.1.21 was not published at check time.
- All six versioned documentation anchors exist in the release source.
- Types/model checks, formatting, build and `git diff --check` passed.
- Packed the actual 0.1.21 artifact: 282-entry static package validation and full installed smoke passed, including public imports, NodeNext types, CLI, credential locks, 118 bundled plugin files, bundled Codex and a nested worker.

Native Windows/Linux and the full SDK suite were not rerun locally. The fixture change addresses the exact-head Windows failure, but Windows confirmation remains for CI. CI was not awaited.

## Risk and rollout

No production behavior or public CLI change beyond the existing release metadata. Patch-risk assessment remains opt-in and advisory. Finish older-version operations before upgrading; custom Codex executables need 0.149.1+ attribution support, and invalid existing Windows state permissions need the documented fresh-state recovery.

No tag, release or package was published. Required checks and review must pass on the eventual release commit; recheck version availability before merging. Publication remains protected by the existing release workflow and npm environment.

## Public disclosure review

Reviewed the branch, title, description, commits, three-file diff, comment, CI logs and documentation links. New material is technical and generic. Historical commit contact metadata and a restricted automated settings link remain, so the second attestation is intentionally unchecked. No screenshots or attachments were added.

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [ ] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
