### PR TITLE
fix(ci): guard generated plugin Markdown changes

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -48,7 +48,8 @@ jobs:
             markdown_only=true
             while IFS= read -r -d '' path; do
               changed=true
-              if [[ "$path" != *.md ]]; then
+              if [[ "$path" != *.md ||
+                    "$path" == sdk/typescript/_bundled_plugin/* ]]; then
                 markdown_only=false
               fi
             done < "$changed_files"

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -4043,6 +4043,13 @@ describe("GitHub release workflow safeguards", () => {
       ["README.md", "docs/guide.md"],
       "markdown",
     ],
+    [
+      "generated-plugin Markdown-only PR",
+      "pull_request",
+      false,
+      ["sdk/typescript/_bundled_plugin/skills/example/SKILL.md"],
+      "full",
+    ],
     ["base retarget", "pull_request", true, ["README.md"], "full"],
     ["mixed PR", "pull_request", false, ["README.md", "src/index.ts"], "full"],
     [


### PR DESCRIPTION
## Summary

Route Markdown-only changes under `sdk/typescript/_bundled_plugin/` through full CI so the generated-plugin ownership check cannot be skipped.

## Changes

- Treat every `_bundled_plugin/**` change as a full-CI change, including Markdown files.
- Add regression coverage for the Markdown-only generated-plugin case.

## Testing

- `pnpm --package=bun@1.3.14 dlx bun test --timeout 30000 ./tests-ts/release-automation.test.ts` — 279 passed

## Risk and rollout

- This follows the generated-plugin ownership enforcement merged in #675.
- Heads up: after this PR merges, any PR that modifies `sdk/typescript/_bundled_plugin/` will be rejected by CI.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.

<!-- explain-pr:impact:start -->
## Change impact

Markdown files under the generated payload now trigger full CI, so the existing ownership check always gets a chance to reject them.

```mermaid
flowchart LR
  subgraph column_0["Changed path"]
    direction TB
    node_0["Generated Markdown change<br/><code>_bundled_plugin/*.md</code>"]
  end
  subgraph column_1["CI routing"]
    direction TB
    node_1["Select full CI<br/><code>ci-mode=full</code>"]
  end
  subgraph column_2["Ownership gate"]
    direction TB
    node_2["Run ownership check<br/><code>check-plugin-source.mjs</code>"]
  end
  subgraph column_3["Outcome"]
    direction TB
    node_3["Reject tracked payload<br/><code>_bundled_plugin/**</code>"]
  end
  node_0 -->|"classifies"| node_1
  node_1 -->|"runs"| node_2
  node_2 -->|"fails on"| node_3
  class node_0 context
  class node_1 changed
  class node_2 affected
  class node_3 affected
  classDef changed fill:#d7f5e5,stroke:#237a4b,color:#111
  classDef affected fill:#e6f0ff,stroke:#3569a8,color:#111
  classDef context fill:#f2f3f5,stroke:#6e7781,color:#111
```

> **Limits:** This changes GitHub Actions routing; it does not prevent local untracked generated files. · GitHub CI was still running at the collected exact head.

<details>
<summary>Source evidence (4)</summary>

- [`.github/workflows/node-ci.yml:L41-L58`](https://github.com/openai/codex-security/blob/8b7c4a67792f12f0d92b11843009943e00155cd4/.github/workflows/node-ci.yml#L41-L58) — The classifier keeps ordinary Markdown on reduced CI but treats every generated-plugin path as a full-CI change.
- [`.github/workflows/node-ci.yml:L152-L154`](https://github.com/openai/codex-security/blob/8b7c4a67792f12f0d92b11843009943e00155cd4/.github/workflows/node-ci.yml#L152-L154) — Full CI runs the existing plugin source-boundary checker on the Ubuntu Node 22 job.
- [`sdk/typescript/scripts/check-plugin-source.mjs:L10-L24`](https://github.com/openai/codex-security/blob/8b7c4a67792f12f0d92b11843009943e00155cd4/sdk/typescript/scripts/check-plugin-source.mjs#L10-L24) — The existing checker lists tracked \`\_bundled\_plugin\` files and throws if it finds any.
- [`sdk/typescript/tests-ts/release-automation.test.ts:L4038-L4052`](https://github.com/openai/codex-security/blob/8b7c4a67792f12f0d92b11843009943e00155cd4/sdk/typescript/tests-ts/release-automation.test.ts#L4038-L4052) — The added case proves generated-plugin Markdown selects full CI.

</details>
<!-- explain-pr:impact:end -->
