### PR TITLE
docs(server): include plugin setup in source startup

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -953,6 +953,8 @@ From `sdk/typescript`, install dependencies, build, and start:
 
 ```bash
 pnpm install --frozen-lockfile
+npm ci --prefix ../../plugins/codex-security/mcp-app --no-audit --no-fund
+pnpm run build:plugin
 pnpm run build
 pnpm run start:server
 ```


### PR DESCRIPTION
## Summary

The findings-server source-start recipe omits the generated plugin required by
storage initialization. Document the existing prerequisites before starting the
compiled server.

## Changes

- Install the canonical MCP app's locked dependencies using the command already
  documented in the SDK testing guide.
- Run `pnpm run build:plugin` before the existing package build and server start.

## Testing

- `prettier --check README.md` passed with Prettier 3.2.5.
- `git diff --check` passed.
- Reviewed a native Windows source-start probe using lockfile-matched SDK and MCP
  dependencies reused read-only, with package scripts invoked through
  `node --run`. The package build succeeded, but compiled startup failed before
  readiness with the missing-plugin error. After `node --run build:plugin`, the
  same compiled entrypoint served the expected HTTP 501 stubs and initialized
  SQLite.
- No fresh dependency installation or full-suite rerun was performed for this
  documentation-only change.

## Risk and rollout

Documentation only. The added commands are existing source-build steps and apply
across supported platforms. No runtime, API, default, or published-package
behavior changes; no migration is required.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.

