### PR TITLE
test(windows): make canonical plugin path fixtures portable

### DIFF
--- a/plugins/codex-security/tests/test_generate_rank_input.py
+++ b/plugins/codex-security/tests/test_generate_rank_input.py
@@ -227,6 +227,7 @@ def test_make_repo_rank_input_preserves_legacy_tilde_scope(
     (repo / "src").mkdir(parents=True)
     (repo / "src" / "runtime.py").write_text("runtime = True", encoding="utf-8")
     monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
     output = tmp_path / "rank_input.jsonl"
 
     run_cli(

--- a/plugins/codex-security/tests/test_workbench_target.py
+++ b/plugins/codex-security/tests/test_workbench_target.py
@@ -57,9 +57,8 @@ def test_git_output_decodes_repository_paths_as_utf8(
     initialize_git_repository(target)
     monkeypatch.setattr(subprocess, "_text_encoding", lambda: encoding)
 
-    assert WORKBENCH_TARGET["git_output"](target, "rev-parse", "--show-toplevel") == str(
-        target
-    )
+    output = WORKBENCH_TARGET["git_output"](target, "rev-parse", "--show-toplevel")
+    assert Path(output) == target
 
 
 def test_directory_content_digest_uses_git_file_set(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fix three reproducible failures in the shared Python contract tests when run natively on Windows. These are test-fixture portability defects, not demonstrated failures of the installed CLI.

## Changes

- Compare the UTF-8 Git repository-root result as a `Path`, so Git's forward slashes and native Windows separators identify the same fixture. Keep both `cp932` and `cp949` decoding cases.
- Set synthetic `USERPROFILE` alongside `HOME` in the legacy tilde-scope fixture, matching Python's Windows home expansion.
- Change only the two existing test files. Production behavior, workflows, dependencies, and test skips are unchanged.

## Testing

- Before the fix, all three cases failed on an unmodified source snapshot of main `9bd256a`; the two relevant scripts and both tests were checked against that commit's Git blobs.
- Native Windows, Python `3.12.13` / pytest `9.0.3`: `python -m pytest plugins/codex-security/tests/test_workbench_target.py plugins/codex-security/tests/test_generate_rank_input.py -v` — **70 passed, 0 failed, 0 skipped**, 78.43 seconds. JUnit output confirms the same totals.
- `git diff --check`: passed. No Python formatter is configured for these files; the existing style is preserved.
- An initial two-file run placed temporary non-Git fixtures inside an ignored checkout directory and produced 67 passes / 3 failures. The same tests passed after moving only their temporary directories outside Git ancestry; no ignore rules, assertions, or skips changed between those runs. Initial logs are retained separately.
- Cross-platform CI remains required. The existing canonical Python CI job runs on Ubuntu, so the native Windows run above supplies the additional platform check.

## Risk and rollout

Test-only change with no runtime or public CLI changes. Unicode decoding and legacy tilde behavior remain asserted on both platforms. No extra dependencies, arbitrary limits, or platform exclusions are introduced.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
