### PR TITLE
fix(windows): retry credential snapshots when files disappear

### DIFF
--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -906,7 +906,12 @@ async function secureWindowsCredentialHome(path: string): Promise<void> {
     "  foreach ($entry in $entries) {",
     "    if (($entry.Attributes -band 1024) -and ($entry.LinkType -in @('SymbolicLink', 'Junction'))) { throw 'Windows credential home contains a symbolic link or junction' }",
     "    if ($entry.PSObject.TypeNames -notcontains 'System.IO.DirectoryInfo' -and $entry.PSObject.TypeNames -notcontains 'System.IO.FileInfo') { throw 'Windows credential home contains an unsafe entry' }",
-    "    try { Write-CredentialAcl $entry.FullName } catch { if ($_.FullyQualifiedErrorId -like 'GetAcl_PathNotFound,*') { continue }; throw }",
+    "    try { Write-CredentialAcl $entry.FullName } catch {",
+    // A descendant can disappear inside Get-Acl after it was enumerated.
+    `      if ($_.FullyQualifiedErrorId -eq 'System.IO.FileNotFoundException,Microsoft.PowerShell.Commands.GetAclCommand') { exit ${WINDOWS_CREDENTIAL_DESCENDANTS_CHANGED_EXIT_CODE} }`,
+    "      if ($_.FullyQualifiedErrorId -like 'GetAcl_PathNotFound,*') { continue }",
+    "      throw",
+    "    }",
     "    if ($entry.PSIsContainer) { Read-CredentialDescendants $entry.FullName }",
     "  }",
     "}",

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -2831,6 +2831,100 @@ describe("runtime directories and plugin Python boundary", () => {
     });
   });
 
