### PR TITLE
build: align pnpm toolchain on 11.19

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -91,7 +91,7 @@ jobs:
         if: steps.scope.outputs.check-markdown == 'true'
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          package_json_file: sdk/typescript/package.json
+          package_json_file: package.json
           cache: true
           cache_dependency_path: sdk/typescript/pnpm-lock.yaml
 
@@ -134,7 +134,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          package_json_file: sdk/typescript/package.json
+          package_json_file: package.json
           cache: true
           cache_dependency_path: |
             sdk/typescript/pnpm-lock.yaml
@@ -168,7 +168,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          package_json_file: sdk/typescript/package.json
+          package_json_file: package.json
           cache: true
           cache_dependency_path: |
             sdk/typescript/pnpm-lock.yaml
@@ -218,7 +218,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          package_json_file: sdk/typescript/package.json
+          package_json_file: package.json
           cache: true
           cache_dependency_path: |
             sdk/typescript/pnpm-lock.yaml
@@ -318,7 +318,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          package_json_file: sdk/typescript/package.json
+          package_json_file: package.json
           cache: true
           cache_dependency_path: plugins/codex-security/mcp-app/pnpm-lock.yaml
       - name: Set up Node.js
@@ -442,7 +442,9 @@ jobs:
         with:
           node-version: "22.13.0"
       - name: Set up pnpm
-        run: npm install --global pnpm@11.19.0 --no-audit --no-fund
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          package_json_file: package.json
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -318,7 +318,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          package_json_file: plugins/codex-security/mcp-app/package.json
+          package_json_file: sdk/typescript/package.json
           cache: true
           cache_dependency_path: plugins/codex-security/mcp-app/pnpm-lock.yaml
       - name: Set up Node.js
@@ -442,7 +442,7 @@ jobs:
         with:
           node-version: "22.13.0"
       - name: Set up pnpm
-        run: npm install --global pnpm@11.9.0 --no-audit --no-fund
+        run: npm install --global pnpm@11.19.0 --no-audit --no-fund
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Enable pnpm
         shell: bash
-        run: corepack enable && corepack prepare "$(node -p 'require("./sdk/typescript/package.json").packageManager')" --activate
+        run: corepack enable && corepack prepare "$(node -p 'require("./package.json").packageManager')" --activate
 
       - name: Validate release tag
         id: release

--- a/.github/workflows/test-quality.yml
+++ b/.github/workflows/test-quality.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          package_json_file: sdk/typescript/package.json
+          package_json_file: package.json
           cache: true
           cache_dependency_path: |
             sdk/typescript/pnpm-lock.yaml
@@ -143,7 +143,7 @@ jobs:
           node-version: "22.13.0"
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          package_json_file: sdk/typescript/package.json
+          package_json_file: package.json
           cache: true
           cache_dependency_path: sdk/typescript/pnpm-lock.yaml
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2

--- a/.ona/automations.yml
+++ b/.ona/automations.yml
@@ -2,7 +2,7 @@ tasks:
   install:
     name: Install dependencies
     command: |
-      npm install --global pnpm@11.9.0 bun@1.3.14 --no-audit --no-fund
+      npm install --global pnpm@11.19.0 bun@1.3.14 --no-audit --no-fund
       if ! command -v rg >/dev/null 2>&1; then
         sudo apt-get update \
           -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/ubuntu.sources \

--- a/.ona/automations.yml
+++ b/.ona/automations.yml
@@ -2,7 +2,8 @@ tasks:
   install:
     name: Install dependencies
     command: |
-      npm install --global pnpm@11.19.0 bun@1.3.14 --no-audit --no-fund
+      pnpm_package="$(node -p 'require("./package.json").packageManager.split("+")[0]')"
+      npm install --global "$pnpm_package" bun@1.3.14 --no-audit --no-fund
       if ! command -v rg >/dev/null 2>&1; then
         sudo apt-get update \
           -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/ubuntu.sources \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,12 @@ RUN apt-get update \
 
 WORKDIR /build/sdk/typescript
 
