### PR TITLE
ci: run static checks independently of package builds

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -120,6 +120,38 @@ jobs:
             pnpm --dir sdk/typescript exec prettier --check "${files[@]}"
           fi
 
+  static-checks:
+    name: typecheck and formatting
+    needs: validate-title
+    if: needs.validate-title.outputs.ci-mode == 'full'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          package_json_file: sdk/typescript/package.json
+          cache: true
+          cache_dependency_path: |
+            sdk/typescript/pnpm-lock.yaml
+            plugins/codex-security/mcp-app/pnpm-lock.yaml
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: "22.13.0"
+      - name: Install dependencies
+        run: |
+          pnpm --dir sdk/typescript install --frozen-lockfile
+          pnpm --dir plugins/codex-security/mcp-app install --frozen-lockfile
+      - name: Typecheck
+        run: pnpm --dir sdk/typescript run types
+      - name: Check formatting
+        run: pnpm --dir sdk/typescript run format
+
   package:
     name: build and check package
     needs: validate-title
@@ -152,10 +184,6 @@ jobs:
       - name: Audit production dependencies
         continue-on-error: true
         run: pnpm --dir sdk/typescript run audit:prod
-      - name: Typecheck
-        run: pnpm --dir sdk/typescript run types
-      - name: Check formatting
-        run: pnpm --dir sdk/typescript run format
       - name: Pack
         working-directory: sdk/typescript
         run: pnpm pack --pack-destination ../../dist
@@ -373,7 +401,16 @@ jobs:
 
   required-test:
     name: ${{ matrix.os }} / node-22
-    needs: [validate-title, package, test, compatibility, mcp, plugin-source]
+    needs:
+      [
+        validate-title,
+        static-checks,
+        package,
+        test,
+        compatibility,
+        mcp,
+        plugin-source,
+      ]
     if: always()
     runs-on: ubuntu-latest
     strategy:
@@ -382,7 +419,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Require every Unix coverage job
-        if: needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && (needs.package.result != 'success' || needs.test.result != 'success' || needs.compatibility.result != 'success' || needs.mcp.result != 'success' || needs.plugin-source.result != 'success')) || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown')
+        if: needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && (needs.static-checks.result != 'success' || needs.package.result != 'success' || needs.test.result != 'success' || needs.compatibility.result != 'success' || needs.mcp.result != 'success' || needs.plugin-source.result != 'success')) || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown')
         run: exit 1
 
   windows-test:
@@ -490,12 +527,12 @@ jobs:
     name: windows-latest / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }}
     runs-on: ubuntu-latest
     if: always()
-    needs: [validate-title, windows-test, windows-verify]
+    needs: [validate-title, static-checks, windows-test, windows-verify]
     strategy:
       fail-fast: false
       matrix:
         node: ["22.13.0", "24"]
     steps:
       - name: Require every Windows coverage job
-        if: needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && (needs.windows-test.result != 'success' || needs.windows-verify.result != 'success')) || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown')
+        if: needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && (needs.static-checks.result != 'success' || needs.windows-test.result != 'success' || needs.windows-verify.result != 'success')) || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown')
         run: exit 1

--- a/sdk/typescript/TESTING.md
+++ b/sdk/typescript/TESTING.md
@@ -88,6 +88,9 @@ workflow run, using the commit SHA in the artifact name. Every supported Node
 runtime still installs and inspects the package, including a strict NodeNext
 TypeScript consumer, the actual CLI, credential locking, dashboard assets, and
 a nested Codex worker. Native plugin-build tests remain in the shared Bun suite.
