### PR TITLE
fix(container): publish metadata on multi-architecture images

### DIFF
--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -250,6 +250,8 @@ jobs:
     outputs:
       image: ${{ steps.release.outputs.image }}
       version: ${{ steps.release.outputs.version }}
+      labels: ${{ steps.metadata.outputs.labels }}
+      metadata: ${{ steps.metadata.outputs.json }}
 
     steps:
       - name: Checkout release source
@@ -314,6 +316,21 @@ jobs:
 
           sh docker/verify-container-release-version.sh "$endpoint" "$VERSION"
 
+      - name: Generate release image metadata
+        id: metadata
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ steps.release.outputs.image }}
+          # Use the release version for metadata; only promote publishes stable tags.
+          tags: type=raw,value=${{ steps.release.outputs.version }}
+          labels: |
+            org.opencontainers.image.title=Codex Security
+            org.opencontainers.image.description=Codex Security scanner with a preview findings API and dashboard.
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.vendor=OpenAI
+            org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}/releases/tag/npm-v${{ steps.release.outputs.version }}
+            org.opencontainers.image.documentation=${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/docker/README.md
+
   publish-platform:
     name: publish-linux-${{ matrix.architecture }}
     needs: authorize
@@ -358,16 +375,14 @@ jobs:
           sbom: true
           cache-from: type=gha,scope=codex-security-${{ matrix.architecture }}
           cache-to: type=gha,mode=max,scope=codex-security-${{ matrix.architecture }}
-          labels: |
-            org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.version=${{ needs.authorize.outputs.version }}
-            org.opencontainers.image.revision=${{ github.sha }}
+          labels: ${{ needs.authorize.outputs.labels }}
 
       - name: Verify the exact published native image
         env:
           EXPECTED_ARCHITECTURE: ${{ matrix.architecture }}
           IMAGE: ${{ needs.authorize.outputs.image }}
           IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE_METADATA: ${{ needs.authorize.outputs.metadata }}
         shell: bash
         run: |
           set -euo pipefail
@@ -385,6 +400,12 @@ jobs:
             echo "Expected a native $EXPECTED_ARCHITECTURE image; found $actual_architecture." >&2
             exit 1
           fi
+
+          docker image inspect --format '{{json .Config.Labels}}' "$reference" |
+            jq --exit-status --argjson metadata "$IMAGE_METADATA" '
+              . as $labels
+              | all($metadata.labels | to_entries[]; $labels[.key] == .value)
+            ' > /dev/null
 
           docker run --rm "$reference" --version
           docker run --rm "$reference" bulk-scan --help
@@ -464,6 +485,8 @@ jobs:
         id: manifest
         env:
           IMAGE: ${{ needs.authorize.outputs.image }}
+          IMAGE_LABELS: ${{ needs.authorize.outputs.labels }}
+          IMAGE_METADATA: ${{ needs.authorize.outputs.metadata }}
         shell: bash
         run: |
           set -euo pipefail
@@ -486,8 +509,14 @@ jobs:
             references+=("$IMAGE@sha256:$digest")
           done
 
+          annotations=()
+          while IFS= read -r label; do
+            annotations+=(--annotation "index:$label")
+          done <<< "$IMAGE_LABELS"
+
           candidate="$IMAGE:release-candidate-$GITHUB_SHA"
           docker buildx imagetools create \
+            "${annotations[@]}" \
             --tag "$candidate" \
             "${references[@]}"
 
@@ -500,9 +529,13 @@ jobs:
           printf 'candidate=%s\n' "$candidate" >> "$GITHUB_OUTPUT"
 
           docker buildx imagetools inspect "$candidate" --raw |
-            jq --exit-status '
-              [.manifests[] | select(.platform.os == "linux") | .platform.architecture]
-              | (index("amd64") != null and index("arm64") != null)
+            jq --exit-status --argjson metadata "$IMAGE_METADATA" '
+              . as $index
+              | all($metadata.labels | to_entries[]; $index.annotations[.key] == .value)
+                and (
+                  [.manifests[] | select(.platform.os == "linux") | .platform.architecture]
+                  | (index("amd64") != null and index("arm64") != null)
+                )
             ' > /dev/null
 
       - name: Verify customers can pull the candidate without GitHub credentials
@@ -640,3 +673,27 @@ jobs:
           docker logout ghcr.io
           docker pull "$IMAGE:$VERSION"
           docker run --rm --entrypoint codex-security "$IMAGE:$VERSION" --version
+
+      - name: Summarize published container release
+        continue-on-error: true
+        env:
+          IMAGE: ${{ needs.authorize.outputs.image }}
+          VERSION: ${{ needs.authorize.outputs.version }}
+          MANIFEST_DIGEST: ${{ needs.manifest.outputs.digest }}
+          RELEASE_URL: ${{ fromJSON(needs.authorize.outputs.metadata).labels['org.opencontainers.image.url'] }}
+          DOCUMENTATION_URL: ${{ fromJSON(needs.authorize.outputs.metadata).labels['org.opencontainers.image.documentation'] }}
+        shell: bash
+        run: |
+          {
+            printf '## Codex Security container %s\n\n' "$VERSION"
+            printf 'Platforms: linux/amd64, linux/arm64.\n\n'
+            printf 'Source: [%s](%s/%s/commit/%s)\n\n' \
+              "$GITHUB_SHA" "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_SHA"
+            printf '[Container guide](%s) | [Release notes](%s)\n\n' \
+              "$DOCUMENTATION_URL" "$RELEASE_URL"
+            printf '```bash\n'
+            printf 'docker pull %s:%s@%s\n' "$IMAGE" "$VERSION" "$MANIFEST_DIGEST"
+            printf 'gh attestation verify oci://%s@%s --repo %s\n' \
+              "$IMAGE" "$MANIFEST_DIGEST" "$GITHUB_REPOSITORY"
+            printf '```\n'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,6 +13,44 @@ publishing the multiarchitecture manifest. Anonymous
 pulls and attestation must succeed before promoting version, `sha-<commit>`, and
 `latest` tags. Stable version tags cannot be overwritten.
 
+## Image metadata and verification
+
+Release images include OCI metadata in each platform's image labels and in the
+final multiarchitecture index: title, description, source, license, vendor,
+version, source commit, build timestamp, release notes, and documentation pinned
+to that commit. GHCR reads the multiarchitecture description from the index,
+not from the Dockerfile labels alone.
+
+The workflow generates metadata once for both architectures, verifies it on the
+published candidate, then signs and promotes that exact digest. Metadata changes
+require a new digest and a new release; existing stable versions are not updated.
+The successful release run's summary includes the digest, supported platforms,
+documentation links, and commands to pull and verify the published image.
+
+Replace `VERSION` with an available stable version. Resolve its index digest once
+and use that reference for inspection, verification, and deployment:
+
+```bash
+image=ghcr.io/openai/codex-security
+version=VERSION
+digest="$(docker buildx imagetools inspect "$image:$version" --format '{{.Manifest.Digest}}')"
+reference="$image@$digest"
+
+docker buildx imagetools inspect "$reference" --raw | jq '.annotations'
+gh attestation verify "oci://$reference" --repo openai/codex-security
+docker pull "$reference"
+```
+
+Set `CODEX_SECURITY_IMAGE` or `CODEX_SECURITY_FINDINGS_IMAGE` to the verified
+`reference` when using Compose. The index selects the native `amd64` or `arm64`
+image. Its `unknown/unknown` entries contain the per-platform SBOM and build
+provenance; they are not runnable platforms and should not be removed.
+
+All labels, annotations, SBOMs, and provenance are public. Keep private URLs,
+scan data, and credentials out of them. BuildKit's maximum-mode provenance
+includes build arguments, so pass build credentials through secret mounts rather
+than build arguments.
+
 ## GHCR administrator setup
 
 Before the first release, an administrator must prepare the package:


### PR DESCRIPTION
## Summary

GHCR reads multi-architecture descriptions from the final image index, but the release workflow currently adds metadata only to platform image labels. Published versions therefore show no description.

This change adds consistent OCI metadata to the platform images and final index, including links to release notes and documentation for the exact source commit.

## Changes

- Generate release metadata once with a pinned Docker metadata action and reuse it across both architectures and the final index.
- Verify the published labels and index annotations before signing. Preserve the existing SBOMs, provenance, and immutable tag promotion.
- Add an optional release summary with digest-pinned pull and verification commands, and document metadata inspection in the container guide.

## Testing

- Actionlint passed with external checks disabled; Bash syntax checks and ShellCheck passed separately for all three changed shell steps.
- Prettier and `git diff --check` passed.
- An actual Buildx registry dry run attached all ten metadata fields while preserving both platform images and their attestation descriptors.
- The workflow's metadata checks accepted valid metadata and rejected the original unannotated index, missing description, mismatched revision or native-image version, and missing architecture.
- Executed the release summary with synthetic data and verified its digest-pinned commands. Confirmed signing and tag promotion steps are unchanged.
- Full container builds and runtime checks were not run locally because no Docker daemon was available; these still need CI validation.

## Risk and rollout

Release workflow and documentation only; no public CLI changes. The new Docker action is pinned to its full commit SHA. Metadata is applied before signing because annotations change the index digest. Existing stable versions are not rewritten; the improvement takes effect with the next protected container release. No image publication or release was triggered during local validation.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
