### PR TITLE
fix(package): preserve bundled MCP launcher permissions

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -36,7 +36,10 @@
     "README.md"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "executableFiles": [
+      "_bundled_plugin/scripts/launch_codex_security_mcp"
+    ]
   },
   "scripts": {
     "audit:prod": "pnpm audit --prod --audit-level high",

--- a/sdk/typescript/scripts/check-package.mjs
+++ b/sdk/typescript/scripts/check-package.mjs
@@ -236,13 +236,15 @@ if (
 ) {
   throw new Error("npm tarball contains an invalid tar entry.");
 }
-const launcherPermissions =
-  listingLines[entries.indexOf("package/bin/codex-security.mjs")]?.split(
-    /\s/u,
-    1,
-  )[0] ?? "";
-if ([3, 6, 9].some((index) => launcherPermissions[index] !== "x")) {
-  throw new Error("npm package CLI launcher is not executable.");
+for (const [path, name] of [
+  ["package/bin/codex-security.mjs", "CLI"],
+  ["package/_bundled_plugin/scripts/launch_codex_security_mcp", "MCP"],
+]) {
+  const permissions =
+    listingLines[entries.indexOf(path)]?.split(/\s/u, 1)[0] ?? "";
+  if ([3, 6, 9].some((index) => permissions[index] !== "x")) {
+    throw new Error(`npm package ${name} launcher is not executable.`);
+  }
 }
 const packageJson = JSON.parse(
   archiveFile("package/package.json").toString("utf8"),

--- a/sdk/typescript/scripts/smoke-package.mjs
+++ b/sdk/typescript/scripts/smoke-package.mjs
@@ -203,6 +203,50 @@ async function smokeNestedDeepScanWorker(installedRoot, consumer) {
     "The installed plugin must propagate the bundled Codex path into nested workers.",
   );
 
+  const pluginRoot = join(installedRoot, "_bundled_plugin");
+  const mcpLauncher = join(pluginRoot, "scripts", "launch_codex_security_mcp");
+  const windows = process.platform === "win32";
+  const initialized = spawnSync(
+    windows
+      ? process.env.ComSpec ??
+          join(process.env.SystemRoot ?? "C:\\Windows", "System32", "cmd.exe")
+      : mcpLauncher,
+    windows
+      ? ["/d", "/s", "/c", "call", `${mcpLauncher}.cmd`, "--stdio"]
+      : ["--stdio"],
+    {
+      cwd: pluginRoot,
+      encoding: "utf8",
+      env: { ...workerEnvironment, CODEX_MCP_NODE_PATH: process.execPath },
+      input: `${JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          clientInfo: {
+            name: "codex-security-package-smoke",
+            version: "0.1.0",
+          },
+        },
+      })}\n`,
+      timeout: PACKAGE_SMOKE_TIMEOUT_MS,
+      windowsHide: true,
+    },
+  );
+  if (initialized.error !== undefined) {
+    throw new Error("Installed MCP launcher did not start.", {
+      cause: initialized.error,
+    });
+  }
+  assert.equal(initialized.status, 0, initialized.stderr);
+  assert.equal(
+    JSON.parse(initialized.stdout.trim()).result.serverInfo.name,
+    "codex-security",
+    "The installed MCP launcher must initialize the bundled security server.",
+  );
+
   const globalCodex = spawnSync("codex", ["--version"], {
     cwd: consumer,
     encoding: "utf8",
@@ -569,7 +613,7 @@ try {
   await smokeNestedDeepScanWorker(installedRoot, consumer);
 
   console.log(
-    `Validated installed ${packageManifest.name}@${packageManifest.version}: public import, NodeNext types, CLI, credential locking, ${expectedPluginFiles.length} bundled plugin files, bundled Codex version, and a nested worker without global codex.`,
+    `Validated installed ${packageManifest.name}@${packageManifest.version}: public import, NodeNext types, CLI, credential locking, ${expectedPluginFiles.length} bundled plugin files, MCP initialization, bundled Codex version, and a nested worker without global codex.`,
   );
 } finally {
   await rm(consumer, {


### PR DESCRIPTION
## Summary

`pnpm pack` strips the executable bit from the bundled POSIX MCP launcher because it is not an npm `bin` entry. This prevents the installed plugin from starting its MCP server on Linux and macOS.

Closes #652.

## Changes

- Declare the bundled POSIX MCP launcher in `publishConfig.executableFiles`.
- Reject package archives whose CLI or MCP launcher is not executable.
- Start the installed MCP launcher and complete JSON-RPC initialization in the package smoke test.

## Testing

- `pnpm pack --pack-destination <temporary-directory>`
- `tar -tvzf <packed-tarball> package/_bundled_plugin/scripts/launch_codex_security_mcp package/bin/codex-security.mjs` (both launchers were `0755`)
- `node scripts/check-package.mjs <packed-tarball>`
- `pnpm run types`
- `pnpm exec prettier --check package.json scripts/check-package.mjs scripts/smoke-package.mjs`
- Confirmed the updated package checker rejects a pre-fix archive with `npm package MCP launcher is not executable.`

## Risk and rollout

The change affects npm archive metadata and package verification only. Windows continues to use the existing `.cmd` launcher. A new npm release is required for users to receive the corrected file mode.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.

<!-- explain-pr:impact:start -->
## Change impact

The package now preserves the launcher's POSIX mode and proves the installed MCP server can start.

```mermaid
flowchart LR
  subgraph column_0["Package input"]
    direction TB
    node_0["Declare executable launcher<br/><code>publishConfig.executableFiles</code>"]
  end
  subgraph column_1["Packed artifact"]
    direction TB
    node_1["Tarball keeps execute mode<br/><code>npm package</code>"]
  end
  subgraph column_2["Package checks"]
    direction TB
    node_2["Check both launcher modes<br/><code>check-package.mjs</code>"]
    node_3["Start installed launcher<br/><code>smoke-package.mjs</code>"]
  end
  subgraph column_3["Outcome"]
    direction TB
    node_4["Block broken release archive<br/><code>node-release.yml</code>"]
    node_5["MCP initialization succeeds<br/><code>codex-security</code>"]
  end
  node_0 -->|"marks executable"| node_1
  node_1 -->|"checks mode"| node_2
  node_1 -->|"installs"| node_3
  node_2 -->|"runs smoke"| node_3
  node_2 -->|"gates"| node_4
  node_3 -->|"initializes"| node_5
  class node_0 changed
  class node_1 affected
  class node_2 changed
  class node_3 changed
  class node_4 affected
  class node_5 affected
  classDef changed fill:#d7f5e5,stroke:#237a4b,color:#111
  classDef affected fill:#e6f0ff,stroke:#3569a8,color:#111
  classDef context fill:#f2f3f5,stroke:#6e7781,color:#111
```

> **Limits:** The exact-head CI matrix was still running when this evidence snapshot was collected. · A new npm release is still required before installed users receive the corrected archive.

<details>
<summary>Source evidence (6)</summary>

- [`sdk/typescript/package.json:L38-L42`](https://github.com/openai/codex-security/blob/5e02916b2ac4257c5aabbc391f08e6daac717dbf/sdk/typescript/package.json#L38-L42) — publishConfig declares the bundled POSIX launcher as an executable file.
- [`sdk/typescript/scripts/check-package.mjs:L229-L248`](https://github.com/openai/codex-security/blob/5e02916b2ac4257c5aabbc391f08e6daac717dbf/sdk/typescript/scripts/check-package.mjs#L229-L248) — The archive listing is parsed and both launcher permission strings must contain execute bits.
- [`sdk/typescript/scripts/smoke-package.mjs:L355-L388`](https://github.com/openai/codex-security/blob/5e02916b2ac4257c5aabbc391f08e6daac717dbf/sdk/typescript/scripts/smoke-package.mjs#L355-L388) — The smoke test installs the packed archive and verifies the complete bundled plugin tree.
- [`sdk/typescript/scripts/smoke-package.mjs:L206-L248`](https://github.com/openai/codex-security/blob/5e02916b2ac4257c5aabbc391f08e6daac717dbf/sdk/typescript/scripts/smoke-package.mjs#L206-L248) — The installed launcher receives an initialize request and must return the codex-security server name.
- [`sdk/typescript/scripts/check-package.mjs:L312-L335`](https://github.com/openai/codex-security/blob/5e02916b2ac4257c5aabbc391f08e6daac717dbf/sdk/typescript/scripts/check-package.mjs#L312-L335) — Full package inspection runs the installed-package smoke script after archive validation.
- [`.github/workflows/node-release.yml:L150-L162`](https://github.com/openai/codex-security/blob/5e02916b2ac4257c5aabbc391f08e6daac717dbf/.github/workflows/node-release.yml#L150-L162) — The release workflow packs the npm archive and runs check:package before publication continues.

</details>
<!-- explain-pr:impact:end -->
