### PR TITLE
fix(cli): use shell-neutral env-var removal guidance

### DIFF
--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -3294,6 +3294,22 @@ export function scanAuthentication(
     : { method: "api_key", source: key.source, verified: false };
 }
 
+/** Shell-neutral guidance so PowerShell users are not told to run POSIX `unset`. */
+export function formatEnvironmentVariableRemovalGuidance(
+  names: readonly string[],
+): string {
+  if (names.length === 0) {
+    return "remove OPENAI_API_KEY and CODEX_API_KEY from the environment";
+  }
+  if (names.length === 1) {
+    return `remove ${names[0]} from the environment`;
+  }
+  if (names.length === 2) {
+    return `remove ${names[0]} and ${names[1]} from the environment`;
+  }
+  return `remove ${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]} from the environment`;
+}
+
 async function runtimeScanAuthentication(
   environment: ProcessEnvironment,
   codexHome: string,

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -52,6 +52,7 @@ import {
   CodexSecurity,
   createSecurityInternal,
   environmentValue,
+  formatEnvironmentVariableRemovalGuidance,
   listRepositoryFindings,
   SCAN_AUTH_MODES,
   scanAuthentication,
@@ -4299,7 +4300,7 @@ export async function main(
               `Effective scan authentication: API key from ${authentication.source}.\n`,
             );
             errorOutput.write(
-              "To use a ChatGPT sign-in, unset OPENAI_API_KEY and CODEX_API_KEY.\n",
+              `To use a ChatGPT sign-in, ${formatEnvironmentVariableRemovalGuidance(["OPENAI_API_KEY", "CODEX_API_KEY"])}.\n`,
             );
           }
         } else if (exitCode === 0 && !options.withApiKey) {
@@ -4324,8 +4325,8 @@ export async function main(
               : "your ChatGPT sign-in";
             errorOutput.write(
               loginWarning +
-                `To use ${storedCredentials}, pass '--auth chatgpt' or run ` +
-                `'unset ${configuredApiKeyVariables.join(" ")}'.\n`,
+                `To use ${storedCredentials}, pass '--auth chatgpt' or ` +
+                `${formatEnvironmentVariableRemovalGuidance(configuredApiKeyVariables)}.\n`,
             );
           }
         }

