### PR TITLE
test: make delivered scan fixtures explicit

### DIFF
--- a/plugins/codex-security/tests/test_windows_report_e2e.py
+++ b/plugins/codex-security/tests/test_windows_report_e2e.py
@@ -13,6 +13,7 @@ from workbench_test_support import (
     SCRIPT,
     create_saved_workspace,
     run_workbench,
+    start_delivered_scan,
     write_completed_contract,
 )
 
@@ -31,9 +32,8 @@ def test_workbench_completion_and_exports_use_windows_file_backend(tmp_path: Pat
     source.parent.mkdir()
     source.write_text("".join(f"line {line}\n" for line in range(1, 46)))
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -43,9 +43,6 @@ def test_workbench_completion_and_exports_use_windows_file_backend(tmp_path: Pat
     scan_dir = Path(str(started["results"]["scanDir"]))
     write_completed_contract(scan_dir, scan_id, target)
     (scan_dir / "report.html").write_text("stale report")
-    with sqlite3.connect(state_dir / "workbench.sqlite3") as connection:
-        connection.execute("UPDATE scans SET handoff_status = 'delivered' WHERE id = ?", (scan_id,))
-
     namespace = runpy.run_path(str(SCRIPT), run_name="codex_security_workbench_db")
     finalizer = sys.modules[namespace["finalize_scan"].__module__]
     backend = mock.Mock()

--- a/plugins/codex-security/tests/test_workbench_cancellation.py
+++ b/plugins/codex-security/tests/test_workbench_cancellation.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import uuid
 from pathlib import Path
 
-from workbench_test_support import create_saved_workspace, run_workbench, write_completed_contract
+from workbench_test_support import (
+    create_saved_workspace,
+    run_workbench,
+    start_delivered_scan,
+    write_completed_contract,
+)
 
 
 def test_workbench_records_scan_failure(tmp_path: Path) -> None:
@@ -112,7 +117,7 @@ def test_workbench_cancels_running_scan_and_rejects_late_updates(tmp_path: Path)
     assert delivered["results"]["progress"]["status"] == "canceled"
     assert delivered["results"]["handoffStatus"] == "delivered"
 
-    restarted = run_workbench(state_dir, "start-scan", "--workspace-id", str(saved["id"]))
+    restarted = start_delivered_scan(state_dir, "--workspace-id", str(saved["id"]))
     restarted_scan_id = str(restarted["results"]["scanId"])
     assert restarted_scan_id != scan_id
     assert restarted["results"]["progress"]["status"] == "running"

--- a/plugins/codex-security/tests/test_workbench_completion_binding.py
+++ b/plugins/codex-security/tests/test_workbench_completion_binding.py
@@ -16,6 +16,7 @@ from workbench_test_support import (
     run_workbench,
     source_plugin_version,
     stable_target_id,
+    start_delivered_scan,
     write_completed_contract,
 )
 
@@ -25,9 +26,8 @@ def _start_scan_with_draft_findings(tmp_path: Path) -> tuple[Path, str, Path]:
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -46,9 +46,8 @@ def _start_deep_scan_with_draft_findings(tmp_path: Path) -> tuple[Path, str, Pat
     saved = create_saved_workspace(
         state_dir, target, thread_id="thread-completion-binding", mode="deep"
     )
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -263,9 +262,8 @@ def test_completion_populates_coverage_mode_from_selected_scan_mode(tmp_path: Pa
             "--mode",
             mode,
         )
-        started = run_workbench(
+        started = start_delivered_scan(
             state_dir,
-            "start-scan",
             "--workspace-id",
             workspace_id,
             "--scan-root",
@@ -314,9 +312,8 @@ def test_completion_populates_workbench_owned_unsealed_envelope(tmp_path: Path) 
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",

--- a/plugins/codex-security/tests/test_workbench_db.py
+++ b/plugins/codex-security/tests/test_workbench_db.py
@@ -20,6 +20,7 @@ from workbench_test_support import (
     initialize_git_repository,
     run_workbench,
     stable_target_id,
+    start_delivered_scan,
     write_completed_contract,
 )
 
@@ -586,9 +587,8 @@ def test_completion_normalizes_unsealed_deep_inventory_strategy_alias(
         "--mode",
         "deep",
     )
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         workspace_id,
         "--scan-root",
@@ -640,9 +640,8 @@ def test_completion_warns_after_plain_directory_changes(tmp_path: Path) -> None:
     source = target / "app.py"
     source.write_text("version = 1\n")
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -673,9 +672,8 @@ def test_completion_warns_when_scanned_directory_becomes_unavailable(tmp_path: P
     target.mkdir()
     (target / "app.py").write_text("version = 1\n")
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -721,9 +719,8 @@ def test_workbench_serializes_concurrent_scan_completion(tmp_path: Path) -> None
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -763,9 +760,8 @@ def test_workbench_persists_scan_model_and_updates_it_from_progress(tmp_path: Pa
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--model",
@@ -1006,9 +1002,8 @@ def test_completed_findings_are_summarized_and_sorted_by_severity(tmp_path: Path
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -1073,9 +1068,8 @@ def test_completed_finding_triage_and_remediation_persist(
     source = target / "source.txt"
     source.write_bytes(f"vulnerable{line_ending}".encode())
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -1651,9 +1645,8 @@ def test_completed_scan_disables_remediation_after_checkout_revision_changes(
     target = tmp_path / "target"
     revision = initialize_git_repository(target)
     saved = create_saved_git_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -1698,9 +1691,8 @@ def assert_completed_scan_disables_remediation_after_checkout_path_is_replaced(
     target.mkdir()
     (target / "source.txt").write_text("vulnerable\n")
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -1767,9 +1759,8 @@ def test_finding_management_rejects_invalid_state_transitions(tmp_path: Path) ->
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -1990,9 +1981,8 @@ def test_finding_remediation_rejects_apply_after_checkout_changes(tmp_path: Path
         "--mode",
         "standard",
     )
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         workspace_id,
         "--scan-root",
@@ -2166,9 +2156,8 @@ def test_finding_remediation_rejects_delayed_update_after_superseding_patch(tmp_
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -2254,9 +2243,8 @@ def test_finding_remediation_rejects_unversioned_directory_changes(tmp_path: Pat
     source = target / "source.txt"
     source.write_text("original\n")
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -2788,7 +2776,7 @@ def test_workbench_replaces_context_only_for_running_owned_scan(tmp_path: Path) 
     target = tmp_path / "target"
     target.mkdir()
     workspace = create_saved_workspace(state_dir, target)
-    started = run_workbench(state_dir, "start-scan", "--workspace-id", str(workspace["id"]))
+    started = start_delivered_scan(state_dir, "--workspace-id", str(workspace["id"]))
     scan_id = str(started["results"]["scanId"])
 
     updated = run_workbench(
@@ -3072,9 +3060,8 @@ def test_workbench_warns_after_working_tree_changes(tmp_path: Path) -> None:
         "--diff-base-revision",
         revision,
     )
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         workspace_id,
         "--scan-root",
@@ -3139,9 +3126,8 @@ def test_workbench_warns_after_working_tree_head_changes(
         "--diff-base-revision",
         revision,
     )
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         workspace_id,
         "--scan-root",
@@ -3210,9 +3196,8 @@ def test_workbench_can_validate_legacy_nested_working_tree_scan(tmp_path: Path) 
         "--diff-base-revision",
         revision,
     )
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         workspace_id,
         "--scan-root",
@@ -3278,9 +3263,8 @@ def test_workbench_populates_manifest_with_working_tree_digest(tmp_path: Path) -
         "--diff-content-digest",
         str(diff_target["contentDigest"]),
     )
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         workspace_id,
         "--scan-root",
@@ -3375,9 +3359,8 @@ def test_workbench_populates_completed_manifest_with_exact_diff_target(tmp_path:
         revision,
     )
     diff_target = saved["diffTarget"]
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         workspace_id,
         "--scan-root",
@@ -3808,7 +3791,7 @@ def test_workbench_rejects_progress_completed_above_total(tmp_path: Path) -> Non
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(state_dir, "start-scan", "--workspace-id", str(saved["id"]))
+    started = start_delivered_scan(state_dir, "--workspace-id", str(saved["id"]))
     failed = run_workbench(
         state_dir,
         "update-progress",
@@ -3829,7 +3812,7 @@ def test_workbench_rejects_regressive_progress(tmp_path: Path) -> None:
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(state_dir, "start-scan", "--workspace-id", str(saved["id"]))
+    started = start_delivered_scan(state_dir, "--workspace-id", str(saved["id"]))
     scan_id = str(started["results"]["scanId"])
     run_workbench(
         state_dir,
@@ -3896,7 +3879,7 @@ def test_workbench_tracks_review_pass_for_deep_scan_only(tmp_path: Path) -> None
         "--mode",
         "deep",
     )
-    started = run_workbench(state_dir, "start-scan", "--workspace-id", str(saved["id"]))
+    started = start_delivered_scan(state_dir, "--workspace-id", str(saved["id"]))
     scan_id = str(started["results"]["scanId"])
     assert started["results"]["progress"]["reviewPass"] is None
 
@@ -3932,9 +3915,8 @@ def test_workbench_tracks_review_pass_for_deep_scan_only(tmp_path: Path) -> None
     standard_target = tmp_path / "standard-target"
     standard_target.mkdir()
     standard = create_saved_workspace(state_dir, standard_target)
-    standard_scan = run_workbench(
+    standard_scan = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(standard["id"]),
     )
@@ -3956,7 +3938,7 @@ def test_workbench_updates_progress_timestamp_for_phase_and_failure(tmp_path: Pa
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(state_dir, "start-scan", "--workspace-id", str(saved["id"]))
+    started = start_delivered_scan(state_dir, "--workspace-id", str(saved["id"]))
     scan_id = str(started["results"]["scanId"])
     started_at = str(started["results"]["progress"]["updatedAt"])
     time.sleep(0.001)
@@ -3980,7 +3962,7 @@ def test_workbench_preserves_scan_when_git_revision_cannot_be_rechecked(tmp_path
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(state_dir, "start-scan", "--workspace-id", str(saved["id"]))
+    started = start_delivered_scan(state_dir, "--workspace-id", str(saved["id"]))
     scan_id = str(started["results"]["scanId"])
     with sqlite3.connect(state_dir / "workbench.sqlite3") as connection:
         connection.execute("UPDATE scans SET target_revision = 'deadbeef' WHERE id = ?", (scan_id,))
@@ -4005,7 +3987,7 @@ def test_completed_finding_projects_writeup_and_poc_artifact_paths(tmp_path: Pat
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(state_dir, "start-scan", "--workspace-id", str(saved["id"]))
+    started = start_delivered_scan(state_dir, "--workspace-id", str(saved["id"]))
     scan_id = str(started["results"]["scanId"])
     scan_dir = Path(str(started["results"]["scanDir"]))
     write_completed_contract(scan_dir, scan_id, target)
@@ -4063,7 +4045,7 @@ def test_workbench_populates_clean_git_scan_revision_with_large_source_excerpt(
         text=True,
     ).stdout.strip()
     saved = create_saved_git_workspace(state_dir, target)
-    started = run_workbench(state_dir, "start-scan", "--workspace-id", str(saved["id"]))
+    started = start_delivered_scan(state_dir, "--workspace-id", str(saved["id"]))
     scan_id = str(started["results"]["scanId"])
     assert started["results"]["contract"]["target"]["allowedKinds"] == ["git_revision"]
     assert "requiredSnapshotDigest" not in started["results"]["contract"]["target"]
@@ -4101,7 +4083,7 @@ def test_workbench_preserves_in_flight_git_scan_during_migration_normalization(
     target = tmp_path / "target"
     revision = initialize_git_repository(target)
     saved = create_saved_git_workspace(state_dir, target)
-    started = run_workbench(state_dir, "start-scan", "--workspace-id", str(saved["id"]))
+    started = start_delivered_scan(state_dir, "--workspace-id", str(saved["id"]))
     scan_id = str(started["results"]["scanId"])
     allowed_kinds = started["results"]["contract"]["target"]["allowedKinds"]
     database = state_dir / "workbench.sqlite3"
@@ -4140,7 +4122,7 @@ def test_workbench_preserves_dirty_git_scan_after_worktree_changes(tmp_path: Pat
     dirty_content = "fixture\nlocal change\n"
     (target / "README.md").write_text(dirty_content)
     saved = create_saved_git_workspace(state_dir, target)
-    started = run_workbench(state_dir, "start-scan", "--workspace-id", str(saved["id"]))
+    started = start_delivered_scan(state_dir, "--workspace-id", str(saved["id"]))
     scan_id = str(started["results"]["scanId"])
     contract = started["results"]["contract"]["target"]
     assert contract["allowedKinds"] == ["git_worktree"]
@@ -4166,7 +4148,7 @@ def test_workbench_preserves_dirty_git_scan_after_worktree_changes(tmp_path: Pat
         == "running"
     )
 
-    started = run_workbench(state_dir, "start-scan", "--workspace-id", str(saved["id"]))
+    started = start_delivered_scan(state_dir, "--workspace-id", str(saved["id"]))
     scan_id = str(started["results"]["scanId"])
     snapshot_digest = str(started["results"]["contract"]["target"]["requiredSnapshotDigest"])
 
@@ -4194,7 +4176,7 @@ def test_workbench_generates_reports_during_completion(tmp_path: Path) -> None:
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(state_dir, "start-scan", "--workspace-id", str(saved["id"]))
+    started = start_delivered_scan(state_dir, "--workspace-id", str(saved["id"]))
     scan_id = str(started["results"]["scanId"])
     scan_dir = Path(str(started["results"]["scanDir"]))
     write_completed_contract(scan_dir, scan_id, target)
@@ -4216,7 +4198,7 @@ def test_workbench_omits_unsafe_symlink_source_path_without_hiding_finding(tmp_p
     outside.mkdir()
     (target / "src").symlink_to(outside, target_is_directory=True)
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(state_dir, "start-scan", "--workspace-id", str(saved["id"]))
+    started = start_delivered_scan(state_dir, "--workspace-id", str(saved["id"]))
     scan_id = str(started["results"]["scanId"])
     write_completed_contract(Path(str(started["results"]["scanDir"])), scan_id, target)
     completed = run_workbench(state_dir, "complete-scan", "--scan-id", scan_id)
@@ -4230,7 +4212,7 @@ def test_workbench_hides_missing_artifact_on_reopen(tmp_path: Path) -> None:
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(state_dir, "start-scan", "--workspace-id", str(saved["id"]))
+    started = start_delivered_scan(state_dir, "--workspace-id", str(saved["id"]))
     scan_id = str(started["results"]["scanId"])
     scan_dir = Path(str(started["results"]["scanDir"]))
     write_completed_contract(scan_dir, scan_id, target)

--- a/plugins/codex-security/tests/test_workbench_db_exports.py
+++ b/plugins/codex-security/tests/test_workbench_db_exports.py
@@ -18,6 +18,7 @@ from workbench_test_support import (
     initialize_git_repository,
     mark_deep_coordinator_succeeded,
     run_workbench,
+    start_delivered_scan,
     write_checkpoint,
     write_completed_contract,
 )
@@ -29,9 +30,8 @@ def test_stopped_scan_keeps_saved_findings_and_exports(tmp_path: Path, terminati
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -92,9 +92,8 @@ def test_late_parent_draft_is_retained_without_mutating_frozen_stopped_seal(
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -202,9 +201,8 @@ def test_stopped_clean_git_checkpoint_uses_revision_target(tmp_path: Path) -> No
     target = tmp_path / "target"
     revision = initialize_git_repository(target)
     saved = create_saved_git_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -246,9 +244,8 @@ def test_stopped_diff_checkpoint_uses_canonical_snapshot_digest(
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -301,9 +298,8 @@ def test_frozen_stopped_results_ignore_late_index_field_changes(tmp_path: Path) 
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -387,9 +383,8 @@ def test_frozen_stopped_results_skip_late_checkpoint_reindexing(tmp_path: Path) 
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -468,9 +463,8 @@ def test_frozen_stopped_results_ignore_late_foreign_checkpoint_warning(tmp_path:
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -506,9 +500,8 @@ def test_final_candidate_disposition_supersedes_pending_checkpoint(
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -557,9 +550,8 @@ def test_incomplete_parent_checkpoint_cannot_complete_scan(tmp_path: Path) -> No
     state_dir, target = tmp_path / "state", tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -587,9 +579,8 @@ def test_completed_findings_export_inside_scan_directory(tmp_path: Path) -> None
     source.parent.mkdir()
     source.write_text("".join(f"line {line}\n" for line in range(1, 46)))
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -744,9 +735,8 @@ def test_deep_csv_export_adds_only_candidate_id_column(
         "--mode",
         "deep",
     )
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         workspace_id,
         "--scan-root",
@@ -819,9 +809,8 @@ def test_csv_export_escapes_newline_and_full_width_formula_prefixes(tmp_path: Pa
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -860,9 +849,8 @@ def test_completed_findings_are_returned_in_bounded_pages(tmp_path: Path) -> Non
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -988,9 +976,8 @@ def test_embedded_and_paged_findings_normalize_scalar_attack_path_assessments(
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -1112,9 +1099,8 @@ def test_primary_location_prefers_root_control_in_bounded_and_csv_results(
         (target / f"support-{index}.py").write_text("support\n")
     (target / "root.py").write_text("vulnerable\n")
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -1158,9 +1144,8 @@ def test_csv_export_rejects_symlinked_exports_directory(tmp_path: Path) -> None:
     target.mkdir()
     outside.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -1193,9 +1178,8 @@ def test_export_rejects_replaced_scan_directory(tmp_path: Path) -> None:
     target.mkdir()
     outside.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -1226,9 +1210,8 @@ def test_csv_export_rejects_replaced_scan_directory_ancestor(tmp_path: Path) -> 
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -1263,9 +1246,8 @@ def test_completion_rejects_replaced_scan_directory(tmp_path: Path) -> None:
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -1287,9 +1269,8 @@ def test_completion_rejects_replaced_scan_directory_ancestor(tmp_path: Path) -> 
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",
@@ -1315,9 +1296,8 @@ def test_remediation_apply_rejects_replaced_scan_directory_ancestor(tmp_path: Pa
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",

--- a/plugins/codex-security/tests/test_workbench_deep_scan.py
+++ b/plugins/codex-security/tests/test_workbench_deep_scan.py
@@ -18,6 +18,7 @@ from workbench_test_support import (
     mark_deep_coordinator_succeeded,
     run_workbench,
     stable_target_id,
+    start_delivered_scan,
     write_completed_contract,
 )
 
@@ -2163,9 +2164,8 @@ def test_target_continuation_does_not_reuse_another_threads_app_scan(
         "deep",
         environment=deep_environment(codex_home),
     )
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         workspace_id,
         "--scan-root",

--- a/plugins/codex-security/tests/test_workbench_feedback.py
+++ b/plugins/codex-security/tests/test_workbench_feedback.py
@@ -11,6 +11,7 @@ from workbench_test_support import (
     create_saved_workspace,
     run_workbench,
     stable_target_id,
+    start_delivered_scan,
     write_completed_contract,
 )
 
@@ -23,9 +24,8 @@ def _create_workspace(state_dir: Path, target: Path) -> str:
 
 
 def _start_scan(state_dir: Path, workspace_id: str, scan_root: Path) -> dict[str, Any]:
-    return run_workbench(
+    return start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         workspace_id,
         "--scan-root",

--- a/plugins/codex-security/tests/test_workbench_handoff.py
+++ b/plugins/codex-security/tests/test_workbench_handoff.py
@@ -600,7 +600,10 @@ def test_released_pending_handoff_rejects_tokenless_mutations(
         scan_id,
         *arguments,
         check=False,
-        deliver_unclaimed_scan_before_mutation=False,
     )
 
     assert "owned by another continuation" in str(rejected["stderr"])
+    assert (
+        run_workbench(state_dir, "get-scan", "--scan-id", scan_id)["scan"]["handoffStatus"]
+        == "pending"
+    )

--- a/plugins/codex-security/tests/test_workbench_native_indexes.py
+++ b/plugins/codex-security/tests/test_workbench_native_indexes.py
@@ -9,6 +9,7 @@ from workbench_test_support import (
     create_saved_workspace,
     run_workbench,
     stable_target_id,
+    start_delivered_scan,
     write_completed_contract,
 )
 
@@ -37,7 +38,7 @@ def complete_scan(
             "--mode",
             "standard",
         )
-    started = run_workbench(state_dir, "start-scan", "--workspace-id", str(workspace["id"]))
+    started = start_delivered_scan(state_dir, "--workspace-id", str(workspace["id"]))
     scan_id = str(started["results"]["scanId"])
     scan_dir = Path(str(started["results"]["scanDir"]))
     write_completed_contract(
@@ -258,9 +259,7 @@ def test_repository_index_reports_latest_scan_open_findings_and_missing_checkout
         "Fixture close decision.",
     )
     running_workspace = create_saved_workspace(state_dir, first_target)
-    older_running = run_workbench(
-        state_dir, "start-scan", "--workspace-id", str(running_workspace["id"])
-    )
+    older_running = start_delivered_scan(state_dir, "--workspace-id", str(running_workspace["id"]))
     complete_scan(state_dir, first_target, identity_anchor="first-finding")
     distinct_first = complete_scan(
         state_dir,

--- a/plugins/codex-security/tests/test_workbench_progress.py
+++ b/plugins/codex-security/tests/test_workbench_progress.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from workbench_test_support import create_saved_workspace, run_workbench
+from workbench_test_support import create_saved_workspace, run_workbench, start_delivered_scan
 
 
 def test_validation_clears_discovery_finding_count(tmp_path: Path) -> None:
@@ -9,7 +9,7 @@ def test_validation_clears_discovery_finding_count(tmp_path: Path) -> None:
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(state_dir, "start-scan", "--workspace-id", str(saved["id"]))
+    started = start_delivered_scan(state_dir, "--workspace-id", str(saved["id"]))
     scan_id = str(started["results"]["scanId"])
 
     discovery = run_workbench(
@@ -40,7 +40,7 @@ def test_phase_progress_tracks_and_resets_phase_specific_receipts(tmp_path: Path
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(state_dir, "start-scan", "--workspace-id", str(saved["id"]))
+    started = start_delivered_scan(state_dir, "--workspace-id", str(saved["id"]))
     scan_id = str(started["results"]["scanId"])
 
     discovery = run_workbench(
@@ -101,7 +101,7 @@ def test_phase_progress_rejects_regression_within_one_phase(tmp_path: Path) -> N
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(state_dir, "start-scan", "--workspace-id", str(saved["id"]))
+    started = start_delivered_scan(state_dir, "--workspace-id", str(saved["id"]))
     scan_id = str(started["results"]["scanId"])
     run_workbench(
         state_dir,
@@ -134,7 +134,7 @@ def test_preflight_issues_replace_and_remain_visible_after_preflight(tmp_path: P
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(state_dir, "start-scan", "--workspace-id", str(saved["id"]))
+    started = start_delivered_scan(state_dir, "--workspace-id", str(saved["id"]))
     scan_id = str(started["results"]["scanId"])
     blocked_issue = {
         "capability": "usable_worker_slots_6",
@@ -221,7 +221,7 @@ def test_preflight_unknown_check_completes_only_after_clean_rerun(tmp_path: Path
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(state_dir, "start-scan", "--workspace-id", str(saved["id"]))
+    started = start_delivered_scan(state_dir, "--workspace-id", str(saved["id"]))
     scan_id = str(started["results"]["scanId"])
     unknown_issue = {
         "capability": "delegated_workers",
@@ -276,7 +276,7 @@ def test_preflight_issues_reject_non_displayable_severity(tmp_path: Path) -> Non
     target = tmp_path / "target"
     target.mkdir()
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(state_dir, "start-scan", "--workspace-id", str(saved["id"]))
+    started = start_delivered_scan(state_dir, "--workspace-id", str(saved["id"]))
     rejected = run_workbench(
         state_dir,
         "update-progress",

--- a/plugins/codex-security/tests/test_workbench_remediation_cancellation.py
+++ b/plugins/codex-security/tests/test_workbench_remediation_cancellation.py
@@ -5,7 +5,12 @@ import subprocess
 import uuid
 from pathlib import Path
 
-from workbench_test_support import create_saved_workspace, run_workbench, write_completed_contract
+from workbench_test_support import (
+    create_saved_workspace,
+    run_workbench,
+    start_delivered_scan,
+    write_completed_contract,
+)
 
 
 def test_cancel_finding_remediation_request_restores_previous_state(tmp_path: Path) -> None:
@@ -15,9 +20,8 @@ def test_cancel_finding_remediation_request_restores_previous_state(tmp_path: Pa
     source = target / "source.txt"
     source.write_text("vulnerable\n")
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",

--- a/plugins/codex-security/tests/test_workbench_remediation_retry.py
+++ b/plugins/codex-security/tests/test_workbench_remediation_retry.py
@@ -7,7 +7,12 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-from workbench_test_support import create_saved_workspace, run_workbench, write_completed_contract
+from workbench_test_support import (
+    create_saved_workspace,
+    run_workbench,
+    start_delivered_scan,
+    write_completed_contract,
+)
 
 
 def update_remediation(
@@ -44,9 +49,8 @@ def test_failed_remediation_steps_can_retry_or_regenerate(tmp_path: Path) -> Non
     source = target / "source.txt"
     source.write_text("vulnerable\n")
     saved = create_saved_workspace(state_dir, target)
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(saved["id"]),
         "--scan-root",

--- a/plugins/codex-security/tests/test_workbench_scan_usage.py
+++ b/plugins/codex-security/tests/test_workbench_scan_usage.py
@@ -17,6 +17,7 @@ from workbench_test_support import (
     initialize_git_repository,
     mark_deep_coordinator_succeeded,
     run_workbench,
+    start_delivered_scan,
     write_completed_contract,
 )
 
@@ -80,9 +81,8 @@ def _start_scan(tmp_path: Path, *, mode: str = "standard") -> ScanFixture:
         workspace = create_saved_workspace(state_dir, target, thread_id="scan-parent")
         workspace_id = str(workspace["id"])
 
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         workspace_id,
         "--scan-root",

--- a/plugins/codex-security/tests/test_workbench_setup_and_migrations.py
+++ b/plugins/codex-security/tests/test_workbench_setup_and_migrations.py
@@ -22,6 +22,7 @@ from workbench_test_support import (
     create_saved_workspace,
     initialize_git_repository,
     run_workbench,
+    start_delivered_scan,
     write_completed_contract,
 )
 
@@ -356,9 +357,8 @@ def test_nested_target_name_is_a_literal_git_pathspec(tmp_path: Path) -> None:
         "--mode",
         "standard",
     )
-    started = run_workbench(
+    started = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         workspace_id,
         "--scan-root",
@@ -1830,9 +1830,8 @@ def test_workbench_reconciles_legacy_execution_profile_migrations(
         assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
 
     current_workspace = create_saved_workspace(state_dir, target)
-    current_scan = run_workbench(
+    current_scan = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(current_workspace["id"]),
         "--scan-root",
@@ -2498,9 +2497,8 @@ def test_workbench_upgrades_legacy_execution_profile_migrations(
         assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
 
     current_workspace = create_saved_workspace(state_dir, target)
-    current_scan = run_workbench(
+    current_scan = start_delivered_scan(
         state_dir,
-        "start-scan",
         "--workspace-id",
         str(current_workspace["id"]),
         "--scan-root",

--- a/plugins/codex-security/tests/workbench_test_support.py
+++ b/plugins/codex-security/tests/workbench_test_support.py
@@ -86,28 +86,7 @@ def run_workbench(
     check: bool = True,
     environment: dict[str, str] | None = None,
     input_text: str | None = None,
-    deliver_unclaimed_scan_before_mutation: bool = True,
 ) -> dict[str, object]:
-    state_database = state_dir / "workbench.sqlite3"
-    # Lifecycle tests that omit a capability model a delivered, non-handoff scan.
-    if (
-        deliver_unclaimed_scan_before_mutation
-        and args[0] in {"begin-deep-scan", "update-progress", "complete-scan", "fail-scan"}
-        and "--scan-id" in args
-        and "--claim-token" not in args
-        and state_database.exists()
-    ):
-        scan_id = args[args.index("--scan-id") + 1]
-        with sqlite3.connect(state_database) as connection:
-            connection.execute(
-                """
-                UPDATE scans
-                SET handoff_status = 'delivered'
-                WHERE id = ? AND status = 'running' AND handoff_status = 'pending'
-                    AND handoff_claim_token IS NULL AND continuation_thread_id IS NULL
-                """,
-                (scan_id,),
-            )
     completed = subprocess.run(
         [sys.executable, str(SCRIPT), *args],
         check=check,
@@ -123,6 +102,22 @@ def run_workbench(
     if not check:
         return {"returncode": completed.returncode, "stderr": completed.stderr}
     return json.loads(completed.stdout)
+
+
+def start_delivered_scan(
+    state_dir: Path,
+    *args: str,
+    environment: dict[str, str] | None = None,
+) -> dict[str, object]:
+    """Prepare an unclaimed, delivered scan for tests outside handoff ownership."""
+    started = run_workbench(state_dir, "start-scan", *args, environment=environment)
+    scan = started["results"]
+    with sqlite3.connect(state_dir / "workbench.sqlite3") as connection:
+        connection.execute(
+            "UPDATE scans SET handoff_status = 'delivered' WHERE id = ?", (scan["scanId"],)
+        )
+    scan["handoffStatus"] = "delivered"
+    return started
 
 
 def initialize_git_repository(target: Path) -> str:


### PR DESCRIPTION
## Summary

The workbench test command helper silently marked pending scans as delivered before certain mutations. That fixture repair could hide failures in the handoff ownership rules. Make the setup explicit so test commands exercise the state the test actually created.

## Changes

- Keep `run_workbench` as a plain command invocation with no database changes.
- Add `start_delivered_scan` for lifecycle tests that intentionally model an unclaimed, delivered scan, and move those tests to it.
- Keep handoff and claim tests on the real start path. Assert that rejected tokenless mutations leave the pending handoff unchanged.
- Remove the helper opt-out and a now-redundant manual database update.

## Testing

- Full Python suite: 1,067 passed, 5 skipped, and 104 subtests passed.
- Focused handoff, progress, completion, Windows backend, and cancellation tests passed.
- Ruff lint and format checks passed for the plugin and compatibility scripts.
- Checked that the mechanical call-site changes leave the rest of each test unchanged.

## Risk and rollout

Test-only change; no production behavior, database schema, or ownership policy changes. Tests that require a delivered scan now declare that fixture at creation. Handoff tests continue to use production transitions.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
