### PR TITLE
fix(ci): install ripgrep for npm release verification

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -138,6 +138,11 @@ jobs:
           sfw pnpm --dir sdk/typescript install --frozen-lockfile
           sfw npm ci --prefix plugins/codex-security/mcp-app --no-audit --no-fund
 
+      - name: Install ripgrep
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes ripgrep
+
       - name: Audit production dependencies
         continue-on-error: true
         run: sfw pnpm --dir sdk/typescript run audit:prod


### PR DESCRIPTION
## Summary

The npm release verification job runs MCP tests that invoke `rg` to generate the file inventory. The Ubuntu release runner does not have ripgrep installed, so verification fails before packaging.

## Changes

Install ripgrep before release verification using the same apt commands as normal CI. Keep all existing verification steps unchanged.

## Testing

- Workflow YAML parsing and setup-order checks passed; the apt commands match normal CI.
- Prettier and `git diff --check` passed.
- Focused SDK skeleton and release-automation tests: 292 passed, 0 failed.
- `pnpm --dir sdk/typescript run test:mcp` passed with `umask 022`, including the inventory test that previously failed. The initial run hit a local fixture-directory permission mismatch under a group-writable umask; no source or test change was needed.
- Actionlint 1.7.12 reports the same pre-existing unsupported `concurrency.queue` key on the base and patched workflow; it passes with only that diagnostic ignored.

## Risk and rollout

This changes only release-runner setup and adds no public CLI or runtime behavior. Existing release tags remain unchanged; retrying an older tag still uses its original workflow. Future release commits must include this fix. No release was published as part of this PR.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
