### PR TITLE
fix(sdk): reject control characters in remote targets

### DIFF
--- a/sdk/typescript/src/contract.ts
+++ b/sdk/typescript/src/contract.ts
@@ -19,6 +19,7 @@ import {
   requirePrivateOutputDirectory,
   requireSecureOutputAncestry,
 } from "./runtime.js";
+import { MODEL_UNSAFE_STRING } from "./string-safety.js";
 import type { NormalizedTarget, ScanMode } from "./targets.js";
 import { isWindowsUnsafePathComponent } from "./windows-path.js";
 
@@ -428,7 +429,11 @@ function validateCanonicalContract(
     const authority = /^[A-Za-z][A-Za-z0-9+.-]*:\/\/([^/?#]+)/.exec(
       remote,
     )?.[1];
-    if (remote.includes("\\") || authority === undefined) {
+    if (
+      MODEL_UNSAFE_STRING.test(remote) ||
+      remote.includes("\\") ||
+      authority === undefined
+    ) {
       throw new ContractValidationError(
         "scan.target.remote: expected a sanitized canonical absolute URL.",
       );

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -63,6 +63,7 @@ import {
   isWindowsUnsafePathComponent,
   windowsUnsafePathComponent,
 } from "./windows-path.js";
+import { MODEL_UNSAFE_STRING } from "./string-safety.js";
 
 const execFile = promisify(execFileCallback);
 
@@ -73,7 +74,6 @@ const MAX_ZIP_ENTRIES = 4_096;
 const MAX_ZIP_CENTRAL_DIRECTORY = 16 * 1024 * 1024;
 const MAX_ZIP_ENTRY_SIZE = 128 * 1024 * 1024;
 const MAX_ZIP_EXPANDED_SIZE = 512 * 1024 * 1024;
-const MODEL_UNSAFE_PATH = /[\u0000-\u001f\u007f-\u009f\u2028\u2029]/u;
 const CREDENTIAL_LOCK_NAME = ".codex-security-scan.lock";
 const CREDENTIAL_LOCK_DATABASE = ".codex-security-scan.sqlite3";
 const CREDENTIAL_LOGOUT_MARKER = ".codex-security-logged-out";
@@ -1828,7 +1828,7 @@ export async function planOutputArchive(
 }
 
 export function requireModelSafeOutputDir(path: string): void {
-  if (MODEL_UNSAFE_PATH.test(path)) {
+  if (MODEL_UNSAFE_STRING.test(path)) {
     throw new OutputDirectoryError(
       "Scan output directory must not contain control or line-separator characters.",
     );

--- a/sdk/typescript/src/string-safety.ts
+++ b/sdk/typescript/src/string-safety.ts
@@ -1,0 +1,1 @@
+export const MODEL_UNSAFE_STRING = /[\u0000-\u001f\u007f-\u009f\u2028\u2029]/u;

--- a/sdk/typescript/tests-ts/contract.test.ts
+++ b/sdk/typescript/tests-ts/contract.test.ts
@@ -988,6 +988,30 @@ describe("canonical scan contract", () => {
         },
         "scan.target.remote",
       ],
+      [
+        "tab in remote",
+        (manifest) => {
+          manifest["scan"]["target"]["remote"] =
+            "https://example.com\thttps://evil.example.net";
+        },
+        "scan.target.remote",
+      ],
+      [
+        "line feed in remote",
+        (manifest) => {
+          manifest["scan"]["target"]["remote"] =
+            "https://example.com\nhttps://evil.example.net";
+        },
+        "scan.target.remote",
+      ],
+      [
+        "carriage return in remote",
+        (manifest) => {
+          manifest["scan"]["target"]["remote"] =
+            "https://example.com\rhttps://evil.example.net";
+        },
+        "scan.target.remote",
+      ],
     ];
 
     for (const [_name, mutate, expected] of cases) {


### PR DESCRIPTION
## Summary

The canonical contract validator accepts tab, line-feed, and carriage-return characters inside `scan.target.remote`. The WHATWG URL parser removes those characters before validation, while the original unsanitized value remains in the loaded manifest.

This can make a validated remote target contain embedded line or control characters and contradict the SDK contract that the value is sanitized.

Fixes #231.

## Changes

- Move the existing model-unsafe control and line-separator character pattern into a shared internal module.
- Reuse that pattern for both output-directory and canonical remote validation.
- Reject control and line-separator characters in `scan.target.remote` before URL parsing.
- Add regression coverage for tab, line-feed, and carriage-return remote values.

## Testing

- `bun test --timeout 30000 ./tests-ts/contract.test.ts -t "rejects schema-valid but canonically invalid contract data"`: 1 passed, 40 skipped, 15 expect calls
- `pnpm run check:plugin-source`: passed
- `pnpm run types`: passed
- `pnpm run lint`: passed
- `pnpm run format`: passed
- `git diff --check`: passed

The local Node runtime is 25.4.0 and emits the repository engine warning; the package requires Node 22, 24, or 26.

## Risk and rollout

Low and limited to invalid contract input. Valid URL handling, manifest schemas, output-directory behavior, and the public API shape remain unchanged. The shared pattern preserves the existing output-directory validation behavior.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.