### PR TITLE
docs: clarify supported Node.js release lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Trusted Access for Cyber. To join the program, visit
 
 ## Quick start
 
-Requires Node.js 22.13.0 or later and Python 3.10 or later.
+Requires Node.js 22.13.0+ (22.x), 24.x, or 26.x, plus Python 3.10+.
 
 ```bash
 npm install @openai/codex-security


### PR DESCRIPTION
## Summary

The root quick start said Codex Security requires "Node.js 22.13.0 or later," which implied that unsupported odd-numbered releases such as Node 23 and 25 were accepted. The package engine contract and CI matrix support Node 22.13.0+ on the 22.x line, 24.x, and 26.x.

Align the root quick start with the exact release lines already documented by the SDK README and enforced by the package.

## Changes

- Replace the open-ended Node.js minimum in the root README with the supported 22.x, 24.x, and 26.x release lines.
- Keep the existing Python 3.10+ requirement unchanged.

## Testing

- `pnpm --dir sdk/typescript exec prettier --check ../../README.md` — passed.
- Verified `sdk/typescript/package.json` declares `^22.13.0 || ^24.0.0 || ^26.0.0`.
- `git diff --check` — passed.

No runtime tests were needed for this documentation-only correction.

## Risk and rollout

Documentation only. Package engines, CI coverage, installation behavior, dependencies, and public CLI behavior are unchanged.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
