### PR TITLE
docs: clarify plugin source ownership

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,10 @@ published here through a one-way mirror. The plugin source under
 source, and it is mirrored one way into OpenAI's internal repository.
 
 The npm runtime under `sdk/typescript/_bundled_plugin/` is generated from the
-plugin source during build and release. Do not edit or commit files in that
-directory. See the [SDK testing guide](sdk/typescript/TESTING.md) for the
-generation and validation commands.
+plugin source by `pnpm run build:plugin` and automatically during `prepack` for
+packages and releases. Do not edit or commit files in that directory. See the
+[SDK testing guide](sdk/typescript/TESTING.md) for the generation and validation
+commands.
 
 Search [existing issues](https://github.com/openai/codex-security/issues)
 before opening a new one. We can't import pull requests that change mirrored

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,8 @@ maintainers.
 
 ## How this repository works
 
-Most Codex Security code is developed in OpenAI's canonical repository and
-published here through a one-way mirror. The plugin source under
-`plugins/codex-security/` is the exception: this repository is its canonical
-source, and it is mirrored one way into OpenAI's internal repository.
+`plugins/codex-security/` is the canonical source for the Codex Security
+plugin. Make plugin changes there.
 
 The npm runtime under `sdk/typescript/_bundled_plugin/` is generated from the
 plugin source by `pnpm run build:plugin` and automatically during `prepack` for
@@ -18,10 +16,8 @@ packages and releases. Do not edit or commit files in that directory. See the
 commands.
 
 Search [existing issues](https://github.com/openai/codex-security/issues)
-before opening a new one. We can't import pull requests that change mirrored
-code back into its canonical source. Maintainers can carry accepted changes
-into that source or invite a focused pull request for a path maintained in this
-repository.
+before opening a new one. Maintainers may invite a focused pull request for a
+path maintained in this repository.
 
 ## Support for open-source projects
 
@@ -52,11 +48,10 @@ project's maintainers through their security policy.
 
 ## Dependency and release maintenance
 
-Maintainers update package dependencies and committed lockfiles alongside
-their canonical source. The public release workflow installs those locked
-graphs, tests the package, and publishes a verified artifact with npm
-provenance. GitHub Actions dependencies are maintained separately in this
-repository.
+Maintainers update package dependencies and committed lockfiles with the
+affected source. The public release workflow installs those locked graphs,
+tests the package, and publishes a verified artifact with npm provenance.
+GitHub Actions dependencies are maintained separately in this repository.
 
 [GitHub Releases](https://github.com/openai/codex-security/releases) is the
 canonical changelog. Maintainers should follow [RELEASING.md](RELEASING.md) to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,13 +6,21 @@ maintainers.
 
 ## How this repository works
 
-Codex Security is developed in OpenAI's canonical repository and published
-here through a one-way mirror. We can't import pull requests from this
-repository into the canonical source.
+Most Codex Security code is developed in OpenAI's canonical repository and
+published here through a one-way mirror. The plugin source under
+`plugins/codex-security/` is the exception: this repository is its canonical
+source, and it is mirrored one way into OpenAI's internal repository.
+
+The npm runtime under `sdk/typescript/_bundled_plugin/` is generated from the
+plugin source during build and release. Do not edit or commit files in that
+directory. See the [SDK testing guide](sdk/typescript/TESTING.md) for the
+generation and validation commands.
 
 Search [existing issues](https://github.com/openai/codex-security/issues)
-before opening a new one. Maintainers can carry accepted changes into the
-canonical source or invite a focused pull request for this public repository.
+before opening a new one. We can't import pull requests that change mirrored
+code back into its canonical source. Maintainers can carry accepted changes
+into that source or invite a focused pull request for a path maintained in this
+repository.
 
 ## Support for open-source projects
 
@@ -43,10 +51,11 @@ project's maintainers through their security policy.
 
 ## Dependency and release maintenance
 
-Maintainers update package dependencies and the committed lockfile in the
-canonical repository. The public release workflow installs that locked graph,
-tests the package, and publishes a verified artifact with npm provenance.
-GitHub Actions dependencies are maintained separately in this repository.
+Maintainers update package dependencies and committed lockfiles alongside
+their canonical source. The public release workflow installs those locked
+graphs, tests the package, and publishes a verified artifact with npm
+provenance. GitHub Actions dependencies are maintained separately in this
+repository.
 
 [GitHub Releases](https://github.com/openai/codex-security/releases) is the
 canonical changelog. Maintainers should follow [RELEASING.md](RELEASING.md) to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,7 @@ packages and releases. Do not edit or commit files in that directory. See the
 commands.
 
 Search [existing issues](https://github.com/openai/codex-security/issues)
-before opening a new one. Maintainers may invite a focused pull request for a
-path maintained in this repository.
+before opening a new one.
 
 ## Support for open-source projects
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -73,6 +73,11 @@ for that exact commit:
    archive before publishing the GitHub release. It prepends the reviewed
    summary to GitHub's categorized notes.
 
+`node-release` generates the npm plugin payload from the canonical source under
+`plugins/codex-security/` during `prepack`. The generated
+`sdk/typescript/_bundled_plugin/` directory is not a committed release input;
+do not prepare a release by editing or committing files there.
+
 Monitor all three workflows. A version bump is not a completed release until
 the npm package and GitHub release both exist and match the tag.
 


### PR DESCRIPTION
## Summary

Document `plugins/codex-security/` as the canonical plugin source and clarify that `build:plugin` and release `prepack` generate the npm plugin payload.

## Changes

- Explain that `plugins/codex-security/` is the canonical plugin source.
- Tell contributors and release maintainers not to edit or commit the generated `sdk/typescript/_bundled_plugin/` payload.
- Generalize dependency guidance so lockfiles are updated alongside the source that owns them.

## Testing

- `git diff --check`
- `prettier --check CONTRIBUTING.md RELEASING.md`

## Risk and rollout

Documentation only. This does not change build, release, or runtime behavior.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.

<!-- explain-pr:impact:start -->
## Change impact

Contributors and release maintainers now see which plugin tree is canonical and which npm payload is generated.

```mermaid
flowchart LR
  subgraph column_0["Contributor guidance"]
    direction TB
    node_0["Contributors choose the owned source<br/><code>CONTRIBUTING.md</code>"]
  end
  subgraph column_1["Canonical source"]
    direction TB
    node_1["Public plugin tree stays canonical<br/><code>plugins/codex-security</code>"]
  end
  subgraph column_2["Generated release input"]
    direction TB
    node_2["Prepack generates the npm payload<br/><code>sdk/typescript/_bundled_plugin</code>"]
  end
  node_0 -->|"edits"| node_1
  node_1 -->|"generates"| node_2
  class node_0 changed
  class node_1 context
  class node_2 affected
  classDef changed fill:#d7f5e5,stroke:#237a4b,color:#111
  classDef affected fill:#e6f0ff,stroke:#3569a8,color:#111
  classDef context fill:#f2f3f5,stroke:#6e7781,color:#111
```

> **Limits:** This PR changes documentation only; it does not alter plugin staging, prepack, or release workflows.

<details>
<summary>Source evidence (3)</summary>

- [`CONTRIBUTING.md:L9-L19`](https://github.com/openai/codex-security/blob/ea50d30705a84ba2e7e7ca81a528b4ad1be3f8c4/CONTRIBUTING.md#L9-L19) — The contribution guide identifies the public plugin tree as canonical and names build:plugin and prepack as the payload staging paths.
- [`CONTRIBUTING.md:L48-L53`](https://github.com/openai/codex-security/blob/ea50d30705a84ba2e7e7ca81a528b4ad1be3f8c4/CONTRIBUTING.md#L48-L53) — Dependency and lockfile maintenance now follows the repository that owns each source tree.
- [`RELEASING.md:L68-L79`](https://github.com/openai/codex-security/blob/ea50d30705a84ba2e7e7ca81a528b4ad1be3f8c4/RELEASING.md#L68-L79) — The release guide says prepack generates the npm plugin payload and that the generated directory is not a committed release input.

</details>
<!-- explain-pr:impact:end -->
