### PR TITLE
release: bump Codex Security to 0.1.22

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,36 +1,56 @@
-<!-- release-version: 0.1.21 -->
+<!-- release-version: 0.1.22 -->
 
 ## Highlights
 
-- Request an advisory assessment of a completed patch with
-  `patch --assess-patch-risk`. Add `--create-pr` to include its concise summary
-  in the draft pull request. The assessment is opt-in and does not approve or
-  merge changes. See
-  [patching and risk assessment](https://github.com/openai/codex-security/blob/npm-v0.1.21/sdk/typescript/README.md#validate-and-patch-findings).
-- Import GitHub code scanning alerts through the CLI or SDK for validation
-  against a local checkout. Imports are read-only and preserve the upstream
-  alert context. See
-  [GitHub alert imports](https://github.com/openai/codex-security/blob/npm-v0.1.21/sdk/typescript/README.md#import-github-code-scanning-alerts).
-- Publish findings from CSV with `publish scan --to cloud --csv PATH`, or
-  preview the upload without signing in or sending data with `--dry-run`.
-  See
-  [Cloud publication](https://github.com/openai/codex-security/blob/npm-v0.1.21/sdk/typescript/README.md#publish-findings-to-cloud).
-- Improve repeated-scan credential handling on Windows, sign-in recovery
-  messages, cleanup after interrupted publication, and refreshes of changed
-  bundled plugins.
+- Store complete findings and embeddings in the preview findings service, with
+  paginated listing, repository-scoped candidate retrieval, and durable duplicate
+  groups. Publish a completed scan with
+  `publish scan --to custom --scan SCAN_ID --findings-url URL`, or preview the
+  payload with `--dry-run`. See the
+  [findings service](https://github.com/openai/codex-security/blob/npm-v0.1.22/sdk/typescript/README.md#findings-service-preview)
+  and [custom publication](https://github.com/openai/codex-security/blob/npm-v0.1.22/sdk/typescript/README.md#publishing-to-a-custom-findings-service).
+- Review potential duplicates from the CLI or SDK with
+  `dedupe --scan SCAN_ID --findings-url URL`. Reviews run on the calling host and save accepted groups
+  without replacing original findings. Searches default to the scan's repository;
+  `--all-repositories` explicitly broadens the scope. Add `--workflow-id` to scan,
+  custom publication, and deduplication to reuse completed stages and checkpointed
+  reviews after interruption. See
+  [deduplication](https://github.com/openai/codex-security/blob/npm-v0.1.22/sdk/typescript/README.md#deduplication-from-the-sdk-and-cli)
+  and [workflow recovery](https://github.com/openai/codex-security/blob/npm-v0.1.22/sdk/typescript/README.md#resuming-a-local-findings-workflow).
+- Browse stored findings and duplicate groups in the service's read-only
+  `/dashboard`, with search, repository filters, sorting, and record details.
+  The dashboard shows service-owned data, not local scan or workflow history.
+  See the [dashboard guide](https://github.com/openai/codex-security/blob/npm-v0.1.22/sdk/typescript/README.md#read-only-dashboard).
+- Add a separate findings-service container release and a Compose runner for the
+  existing scanner CLI, with persistent state and source mounts. Both images
+  support Linux `amd64` and `arm64`. See
+  [container releases and the workflow runner](https://github.com/openai/codex-security/blob/npm-v0.1.22/docker/README.md).
+- Preserve sealed scan artifacts when optional follow-up instructions fail,
+  propagate caller cancellation during cloud publication, respect the exact
+  POSIX `PATH` when resolving trusted executables, and retain nested attack-path
+  evidence strings in saved finding previews.
 
 ## Upgrade notes
 
-- Finish operations using older versions before upgrading; credential-home
-  locks now follow the owning process's lifetime. See
-  [authentication](https://github.com/openai/codex-security/blob/npm-v0.1.21/sdk/typescript/README.md#authentication).
-- The bundled Codex runtime and SDK are now `0.149.1`. Custom executables
-  selected with `CODEX_CLI_PATH` need thread-source attribution support for
-  both `exec` and `app-server` (Codex `0.149.1+`). See
-  [runtime configuration](https://github.com/openai/codex-security/blob/npm-v0.1.21/sdk/typescript/README.md#environment-variables).
-- Existing Windows state with invalid ancestor permissions is not repaired
-  automatically. Keep the old reports and select a new private state
-  directory as described in
-  [scan history and recovery](https://github.com/openai/codex-security/blob/npm-v0.1.21/sdk/typescript/README.md#scan-history-and-reruns).
+- The findings API and dashboard have no built-in authentication. Keep the
+  service on a trusted local endpoint or behind an authenticated TLS proxy;
+  Compose publishes only to host loopback. Nonempty imports send complete finding
+  JSON to the OpenAI embeddings API and require an API key. A ChatGPT login is not
+  an embedding credential. Duplicate review uses the calling host's Codex
+  credentials separately, and embedding and review calls can incur usage charges.
+- Stop the findings service and back up its entire state directory before
+  upgrading. Startup applies SQLite migrations automatically; rollback requires
+  the pre-upgrade backup and previous image. Existing findings are not
+  automatically embedded: import them with their repository ID before using
+  repository-scoped deduplication. Keep runner state separate from service state.
+  See [backups and upgrades](https://github.com/openai/codex-security/blob/npm-v0.1.22/sdk/typescript/README.md#upgrades-and-backups).
+- Container publication is separate from npm publication. Use a version or digest
+  only after the selected image release is available; source builds remain
+  supported. Follow the [container setup](https://github.com/openai/codex-security/blob/npm-v0.1.22/docker/README.md#ghcr-administrator-setup)
+  before the first registry release.
+- Source checkouts now generate the SDK's bundled plugin from
+  `plugins/codex-security`. Contributors should edit the canonical plugin source
+  and run `pnpm run build:plugin`; the published npm package still includes the
+  runtime payload. See [plugin source ownership](https://github.com/openai/codex-security/blob/npm-v0.1.22/sdk/typescript/TESTING.md).
 
 The categorized list below contains the individual changes.

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-security",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "TypeScript SDK and CLI for Codex Security",
   "license": "Apache-2.0",
   "author": "OpenAI",


### PR DESCRIPTION
## Summary

Prepare Codex Security 0.1.22 with a version-matched changes report covering the changes since 0.1.21, including the consolidated findings service work in #660.

**Merge after #660.** Its planned functionality is included in the release notes, but its implementation is not copied into this PR. The release must include #660 before this version bump reaches main.

## Changes

- Bump `sdk/typescript/package.json` from 0.1.21 to 0.1.22. The lockfile does not record the root package version and needs no change.
- Update `.github/release-notes.md` with findings storage and embeddings, custom publication, duplicate review and groups, resumable workflows, the read-only dashboard, and container distribution from #660.
- Summarize the merged artifact-restoration, cloud-cancellation, executable-resolution, finding-preview, and canonical plugin-source changes.
- Include authentication, API usage, backup and migration, separate container publication, and source-build considerations, with versioned public documentation links. The release workflow supplies the categorized PR inventory.

This PR changes only release metadata and documentation. The CLI commands and flags described in the notes belong to #660; this PR adds no public CLI surface.

## Testing

- Release automation and release-cut workflow tests: 281 passed, zero failures, Bun 1.3.14, seed 122.
- Generated model check, SDK TypeScript check (`tsc --noEmit`), and SDK build passed on Node 22.13.1.
- Prettier checks for both changed files and `git diff --check` passed.
- Verified the manifest changes only the version, the release-note marker matches, and 0.1.22 exceeds 0.1.21 and every published stable npm version. The registry still reported 0.1.21 as the newest version at preparation time.
- Verified all nine versioned documentation paths and anchors against the source included in #660. The 0.1.22 tag links become available when the release tag is created.

The full SDK suite, MCP typecheck, installed-package smoke, container tests, and native Windows/macOS checks were not run for this two-file change. Hosted CI is pending. This validation does not claim to retest #660's implementation.

## Risk and rollout

Do not merge before #660. After it lands, confirm the release notes still match its final scope and required CI/review passes for the release commit. Merging this bump starts the existing npm release process after successful main CI; no tag, npm package, or container image has been published by this PR preparation.

The findings service remains an unauthenticated preview. The notes call out its local access boundary, embedding and review credentials/costs, automatic database migrations and backup requirements. Container releases remain separate from npm publication and depend on the documented registry setup.

## Public disclosure review

Reviewed the branch name, title, description, proposed commit, complete two-file diff, validation output, and all documentation links. This PR adds no comments, screenshots, attachments, or uploaded logs; examples use generic selectors and URLs.

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
