### PR TITLE
docs: clarify safe documentation examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ customer data, and security findings before posting.
 Open an issue describing the problem and the workflow you want to support.
 Documentation corrections and safe examples are welcome.
 Use synthetic examples when documenting expected behavior.
+Keep example values fictional and safe to share.
 
 ## Report a security issue
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ Open an issue describing the problem and the workflow you want to support.
 Documentation corrections and safe examples are welcome.
 Use synthetic examples when documenting expected behavior.
 Keep example values fictional and safe to share.
+Do not include credentials or private information in examples.
 
 ## Report a security issue
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ customer data, and security findings before posting.
 
 Open an issue describing the problem and the workflow you want to support.
 Documentation corrections and safe examples are welcome.
+Use synthetic examples when documenting expected behavior.
 
 ## Report a security issue
 


### PR DESCRIPTION
## Summary

Clarify guidance for safe public documentation examples.

## Changes

- Add a brief reminder to use synthetic examples in contributor documentation.

## Testing

- Documentation-only change; no executable code is modified.
- Repository review automation will run on this pull request.

## Risk and rollout

- Documentation only.
- This pull request is for review validation and must not be merged.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
