### PR TITLE
fix(sdk): prefer exact POSIX PATH for trusted executables

### DIFF
--- a/sdk/typescript/src/trusted-executable.ts
+++ b/sdk/typescript/src/trusted-executable.ts
@@ -23,9 +23,11 @@ export async function resolveTrustedExecutable(
   const root = await realpath(protectedRoot).catch(() =>
     resolve(protectedRoot),
   );
-  const path = Object.entries(environment).find(
-    ([name]) => name.toUpperCase() === "PATH",
-  )?.[1];
+  const path =
+    environment["PATH"] ??
+    Object.entries(environment).find(
+      ([name]) => name.toUpperCase() === "PATH",
+    )?.[1];
   const entries: string[] = [];
   for (let entry of path?.split(delimiter) ?? []) {
     if (

--- a/sdk/typescript/tests-ts/trusted-executable.test.ts
+++ b/sdk/typescript/tests-ts/trusted-executable.test.ts
@@ -114,6 +114,33 @@ describe("trusted executable resolution", () => {
   });
 
   test.skipIf(process.platform === "win32")(
+    "prefers the exact POSIX PATH variable over a lowercase path variable",
+    async () => {
+      const root = await temporaryDirectory();
+      const repository = join(root, "repository");
+      const decoy = join(root, "decoy");
+      const trusted = join(root, "trusted");
+      await Promise.all([mkdir(repository), mkdir(decoy), mkdir(trusted)]);
+      await Promise.all([
+        writeFile(join(decoy, "git"), "decoy executable"),
+        writeFile(join(trusted, "git"), "trusted executable"),
+      ]);
+      await chmod(join(trusted, "git"), 0o700);
+
+      await expect(
+        resolveTrustedExecutable(
+          "git",
+          { path: decoy, PATH: trusted },
+          repository,
+        ),
+      ).resolves.toEqual({
+        executable: join(trusted, "git"),
+        environment: { PATH: trusted },
+      });
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
     "preserves the invocation name of a trusted symlinked executable",
     async () => {
       const root = await temporaryDirectory();


### PR DESCRIPTION
## Summary

On POSIX systems, `resolveTrustedExecutable` can select a case-variant `path` environment entry instead of the exact `PATH` entry. That can cause trusted executable resolution to inspect the wrong search path.

Reproduction:

- Provide both `path=/tmp/decoy` and `PATH=/tmp/trusted` in the environment.
- Resolve an executable that exists only under `/tmp/trusted`.

Expected: the exact POSIX `PATH` value is used.

Actual: the first case-insensitive match can select `path` instead.

## Changes

- Prefer the exact `PATH` key before the existing case-insensitive fallback.
- Add a POSIX regression test that uses distinct decoy and trusted directories.

## Testing

- `bun test --timeout 30000 -t 'prefers the exact POSIX PATH' tests-ts/trusted-executable.test.ts` (1 passed, 9 skipped)
- `git diff --check`

## Risk and rollout

This is a narrow POSIX environment-selection fix. It does not change the public API or the Windows fallback behavior. The exact `PATH` value is now preferred when present; case-insensitive fallback remains available for environments that do not provide it.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
