### PR TITLE
feat(sdk): deduplicate sealed scan directories

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1162,6 +1162,22 @@ const result = await deduplicateScan("scan_example_001", {
 console.log(result.duplicateGroups);
 ```
 
+For a complete, sealed scan directory that is not registered in local scan
+history, provide the repository checkout separately:
+
+```typescript
+import { deduplicateScanDirectory } from "@openai/codex-security";
+
+const result = await deduplicateScanDirectory("/path/to/completed-scan", {
+  repository: "/path/to/repository",
+  findingsUrl: "http://127.0.0.1:3000",
+  // expectedScanId: "scan_example_001",
+  // allRepositories: true,
+  // signal: controller.signal,
+});
+console.log(result.duplicateGroups);
+```
+
 The CLI and SDK return the same result:
 
 ```json
@@ -1494,7 +1510,9 @@ The local workflow lives under `src/deduplication/`. `FindingDeduplicator`
 receives a candidate API client and a `DeduplicationReviewer`, keeping grouping
 separate from HTTP and model transport. `CodexDeduplicationReviewer` owns prompts
 and result validation; `CodexReviewRunner` owns app-server sessions and cleanup.
-`deduplicateScan` validates saved scan artifacts before running the workflow.
+`deduplicateScan` validates saved scan artifacts before running the workflow;
+`deduplicateScanDirectory` performs the same validation for an explicit sealed
+scan directory without consulting local scan history.
 The SDK reuses the existing Codex runtime and credentials without additional
 runtime dependencies.
 

--- a/sdk/typescript/src/deduplication/scan.ts
+++ b/sdk/typescript/src/deduplication/scan.ts
@@ -30,15 +30,24 @@ import {
   CheckpointedReviewRunner,
   reviewSettingsDigest,
 } from "./checkpointed-review.js";
+import { normalizeRepository } from "../targets.js";
 
 export interface DeduplicateScanOptions {
   /** Resume the named local findings workflow, including custom publication. */
   workflowId?: string;
   /** Findings API base URL. The scan's findings must already be indexed there. */
   findingsUrl: string;
-  /** Search all repositories instead of the saved scan's targetId. Defaults to false. */
+  /** Search all repositories instead of the scan's targetId. Defaults to false. */
   allRepositories?: boolean;
   signal?: AbortSignal;
+}
+
+export interface DeduplicateScanDirectoryOptions
+  extends DeduplicateScanOptions {
+  /** Local repository checkout used to review duplicate candidates. */
+  repository: string;
+  /** Require the sealed artifacts to belong to this scan. */
+  expectedScanId?: string;
 }
 
 export interface DeduplicateScanResult extends DeduplicationResult {
@@ -53,16 +62,48 @@ export async function deduplicateScan(
   return await deduplicateScanInternal(scanId, options);
 }
 
+/** Review a complete, sealed scan directory without resolving local scan history. */
+export async function deduplicateScanDirectory(
+  scanDirectory: string,
+  options: DeduplicateScanDirectoryOptions,
+): Promise<DeduplicateScanResult> {
+  return await deduplicateScanDirectoryInternal(scanDirectory, options);
+}
+
+type DeduplicateScanDependencies = Partial<SavedScanDependencies> & {
+  environment?: NodeJS.ProcessEnv;
+  reviewer?: DeduplicationReviewer;
+  reviewRunner?: Pick<CodexReviewRunner, "run">;
+  fetch?: FindingsRequest;
+};
+
+/** @internal */
+export async function deduplicateScanDirectoryInternal(
+  scanDirectory: string,
+  options: DeduplicateScanDirectoryOptions,
+  dependencies: DeduplicateScanDependencies = {},
+): Promise<DeduplicateScanResult> {
+  options.signal?.throwIfAborted();
+  const repository = await normalizeRepository(
+    options.repository,
+    options.signal,
+  );
+  return await deduplicateResolvedScan(
+    scanDirectory,
+    repository,
+    options.expectedScanId,
+    options,
+    dependencies,
+    await bundledPluginRoot(),
+    true,
+  );
+}
+
 /** @internal */
 export async function deduplicateScanInternal(
   scanId: string,
   options: DeduplicateScanOptions,
-  dependencies: Partial<SavedScanDependencies> & {
-    environment?: NodeJS.ProcessEnv;
-    reviewer?: DeduplicationReviewer;
-    reviewRunner?: Pick<CodexReviewRunner, "run">;
-    fetch?: FindingsRequest;
-  } = {},
+  dependencies: DeduplicateScanDependencies = {},
 ): Promise<DeduplicateScanResult> {
   options.signal?.throwIfAborted();
   const environment = dependencies.environment ?? process.env;
@@ -90,14 +131,36 @@ export async function deduplicateScanInternal(
         );
       }),
   });
