### PR TITLE
fix(sdk): preserve caller cancellation in cloud publication

### DIFF
--- a/sdk/typescript/src/cloud-publish.ts
+++ b/sdk/typescript/src/cloud-publish.ts
@@ -455,6 +455,7 @@ async function publishCloudPayload(
       signal,
     });
   } catch {
+    dependencies.signal?.throwIfAborted();
     // A lost response does not establish whether the server accepted the POST.
     throw new CodexSecurityError(
       "Cloud publication was not confirmed. The request was not retried; check whether it was accepted before submitting again.",
@@ -475,7 +476,10 @@ async function publishCloudPayload(
     );
   }
   const receipt = receiptSchema.safeParse(
-    await response.json().catch(() => undefined),
+    await response.json().catch(() => {
+      dependencies.signal?.throwIfAborted();
+      return undefined;
+    }),
   );
   // Cloud assigns opaque IDs in request order, so they cannot be compared to
   // local finding IDs. The authenticated response must still preserve the

--- a/sdk/typescript/tests-ts/cloud-publish.test.ts
+++ b/sdk/typescript/tests-ts/cloud-publish.test.ts
@@ -684,6 +684,58 @@ describe("Cloud publication", () => {
     expect(requests).toBe(1);
   });
 
+  test("preserves caller cancellation during the publication request", async () => {
+    const { scan, environment } = await fixture();
+    const controller = new AbortController();
+    const cancellation = new Error("publication cancelled");
+
+    await expect(
+      publishScanToCloud(scan, {
+        environment,
+        signal: controller.signal,
+        fetch: async (_url, options) => {
+          const signal = options.signal as AbortSignal;
+          return await new Promise<Response>((_resolve, reject) => {
+            signal.addEventListener(
+              "abort",
+              () => reject(signal.reason),
+              { once: true },
+            );
+            controller.abort(cancellation);
+          });
+        },
+      }),
+    ).rejects.toBe(cancellation);
+  });
+
+  test("preserves caller cancellation while parsing the acceptance receipt", async () => {
+    const { scan, environment } = await fixture();
+    const controller = new AbortController();
+    const cancellation = new Error("receipt parsing cancelled");
+    const response = {
+      ok: true,
+      status: 201,
+      body: null,
+      json: async () =>
+        await new Promise<never>((_resolve, reject) => {
+          controller.signal.addEventListener(
+            "abort",
+            () => reject(controller.signal.reason),
+            { once: true },
+          );
+          controller.abort(cancellation);
+        }),
+    } as unknown as Response;
+
+    await expect(
+      publishScanToCloud(scan, {
+        environment,
+        signal: controller.signal,
+        fetch: async () => response,
+      }),
+    ).rejects.toBe(cancellation);
+  });
+
   test("requires a complete acceptance receipt instead of treating any 2xx as success", async () => {
     const { scan, environment } = await fixture();
     for (const body of [

--- a/sdk/typescript/tests-ts/cloud-publish.test.ts
+++ b/sdk/typescript/tests-ts/cloud-publish.test.ts
@@ -696,11 +696,9 @@ describe("Cloud publication", () => {
         fetch: async (_url, options) => {
           const signal = options.signal as AbortSignal;
           return await new Promise<Response>((_resolve, reject) => {
-            signal.addEventListener(
-              "abort",
-              () => reject(signal.reason),
-              { once: true },
-            );
+            signal.addEventListener("abort", () => reject(signal.reason), {
+              once: true,
+            });
             controller.abort(cancellation);
           });
         },


### PR DESCRIPTION
## Summary

Caller cancellation during cloud publication is currently caught and rethrown as a generic `CodexSecurityError`. This loses the caller's cancellation identity and can make cancellation look like a publication failure.

Reproduction:

- Start a cloud publication with an `AbortSignal`.
- Abort the signal while the publication request is in flight, or while the acceptance receipt is being decoded.

Expected: the original cancellation error is propagated unchanged.

Actual: the generic cloud-publication error wrapper is thrown instead.

## Changes

- Re-throw an aborted caller signal before wrapping publication request failures.
- Re-throw an aborted caller signal before wrapping acceptance receipt decoding failures.
- Add regression tests for both cancellation points.

## Testing

- `bun test --timeout 30000 ./tests-ts/cloud-publish.test.ts` (35 passed)
- `pnpm run types`
- `pnpm run format`
- `pnpm run test:ci` (1,917 passed, 30 platform-specific skips, 0 failed)
- `pnpm pack --pack-destination ../../dist`
- `pnpm run check:package /tmp/codex-security-verify/dist/openai-codex-security-0.1.20.tgz`
- `pnpm run test:package`
- `git diff --check`

The package archive inspection and installed-package smoke test validated the public import, NodeNext types, CLI, credential locking, bundled plugin files, bundled Codex version, and a nested worker without a global `codex` executable.

## Risk and rollout

This preserves the existing cancellation contract without changing the public API or successful publication behavior. Non-cancellation failures continue through the existing `CodexSecurityError` handling.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
