### PR TITLE
release: bump Codex Security to 0.1.25

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,43 +1,32 @@
-<!-- release-version: 0.1.24 -->
+<!-- release-version: 0.1.25 -->
 
 ## Highlights
 
-- Start the preview findings service directly with
-  `codex-security serve [--port PORT]`, without Docker or an internal package
-  path. The command reuses the existing service, state, and shutdown behavior;
-  `--port` overrides `PORT`, and port `0` selects a free port. See
-  [running without Docker](https://github.com/openai/codex-security/blob/npm-v0.1.24/sdk/typescript/README.md#running-without-docker).
-- Observe durable Deep Scan progress from the SDK with the optional
-  `onDeepProgress({ completed, active, maximum })` callback. Updates report
-  changed completed and active independent-review counts without blocking the
-  scan. See
-  [SDK scan options](https://github.com/openai/codex-security/blob/npm-v0.1.24/sdk/typescript/README.md#sdk-configuration-and-scan-options).
-- Make stopped-result handling explicit and stable. Read, list, and export
-  operations no longer publish late retained results as a side effect; the app
-  reports when recovery is needed and can recover validated results on request.
-  See
-  [stopped result recovery](https://github.com/openai/codex-security/blob/npm-v0.1.24/plugins/codex-security/references/scan-contract.md#stopped-result-recovery).
-- Include changed PowerShell `.ps1` files in diff-scan inventories and remove a
-  conflicting reporting rule so valid internal attack paths remain eligible for
-  review. Nested Deep Scan workers now also receive an explicitly configured
-  OpenAI provider credential through the plugin's existing environment boundary.
-- Improve Windows reliability by preserving case-insensitive `CODEX_HOME`
-  entries and repository paths from ordinary PowerShell activity, and by
-  retrying credential snapshots when a descendant file disappears during ACL
-  inspection. Existing path-safety and permission failures remain fatal.
+- Include PowerShell module (`.psm1`) and data (`.psd1`) files in scan
+  inventories, and recognize BOM-marked UTF-16 source files as text.
+- Preserve scoped scan and component-plan inventories after directory renames
+  that change only letter casing on case-insensitive filesystems.
+- Support long Codex executable paths on Windows, including nested Deep Scan
+  workers, and retry credential snapshots for another `Get-Acl` path-not-found
+  race when a descendant disappears during inspection.
+- Honor case-insensitive Windows environment variable names during finding
+  deduplication, so configured API credentials and private configuration paths
+  are used consistently.
+- Include complete OCI metadata in container image labels and multiarchitecture
+  annotations, with documentation pinned to the source commit and image
+  verification commands in the release workflow summary. See
+  [container metadata and verification](https://github.com/openai/codex-security/blob/npm-v0.1.25/docker/README.md#image-metadata-and-verification).
 
 ## Upgrade notes
 
-- The findings API and dashboard still have no built-in authentication.
-  `codex-security serve` binds to loopback by default; keep it local or place it
-  behind an authenticated TLS proxy before sharing access. Python is still
-  required, and nonempty imports still require an embeddings API credential.
-- Stopped-scan recovery is now explicit. App clients should check
-  `resultsRecoveryNeeded` and request recovery when they want validated late
-  results republished. Canceled scans remain immutable and cannot use this
-  recovery path.
-- `onDeepProgress.maximum` is the configured independent-review cap, not a
-  percentage denominator. The SDK polls the durable projection only when the
-  callback is supplied.
+- No new CLI flags, SDK options, or required application migrations are
+  introduced.
+- Source builds now use the repository-pinned pnpm for MCP app dependencies.
+  From the repository root, run
+  `pnpm --dir plugins/codex-security/mcp-app install --frozen-lockfile`.
+  See
+  [running without Docker](https://github.com/openai/codex-security/blob/npm-v0.1.25/sdk/typescript/README.md#running-without-docker).
+- Container publication remains separate from npm publication. Existing stable
+  container tags are not updated in place.
 
 The categorized list below contains the individual changes.

--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -2,6 +2,32 @@
 
 ## Highlights
 
+- Preserve confirmed finding identities across scans and comparisons, and show
+  related findings with their reasons while keeping distinct findings separate.
+  Large comparisons now use bounded batches without truncating finding text;
+  inputs that cannot fit leave matching explicitly incomplete.
+- Improve deduplication with separate screening and pair reviews, validated
+  pair assignments, and groups that respect explicit `DISTINCT` decisions.
+  Invalid submissions receive one corrective turn; blocked reviews fail without
+  recording a verdict. `DeduplicationReviewError` exposes structured, sanitized
+  failure details. The SDK also adds `deduplicateScanDirectory` for complete,
+  sealed scans outside local history.
+- Generate synthetic Standard scan results with `scan --mock` or the SDK's
+  `mock: true`, without authentication or model calls. Mock results support
+  normal reports, exports, history, and reruns. See
+  [mock scans](https://github.com/openai/codex-security/blob/npm-v0.1.25/sdk/typescript/README.md#generate-mock-scan-results).
+- Increase a running scan's total budget from the interactive dashboard when
+  usage reaches 80% of its limit, or use the SDK's `onBudgetApproaching`
+  callback. The existing limit remains enforced until an increase is saved.
+  See [scan cost limits](https://github.com/openai/codex-security/blob/npm-v0.1.25/sdk/typescript/README.md#progress-and-cost).
+- Recognize existing Codex authentication in CLI and SDK login status. SDK
+  scans, comparisons, and deduplication reviews now honor native command-auth
+  providers, including renewable tokens.
+- Configure the findings service's full embeddings endpoint with
+  `CODEX_SECURITY_EMBEDDINGS_URL`. The new `@openai/codex-security/server`
+  exports support embedding credentials supplied by a callback before each
+  HTTP batch. See
+  [embeddings and storage](https://github.com/openai/codex-security/blob/npm-v0.1.25/sdk/typescript/README.md#embeddings-and-storage).
 - Include PowerShell module (`.psm1`) and data (`.psd1`) files in scan
   inventories, and recognize BOM-marked UTF-16 source files as text.
 - Preserve scoped scan and component-plan inventories after directory renames
@@ -12,6 +38,8 @@
 - Honor case-insensitive Windows environment variable names during finding
   deduplication, so configured API credentials and private configuration paths
   are used consistently.
+- Stream tracked binary diffs when hashing repository snapshots, reducing
+  memory use while preserving the existing digest format.
 - Include complete OCI metadata in container image labels and multiarchitecture
   annotations, with documentation pinned to the source commit and image
   verification commands in the release workflow summary. See
@@ -19,14 +47,28 @@
 
 ## Upgrade notes
 
-- No new CLI flags, SDK options, or required application migrations are
-  introduced.
-- Source builds now use the repository-pinned pnpm for MCP app dependencies.
+- Mock mode is opt-in and saves clearly marked synthetic findings in local
+  history; use a separate `CODEX_SECURITY_STATE_DIR` for disposable test data.
+  It supports Standard scans only and does not audit the repository.
+- Interactive budget increases are unavailable in CI, JSON/JSONL, headless,
+  and verbose modes. Existing cost limits continue to apply in those modes.
+- The embeddings URL defaults to the existing OpenAI endpoint. A configured
+  endpoint receives finding inputs and the bearer credential and must support
+  the OpenAI embeddings format. Embeddings credentials remain separate from
+  Codex ChatGPT sign-in.
+- Local history applies an automatic database index migration. Completed scan
+  artifacts remain unchanged.
+- Source builds now use repository-pinned pnpm 11.19.0, including MCP app
+  dependencies, whose configuration requires a seven-day minimum release age.
   From the repository root, run
   `pnpm --dir plugins/codex-security/mcp-app install --frozen-lockfile`.
   See
   [running without Docker](https://github.com/openai/codex-security/blob/npm-v0.1.25/sdk/typescript/README.md#running-without-docker).
 - Container publication remains separate from npm publication. Existing stable
   container tags are not updated in place.
+
+Build and CI updates also improve package verification, portable Python checks,
+Windows fixtures, and test scheduling. Documentation clarifies portable
+environment-variable guidance and safe examples.
 
 The categorized list below contains the individual changes.

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-security",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "TypeScript SDK and CLI for Codex Security",
   "license": "Apache-2.0",
   "author": "OpenAI",


### PR DESCRIPTION
## Summary

Prepare `@openai/codex-security` 0.1.25 with release notes covering all 40 commits merged since `npm-v0.1.24` through `main` at `3f3aa8e97b520df56b6edb66a908ca132fe02885` on September 1, 2026.

## Changes

- Bump the package version from 0.1.24 to 0.1.25 and refresh the reviewed release summary.
- Cover cross-scan finding identities and relationships, batched comparisons, deduplication validation and diagnostics, and the sealed-scan-directory SDK API.
- Include mock scans, interactive budget increases, native command authentication, renewable embeddings credentials, and the configurable embeddings endpoint.
- Retain Windows, PowerShell, UTF-16, scoped inventory, and container metadata fixes; add streamed snapshot hashing and summarize build, CI, and documentation updates.
- Correct the previous claim that this release adds no CLI or SDK surface, and document defaults, opt-in behavior, and the automatic history index migration.

This PR changes release metadata and documentation only. The implementations are already on `main`; GitHub's generated release section supplies the individual PR inventory.

## Testing

For this notes refresh:

- Pulled current `main` in an isolated checkout and reviewed all 40 commits since `npm-v0.1.24` against current source and documentation.
- `git diff --check` passed.
- Prettier: `--check .github/release-notes.md sdk/typescript/package.json` passed.
- Verified that the release-note marker matches package version 0.1.25 and all five versioned documentation links resolve to files and headings in current `main`.

Runtime suites were not rerun for this documentation-only refresh. Required hosted CI and review must pass on the updated head.

## Risk and rollout

Merging the bump starts the existing release process after `node-ci` succeeds for the exact merged commit; npm publication uses the protected environment. Before merging, confirm 0.1.25 remains unpublished and refresh the notes if more changes reach `main`. Container publication remains separate, and existing stable container tags are not updated in place.

## Public disclosure review

Reviewed the existing PR artifacts and this update; the added content contains only public technical behavior and public repository links. No logs, screenshots, or attachments are added.

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
