### PR TITLE
fix(plugin): allow 120 seconds for MCP startup

### DIFF
--- a/plugins/codex-security/.mcp.json
+++ b/plugins/codex-security/.mcp.json
@@ -49,6 +49,7 @@
         "NODE_EXTRA_CA_CERTS",
         "XDG_CACHE_HOME"
       ],
+      "startup_timeout_sec": 120,
       "tool_timeout_sec": 349200
     }
   }


### PR DESCRIPTION
## Summary

Slow MCP initialization can exceed the host's default startup allowance before scan tools become available. Give the Codex Security MCP server 120 seconds per startup phase.

## Changes

- Set `startup_timeout_sec` to `120` in the plugin's MCP manifest.

## Testing

- Parsed the manifest and verified the startup timeout is 120 seconds.
- Plugin source compatibility checks passed.
- Required Ruff lint and formatting checks passed.
- `git diff --check` passed.

## Risk and rollout

Slow or failed initialization can wait longer before reporting an error. This mitigates premature startup failures; it does not address their underlying cause. The change takes effect when an updated plugin payload is distributed and the MCP connection starts again.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
