### PR TITLE
fix(ci): run behavioral checks for authored plugin Markdown

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -49,6 +49,7 @@ jobs:
             while IFS= read -r -d '' path; do
               changed=true
               if [[ "$path" != *.md ||
+                    "$path" == plugins/codex-security/* ||
                     "$path" == sdk/typescript/_bundled_plugin/* ]]; then
                 markdown_only=false
               fi

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -4051,6 +4051,13 @@ describe("GitHub release workflow safeguards", () => {
       ["sdk/typescript/_bundled_plugin/skills/example/SKILL.md"],
       "full",
     ],
+    [
+      "authored-plugin Markdown-only PR",
+      "pull_request",
+      false,
+      ["plugins/codex-security/skills/example/SKILL.md"],
+      "full",
+    ],
     ["base retarget", "pull_request", true, ["README.md"], "full"],
     ["mixed PR", "pull_request", false, ["README.md", "src/index.ts"], "full"],
     [


### PR DESCRIPTION
## Summary

Changes to shipped plugin skills could take the Markdown-only CI path and skip the behavioral tests that validate those skills. Authored plugin Markdown now selects full CI, just like the generated plugin payload.

## Changes

- Exclude `plugins/codex-security/**` from the Markdown-only shortcut.
- Add a regression case that executes the workflow's classifier for an authored `SKILL.md` change.
- Preserve the fast path for ordinary documentation and all existing required-check gates.

## Testing

- Confirmed the new regression failed before the classifier change.
- `bun test --timeout 30000 tests-ts/release-automation.test.ts`: 281 passed, 0 failed with Bun 1.3.14.
- `prettier --check tests-ts/release-automation.test.ts`: passed.
- `git diff --check`: passed.

## Risk and rollout

This expands CI execution for Markdown changes under the authored plugin directory. It does not change runtime behavior or skip any existing check. No migration or configuration change is needed.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