-  const { contract, scanDirectory } = await loadContractWithScanDirectory(
+  return await deduplicateResolvedScan(
     scan.scanDir,
+    scan["targetPath"] as string,
+    scan.scanId,
+    options,
+    dependencies,
+    pluginRoot,
+    false,
+  );
+}
+
+async function deduplicateResolvedScan(
+  selectedDirectory: string,
+  repositoryPath: string,
+  expectedScanId: string | undefined,
+  options: DeduplicateScanOptions,
+  dependencies: DeduplicateScanDependencies,
+  pluginRoot: string,
+  bindRepository: boolean,
+): Promise<DeduplicateScanResult> {
+  const environment = dependencies.environment ?? process.env;
+  const { contract, scanDirectory } = await loadContractWithScanDirectory(
+    selectedDirectory,
     {
       pluginRoot,
-      expectedScanId: scan.scanId,
+      expectedScanId,
       signal: options.signal,
     },
   );
+  const scanId = contract.manifest.scan.id;
   const client = new FindingsClient(
     options.findingsUrl,
     options.signal,
@@ -121,7 +184,8 @@ export async function deduplicateScanInternal(
   if (workflow) {
     await workflow.protectArtifacts(scanDirectory);
     await workflow.bind({
-      scanId: scan.scanId,
+      ...(bindRepository ? { repositoryPath } : {}),
+      scanId,
       scanDir: scanDirectory,
       artifactDigest: workflowDigest(contract),
       destination: workflowDestination(options.findingsUrl),
@@ -133,7 +197,7 @@ export async function deduplicateScanInternal(
       {
         findingsUrl: options.findingsUrl,
         workflowId: options.workflowId,
-        expectedScanId: scan.scanId,
+        expectedScanId: scanId,
         signal: options.signal,
       },
       {
@@ -159,13 +223,13 @@ export async function deduplicateScanInternal(
         environment,
         undefined,
         options.signal,
-        scan["targetPath"] as string,
+        repositoryPath,
       );
     const checkpoints = workflow
       ? new CheckpointedReviewRunner(
           workflow,
           runner,
-          await workflow.sourceSnapshot(scan["targetPath"] as string),
+          await workflow.sourceSnapshot(repositoryPath),
           scope,
           await reviewSettingsDigest(environment),
         )
@@ -184,7 +248,7 @@ export async function deduplicateScanInternal(
     );
     await checkpoints?.assertSourceUnchanged();
     options.signal?.throwIfAborted();
-    const result: DeduplicateScanResult = { scanId: scan.scanId, ...reviewed };
+    const result: DeduplicateScanResult = { scanId, ...reviewed };
     await workflow?.prepareDedupe(result, { groups: result.duplicateGroups });
     await client.storeDedupeGroups(result.duplicateGroups);
     return result;

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -71,8 +71,12 @@ export type {
   PublishScanToCustomOptions,
   CustomPublicationResult,
 } from "./custom-publish.js";
-export { deduplicateScan } from "./deduplication/scan.js";
+export {
+  deduplicateScan,
+  deduplicateScanDirectory,
+} from "./deduplication/scan.js";
 export type {
+  DeduplicateScanDirectoryOptions,
   DeduplicateScanOptions,
   DeduplicateScanResult,
 } from "./deduplication/scan.js";

--- a/sdk/typescript/tests-ts/finding-deduplication.test.ts
+++ b/sdk/typescript/tests-ts/finding-deduplication.test.ts
@@ -17,7 +17,11 @@ import {
 } from "../src/deduplication/deduplication-reviewer.js";
 import { CodexSecurityError } from "../src/errors.js";
 import { FindingsClient } from "../src/findings-client.js";
-import { deduplicateScanInternal } from "../src/deduplication/scan.js";
+import { deduplicateScanDirectory } from "../src/index.js";
+import {
+  deduplicateScanDirectoryInternal,
+  deduplicateScanInternal,
+} from "../src/deduplication/scan.js";
 import { PLUGIN_ROOT } from "./plugin-root.js";
 import type { JsonObject } from "../src/config.js";
 
@@ -494,6 +498,75 @@ test("resolves a saved scan and retrieves its IDs without uploading or modifying
     ).rejects.toThrow("do not match selected scan");
   } finally {
     await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("deduplicates an explicit sealed scan directory without reading scan history", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "dedupe-directory-"));
+  const repository = await mkdtemp(join(tmpdir(), "dedupe-repository-"));
+  try {
+    await cp(join(PLUGIN_ROOT, "examples/completed-scan"), directory, {
+      recursive: true,
+    });
+    if (process.platform !== "win32") await chmod(directory, 0o700);
+    const original = await readFile(join(directory, "findings.json"), "utf8");
+    const commands: string[][] = [];
+    const requests: string[] = [];
+    const result = await deduplicateScanDirectoryInternal(
+      directory,
+      {
+        repository,
+        expectedScanId: "scan_example_001",
+        findingsUrl: "http://synthetic.test/api",
+      },
+      {
+        runWorkbench: async (args) => {
+          commands.push([...args]);
+          throw new Error("Explicit scan directories must not read history");
+        },
+        fetch: async (url, options) => {
+          requests.push(String(url));
+          expect(options?.method).toBeUndefined();
+          return Response.json({
+            finding: document.findings[0],
+            potentialDuplicates: [],
+          });
+        },
+        reviewer: {
+          async screen() {
+            throw new Error("No review for an empty neighborhood");
+          },
+          async reviewPair() {
+            throw new Error("No pair to review");
+          },
+        },
+      },
+    );
+    expect(result).toEqual({
+      scanId: "scan_example_001",
+      uniqueFindingIds: document.findings.map((finding) => finding.findingId),
+      duplicateGroups: [],
+      deduplicationStatus: "completed",
+    });
+    expect(commands).toEqual([]);
+    expect(requests).toEqual([
+      `http://synthetic.test/api/v1/finding/${document.findings[0]!.findingId}/potential-duplicates?repositoryId=target_sha256_example`,
+    ]);
+    expect(await readFile(join(directory, "findings.json"), "utf8")).toBe(
+      original,
+    );
+    await expect(
+      deduplicateScanDirectory(directory, {
+        repository,
+        expectedScanId: "scan_other",
+        findingsUrl: "http://synthetic.test/api",
+      }),
+    ).rejects.toThrow("do not match selected scan");
+  } finally {
+    await Promise.all([
+      rm(directory, { recursive: true, force: true }),
+      rm(repository, { recursive: true, force: true }),
+    ]);
   }
 });
 

--- a/sdk/typescript/tests-ts/finding-workflow-publication.test.ts
+++ b/sdk/typescript/tests-ts/finding-workflow-publication.test.ts
@@ -1,9 +1,10 @@
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { expect, test } from "bun:test";
 import type { JsonObject } from "../src/config.js";
 import { publishScanToCustomInternal } from "../src/custom-publish.js";
 import {
+  deduplicateScanDirectoryInternal,
   deduplicateScanInternal,
   type DeduplicateScanResult,
 } from "../src/deduplication/scan.js";
@@ -36,6 +37,122 @@ function publicationBinding(
     { request: { id, action: "complete", stage: "scan", result: null } },
   ];
 }
+
+test("deduplicates an external scan through its bound workflow without reading scan history", async () => {
+  await using fixture = await workflowFixture();
+  const { scanDir, repository, environment, document } = fixture;
+  const id = "external-directory";
+  const options = {
+    workflowId: id,
+    findingsUrl: "http://synthetic.test/service",
+    repository: relative(process.cwd(), repository),
+    expectedScanId: document.scanId,
+    allRepositories: true,
+  };
+  const result: DeduplicateScanResult = {
+    scanId: document.scanId,
+    uniqueFindingIds: document.findings.map((finding) => finding.findingId),
+    duplicateGroups: [],
+    deduplicationStatus: "completed",
+  };
+  const source = {
+    repository,
+    revision: "synthetic-revision",
+    refsDigest: "synthetic-refs",
+    content: "synthetic-content",
+  };
+  const binding = {
+    scanId: document.scanId,
+    scanDir,
+    artifactDigest: expect.stringMatching(/^[a-f0-9]{64}$/),
+    destination: "http://synthetic.test/service/",
+  };
+  const workbench = scriptedWorkbench([
+    {
+      request: {
+        id,
+        action: "bind",
+        binding: {
+          repositoryPath: repository,
+          ...binding,
+          scope: { allRepositories: true },
+        },
+      },
+    },
+    { request: { id, action: "complete", stage: "scan", result: null } },
+    { request: { id, action: "bind", binding } },
+    { request: { id, action: "complete", stage: "scan", result: null } },
+    {
+      request: { id, action: "begin", stage: "publish" },
+      response: {
+        workflow: {
+          stages: {
+            publish: {
+              status: "completed",
+              result: {
+                findingIds: document.findings.map(
+                  (finding) => finding.findingId,
+                ),
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      request: { id, action: "begin", stage: "dedupe" },
+      response: { workflow: { stages: { dedupe: { status: "running" } } } },
+    },
+    {
+      request: { id, action: "get" },
+      response: { workflow: { stages: { dedupe: { status: "running" } } } },
+    },
+    { request: { id, action: "source", repository }, response: { source } },
+    { request: { id, action: "source", repository }, response: { source } },
+    {
+      request: {
+        id,
+        action: "prepare-dedupe",
+        stage: "dedupe",
+        result,
+        pendingWrite: { groups: [] },
+      },
+    },
+    { request: { id, action: "complete", stage: "dedupe", result } },
+  ]);
+  const requests: string[] = [];
+  expect(
+    await deduplicateScanDirectoryInternal(scanDir, options, {
+      environment,
+      runWorkbench: (args, input) =>
+        workbench.run(
+          { environment, pluginRoot: PLUGIN_ROOT, python: "unused" },
+          args,
+          input,
+        ),
+      fetch: async (url, init) => {
+        requests.push(String(url));
+        expect(init.method).toBeUndefined();
+        return Response.json({
+          finding: document.findings[0],
+          potentialDuplicates: [],
+        });
+      },
+      reviewer: {
+        async screen() {
+          throw new Error("No review for an empty neighborhood");
+        },
+        async reviewPair() {
+          throw new Error("No pair to review");
+        },
+      },
+    }),
+  ).toEqual(result);
+  expect(requests).toEqual([
+    `http://synthetic.test/service/v1/finding/${document.findings[0]!.findingId}/potential-duplicates?allRepositories=true`,
+  ]);
+  workbench.assertDone();
+});
 
 test("failed publication records its error, dry-run does not advance it, and retry records the receipt", async () => {
   await using fixture = await workflowFixture();


### PR DESCRIPTION
## Summary

Complete sealed scan artifacts can exist without registration in local scan history. Expose a public SDK entry point that deduplicates those artifacts without requiring imports from internal package modules.

## Changes

- add `deduplicateScanDirectory` to the public TypeScript SDK
- validate the sealed scan contract and optionally require an expected scan ID
- normalize the supplied repository checkout and bind it to resumable review workflows
- reuse existing publication, checkpoint, resume, and dedupe-group write behavior
- document the API and cover direct-directory and workflow use

## Testing

- `bun test --timeout 30000 tests-ts/finding-deduplication.test.ts tests-ts/finding-workflow-publication.test.ts` (17 passed)
- `pnpm run types`
- `pnpm run format`
- `pnpm run build`
- `git diff --check`
- `pnpm run test --seed 12345` (2,151 passed, 41 skipped, 13 environment-only failures: existing subprocess/trusted-ancestry checks in the isolated checkout and an ambient-auth expectation)
- three independent native Codex review passes plus independent pre-publish normalization verification

## Risk and rollout

This is an additive SDK API. Existing saved-scan deduplication and CLI behavior are unchanged. The new entry point uses the same sealed-artifact validation, findings scope, model review, workflow persistence, and write-back paths as the existing SDK method.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
