### PR TITLE
fix(plugin): include PowerShell module and data files

### DIFF
--- a/plugins/codex-security/scripts/rank_preview.py
+++ b/plugins/codex-security/scripts/rank_preview.py
@@ -43,6 +43,8 @@ TEXT_CODE_EXTENSIONS = {
     ".php",
     ".proto",
     ".ps1",
+    ".psd1",
+    ".psm1",
     ".py",
     ".rb",
     ".rs",

--- a/plugins/codex-security/tests/test_generate_in_scope_files.py
+++ b/plugins/codex-security/tests/test_generate_in_scope_files.py
@@ -162,6 +162,12 @@ def test_diff_inventory_includes_power_shell_files(tmp_path: Path) -> None:
 
     write_file(repository, "config.json", b'{"enabled": true}\n')
     write_file(repository, "build.ps1", b'Write-Output "build"\n')
+    write_file(repository, "module.psm1", b"function Get-Example { 'example' }\n")
+    write_file(
+        repository,
+        "module.psd1",
+        b"@{ RootModule = 'module.psm1'; ModuleVersion = '1.0.0' }\n",
+    )
     git(repository, "add", ".")
     git(repository, "commit", "-qm", "add diff files")
     head = git(repository, "rev-parse", "HEAD")
@@ -178,6 +184,8 @@ def test_diff_inventory_includes_power_shell_files(tmp_path: Path) -> None:
     assert output.read_text(encoding="utf-8").splitlines() == [
         "build.ps1",
         "config.json",
+        "module.psd1",
+        "module.psm1",
     ]
 
 


### PR DESCRIPTION
<!-- Use a Conventional Commit title: <type>[optional scope][!]: <description>. See RELEASING.md. -->

## Summary

Extend the PowerShell file coverage added in #707: the shared text-extension list includes `.ps1`, but still omits `.psm1` script modules and `.psd1` manifests/data files. Otherwise eligible files of these types are skipped by automatic diff-inventory and rank-input selection.

Explicit files supplied through a scopes file can already bypass extension filtering; this is not a claim that these file types cannot be targeted by any route.

## Changes

- Add `.psm1` and `.psd1` to the existing shared `TEXT_CODE_EXTENSIONS` set.
- Extend the existing diff-inventory regression fixture with module and manifest/data files, retaining the `.ps1` and JSON controls.
- Reuse the existing sampled-text preview and selection logic; no PowerShell-specific parser or separate extension lists.

## Testing

On native Windows with Python 3.12.13 and pytest 9.0.3:

- The original `.ps1`/JSON regression passed on the unchanged production code.
- With the expanded module fixture but unchanged production code, the regression failed as expected: the command succeeded but its inventory omitted both module files.
- With the two extension entries added, the same regression passed.
- `python -B -m pytest -q tests/test_generate_in_scope_files.py tests/test_generate_rank_input.py tests/test_rank_preview.py` (with isolated temporary/cache directories and JUnit output): **115 passed, 2 skipped**. Both skips are existing executable-script-shim cases unsupported on Windows.
- `git diff --check`: passed.

The full TypeScript suite was not rerun locally for this Python-only selection change. Hosted CI at `34d06af` passed all three required checks and all 28 node-ci jobs, including all 18 Windows jobs; the other four applicable workflows also passed.

## Risk and rollout

Automatic selection will include these additional source/configuration files on all host platforms, so affected repositories may produce more candidates.

Files remain data: they are not imported or executed by PowerShell. No commands, flags, execution-policy settings or sandbox behavior change. Existing excluded-path, binary-content and file/path checks remain in place. This does not add UTF-16 decoding; the existing NUL-byte filter still excludes UTF-16 files. That separate decoding fix is in #716. No data migration is required.

## Public disclosure review

<!-- Review every public artifact before checking all three attestations. -->

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
