### PR TITLE
ci: run full checks for authored plugin Markdown

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -49,6 +49,7 @@ jobs:
             while IFS= read -r -d '' path; do
               changed=true
               if [[ "$path" != *.md ||
+                    "$path" == plugins/codex-security/* ||
                     "$path" == sdk/typescript/_bundled_plugin/* ]]; then
                 markdown_only=false
               fi

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           set -euo pipefail
           ci_mode=full
+          check_markdown=false
           if [[ "$EVENT_NAME" == "pull_request" &&
                 "$BASE_CHANGED" != "true" ]]; then
             changed_files="$(mktemp)"
@@ -46,19 +47,26 @@ jobs:
 
             changed=false
             markdown_only=true
+            plugin_changed=false
             while IFS= read -r -d '' path; do
               changed=true
-              if [[ "$path" != *.md ||
-                    "$path" == plugins/codex-security/* ||
-                    "$path" == sdk/typescript/_bundled_plugin/* ]]; then
+              if [[ "$path" != *.md ]]; then
                 markdown_only=false
+              fi
+              if [[ "$path" == plugins/codex-security/* ||
+                    "$path" == sdk/typescript/_bundled_plugin/* ]]; then
+                plugin_changed=true
               fi
             done < "$changed_files"
             if [[ "$changed" == "true" && "$markdown_only" == "true" ]]; then
-              ci_mode=markdown
+              check_markdown=true
+              if [[ "$plugin_changed" == "false" ]]; then
+                ci_mode=markdown
+              fi
             fi
           fi
           printf 'ci-mode=%s\n' "$ci_mode" >> "$GITHUB_OUTPUT"
+          printf 'check-markdown=%s\n' "$check_markdown" >> "$GITHUB_OUTPUT"
 
       - name: Require a Conventional Commit pull request title
         if: github.event_name == 'pull_request'
@@ -80,7 +88,7 @@ jobs:
           python .github/scripts/check_plugin_source_compatibility.py
 
       - name: Set up pnpm
-        if: steps.scope.outputs.ci-mode == 'markdown'
+        if: steps.scope.outputs.check-markdown == 'true'
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           package_json_file: sdk/typescript/package.json
@@ -88,7 +96,7 @@ jobs:
           cache_dependency_path: sdk/typescript/pnpm-lock.yaml
 
       - name: Set up Node.js
-        if: steps.scope.outputs.ci-mode == 'markdown'
+        if: steps.scope.outputs.check-markdown == 'true'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "22.13.0"
@@ -96,11 +104,11 @@ jobs:
           cache-dependency-path: sdk/typescript/pnpm-lock.yaml
 
       - name: Install dependencies
-        if: steps.scope.outputs.ci-mode == 'markdown'
+        if: steps.scope.outputs.check-markdown == 'true'
         run: pnpm --dir sdk/typescript install --frozen-lockfile
 
       - name: Check Markdown formatting
-        if: steps.scope.outputs.ci-mode == 'markdown'
+        if: steps.scope.outputs.check-markdown == 'true'
         shell: bash
         run: |
           files=()

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -3947,17 +3947,11 @@ describe("GitHub release workflow safeguards", () => {
     }
     expect(workflow.jobs["markdown-checks"]).toBeUndefined();
     const validationSteps = workflow.jobs["validate-title"]?.steps ?? [];
-    for (const stepName of [
-      "Set up pnpm",
-      "Set up Node.js",
-      "Install dependencies",
-      "Check Markdown formatting",
-      "Check plugin source compatibility",
-    ]) {
-      expect(validationSteps.find(({ name }) => name === stepName)?.if).toBe(
-        "steps.scope.outputs.ci-mode == 'markdown'",
-      );
-    }
+    expect(
+      validationSteps.find(
+        ({ name }) => name === "Check plugin source compatibility",
+      )?.if,
+    ).toBe("steps.scope.outputs.ci-mode == 'markdown'");
     const markdownCommand =
       validationSteps.find(({ name }) => name === "Check Markdown formatting")
         ?.run ?? "";
@@ -4043,6 +4037,7 @@ describe("GitHub release workflow safeguards", () => {
       false,
       ["README.md", "docs/guide.md"],
       "markdown",
+      true,
     ],
     [
       "generated-plugin Markdown-only PR",
@@ -4050,6 +4045,7 @@ describe("GitHub release workflow safeguards", () => {
       false,
       ["sdk/typescript/_bundled_plugin/skills/example/SKILL.md"],
       "full",
+      true,
     ],
     [
       "authored-plugin skill Markdown-only PR",
@@ -4057,6 +4053,7 @@ describe("GitHub release workflow safeguards", () => {
       false,
       ["plugins/codex-security/skills/example/SKILL.md"],
       "full",
+      true,
     ],
     [
       "authored-plugin reference Markdown-only PR",
@@ -4064,24 +4061,37 @@ describe("GitHub release workflow safeguards", () => {
       false,
       ["plugins/codex-security/skills/example/references/contract.md"],
       "full",
+      true,
     ],
-    ["base retarget", "pull_request", true, ["README.md"], "full"],
-    ["mixed PR", "pull_request", false, ["README.md", "src/index.ts"], "full"],
+    ["base retarget", "pull_request", true, ["README.md"], "full", false],
+    [
+      "mixed PR",
+      "pull_request",
+      false,
+      ["README.md", "src/index.ts"],
+      "full",
+      false,
+    ],
     [
       "source-to-Markdown rename",
       "pull_request",
       false,
       ["src/index.ts", "docs/index.md"],
       "full",
+      false,
     ],
-    ["empty merge diff", "pull_request", false, [], "full"],
-    ["push", "push", false, ["README.md"], "full"],
+    ["empty merge diff", "pull_request", false, [], "full", false],
+    ["push", "push", false, ["README.md"], "full", false],
   ] as const)(
-    "selects the conservative CI mode for %s",
-    (_name, eventName, baseChanged, changedPaths, ciMode) => {
+    "selects CI and formatting checks for %s",
+    (_name, eventName, baseChanged, changedPaths, ciMode, checkMarkdown) => {
       const workspace = mkdtempSync(join(tmpdir(), "release-ci-scope-"));
       const output = join(workspace, "output");
       const script = workflowStepShell(nodeCiWorkflow, "Decide CI mode");
+      const workflow = Bun.YAML.parse(nodeCiWorkflow) as {
+        jobs: Record<string, { steps: Array<{ name?: string; if?: string }> }>;
+      };
+      const validationSteps = workflow.jobs["validate-title"]!.steps;
       const gitMock = `git() {
       [[ "$*" == "diff --no-renames --name-only -z HEAD^1 HEAD" ]] || return 64
       while IFS= read -r path; do
@@ -4099,7 +4109,31 @@ describe("GitHub release workflow safeguards", () => {
           },
         });
         expect(result.status).toBe(0);
-        expect(readFileSync(output, "utf8")).toBe(`ci-mode=${ciMode}\n`);
+        const outputs: Record<string, string> = Object.fromEntries(
+          readFileSync(output, "utf8")
+            .trim()
+            .split("\n")
+            .map((line) => line.split("=")),
+        );
+        expect(outputs["ci-mode"]).toBe(ciMode);
+        const values = Object.fromEntries(
+          Object.entries(outputs).map(([key, value]) => [
+            `steps.scope.outputs.${key}`,
+            value,
+          ]),
+        );
+        for (const stepName of [
+          "Set up pnpm",
+          "Set up Node.js",
+          "Install dependencies",
+          "Check Markdown formatting",
+        ]) {
+          const condition =
+            validationSteps.find(({ name }) => name === stepName)?.if ?? "";
+          expect(evaluateWorkflowCondition(condition, values), stepName).toBe(
+            checkMarkdown,
+          );
+        }
       } finally {
         rmSync(workspace, { recursive: true, force: true });
       }

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -4051,6 +4051,20 @@ describe("GitHub release workflow safeguards", () => {
       ["sdk/typescript/_bundled_plugin/skills/example/SKILL.md"],
       "full",
     ],
+    [
+      "authored-plugin skill Markdown-only PR",
+      "pull_request",
+      false,
+      ["plugins/codex-security/skills/example/SKILL.md"],
+      "full",
+    ],
+    [
+      "authored-plugin reference Markdown-only PR",
+      "pull_request",
+      false,
+      ["plugins/codex-security/skills/example/references/contract.md"],
+      "full",
+    ],
     ["base retarget", "pull_request", true, ["README.md"], "full"],
     ["mixed PR", "pull_request", false, ["README.md", "src/index.ts"], "full"],
     [


### PR DESCRIPTION
## Summary

Markdown in the authored plugin tree controls scan behavior, but `node-ci` classified those changes as documentation-only. Its exception covered the generated `_bundled_plugin` path, allowing authored skill and reference changes to skip the behavioral tests and package checks.

## Changes

- Run full CI for changes under `plugins/codex-security`, including Markdown.
- Preserve the existing generated-plugin exception and the fast path for ordinary documentation.
- Keep changed-file formatting and its setup steps enabled for Markdown-only PRs, independently of whether they need full CI.
- Extend the existing shell-based classification tests with authored skill and reference cases, and evaluate the actual formatting-step conditions for every case.

## Testing

- Both new classification cases failed before the workflow fix; all 9 classification cases pass afterward.
- Reproduced the formatting-check regression found in review, then verified that all 9 cases select both CI and formatter setup correctly. The actual formatting step rejects an unformatted synthetic plugin skill and passes after formatting while selecting full CI.
- Targeted CI, formatter, and required-context regressions: 11 passed, 0 failed.
- `pnpm run types`, `pnpm run format`, workflow formatting, and `git diff --check` passed.
- Full SDK suite on the final code with seeds 12345 and 3808443279: 2,057 passed, 36 skipped, and 0 failed in each run. These runs used process inspection access, which the process-group test requires; initial sandboxed runs had blocked `ps`.

## Risk and rollout

Plugin Markdown changes will now run the existing full CI matrix and use more CI time. Ordinary documentation still uses the reduced checks. This does not change runtime behavior, dependencies, required check names, or release behavior.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
