### PR TITLE
fix(sdk): retry Windows Get-Acl path-not-found races

### DIFF
--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -908,7 +908,7 @@ async function secureWindowsCredentialHome(path: string): Promise<void> {
     "    if ($entry.PSObject.TypeNames -notcontains 'System.IO.DirectoryInfo' -and $entry.PSObject.TypeNames -notcontains 'System.IO.FileInfo') { throw 'Windows credential home contains an unsafe entry' }",
     "    try { Write-CredentialAcl $entry.FullName } catch {",
     // A descendant can disappear inside Get-Acl after it was enumerated.
-    `      if ($_.FullyQualifiedErrorId -eq 'System.IO.FileNotFoundException,Microsoft.PowerShell.Commands.GetAclCommand') { exit ${WINDOWS_CREDENTIAL_DESCENDANTS_CHANGED_EXIT_CODE} }`,
+    `      if ($_.FullyQualifiedErrorId -eq 'System.IO.FileNotFoundException,Microsoft.PowerShell.Commands.GetAclCommand' -or $_.FullyQualifiedErrorId -eq 'GetAcl_PathNotFound_Exception,Microsoft.PowerShell.Commands.GetAclCommand') { exit ${WINDOWS_CREDENTIAL_DESCENDANTS_CHANGED_EXIT_CODE} }`,
     "      if ($_.FullyQualifiedErrorId -like 'GetAcl_PathNotFound,*') { continue }",
     "      throw",
     "    }",

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -2840,6 +2840,9 @@ describe("runtime directories and plugin Python boundary", () => {
       "access denied",
       "unexpected error",
       "missing home",
+      "transient path-not-found descendant",
+      "persistent path-not-found descendant",
+      "path-not-found home",
     ] as const)("replays Windows credential ACL %s", async (kind) => {
     if (
       runTestInSubprocess(
@@ -2855,24 +2858,31 @@ describe("runtime directories and plugin Python boundary", () => {
     await requireSecureCredentialHome(home);
     const descendant = join(home, ".auth-replay.tmp");
     await writeFile(descendant, "synthetic credential\n", { mode: 0o600 });
-    const missing = kind.includes("missing");
-    const exception = missing
-      ? "System.IO.FileNotFoundException"
-      : kind === "access denied"
-        ? "System.UnauthorizedAccessException"
-        : "System.InvalidOperationException";
-    const errorId = missing
-      ? "System.IO.FileNotFoundException,Microsoft.PowerShell.Commands.GetAclCommand"
-      : kind === "access denied"
-        ? "System.UnauthorizedAccessException,Microsoft.PowerShell.Commands.GetAclCommand"
-        : "SyntheticCredentialAclFailure";
+    const pathNotFound = kind.includes("path-not-found");
+    const missing = pathNotFound || kind.includes("missing");
+    const transient = kind.startsWith("transient ");
+    const persistent = kind.startsWith("persistent ");
+    const exception = pathNotFound
+      ? "System.Management.Automation.ItemNotFoundException"
+      : missing
+        ? "System.IO.FileNotFoundException"
+        : kind === "access denied"
+          ? "System.UnauthorizedAccessException"
+          : "System.InvalidOperationException";
+    const errorId = pathNotFound
+      ? "GetAcl_PathNotFound_Exception,Microsoft.PowerShell.Commands.GetAclCommand"
+      : missing
+        ? "System.IO.FileNotFoundException,Microsoft.PowerShell.Commands.GetAclCommand"
+        : kind === "access denied"
+          ? "System.UnauthorizedAccessException,Microsoft.PowerShell.Commands.GetAclCommand"
+          : "SyntheticCredentialAclFailure";
     const category =
       kind === "access denied"
         ? "PermissionDenied"
-        : missing
+        : missing && !pathNotFound
           ? "NotSpecified"
           : "ObjectNotFound";
-    const failurePath = kind === "missing home" ? home : descendant;
+    const failurePath = kind.endsWith("home") ? home : descendant;
     // Replay the native error without relying on racing a filesystem deletion.
     const injection = `if ($path -eq '${failurePath.replaceAll("'", "''")}') { throw [System.Management.Automation.ErrorRecord]::new([${exception}]::new('synthetic credential ACL error'), '${errorId}', [System.Management.Automation.ErrorCategory]::${category}, $path) };`;
     const marker = "function Write-CredentialAcl($path) {";
@@ -2894,7 +2904,7 @@ describe("runtime directories and plugin Python boundary", () => {
           return originalSpawn(...spawnArgs);
         }
         attempts += 1;
-        if (kind === "transient missing descendant" && attempts > 1) {
+        if (transient && attempts > 1) {
           return originalSpawn(...spawnArgs);
         }
         expect(script.split(marker)).toHaveLength(2);
@@ -2907,16 +2917,16 @@ describe("runtime directories and plugin Python boundary", () => {
       },
     }));
     try {
-      if (kind === "transient missing descendant") {
+      if (transient) {
         await requireSecureCredentialHome(home);
         expect(attempts).toBe(2);
       } else {
         await expect(requireSecureCredentialHome(home)).rejects.toThrow(
-          kind === "persistent missing descendant"
+          persistent
             ? "Windows credential descendants could not be verified"
             : "synthetic credential ACL error",
         );
-        expect(attempts).toBe(kind === "persistent missing descendant" ? 3 : 1);
+        expect(attempts).toBe(persistent ? 3 : 1);
       }
     } finally {
       mock.module("node:child_process", () => ({


### PR DESCRIPTION
## Summary

Windows PowerShell can report a disappearing credential-home temporary file as `GetAcl_PathNotFound_Exception,Microsoft.PowerShell.Commands.GetAclCommand`. The existing snapshot retry handles a different missing-file error, so this variant can abort parallel credential imports.

## Changes

- Route only this additional exact error ID through the existing descendant-only snapshot retry.
- Extend the existing native replay fixture with transient and persistent missing-path descendants and a missing-home control.
- Preserve the three-attempt limit, complete-snapshot checks, and existing credential/path protections.

## Testing

Native Windows checks used Node 24.19.0, Bun 1.3.14, Python 3.12.13, and the existing 30-second per-test timeout.

- Before the production change, the three new native cases produced 1 pass and 2 expected failures: both descendant recovery cases failed; missing-home rejection passed.
- Focused credential controls: 24 passed, 0 skipped, 0 failed (seed `2924365917`).
- Passed `pnpm run types` (model generation check, MCP typecheck, SDK typecheck), `pnpm run format`, `pnpm run build:plugin`, `pnpm run build`, and `pnpm run check:plugin-source`.

| Full package check | Passed | Skipped | Failed |
| --- | ---: | ---: | ---: |
| `pnpm run test --seed 12345` | 2018 | 69 | 4 |
| `pnpm run test` (printed seed `1192751191`) | 2018 | 69 | 4 |

Both full runs failed the four existing release-automation manual-retitle cases (`feat`, `docs`, `fix`, and `chore`). Their causes remain unestablished; no additional release-case diagnostic or replay was run. These are not full-suite passes. All eight native ACL replay cases and the original parallel-import test passed in both runs.

The new cases replay native PowerShell error records deterministically; they do not reproduce the original filesystem timing.

## Risk and rollout

The change is Windows-only. Missing homes and ancestors, permission failures, unexpected errors, unsafe entries, and incomplete snapshots remain fatal. Each retry still requires a complete, safe snapshot within the existing three-attempt limit. The existing missing-path continuation is unchanged; no ACL policy or public CLI setting changes.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
