### PR TITLE
build: run the dev container on arm64 hosts

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -5,6 +5,11 @@
       "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:7d979c4a36d595eb4ab79909caa3f396daf3b6152dcf38e8328ea4eff42206c7",
       "integrity": "sha256:7d979c4a36d595eb4ab79909caa3f396daf3b6152dcf38e8328ea4eff42206c7"
     },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.2",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:7c409bf6316ffd85f04fd92fba85a744282639e603417dd4796409866bdb6805",
+      "integrity": "sha256:7c409bf6316ffd85f04fd92fba85a744282639e603417dd4796409866bdb6805"
+    },
     "ghcr.io/devcontainers/features/node:2": {
       "version": "2.1.0",
       "resolved": "ghcr.io/devcontainers/features/node@sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857",

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,19 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:4": {
+      "version": "4.1.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:7d979c4a36d595eb4ab79909caa3f396daf3b6152dcf38e8328ea4eff42206c7",
+      "integrity": "sha256:7d979c4a36d595eb4ab79909caa3f396daf3b6152dcf38e8328ea4eff42206c7"
+    },
+    "ghcr.io/devcontainers/features/node:2": {
+      "version": "2.1.0",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857",
+      "integrity": "sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "1.8.0",
+      "resolved": "ghcr.io/devcontainers/features/python@sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511",
+      "integrity": "sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,7 @@
   "image": "mcr.microsoft.com/devcontainers/base:noble",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:4": { "moby": false },
+    "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/node:2": {
       "version": "22",
       "pnpmVersion": "none"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,16 @@
 {
   "name": "Ona",
-  "image": "mcr.microsoft.com/devcontainers/universal:4.0.1-noble"
+  // devcontainers/universal publishes a linux/amd64 manifest only, so it cannot
+  // run natively on arm64 hosts. base:noble keeps the Ubuntu Noble userland the
+  // Ona automations expect and supplies the toolchains through features.
+  "image": "mcr.microsoft.com/devcontainers/base:noble",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:4": { "moby": false },
+    "ghcr.io/devcontainers/features/node:2": {
+      "version": "22",
+      "pnpmVersion": "none"
+    },
+    "ghcr.io/devcontainers/features/python:1": { "version": "3.12" }
+  },
+  "onCreateCommand": "sh .devcontainer/install.sh"
 }

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -eu
+
+# Install the development dependencies for the Node.js and Python workflows.
+# Shared by .devcontainer/devcontainer.json and .ona/automations.yml so editors
+# and Ona environments install the same toolchain.
+
+cd "$(dirname "$0")/.."
+
+# Install the pnpm release pinned by packageManager in package.json. Node ships
+# a corepack shim for pnpm, so installing it with npm collides with that shim.
+COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+export COREPACK_ENABLE_DOWNLOAD_PROMPT
+corepack install
+
+# Keep bun aligned with the version pinned in .github/workflows/node-ci.yml.
+npm install --global bun@1.3.14 --no-audit --no-fund
+
+if ! command -v rg >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install --yes ripgrep
+fi
+
+pnpm --dir sdk/typescript install --frozen-lockfile
+pnpm --dir plugins/codex-security/mcp-app install --frozen-lockfile
+python -m pip install --disable-pip-version-check --no-input -e 'plugins/codex-security[test]'

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -18,7 +18,12 @@ corepack install
 npm install --global bun@1.3.14 --no-audit --no-fund
 
 if ! command -v rg >/dev/null 2>&1; then
-    sudo apt-get update
+    # Refresh only the Ubuntu sources. Dev container features add APT sources of
+    # their own, and apt-get update exits 100 when any configured source fails
+    # validation, which would stop this script before ripgrep installs.
+    sudo apt-get update \
+        -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/ubuntu.sources \
+        -o Dir::Etc::sourceparts=-
     sudo apt-get install --yes ripgrep
 fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__/
 /codex-security.json
 /findings.json
 /*.sarif
+.pnpm-store/
 
 # Never publish internal-only plugin data.
 .internal/

--- a/.ona/automations.yml
+++ b/.ona/automations.yml
@@ -1,18 +1,7 @@
 tasks:
   install:
     name: Install dependencies
-    command: |
-      pnpm_package="$(node -p 'require("./package.json").packageManager.split("+")[0]')"
-      npm install --global "$pnpm_package" bun@1.3.14 --no-audit --no-fund
-      if ! command -v rg >/dev/null 2>&1; then
-        sudo apt-get update \
-          -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/ubuntu.sources \
-          -o Dir::Etc::sourceparts=-
-        sudo apt-get install --yes ripgrep
-      fi
-      pnpm --dir sdk/typescript install --frozen-lockfile
-      pnpm --dir plugins/codex-security/mcp-app install --frozen-lockfile
-      python -m pip install --disable-pip-version-check --no-input -e 'plugins/codex-security[test]'
+    command: sh .devcontainer/install.sh
     triggeredBy:
       - manual
       - prebuild


### PR DESCRIPTION
## Summary

The Dev Container added in #697 cannot start on an Apple Silicon Mac. Its image, `mcr.microsoft.com/devcontainers/universal:4.0.1-noble`, publishes a `linux/amd64` manifest only, so there is nothing for an arm64 host to run natively.

## Changes

- Use `mcr.microsoft.com/devcontainers/base:noble`, which publishes `linux/amd64` and `linux/arm64`, and add Node.js 22 and Python 3.12 as features. Staying on Ubuntu Noble keeps the userland the Ona automations expect.
- Add the `docker-in-docker` feature so the container checks from `container-ci.yml` run in the Dev Container: the image build, the `docker compose config` validations, and the findings service smoke test.
- Add the `github-cli` feature. The universal image bundled `gh`, and the documented `bulk-scan` flow needs it to resolve a GitHub token.
- Pin those features by digest in `.devcontainer/devcontainer-lock.json`.
- Install pnpm with `corepack install`, which reads the `packageManager` pin. Node ships a corepack shim for pnpm, so `npm install --global pnpm` fails with `EEXIST` on that shim.
- Share the dependency steps between the Dev Container and the Ona install task through `.devcontainer/install.sh`.
- Ignore `.pnpm-store/`, which pnpm creates in the repository because it cannot hard link across the workspace mount.

## Testing

Ran on an Apple Silicon Mac, in the Dev Container after `Rebuild Container Without Cache` (Ubuntu 24.04.4, `aarch64`):

- `pnpm run test` (SDK): 2241 passed, 41 skipped, 0 failed.
- `pnpm run test:mcp`: 23 passed, 0 failed.
- `python -m pytest` (plugin): 1086 passed, 9 skipped, 109 subtests, 0 failed.
- `pnpm run build`, `pnpm run types`, and `pnpm run format`: clean.
- `ruff check`, `ruff format --check`, and `python .github/scripts/check_plugin_source_compatibility.py`: clean.
- `docker build` of the customer container, then `--version`, `bulk-scan --help`, and `info --json` against it.
- `bun sdk/typescript/scripts/smoke-findings-service.ts`: passed.
- `docker compose config` for `compose.yaml`, the AppArmor overlay, `compose.findings.yaml`, and `compose.runner.yaml`.
- Resolved toolchain: Node v22.23.2, Python 3.12.14, pnpm 11.19.0 matching the `packageManager` pin, bun 1.3.14, ripgrep 14.1.0, gh 2.99.0.

Not tested: the Ona environment itself, which I do not have access to. The task graph, triggers, and working directory are unchanged; only the `install` command now calls the shared script.

## Risk and rollout

Development-environment configuration only. No runtime, packaging, or public CLI behavior changes.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.