+Typechecking and formatting run once in an independent required job, so package
+consumers do not wait for those checks. Package compilation and archive
+validation still finish before the test jobs start.
 
 The full Bun suite runs once per OS under Node 22: three file shards on Linux
 and macOS, and seven on Windows. The other Node versions run the installed

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -3887,9 +3887,6 @@ describe("GitHub release workflow safeguards", () => {
       "types: [opened, edited, reopened, synchronize]",
     );
     expect(nodeCiWorkflow).toContain("needs: validate-title");
-    expect(nodeCiWorkflow).toContain(
-      "needs: [validate-title, windows-test, windows-verify]",
-    );
   });
 
   test("keeps required contexts stable across reduced CI", () => {
@@ -3930,6 +3927,7 @@ describe("GitHub release workflow safeguards", () => {
 
     const fullCiCondition = "needs.validate-title.outputs.ci-mode == 'full'";
     for (const job of [
+      "static-checks",
       "package",
       "test",
       "compatibility",
@@ -3961,12 +3959,6 @@ describe("GitHub release workflow safeguards", () => {
     const requiredJobCondition = "always()";
     expect(workflow.jobs["required-test"]?.if).toBe(requiredJobCondition);
     expect(workflow.jobs["windows"]?.if).toBe(requiredJobCondition);
-    expect(workflow.jobs["required-test"]?.steps[0]?.if).toBe(
-      "needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && (needs.package.result != 'success' || needs.test.result != 'success' || needs.compatibility.result != 'success' || needs.mcp.result != 'success' || needs.plugin-source.result != 'success')) || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown')",
-    );
-    expect(workflow.jobs["windows"]?.steps[0]?.if).toBe(
-      "needs.validate-title.result != 'success' || (needs.validate-title.outputs.ci-mode == 'full' && (needs.windows-test.result != 'success' || needs.windows-verify.result != 'success')) || (needs.validate-title.outputs.ci-mode != 'full' && needs.validate-title.outputs.ci-mode != 'markdown')",
-    );
     for (const [ciMode, validation, upstream, gateFailure] of [
       ["full", "success", "success", false],
       ["full", "success", "skipped", true],
@@ -3976,6 +3968,7 @@ describe("GitHub release workflow safeguards", () => {
       ["unknown", "success", "skipped", true],
     ] as const) {
       const values = {
+        "needs.static-checks.result": upstream,
         "needs.plugin-source.result": upstream,
         "needs.package.result": upstream,
         "needs.compatibility.result": upstream,
@@ -3997,19 +3990,21 @@ describe("GitHub release workflow safeguards", () => {
       }
     }
 
-    const dependencies = [
-      "package",
-      "test",
-      "compatibility",
-      "mcp",
-      "plugin-source",
-    ];
-    for (const dependency of dependencies) {
-      for (const result of ["failure", "cancelled", "skipped"]) {
-        expect(
-          evaluateWorkflowCondition(
-            workflow.jobs["required-test"]?.steps[0]?.if ?? "",
-            {
+    for (const [gate, dependencies] of Object.entries({
+      "required-test": [
+        "static-checks",
+        "package",
+        "test",
+        "compatibility",
+        "mcp",
+        "plugin-source",
+      ],
+      windows: ["static-checks", "windows-test", "windows-verify"],
+    })) {
+      for (const dependency of dependencies) {
+        for (const result of ["failure", "cancelled", "skipped"]) {
+          expect(
+            evaluateWorkflowCondition(workflow.jobs[gate]?.steps[0]?.if ?? "", {
               "needs.validate-title.result": "success",
               "needs.validate-title.outputs.ci-mode": "full",
               ...Object.fromEntries(
@@ -4018,13 +4013,13 @@ describe("GitHub release workflow safeguards", () => {
                   job === dependency ? result : "success",
                 ]),
               ),
-            },
-          ),
-          `${dependency}: ${result}`,
-        ).toBe(true);
+            }),
+            `${gate}: ${dependency}/${result}`,
+          ).toBe(true);
+        }
       }
+      expect(workflow.jobs[gate]?.steps[0]?.run).toBe("exit 1");
     }
-    expect(workflow.jobs["required-test"]?.steps[0]?.run).toBe("exit 1");
 
     const renderName = (template: string, values: Record<string, string>) => {
       let name = template;

--- a/sdk/typescript/tests-ts/skeleton.test.ts
+++ b/sdk/typescript/tests-ts/skeleton.test.ts
@@ -22,7 +22,7 @@ interface WorkflowStep {
 
 interface WorkflowJob {
   name?: string;
-  needs?: string[];
+  needs?: string | string[];
   env?: Record<string, unknown>;
   strategy?: { matrix: Record<string, unknown> };
   steps: WorkflowStep[];
@@ -122,6 +122,7 @@ describe("TypeScript package skeleton", () => {
     expect(jobs["required-test"]?.name).toBe("${{ matrix.os }} / node-22");
     expect(jobs["required-test"]?.needs).toEqual([
       "validate-title",
+      "static-checks",
       "package",
       "test",
       "compatibility",
@@ -130,6 +131,7 @@ describe("TypeScript package skeleton", () => {
     ]);
     expect(jobs["windows"]?.needs).toEqual([
       "validate-title",
+      "static-checks",
       "windows-test",
       "windows-verify",
     ]);
@@ -226,18 +228,18 @@ describe("TypeScript package skeleton", () => {
     ).toBe(false);
   });
 
-  test("runs shared static checks once and keeps every diagnostic upload non-blocking", async () => {
+  test("runs static checks independently and keeps diagnostic uploads non-blocking", async () => {
     const { jobs } = await workflow("node-ci.yml");
     const steps = Object.values(jobs).flatMap((job) => job.steps);
-    for (const name of [
-      "Check plugin source boundary",
-      "Typecheck",
-      "Check formatting",
-    ]) {
+    expect(jobs["static-checks"]?.needs).toBe("validate-title");
+    expect(jobs["package"]?.needs).toBe("validate-title");
+    for (const [name, job] of [
+      ["Check plugin source boundary", "package"],
+      ["Typecheck", "static-checks"],
+      ["Check formatting", "static-checks"],
+    ] as const) {
       expect(steps.filter((step) => step.name === name)).toHaveLength(1);
-      expect(jobs["package"]!.steps.some((step) => step.name === name)).toBe(
-        true,
-      );
+      expect(jobs[job]!.steps.some((step) => step.name === name)).toBe(true);
     }
     for (const name of [
       "Upload test reports",


### PR DESCRIPTION
## Summary

Every SDK test and installed-package job waits for the shared package job. Typechecking and formatting do not need to delay that archive, so run them independently while keeping them required.

## Changes

- Move typechecking and formatting into one independent Ubuntu job.
- Keep compilation, plugin source checks, packing, and archive validation in the package job.
- Make the existing Unix and Windows required checks fail when the new job fails, is canceled, or is unexpectedly skipped.
- Preserve reduced Markdown CI and the existing required check names.
- Extend the gate behavior tests and remove redundant assertions of entire condition strings.

## Testing

- Full SDK suite with seed 12345: 2,072 passed, 39 skipped.
- Full randomized SDK suite with seed 4294301641: 2,072 passed, 39 skipped.
- Focused workflow and release tests: 296 passed.
- Typechecking, formatting, and bundled-plugin build passed.

## Risk and rollout

CI-only change with one additional setup/install job. Package consumers still wait for a compiled and inspected archive, and existing required checks enforce the independent static checks. Hosted timing improvements have not yet been measured for this change.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
