### PR TITLE
fix: restore batching for automatic finding matching

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -39,8 +39,9 @@ try {
 ```
 
 `result.findings` contains this scan's findings; `repositoryFindings` also
-includes earlier open findings when available. Matching earlier findings can
-make one extra model call, even with a cost limit.
+includes earlier open findings when available. Matching earlier findings uses
+additional model calls, with large inputs split into batches. These calls are
+outside the scan's recorded cost and `maxCostUsd` limit.
 
 Keep results outside the repository and restrict access: reports can contain
 source code, vulnerability details, and reproduction steps.

--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -1703,7 +1703,6 @@ export class CodexSecurity {
               ((input, comparisonOptions) =>
                 matchScanFindingsInternal(input, comparisonOptions, {
                   surface: this.#surface,
-                  allowBatching: false,
                 })),
             environment,
             model,

--- a/sdk/typescript/src/scan-comparison.ts
+++ b/sdk/typescript/src/scan-comparison.ts
@@ -174,7 +174,7 @@ export async function matchScanFindings(
 export async function matchScanFindingsInternal(
   input: ScanComparisonInput,
   options: ScanComparisonOptions = {},
-  runtimeOptions: { surface: CodexSecuritySurface; allowBatching?: boolean },
+  runtimeOptions: { surface: CodexSecuritySurface },
 ): Promise<ScanComparisonResult> {
   const comparisons: ScanComparisonResult[] = [];
   const allowHistoricalUncertainty =
@@ -182,7 +182,7 @@ export async function matchScanFindingsInternal(
   const outputSchema = z.toJSONSchema(comparisonSchema.required(), {
     target: "openapi-3.0",
   });
-  for (const batch of comparisonBatches(input, runtimeOptions.allowBatching)) {
+  for (const batch of comparisonBatches(input)) {
     options.signal?.throwIfAborted();
     const finalResponse = await runReadOnlyCodex(
       batch.prompt,
@@ -214,10 +214,9 @@ export async function matchScanFindingsInternal(
 
 function* comparisonBatches(
   input: ScanComparisonInput,
-  allowBatching = true,
 ): Generator<{ input: ScanComparisonInput; prompt: string }> {
   const prompt = comparisonPrompt(input);
-  if (allowBatching && prompt.length > CODEX_MAX_INPUT_CHARACTERS / 2) {
+  if (prompt.length > CODEX_MAX_INPUT_CHARACTERS / 2) {
     // Splitting one side at a time covers every before/after pair exactly once.
     const side =
       input.before.length > 1 &&

--- a/sdk/typescript/tests-ts/scan-comparison-batches.test.ts
+++ b/sdk/typescript/tests-ts/scan-comparison-batches.test.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "bun:test";
 import {
   matchScanFindings,
-  matchScanFindingsInternal,
   type ScanComparisonInput,
   type ScanComparisonOptions,
   type ScanComparisonResult,
@@ -251,36 +250,6 @@ test("uses Codex's full allowance for individual pairs without truncation", asyn
   expect(calls).toHaveLength(1);
   expect(oversized.before[0]!.evidence).toHaveLength(1048576);
 });
-
-test.each([200000, 300000])(
-  "keeps automatic post-scan matching to at most one call (%p characters per finding)",
-  async (characters) => {
-    const input = {
-      before: Array.from({ length: 4 }, (_, index) =>
-        finding(`before-${index}`, characters),
-      ),
-      after: [finding("after")],
-    };
-    const calls: ScanComparisonInput[] = [];
-    const comparison = matchScanFindingsInternal(
-      input,
-      {
-        codex: codex((batch) => {
-          calls.push(batch);
-          return noMatches;
-        }),
-      },
-      { surface: "sdk", allowBatching: false },
-    );
-    if (characters === 300000) {
-      await expect(comparison).rejects.toThrow("input limit");
-      expect(calls).toEqual([]);
-    } else {
-      expect(await comparison).toEqual(noMatches);
-      expect(calls).toEqual([input]);
-    }
-  },
-);
 
 test("stops between batches when canceled", async () => {
   const controller = new AbortController();


### PR DESCRIPTION
## Summary

Restore bounded batching for automatic post-scan history matching. The single-call restriction added in #638 can skip matching for a large history.

## Changes

- Remove the `allowBatching` switch and its two single-call tests.
- Keep the existing batch size limit, group matching, and cancellation behavior.
- Correct the README's one-call claim and state where cost tracking stops.

## Testing

- Focused matcher, component-scan, and API tests: 235 passed, 5 platform-specific tests skipped.
- `pnpm run types`, `pnpm run format`, and `pnpm run build` passed.
- `git diff --check` passed.

## Risk and rollout

Automatic history matching can make several model calls. These calls remain outside the scan's recorded cost and `maxCostUsd` limit. This PR restores batching; it does not add post-scan budget accounting. No CLI flags or result formats change.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
