### PR TITLE
test(windows): retry busy comparison fixture cleanup

### DIFF
--- a/sdk/typescript/tests-ts/scan-comparison.test.ts
+++ b/sdk/typescript/tests-ts/scan-comparison.test.ts
@@ -9,6 +9,7 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import {
   Codex,
   type CodexOptions,
@@ -29,11 +30,27 @@ import {
 
 const temporaryDirectories: string[] = [];
 
+async function removeTemporaryDirectory(path: string): Promise<void> {
+  // Bun 1.3.14 does not implement fs.rm's recursive retry options.
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      await rm(path, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (
+        process.platform !== "win32" ||
+        (error as NodeJS.ErrnoException).code !== "EBUSY" ||
+        attempt >= 10
+      )
+        throw error;
+      await delay(100 * (attempt + 1));
+    }
+  }
+}
+
 afterEach(async () => {
   await Promise.all(
-    temporaryDirectories
-      .splice(0)
-      .map((path) => rm(path, { recursive: true, force: true })),
+    temporaryDirectories.splice(0).map(removeTemporaryDirectory),
   );
 });
 


### PR DESCRIPTION
## Summary

Windows comparison tests can fail while removing a temporary fixture after the native commands have finished. [The observed CI failure](https://github.com/openai/codex-security/actions/runs/33135275915/job/98733747104) is an `EBUSY` teardown error, not a reported comparison or MCP-permission assertion failure. The held resource and its owner are not identified by the log.

## Changes

- Retry fixture removal only for `EBUSY` on Windows, with ten retries and a 100 ms linearly increasing delay, matching the existing package-smoke cleanup policy.
- Rethrow persistent locks and unrelated errors. Keep the production runtime, native command lifecycle, and comparison/MCP assertions unchanged.
- Use explicit retries because the pinned Bun runtime does not apply `fs.rm` retry options in its recursive removal path.

## Testing

- Focused comparison file on Windows with Bun 1.3.14, seed `1555709816`, and the unchanged 120-second CI test timeout: baseline and candidate each passed 25 tests, with one existing platform skip and 56 assertions. Neither local replay reproduced the original CI lock.
- Local native file-handle controls using the exact candidate helper: the single-attempt cleanup returned `EBUSY`; the helper removed a fixture after the holder closed, and a persistently held fixture still rejected with the original final error after 11 attempts.
- A synthetic unrelated `EACCES` error was rethrown immediately, with no retry or ACL changes.
- SDK `tsc --noEmit`, targeted Prettier check, package `pnpm run format`, and `git diff --check`: passed.
- No full local test suite or model scan was run. Applicable remote CI remains required.

## Risk and rollout

Test-only change. A persistently locked fixture still fails after at most 5.5 seconds of scheduled retry delays. No CLI behavior, permission policy, test skip, or test timeout changes are intended. A successful local replay does not identify the original CI lock owner; applicable remote checks still need to pass.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