--- a/sdk/typescript/tests-ts/api-environment.test.ts
+++ b/sdk/typescript/tests-ts/api-environment.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { environmentValue } from "../src/api.js";
+import {
+  environmentValue,
+  formatEnvironmentVariableRemovalGuidance,
+} from "../src/api.js";
 
 describe("environmentValue", () => {
   test("treats empty values as unset and finds case variants", () => {
@@ -16,5 +19,34 @@ describe("environmentValue", () => {
     expect(environmentValue({ Home: "/shell-home" }, "HOME")).toBe(
       "/shell-home",
     );
+  });
+});
+
+describe("formatEnvironmentVariableRemovalGuidance", () => {
+  test("lists one, two, or more names without a shell command", () => {
+    expect(formatEnvironmentVariableRemovalGuidance([])).toBe(
+      "remove OPENAI_API_KEY and CODEX_API_KEY from the environment",
+    );
+    expect(formatEnvironmentVariableRemovalGuidance(["OPENAI_API_KEY"])).toBe(
+      "remove OPENAI_API_KEY from the environment",
+    );
+    expect(
+      formatEnvironmentVariableRemovalGuidance([
+        "OPENAI_API_KEY",
+        "CODEX_API_KEY",
+      ]),
+    ).toBe("remove OPENAI_API_KEY and CODEX_API_KEY from the environment");
+    expect(
+      formatEnvironmentVariableRemovalGuidance([
+        "OPENAI_API_KEY",
+        "CODEX_API_KEY",
+        "Codex_Api_Key",
+      ]),
+    ).toBe(
+      "remove OPENAI_API_KEY, CODEX_API_KEY, and Codex_Api_Key from the environment",
+    );
+    expect(
+      formatEnvironmentVariableRemovalGuidance(["OPENAI_API_KEY"]),
+    ).not.toContain("unset");
   });
 });

--- a/sdk/typescript/tests-ts/cli-authentication.test.ts
+++ b/sdk/typescript/tests-ts/cli-authentication.test.ts
@@ -180,25 +180,25 @@ describe("CLI authentication", () => {
         `Effective scan authentication: API key from ${expectedSource}.`,
       );
       expect(stderr.text()).toContain(
-        "To use a ChatGPT sign-in, unset OPENAI_API_KEY and CODEX_API_KEY.",
+        "To use a ChatGPT sign-in, remove OPENAI_API_KEY and CODEX_API_KEY from the environment.",
       );
       expect(stderr.text()).not.toContain("SYNTHETIC_SECRET");
     }
   });
 
   test("explains interactive choice and how to unset every shadowing key after ChatGPT login", async () => {
-    for (const [argv, environment, source, unsetCommand] of [
+    for (const [argv, environment, source, removalGuidance] of [
       [
         ["login"],
         { OPENAI_API_KEY: "sk-proj-SYNTHETIC_SECRET_123" },
         "OPENAI_API_KEY",
-        "unset OPENAI_API_KEY",
+        "remove OPENAI_API_KEY from the environment",
       ],
       [
         ["login", "--device-auth"],
         { Codex_Api_Key: "sk-proj-SYNTHETIC_SECRET_456" },
         "CODEX_API_KEY",
-        "unset Codex_Api_Key",
+        "remove Codex_Api_Key from the environment",
       ],
       [
         ["login"],
@@ -207,7 +207,7 @@ describe("CLI authentication", () => {
           CODEX_API_KEY: "sk-proj-SYNTHETIC_SECRET_456",
         },
         "OPENAI_API_KEY",
-        "unset OPENAI_API_KEY CODEX_API_KEY",
+        "remove OPENAI_API_KEY and CODEX_API_KEY from the environment",
       ],
     ] as const) {
       const stdout = capture();
@@ -229,22 +229,23 @@ describe("CLI authentication", () => {
         `noninteractive scans will use ${source}.`,
       );
       expect(stderr.text()).toContain("--auth chatgpt");
-      expect(stderr.text()).toContain(`'${unsetCommand}'`);
+      expect(stderr.text()).toContain(removalGuidance);
+      expect(stderr.text()).not.toContain("unset ");
       expect(stderr.text()).not.toContain("SYNTHETIC_SECRET");
     }
   });
 
   test("warns when an environment API key overrides a successful access-token login", async () => {
-    for (const [environment, source, unsetCommand] of [
+    for (const [environment, source, removalGuidance] of [
       [
         { OPENAI_API_KEY: "sk-proj-SYNTHETIC_SECRET_123" },
         "OPENAI_API_KEY",
-        "unset OPENAI_API_KEY",
+        "remove OPENAI_API_KEY from the environment",
       ],
       [
         { Codex_Api_Key: "sk-proj-SYNTHETIC_SECRET_456" },
         "CODEX_API_KEY",
-        "unset Codex_Api_Key",
+        "remove Codex_Api_Key from the environment",
       ],
       [
         {
@@ -252,7 +253,7 @@ describe("CLI authentication", () => {
           CODEX_API_KEY: "sk-proj-SYNTHETIC_SECRET_456",
         },
         "OPENAI_API_KEY",
-        "unset OPENAI_API_KEY CODEX_API_KEY",
+        "remove OPENAI_API_KEY and CODEX_API_KEY from the environment",
       ],
     ] as const) {
       const stdout = capture();
@@ -271,9 +272,9 @@ describe("CLI authentication", () => {
         `Access-token login succeeded, but noninteractive scans will use ${source}.`,
       );
       expect(stderr.text()).toContain(
-        "To use your stored credentials, pass '--auth chatgpt' or run ",
+        `To use your stored credentials, pass '--auth chatgpt' or ${removalGuidance}.`,
       );
-      expect(stderr.text()).toContain(`'${unsetCommand}'`);
+      expect(stderr.text()).not.toContain("unset ");
       expect(stderr.text()).not.toContain("ChatGPT login succeeded");
       expect(stderr.text()).not.toContain("SYNTHETIC_SECRET");
     }


### PR DESCRIPTION
## Summary

`login status` and the post-login warning printed POSIX `unset OPENAI_API_KEY ...`, which is invalid in PowerShell. Windows users following that hint cannot drop the environment API keys that shadow a ChatGPT sign-in.

Fixes #33.

## Changes

- Added `formatEnvironmentVariableRemovalGuidance()` so the CLI prints shell-neutral wording (`remove OPENAI_API_KEY and CODEX_API_KEY from the environment`) instead of a POSIX command.
- Used that helper for the `login status` path and the post-login / access-token warning that lists whichever shadowing keys are actually set.

## Testing

- `bun test --timeout 30000 ./tests-ts/api-environment.test.ts ./tests-ts/cli-authentication.test.ts` — 29 pass, 0 fail
- `pnpm run lint` (`tsc --noEmit`) — exit 0

## Risk and rollout

Documentation-only user-facing strings. No auth, scan, or credential-handling behavior change. Existing CLI authentication tests now assert the shell-neutral text and that `unset` no longer appears.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.