### PR TITLE
test: run scan history query cases in process

### DIFF
--- a/plugins/codex-security/tests/test_workbench_native_index_queries.py
+++ b/plugins/codex-security/tests/test_workbench_native_index_queries.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import ntpath
 from argparse import Namespace
+from types import SimpleNamespace
 
 import pytest
 from workbench_test_support import stable_target_id
@@ -188,3 +190,70 @@ def test_collection_filters_apply_before_pagination(
     if command == "list-repositories":
         assert query(connection, query_args(status="not_scanned"))[collection] == []
         assert query(connection, query_args(status="open_findings"))[collection]
+
+
+def test_scan_list_returns_lightweight_running_first_summaries(workbench_api, indexed_collections):
+    connection, targets = indexed_collections
+    connection.execute(
+        "UPDATE scans SET status = 'running', phase = 'preflight' WHERE id = ?",
+        (SCAN_IDS[1],),
+    )
+    connection.execute(
+        "UPDATE scans SET status = 'failed', canceled_at = updated_at WHERE id = ?", (SCAN_IDS[0],)
+    )
+    scans = workbench_api["scan_history"].list_scans(connection)["scans"]
+
+    assert [scan["scanId"] for scan in scans] == [SCAN_IDS[1], SCAN_IDS[0], SCAN_IDS[2]]
+    assert scans[0]["targetPath"] == str(targets[1])
+    assert scans[0]["targetRevision"] == "synthetic-revision"
+    assert scans[0]["progress"]["status"] == "running"
+    assert scans[0]["progress"]["phase"] == "preflight"
+    assert scans[1]["progress"]["status"] == "canceled"
+    assert "artifacts" not in scans[0]
+    assert "findings" not in scans[0]
+
+
+def test_scan_root_filter_matches_windows_path_aliases(
+    workbench_api, indexed_collections, tmp_path, monkeypatch
+):
+    connection, _ = indexed_collections
+    root = tmp_path / "Scan Results"
+    for scan_id, directory in zip(
+        SCAN_IDS, (root / "first", tmp_path / "Scan Results Other", tmp_path / "unrelated")
+    ):
+        connection.execute("UPDATE scans SET scan_dir = ? WHERE id = ?", (str(directory), scan_id))
+    history = workbench_api["scan_history"]
+    monkeypatch.setattr(history, "os", SimpleNamespace(name="nt", path=ntpath, sep="\\"))
+    args = query_args(scan_root=str(root).upper(), limit=None)
+
+    assert [scan["scanId"] for scan in history.list_scans(connection, args)["scans"]] == [
+        SCAN_IDS[0]
+    ]
+    connection.execute(
+        "UPDATE scans SET scan_dir = ? WHERE id = ?", (ntpath.normpath(str(root)), SCAN_IDS[0])
+    )
+    assert [scan["scanId"] for scan in history.list_scans(connection, args)["scans"]] == [
+        SCAN_IDS[0]
+    ]
+
+
+def test_scan_list_probes_requested_repository_once(
+    workbench_api, indexed_collections, monkeypatch
+):
+    connection, targets = indexed_collections
+    history = workbench_api["scan_history"]
+    probes = []
+    git_output = history.git_output
+
+    def record_git_output(target, *arguments):
+        probes.append((target, arguments))
+        return git_output(target, *arguments)
+
+    monkeypatch.setattr(history, "git_output", record_git_output)
+    result = history.list_scans(connection, query_args(repository=str(targets[0]), limit=1))
+
+    assert [scan["scanId"] for scan in result["scans"]] == [SCAN_IDS[0]]
+    assert [arguments for target, arguments in probes if target == targets[0]] == [
+        ("rev-parse", "--path-format=absolute", "--git-common-dir"),
+        ("remote", "get-url", "origin"),
+    ]

--- a/plugins/codex-security/tests/test_workbench_scan_history.py
+++ b/plugins/codex-security/tests/test_workbench_scan_history.py
@@ -1,18 +1,14 @@
 from __future__ import annotations
 
-import argparse
 import copy
 import json
-import ntpath
 import os
-import runpy
 import shutil
 import sqlite3
 import subprocess
 import sys
 import uuid
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any
 
 from test_workbench_db import HEAD_CHANGED_WARNING, create_saved_workspace
@@ -233,33 +229,6 @@ def insert_scan(
     )
 
 
-def test_scan_list_returns_lightweight_running_first_summaries(tmp_path: Path) -> None:
-    state_dir = tmp_path / "state"
-    first_target = tmp_path / "first-target"
-    second_target = tmp_path / "second-target"
-    first_target.mkdir()
-    second_target.mkdir()
-    first_workspace = create_saved_workspace(state_dir, first_target)
-    first = run_workbench(state_dir, "start-scan", "--workspace-id", str(first_workspace["id"]))
-    run_workbench(state_dir, "cancel-scan", "--scan-id", str(first["results"]["scanId"]))
-    second_workspace = create_saved_workspace(state_dir, second_target)
-    second = run_workbench(state_dir, "start-scan", "--workspace-id", str(second_workspace["id"]))
-
-    scans = run_workbench(state_dir, "list-scans")["scans"]
-
-    assert [scan["scanId"] for scan in scans] == [
-        second["results"]["scanId"],
-        first["results"]["scanId"],
-    ]
-    assert scans[0]["targetPath"] == str(second_target.resolve())
-    assert scans[0]["targetRevision"] == second["results"]["targetRevision"]
-    assert scans[0]["progress"]["status"] == "running"
-    assert scans[0]["progress"]["phase"] == "preflight"
-    assert scans[1]["progress"]["status"] == "canceled"
-    assert "artifacts" not in scans[0]
-    assert "findings" not in scans[0]
-
-
 def test_cli_scan_lifecycle_persists_recipes_lineage_and_filtered_history(tmp_path: Path) -> None:
     state_dir = tmp_path / "state"
     repository = tmp_path / "repository"
@@ -305,38 +274,6 @@ def test_cli_scan_lifecycle_persists_recipes_lineage_and_filtered_history(tmp_pa
     assert any(scan["progress"]["status"] == "failed" for scan in history["scans"])
     assert all(scan["recipeAvailable"] for scan in history["scans"])
     assert len(run_workbench(state_dir, "list-scans", "--repository", str(other))["scans"]) == 1
-
-
-def test_scan_root_filter_matches_windows_path_aliases(tmp_path: Path, monkeypatch: Any) -> None:
-    state_dir = tmp_path / "state"
-    repository = tmp_path / "repository"
-    repository.mkdir()
-    root = tmp_path / "Scan Results"
-    scan = create_cli_scan(state_dir, root, repository, complete=False)
-    create_cli_scan(state_dir, tmp_path / "Scan Results Other", repository, complete=False)
-    namespace = runpy.run_path(str(SCRIPT), run_name="codex_security_workbench_db")
-    scan_history = namespace["scan_history"]
-    monkeypatch.setattr(scan_history, "os", SimpleNamespace(name="nt", path=ntpath, sep="\\"))
-    args = argparse.Namespace(
-        repository=None,
-        scan_root=str(root).upper(),
-        target_id=None,
-        mode=None,
-        status=None,
-        query=None,
-        limit=None,
-        offset=0,
-    )
-    with sqlite3.connect(state_dir / "workbench.sqlite3") as connection:
-        connection.row_factory = sqlite3.Row
-        result = scan_history.list_scans(connection, args)
-        assert [row["scanId"] for row in result["scans"]] == [scan["scanId"]]
-        connection.execute(
-            "UPDATE scans SET scan_dir = ? WHERE id = ?",
-            (ntpath.normpath(str(root)), scan["scanId"]),
-        )
-        result = scan_history.list_scans(connection, args)
-        assert [row["scanId"] for row in result["scans"]] == [scan["scanId"]]
 
 
 def test_cli_scan_persists_its_continuation_thread(tmp_path: Path) -> None:
@@ -722,48 +659,6 @@ def test_scan_list_includes_related_git_worktrees_and_clones(tmp_path: Path) -> 
     assert [scan["scanId"] for scan in scoped] == [worktree_scan["scanId"]]
     other = run_workbench(state_dir, "list-scans", "--repository", str(unrelated))["scans"]
     assert [scan["scanId"] for scan in other] == [unrelated_scan["scanId"]]
-
-
-def test_scan_list_probes_requested_repository_once(tmp_path: Path, monkeypatch: Any) -> None:
-    state_dir = tmp_path / "state"
-    repository = tmp_path / "repository"
-    unrelated = tmp_path / "unrelated"
-    initialize_git_repository(repository)
-    initialize_git_repository(unrelated)
-    root = tmp_path / "results"
-    scan = create_cli_scan(state_dir, root, repository, complete=False)
-    for _ in range(3):
-        create_cli_scan(state_dir, root, unrelated, complete=False)
-
-    namespace = runpy.run_path(str(SCRIPT), run_name="codex_security_workbench_db")
-    scan_history = namespace["scan_history"]
-    args = argparse.Namespace(
-        repository=str(repository),
-        scan_root=None,
-        target_id=None,
-        mode=None,
-        status=None,
-        query=None,
-        limit=1,
-        offset=0,
-    )
-    probes: list[tuple[Path, tuple[str, ...]]] = []
-    original_git_output = scan_history.git_output
-
-    def record_git_output(target: Path, *arguments: str) -> str | None:
-        probes.append((target, arguments))
-        return original_git_output(target, *arguments)
-
-    monkeypatch.setattr(scan_history, "git_output", record_git_output)
-    with sqlite3.connect(state_dir / "workbench.sqlite3") as connection:
-        connection.row_factory = sqlite3.Row
-        result = scan_history.list_scans(connection, args)
-
-    assert [row["scanId"] for row in result["scans"]] == [scan["scanId"]]
-    assert [arguments for target, arguments in probes if target == repository] == [
-        ("rev-parse", "--path-format=absolute", "--git-common-dir"),
-        ("remote", "get-url", "origin"),
-    ]
 
 
 def test_cli_scan_comparison_tracks_stable_findings_without_copying_triage(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Three scan-history query tests repeatedly started Python and created scan lifecycles even though their assertions concern query results. Run those cases against the existing real SQLite fixture and Python API instead.

## Changes

- Move ordering/projection, Windows scan-root matching, and repository-probe-count cases into the existing native-index query suite.
- Reuse the isolated database and indexed collection fixtures; remove duplicate setup and per-test module loading.
- Preserve the real CLI lifecycle, scan registration, Git worktree/clone, completion, and recovery tests.

## Testing

- Full Python source-contract suite with four pytest-xdist workers: 1,067 passed, 5 skipped, 104 subtests passed.
- Focused native-index query suite: 7 passed.
- Ruff 0.16.1 lint and formatting checks passed across the Python source and tests.
- Three alternating local runs of the moved cases: median process elapsed time decreased from 4.52 seconds to 0.34 seconds. This is a local comparison, not an overall CI speedup claim.

## Risk and rollout

Only tests change. The query cases still exercise the production query implementation and real SQLite. Process, filesystem, and CLI integration coverage stays in the existing lifecycle suites. No runtime configuration or release behavior changes.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
