### PR TITLE
fix(multiscan): preserve scan outcome and record receipt when checkout cleanup fails

### DIFF
--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -448,7 +448,14 @@ async function runCampaign(
             warning = `Scan coverage is ${coverage}; results may be incomplete.`;
           }
         } catch (error) {
-          if (options.signal?.aborted === true) options.signal.throwIfAborted();
+          if (options.signal?.aborted === true) {
+            if (checkout !== undefined) {
+              await rm(checkout, { recursive: true, force: true }).catch(
+                () => undefined,
+              );
+            }
+            options.signal.throwIfAborted();
+          }
           if (error instanceof ScanCostLimitExceededError) {
             cost = error.cost;
             exhaustedBudget = true;
@@ -459,9 +466,17 @@ async function runCampaign(
                 `Bulk attempt directory is not empty: ${scanDir}. Existing artifacts and checkout were preserved. Run the same bulk-scan command with --recover to recover interrupted scans or retry failed scans in new attempt directories.`,
               )
             : safeErrorMessage(error);
-        } finally {
-          if (options.recoverScan === undefined && checkout !== undefined) {
+        }
+        if (options.recoverScan === undefined && checkout !== undefined) {
+          try {
             await rm(checkout, { recursive: true, force: true });
+          } catch (error) {
+            notifyProgress(options, {
+              repository: task.id,
+              attempt,
+              status: "started",
+              warning: `Failed to remove checkout directory: ${safeErrorMessage(error)}`,
+            });
           }
         }
         const status =
@@ -491,7 +506,16 @@ async function runCampaign(
           failure === undefined &&
           checkout !== undefined
         ) {
-          await rm(checkout, { recursive: true, force: true });
+          try {
+            await rm(checkout, { recursive: true, force: true });
+          } catch (error) {
+            notifyProgress(options, {
+              repository: task.id,
+              attempt,
+              status: "started",
+              warning: `Failed to remove checkout directory: ${safeErrorMessage(error)}`,
+            });
+          }
         }
         notifyProgress(options, {
           repository: task.id,

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -2669,4 +2669,145 @@ describe("multiscan", () => {
       { id: "complete", status: "completed", attempt: 1, coverage: "complete" },
     ]);
   });
+
+  test("preserves scan failure and writes receipt when checkout cleanup fails", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "cleanup-fail-scan-fail");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\ncleanup-fail,${source.path},${source.revision}\n`,
+    );
+    const checkoutDir = join(paths.output, "checkouts", "cleanup-fail");
+    const originalRm = filesystem.rm;
+    let rmAttempts = 0;
+    const rmSpy = spyOn(filesystem, "rm").mockImplementation(
+      async (path, options) => {
+        if (String(path) === checkoutDir && options?.recursive === true) {
+          rmAttempts += 1;
+          if (rmAttempts >= 2) {
+            throw Object.assign(
+              new Error("EACCES: permission denied, rm checkout"),
+              { code: "EACCES" },
+            );
+          }
+        }
+        return await originalRm(path, options);
+      },
+    );
+
+    const progressEvents: unknown[] = [];
+    const security = client(async () => {
+      throw new Error("ORIGINAL_SCAN_FAILURE");
+    });
+
+    try {
+      const summary = await runMultiscan(
+        options(paths, security, {
+          maxAttempts: 1,
+          onProgress: (event) => progressEvents.push(event),
+        }),
+      );
+
+      expect(summary).toMatchObject({
+        total: 1,
+        completed: 0,
+        incomplete: 0,
+        failed: 1,
+      });
+      const recordedResults = await results(summary.resultsPath);
+      expect(recordedResults).toMatchObject([
+        {
+          id: "cleanup-fail",
+          status: "failed",
+          attempt: 1,
+          error: "ORIGINAL_SCAN_FAILURE",
+        },
+      ]);
+      expect(
+        progressEvents.some(
+          (event: any) =>
+            event.status === "started" &&
+            typeof event.warning === "string" &&
+            event.warning.includes("Failed to remove checkout directory"),
+        ),
+      ).toBe(true);
+      expect(
+        progressEvents.some(
+          (event: any) =>
+            event.status === "failed" &&
+            event.error === "ORIGINAL_SCAN_FAILURE",
+        ),
+      ).toBe(true);
+    } finally {
+      rmSpy.mockRestore();
+    }
+  });
+
+  test("preserves scan success and writes receipt when checkout cleanup fails", async () => {
+    const paths = await fixture();
+    const source = await repository(paths.root, "cleanup-fail-scan-success");
+    await writeFile(
+      paths.input,
+      `id,repository,revision\ncleanup-success,${source.path},${source.revision}\n`,
+    );
+    const checkoutDir = join(paths.output, "checkouts", "cleanup-success");
+    const originalRm = filesystem.rm;
+    let rmAttempts = 0;
+    const rmSpy = spyOn(filesystem, "rm").mockImplementation(
+      async (path, options) => {
+        if (String(path) === checkoutDir && options?.recursive === true) {
+          rmAttempts += 1;
+          if (rmAttempts >= 2) {
+            throw Object.assign(new Error("EBUSY: resource busy or locked"), {
+              code: "EBUSY",
+            });
+          }
+        }
+        return await originalRm(path, options);
+      },
+    );
+
+    const progressEvents: unknown[] = [];
+    const security = client(async (_repo, scanOptions = {}) =>
+      completedScan(scanOptions.outputDir!),
+    );
+
+    try {
+      const summary = await runMultiscan(
+        options(paths, security, {
+          maxAttempts: 1,
+          onProgress: (event) => progressEvents.push(event),
+        }),
+      );
+
+      expect(summary).toMatchObject({
+        total: 1,
+        completed: 1,
+        incomplete: 0,
+        failed: 0,
+      });
+      const recordedResults = await results(summary.resultsPath);
+      expect(recordedResults).toMatchObject([
+        {
+          id: "cleanup-success",
+          status: "completed",
+          attempt: 1,
+          coverage: "complete",
+        },
+      ]);
+      expect(
+        progressEvents.some(
+          (event: any) =>
+            event.status === "started" &&
+            typeof event.warning === "string" &&
+            event.warning.includes("Failed to remove checkout directory"),
+        ),
+      ).toBe(true);
+      expect(
+        progressEvents.some((event: any) => event.status === "completed"),
+      ).toBe(true);
+    } finally {
+      rmSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Preserve multiscan attempt outcomes and ensure attempt receipts are durably recorded in `results.jsonl` when checkout directory removal encounters secondary filesystem errors (such as `EACCES`, `EPERM`, or `EBUSY`).

Fixes #211.

## Changes

- In `sdk/typescript/src/multiscan.ts`, decouple the checkout removal cleanup step from the primary scan outcome capture and receipt appending.
- Treat checkout removal as best-effort cleanup: capture cleanup exceptions without aborting the worker, record the authentic scan attempt status (`completed`, `completed_with_incomplete_coverage`, or `failed`) in the ledger receipt, and emit a non-fatal warning on progress notifications.
- Ensure that if an abort signal is triggered, checkout removal is attempted before rethrowing.
- In `sdk/typescript/tests-ts/multiscan.test.ts`, add regression tests verifying:
  1. A scan failure followed by a checkout cleanup error preserves the original scan failure in the ledger receipt and progress notifications.
  2. A scan success followed by a checkout cleanup error preserves the completed status in the ledger receipt, counts the completion, and does not crash the campaign.

## Testing

- `bun test ./tests-ts/multiscan.test.ts` (53 pass, 2 skip, 0 fail)
- `pnpm --dir sdk/typescript run types` (passed with 0 errors)
- `pnpm --dir sdk/typescript run format` (passed with all files formatted)
- `python .github/scripts/check_plugin_source_compatibility.py` (passed)

## Risk and rollout

Low. This change makes multiscan worker cleanup resilient without modifying the scan execution or ledger format contract.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
