### PR TITLE
test(plugin): cover multi-chunk binary snapshot digests

### DIFF
--- a/plugins/codex-security/tests/test_workbench_target.py
+++ b/plugins/codex-security/tests/test_workbench_target.py
@@ -133,10 +133,12 @@ def test_worktree_content_digest_streams_tracked_binary_patch(
     target = tmp_path / "target"
     initialize_git_repository(target)
     binary = target / "fixture.bin"
-    binary.write_bytes(bytes(range(256)) * 4)
+    # Incompressible fixture bytes keep the binary patch larger than one hash read.
+    fixture_size = 1024 * 1024 + 17
+    binary.write_bytes(hashlib.shake_256(b"original binary fixture").digest(fixture_size))
     subprocess.run(["git", "add", binary.name], cwd=target, check=True)
     subprocess.run(["git", "commit", "-qm", "Add binary fixture"], cwd=target, check=True)
-    binary.write_bytes(bytes(reversed(range(256))) * 4)
+    binary.write_bytes(hashlib.shake_256(b"changed binary fixture").digest(fixture_size))
 
     tracked = subprocess.run(
         [
@@ -156,6 +158,7 @@ def test_worktree_content_digest_streams_tracked_binary_patch(
         capture_output=True,
     ).stdout
     assert b"GIT binary patch" in tracked
+    assert len(tracked) > 1024 * 1024
     expected = hashlib.sha256()
     update_digest_field(expected, b"format", b"codex-security-snapshot/v1")
     update_digest_field(expected, b"tracked-diff", tracked)


### PR DESCRIPTION
## Summary

The binary snapshot regression added in #773 uses a small, highly compressible fixture, so its patch fits in a single read. Generate deterministic, incompressible fixture bytes so the test exercises multiple reads and verifies the complete snapshot digest.

## Changes

- Generate distinct binary contents slightly larger than 1 MiB with SHAKE-256.
- Assert that the generated Git binary patch exceeds the 1 MiB read size.
- Retain the streaming-path check and comparison against the legacy buffered digest.

## Testing

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q plugins/codex-security/tests/test_workbench_target.py`: 11 passed.
- Portable Ruff check with Ruff 0.16.1: passed.
- Portable Ruff format check: 137 files already formatted.
- `python3 .github/scripts/check_plugin_source_compatibility.py`: passed.
- `git diff --check`: passed.

## Risk and rollout

Test-only change. The fixture is generated in the test's temporary directory; no binary artifacts are committed. Runtime behavior and the snapshot digest format are unchanged.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