+COPY package.json /build/package.json
 COPY sdk/typescript/package.json sdk/typescript/pnpm-lock.yaml sdk/typescript/pnpm-workspace.yaml ./
 COPY plugins/codex-security/mcp-app/package.json plugins/codex-security/mcp-app/pnpm-lock.yaml plugins/codex-security/mcp-app/pnpm-workspace.yaml /build/plugins/codex-security/mcp-app/
 
 RUN corepack enable \
-    && corepack prepare "$(node --print 'require("./package.json").packageManager')" --activate \
+    && corepack prepare "$(node --print 'require("/build/package.json").packageManager')" --activate \
     && pnpm install --frozen-lockfile \
     && pnpm --dir /build/plugins/codex-security/mcp-app install --frozen-lockfile
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "packageManager": "pnpm@11.19.0+sha512.7881f3ed590d472c4a955e2b88b2121791116066dcc88cbca3849ec9b60f1bbaa6d2ccb221fa91da4e1c65bef2bcbe379365aea7ac539c7bf86dedc3a1b22dce"
+}

--- a/plugins/codex-security/mcp-app/package.json
+++ b/plugins/codex-security/mcp-app/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.158",
   "type": "module",
   "private": true,
-  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "scripts": {
     "build": "tsc --noEmit",
     "build:mcp": "node scripts/build_mcp_app.mjs --output .preview/mcp",

--- a/plugins/codex-security/mcp-app/pnpm-workspace.yaml
+++ b/plugins/codex-security/mcp-app/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 allowBuilds:
   esbuild: false
+minimumReleaseAge: 10080

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -15,7 +15,7 @@
   "engines": {
     "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
   },
-  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
+  "packageManager": "pnpm@11.19.0+sha512.7881f3ed590d472c4a955e2b88b2121791116066dcc88cbca3849ec9b60f1bbaa6d2ccb221fa91da4e1c65bef2bcbe379365aea7ac539c7bf86dedc3a1b22dce",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -15,7 +15,6 @@
   "engines": {
     "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
   },
-  "packageManager": "pnpm@11.19.0+sha512.7881f3ed590d472c4a955e2b88b2121791116066dcc88cbca3849ec9b60f1bbaa6d2ccb221fa91da4e1c65bef2bcbe379365aea7ac539c7bf86dedc3a1b22dce",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary

Align the repository's pnpm toolchain on 11.19 and make the repository root the single source for pnpm selection. The SDK and MCP packages keep their separate workspaces and lockfiles.

## Changes

- add a private root `package.json` that pins pnpm 11.19 with its integrity hash
- remove the duplicate `packageManager` fields from the SDK and MCP package manifests
- make CI, release automation, development setup, and Docker packaging read the root descriptor
- require a seven-day minimum release age for MCP dependency resolution

## Testing

- `pnpm --dir sdk/typescript install --frozen-lockfile`
- `pnpm --dir plugins/codex-security/mcp-app install --frozen-lockfile`
- `pnpm --dir sdk/typescript run types`
- `pnpm --dir sdk/typescript run lint`
- `pnpm --dir sdk/typescript run test:mcp` (23 passed; generated a 122-file plugin)
- `python3 .github/scripts/check_plugin_source_compatibility.py`
- `python3 -m ruff check --config plugins/codex-security/pyproject.toml .github/scripts/check_plugin_source_compatibility.py .github/scripts/test_check_plugin_source_compatibility.py plugins/codex-security`
- `python3 -m ruff format --check --config plugins/codex-security/pyproject.toml .github/scripts/check_plugin_source_compatibility.py .github/scripts/test_check_plugin_source_compatibility.py plugins/codex-security`
- `pnpm --dir sdk/typescript run format`
- parsed the changed YAML files and verified that the root descriptor is the only tracked `packageManager` owner
- `git diff --check`

## Risk and rollout

This changes repository tooling only; the dependency lockfiles and generated plugin payload are unchanged. The root descriptor selects pnpm but does not create a root workspace or combine dependency resolution. The MCP package no longer selects pnpm when copied independently, so its caller must provide pnpm. Repository CI, development automation, Docker packaging, and release automation all read the root descriptor. The minimum release age intentionally delays newly published MCP dependency versions by seven days.

The local Docker package build was not run because the Docker daemon was stopped. Exact-head GitHub CI is running.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.

<!-- explain-pr:impact:start -->
## Change impact

The repository root selects pnpm 11.19. CI, release, Docker, and development tooling all read the same descriptor.

```mermaid
flowchart LR
  subgraph column_0["Toolchain source"]
    direction TB
    node_0["Canonical pnpm 11.19 pin<br/><code>package.json</code>"]
  end
  subgraph column_1["Repository consumers"]
    direction TB
    node_1["CI, release, dev, and Docker setup<br/><code>pnpm setup</code>"]
  end
  subgraph column_2["Workspace behavior"]
    direction TB
    node_2["SDK workspace keeps its own lock<br/><code>sdk/typescript</code>"]
    node_3["MCP workspace keeps its own lock<br/><code>mcp-app</code>"]
    node_4["New dependency releases wait seven days<br/><code>minimumReleaseAge</code>"]
  end
  node_0 -->|"selects pnpm"| node_1
  node_1 -->|"installs"| node_2
  node_1 -->|"installs"| node_3
  node_3 -->|"applies policy"| node_4
  class node_0 changed
  class node_1 affected
  class node_2 affected
  class node_3 affected
  class node_4 changed
  classDef changed fill:#d7f5e5,stroke:#237a4b,color:#111
  classDef affected fill:#e6f0ff,stroke:#3569a8,color:#111
  classDef context fill:#f2f3f5,stroke:#6e7781,color:#111
```

> **Limits:** Exact-head GitHub CI was still running at collection time. · The local Docker package build was blocked by a stopped Docker daemon. · No npm publication, plugin release, or deployment was performed.

<details>
<summary>Source evidence (9)</summary>

- [`package.json:L1-L4`](https://github.com/openai/codex-security/blob/f4c1da95323f26bdd8dca1c328cf15d5f690b47e/package.json#L1-L4) — The private root descriptor pins pnpm 11.19 with an integrity hash.
- [`.github/workflows/node-ci.yml:L318-L329`](https://github.com/openai/codex-security/blob/f4c1da95323f26bdd8dca1c328cf15d5f690b47e/.github/workflows/node-ci.yml#L318-L329) — MCP CI reads the root package.json but still caches and installs from the MCP lockfile.
- [`.github/workflows/node-ci.yml:L440-L455`](https://github.com/openai/codex-security/blob/f4c1da95323f26bdd8dca1c328cf15d5f690b47e/.github/workflows/node-ci.yml#L440-L455) — Windows CI also reads the root descriptor before installing the SDK and MCP workspaces separately.
- [`.github/workflows/node-release.yml:L75-L77`](https://github.com/openai/codex-security/blob/f4c1da95323f26bdd8dca1c328cf15d5f690b47e/.github/workflows/node-release.yml#L75-L77) — Release automation activates the pnpm version declared at the repository root.
- [`.ona/automations.yml:L1-L14`](https://github.com/openai/codex-security/blob/f4c1da95323f26bdd8dca1c328cf15d5f690b47e/.ona/automations.yml#L1-L14) — Development setup derives the installable pnpm version from the same root descriptor.
- [`Dockerfile:L9-L18`](https://github.com/openai/codex-security/blob/f4c1da95323f26bdd8dca1c328cf15d5f690b47e/Dockerfile#L9-L18) — Docker copies the root descriptor and uses it before installing the two workspaces.
- [`plugins/codex-security/mcp-app/package.json:L1-L10`](https://github.com/openai/codex-security/blob/f4c1da95323f26bdd8dca1c328cf15d5f690b47e/plugins/codex-security/mcp-app/package.json#L1-L10) — The MCP package remains a private workspace package and no longer carries a packageManager pin.
- [`sdk/typescript/package.json:L1-L18`](https://github.com/openai/codex-security/blob/f4c1da95323f26bdd8dca1c328cf15d5f690b47e/sdk/typescript/package.json#L1-L18) — The SDK manifest keeps its package identity and Node engine contract without owning repository pnpm selection.
- [`plugins/codex-security/mcp-app/pnpm-workspace.yaml:L1-L3`](https://github.com/openai/codex-security/blob/f4c1da95323f26bdd8dca1c328cf15d5f690b47e/plugins/codex-security/mcp-app/pnpm-workspace.yaml#L1-L3) — The MCP workspace requires dependency releases to be at least seven days old.

</details>
<!-- explain-pr:impact:end -->
