### PR TITLE
fix(plugin): keep model-authored runtime status out of finalized reports

### DIFF
--- a/plugins/codex-security/examples/completed-scan/report.md
+++ b/plugins/codex-security/examples/completed-scan/report.md
@@ -12,7 +12,6 @@ The scan reviewed the canonical include paths and exclusions listed below.
 - Inventory strategy: repository
 - Included paths: .
 - Excluded paths: none
-- Runtime or test status: not recorded
 
 ### Scan Summary
 

--- a/plugins/codex-security/scripts/report_projection.py
+++ b/plugins/codex-security/scripts/report_projection.py
@@ -828,7 +828,6 @@ def build_report_markdown(
         f"- Inventory strategy: {coverage['inventoryStrategy']}",
         f"- Included paths: {', '.join(include_paths) or 'none'}",
         f"- Excluded paths: {', '.join(exclude_paths) or 'none'}",
-        f"- Runtime or test status: {_text(scope.get('runtimeStatus'), 'not recorded')}",
     ]
     artifacts_reviewed = _strings(scope.get("artifactsReviewed"))
     if artifacts_reviewed:

--- a/plugins/codex-security/tests/test_finalize_scan_contract.py
+++ b/plugins/codex-security/tests/test_finalize_scan_contract.py
@@ -1874,6 +1874,20 @@ The extraction root is not enforced.
             self.assertIn(expected, report)
         self.assertFalse((self.scan_dir / "report.html").exists())
 
+    def test_finalize_does_not_project_model_authored_runtime_status(self) -> None:
+        stale_status = "SDK finalization and sealing intentionally pending."
+        self.manifest["scan"]["scope"]["runtimeStatus"] = stale_status
+        self.write_scan()
+
+        FINALIZER.finalize_scan(self.scan_dir)
+
+        manifest = self.read_json("scan-manifest.json")
+        report = (self.scan_dir / "report.md").read_text(encoding="utf-8")
+        self.assertEqual(manifest["scan"]["status"], "completed")
+        self.assertEqual(manifest["scan"]["sealedAt"], "2026-05-31T18:09:00Z")
+        self.assertNotIn(stale_status, report)
+        self.assertNotIn("Runtime or test status", report)
+
     def test_finalize_accepts_legacy_unstructured_report_semantics(self) -> None:
         finding = self.findings["findings"][0]
         finding["validation"] = {"evidence": "legacy validation evidence"}


### PR DESCRIPTION
## Summary

Finalized reports can retain model-authored `scope.runtimeStatus` text that contradicts the finalizer-owned completed and sealed state. This removes that free-form field from the Markdown projection so lifecycle presentation has one authoritative source.

Fixes #687.

## Changes

- Stop projecting `scope.runtimeStatus` into generated reports.
- Keep the field in the manifest and draft schemas for backward compatibility.
- Add a regression test that seals a scan containing stale pre-finalization narration and verifies the report omits it.
- Update the checked-in completed-scan report fixture.

## Testing

- Focused finalization and report-projection tests: 2 passed.
- Complete plugin suite in Python 3.12 Docker with Git and ripgrep: 1,033 passed, 9 skipped, 103 subtests passed.
- `git diff --check` passed.

## Risk and rollout

Low. This changes only deterministic Markdown presentation. Manifest data, schemas, artifact digests, CLI surface, and finalizer-owned lifecycle fields are unchanged. Existing `runtimeStatus` values remain readable by compatible consumers but are no longer presented as lifecycle status in regenerated reports.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.