### PR TITLE
fix: include PowerShell files in diff inventory

### DIFF
--- a/plugins/codex-security/scripts/rank_preview.py
+++ b/plugins/codex-security/scripts/rank_preview.py
@@ -42,6 +42,7 @@ TEXT_CODE_EXTENSIONS = {
     ".mm",
     ".php",
     ".proto",
+    ".ps1",
     ".py",
     ".rb",
     ".rs",

--- a/plugins/codex-security/tests/test_generate_in_scope_files.py
+++ b/plugins/codex-security/tests/test_generate_in_scope_files.py
@@ -148,6 +148,39 @@ def test_inventory_keeps_ignored_tracked_files_without_ignored_untracked_files(
     assert "./app/ignored.skip" not in paths
 
 
+def test_diff_inventory_includes_power_shell_files(tmp_path: Path) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    subprocess.run(
+        ["git", "init", "-q"],
+        cwd=repository,
+        capture_output=True,
+        check=True,
+    )
+    git(repository, "commit", "--allow-empty", "-qm", "base")
+    base = git(repository, "rev-parse", "HEAD")
+
+    write_file(repository, "config.json", b'{"enabled": true}\n')
+    write_file(repository, "build.ps1", b'Write-Output "build"\n')
+    git(repository, "add", ".")
+    git(repository, "commit", "-qm", "add diff files")
+    head = git(repository, "rev-parse", "HEAD")
+
+    output = tmp_path / "in_scope_files.txt"
+    result = run_inventory(
+        repository,
+        ".",
+        output,
+        arguments=["--diff-base", base, "--diff-head", head],
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output.read_text(encoding="utf-8").splitlines() == [
+        "build.ps1",
+        "config.json",
+    ]
+
+
 def test_inventory_uses_forward_slashes_when_ripgrep_defaults_to_backslashes(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #706. Diff-scan inventories currently omit changed PowerShell files because the shared text-code extension set does not include .ps1. This prevents valid locations in PowerShell files from being recorded as in-scope candidates.

## Changes

- Add .ps1 to the existing text-code extension set used by diff inventories.
- Add a regression test that creates a synthetic Git repository, changes a JSON file and a PowerShell file, and verifies that both appear in the revision inventory.

## Testing

- uv run --project plugins/codex-security --extra test pytest -q plugins/codex-security/tests/test_generate_in_scope_files.py plugins/codex-security/tests/test_rank_preview.py — 57 passed
- ruff check plugins/codex-security/scripts/rank_preview.py plugins/codex-security/tests/test_generate_in_scope_files.py — passed
- python3 -m py_compile plugins/codex-security/scripts/rank_preview.py plugins/codex-security/tests/test_generate_in_scope_files.py — passed
- git diff --check — passed

## Risk and rollout

This is a small compatibility fix with no public CLI or API changes. It only expands the existing diff inventory language allowlist to include PowerShell files; normal inventory behavior and other extension handling are unchanged.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.