### PR TITLE
test(plugin): accept a detached MCP payload

### DIFF
--- a/plugins/codex-security/mcp-app/tests/test_compact_artifact_server.mjs
+++ b/plugins/codex-security/mcp-app/tests/test_compact_artifact_server.mjs
@@ -14,10 +14,9 @@ const applicationRoot = path.resolve(
   ".."
 );
 const pluginRoot = path.resolve(applicationRoot, "..");
-const bundledPluginRoot = path.resolve(
-  applicationRoot,
-  "../../../sdk/typescript/_bundled_plugin"
-);
+const bundledPluginRoot = process.env.CODEX_SECURITY_TEST_PLUGIN_ROOT
+  ? path.resolve(process.env.CODEX_SECURITY_TEST_PLUGIN_ROOT)
+  : path.resolve(applicationRoot, "../../../sdk/typescript/_bundled_plugin");
 const temporaryRoot = await mkdtemp(path.join(tmpdir(), "codex-security-artifact-mcp-"));
 
 try {

--- a/plugins/codex-security/mcp-app/tests/test_mcp_app_smoke.mjs
+++ b/plugins/codex-security/mcp-app/tests/test_mcp_app_smoke.mjs
@@ -18,10 +18,9 @@ const sourcePluginRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../..",
 );
-const pluginRoot = path.resolve(
-  sourcePluginRoot,
-  "../../sdk/typescript/_bundled_plugin",
-);
+const pluginRoot = process.env.CODEX_SECURITY_TEST_PLUGIN_ROOT
+  ? path.resolve(process.env.CODEX_SECURITY_TEST_PLUGIN_ROOT)
+  : path.resolve(sourcePluginRoot, "../../sdk/typescript/_bundled_plugin");
 const mcpAppRoot = path.join(sourcePluginRoot, "mcp-app");
 const pluginManifest = JSON.parse(
   await readFile(path.join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"),


### PR DESCRIPTION
## Summary

Allow MCP runtime and smoke tests to validate a detached, materialized plugin payload instead of requiring the SDK-local generated payload path.

## Changes

- accept `CODEX_SECURITY_TEST_PLUGIN_ROOT` as the complete plugin payload used for shipped-runtime and end-to-end smoke assertions
- preserve the existing SDK `_bundled_plugin` path as the default

## Testing

- confirmed the test fails when the generated SDK payload is absent before this change
- built a complete plugin into a temporary directory with `buildBundledPlugin`
- ran the complete `test:mcp` suite with `CODEX_SECURITY_TEST_PLUGIN_ROOT` set to that temporary plugin

## Risk and rollout

Low risk. Production plugin behavior is unchanged. Existing SDK test callers retain the same default; alternate plugin materializers can opt into the override.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
