### PR TITLE
fix(ci): preserve LF Python source checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 *.json text eol=lf
 *.md text eol=lf
 *.mjs text eol=lf
+*.py text eol=lf
 *.sh text eol=lf
 *.ts text eol=lf
 *.tsx text eol=lf

--- a/.github/scripts/test_check_plugin_source_compatibility.py
+++ b/.github/scripts/test_check_plugin_source_compatibility.py
@@ -63,6 +63,30 @@ def test_accepts_valid_source_and_ignores_untracked_files(tmp_path: Path) -> Non
     assert result.stderr == ""
 
 
+def test_python_checkout_preserves_source_size_with_autocrlf(tmp_path: Path) -> None:
+    attributes = CHECKER.parents[2] / ".gitattributes"
+    (tmp_path / ".gitattributes").write_bytes(attributes.read_bytes())
+    source = tmp_path / "module.py"
+    content = b"pass\n" * 30_000
+    source.write_bytes(content)
+    initialize_repository(tmp_path)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "--local", "core.autocrlf", "true"],
+        check=True,
+    )
+    track(tmp_path, ".gitattributes", "module.py")
+    source.unlink()
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "checkout-index", "--", "module.py"],
+        check=True,
+    )
+
+    result = run_checker(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert source.read_bytes() == content
+
+
 def test_accepts_prose_after_an_opening_thematic_break(tmp_path: Path) -> None:
     (tmp_path / "README.md").write_text(
         """---


### PR DESCRIPTION
## Summary

Windows checkouts with `core.autocrlf=true` can make unchanged Python files exceed the plugin source checker's byte limit. Keep Python source checkouts in LF form so the existing size check measures the intended source bytes.

## Changes

- Add `*.py text eol=lf` alongside the existing extension-specific Git attributes.
- Extend the source checker tests with a real Git checkout under repository-local `core.autocrlf=true`. The test verifies both the checked-out bytes and the checker result.
- Keep the source checker's 150,000-byte limit unchanged.

## Testing

- Native Windows baseline: the unchanged checkout failed the checker for three Python files; the LF checkout passed.
- New regression without the attribute: failed as expected at 180,000 bytes versus the 150,000-byte limit.
- Final source-checker test file: **8 passed, 1 skipped**. The skip is the existing Windows symlink test.
- Ruff 0.16.1 lint and format checks: passed.
- Plugin source compatibility checker: passed.

## Risk and rollout

This changes Python checkout line endings, with no checker or runtime code changes. Existing unchanged CRLF files may remain until a fresh checkout or refresh; preserve local edits before doing that. No global Git settings are changed.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