+  test
+    .skipIf(process.platform !== "win32")
+    .each([
+      "transient missing descendant",
+      "persistent missing descendant",
+      "access denied",
+      "unexpected error",
+      "missing home",
+    ] as const)("replays Windows credential ACL %s", async (kind) => {
+    if (
+      runTestInSubprocess(
+        import.meta.path,
+        `replays Windows credential ACL ${kind}`,
+      )
+    ) {
+      return;
+    }
+    const root = await temporaryDirectory();
+    const home = join(root, "home");
+    await mkdir(home);
+    await requireSecureCredentialHome(home);
+    const descendant = join(home, ".auth-replay.tmp");
+    await writeFile(descendant, "synthetic credential\n", { mode: 0o600 });
+    const missing = kind.includes("missing");
+    const exception = missing
+      ? "System.IO.FileNotFoundException"
+      : kind === "access denied"
+        ? "System.UnauthorizedAccessException"
+        : "System.InvalidOperationException";
+    const errorId = missing
+      ? "System.IO.FileNotFoundException,Microsoft.PowerShell.Commands.GetAclCommand"
+      : kind === "access denied"
+        ? "System.UnauthorizedAccessException,Microsoft.PowerShell.Commands.GetAclCommand"
+        : "SyntheticCredentialAclFailure";
+    const category =
+      kind === "access denied"
+        ? "PermissionDenied"
+        : missing
+          ? "NotSpecified"
+          : "ObjectNotFound";
+    const failurePath = kind === "missing home" ? home : descendant;
+    // Replay the native error without relying on racing a filesystem deletion.
+    const injection = `if ($path -eq '${failurePath.replaceAll("'", "''")}') { throw [System.Management.Automation.ErrorRecord]::new([${exception}]::new('synthetic credential ACL error'), '${errorId}', [System.Management.Automation.ErrorCategory]::${category}, $path) };`;
+    const marker = "function Write-CredentialAcl($path) {";
+    const originalSpawn = childProcess.spawn;
+    let attempts = 0;
+    mock.module("node:child_process", () => ({
+      ...childProcess,
+      spawn: (...spawnArgs: Parameters<typeof childProcess.spawn>) => {
+        const [command, args, options] = spawnArgs;
+        if (
+          options?.env?.["CODEX_SECURITY_CREDENTIAL_ACL_PATH"] !== home ||
+          !Array.isArray(args)
+        ) {
+          return originalSpawn(...spawnArgs);
+        }
+        const scriptIndex = args.indexOf("-Command") + 1;
+        const script = args[scriptIndex];
+        if (typeof script !== "string" || !script.includes(marker)) {
+          return originalSpawn(...spawnArgs);
+        }
+        attempts += 1;
+        if (kind === "transient missing descendant" && attempts > 1) {
+          return originalSpawn(...spawnArgs);
+        }
+        expect(script.split(marker)).toHaveLength(2);
+        const replayArgs = [...args];
+        replayArgs[scriptIndex] = script.replace(
+          marker,
+          `${marker} ${injection}`,
+        );
+        return originalSpawn(command, replayArgs, options);
+      },
+    }));
+    try {
+      if (kind === "transient missing descendant") {
+        await requireSecureCredentialHome(home);
+        expect(attempts).toBe(2);
+      } else {
+        await expect(requireSecureCredentialHome(home)).rejects.toThrow(
+          kind === "persistent missing descendant"
+            ? "Windows credential descendants could not be verified"
+            : "synthetic credential ACL error",
+        );
+        expect(attempts).toBe(kind === "persistent missing descendant" ? 3 : 1);
+      }
+    } finally {
+      mock.module("node:child_process", () => ({
+        ...childProcess,
+        spawn: originalSpawn,
+      }));
+    }
+  });
+
   test("retries interrupted Windows credential ACL enumeration", async () => {
     const root = await temporaryDirectory();
     const home = join(root, "home");


### PR DESCRIPTION
## Summary

Parallel startup can remove a temporary authentication file while another process inspects the credential home's ACLs. Windows PowerShell can report `System.IO.FileNotFoundException,Microsoft.PowerShell.Commands.GetAclCommand` during that inspection, aborting startup instead of retrying the incomplete snapshot.

## Changes

- Route that exact error, only during descendant ACL reads, through the existing complete-snapshot retry.
- Preserve the three-attempt limit, snapshot completion checks, and fatal handling of home/ancestor, permission, unexpected-error, and unsafe-path failures.
- Extend the existing runtime tests with five native PowerShell error-replay cases covering recovery, exhaustion, and fatal errors.

## Testing

- Native replay against the unchanged implementation: 3 passed and 2 expected failures. Candidate: all 5 passed.
- Focused credential/import controls: 21 passed, including the five replay cases.
- SDK/MCP TypeScript checks, generated-model check, package formatting, SDK build, and `git diff --check`: passed.
- Full package run, seed 12345: **1,991 passed, 68 skipped, 5 failed**.
- Separately required unseeded package run, reported seed 3226174681: **1,992 passed, 68 skipped, 4 failed**. All five new replay cases and the existing parallel-import test passed in both full runs.

Four unchanged release-label fixtures failed in each full run. An isolated run reproduced all four failures without importing either changed candidate file. One exact fixture call outside the test runner returned `EPERM` from `uv_spawn`, with undefined status and PID. Its underlying OS/policy/runtime cause remains unknown; no workaround was attempted. The seeded run also failed an authentication-home test while an extra local harness state-directory override took precedence over the fixture's home override. That extra harness override was omitted for the separately required unseeded run, where the authentication-home test passed; this was not an identical-environment replay. **No passing local full suite is claimed.**

These local results use tested base `243436b`. Latest main `3bccb23` changes neither patched file; hosted CI will check the current merge.

The native replay verifies handling of the observed error, not an independent reproduction of the original deletion timing. No model-backed scan or machine-policy change was used.

## Risk and rollout

This classifies one missing-descendant error for an existing bounded retry. It does not relax ACL rules, accept incomplete snapshots, or change CLI options, backend selection, locks, or authentication sources. Persistently changing snapshots still fail after three attempts. No migration is required; applicable hosted CI and review remain required.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
