### PR TITLE
fix(release): retry transient GitHub reads

### DIFF
--- a/sdk/typescript/scripts/release-pr.mjs
+++ b/sdk/typescript/scripts/release-pr.mjs
@@ -648,7 +648,7 @@ export function createGitHubClient(repository, token, fetcher = fetch) {
         retry < 2 &&
         [500, 502, 503, 504].includes(response.status)
       ) {
-        await response.body?.cancel();
+        await response.body?.cancel().catch(() => undefined);
         await delay(1000 * 2 ** retry);
         continue;
       }

--- a/sdk/typescript/scripts/release-pr.mjs
+++ b/sdk/typescript/scripts/release-pr.mjs
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
+import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { isDeepStrictEqual } from "node:util";
 import { assertStableVersion, releaseVersion } from "./release-automation.mjs";
@@ -513,7 +514,7 @@ export async function reconcileReleasePullRequest({
   github,
   dryRun = true,
 }) {
-  // Re-read only when main or the proposal actually moves; API failures are not retried blindly.
+  // Rebuild the plan only when main or the proposal actually moves.
   for (;;) {
     const mainSha = await branchHead(github, "main");
     const history = await readReleaseHistory(repo, mainSha, github);
@@ -630,24 +631,33 @@ export async function reconcileReleasePullRequest({
 export function createGitHubClient(repository, token, fetcher = fetch) {
   const apiRoot = `https://api.github.com/repos/${repository}/`;
   async function responseFor(method, path, body) {
-    const response = await fetcher(`${apiRoot}${path}`, {
-      method,
-      headers: {
-        Accept: "application/vnd.github+json",
-        Authorization: `Bearer ${token}`,
-        "X-GitHub-Api-Version": "2026-03-10",
-        "Content-Type": "application/json",
-      },
-      body: body === undefined ? undefined : JSON.stringify(body),
-    });
-    if (!response.ok) {
+    for (let retry = 0; ; retry += 1) {
+      const response = await fetcher(`${apiRoot}${path}`, {
+        method,
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: `Bearer ${token}`,
+          "X-GitHub-Api-Version": "2026-03-10",
+          "Content-Type": "application/json",
+        },
+        body: body === undefined ? undefined : JSON.stringify(body),
+      });
+      if (response.ok) return response;
+      if (
+        method === "GET" &&
+        retry < 2 &&
+        [500, 502, 503, 504].includes(response.status)
+      ) {
+        await response.body?.cancel();
+        await delay(1000 * 2 ** retry);
+        continue;
+      }
       const error = new Error(
         `GitHub ${method} ${path} failed with HTTP ${response.status}.`,
       );
       error.status = response.status;
       throw error;
     }
-    return response;
   }
   return {
     repository,

--- a/sdk/typescript/tests-ts/release-pr.test.ts
+++ b/sdk/typescript/tests-ts/release-pr.test.ts
@@ -435,6 +435,82 @@ class FakeGitHub {
 }
 
 describe("GitHub request transport", () => {
+  test("recovers from a temporary server error without duplicating paginated results", async () => {
+    const pages: number[] = [];
+    const github = createGitHubClient(
+      "example/release-fixture",
+      "synthetic-release-token",
+      async (url, options) => {
+        expect(options.method).toBe("GET");
+        const page = Number(new URL(url).searchParams.get("page"));
+        pages.push(page);
+        if (pages.length === 2) {
+          return Response.json(
+            { message: "Temporary failure" },
+            { status: 500 },
+          );
+        }
+        return Response.json([{ number: page }], {
+          headers:
+            page === 1
+              ? {
+                  link: '<https://api.github.com/repos/example/release-fixture/pulls?per_page=1&page=2>; rel="next"',
+                }
+              : {},
+        });
+      },
+    );
+    expect(await github.list("pulls?per_page=1")).toEqual([
+      { number: 1 },
+      { number: 2 },
+    ]);
+    expect(pages).toEqual([1, 2, 2]);
+  });
+
+  test("reports a persistent server error after bounded read retries", async () => {
+    let requests = 0;
+    const github = createGitHubClient(
+      "example/release-fixture",
+      "synthetic-release-token",
+      async () => {
+        requests++;
+        return Response.json({ message: "Unavailable" }, { status: 503 });
+      },
+    );
+    await expect(
+      github.request("GET", "git/ref/heads/main"),
+    ).rejects.toMatchObject({
+      status: 503,
+      message: "GitHub GET git/ref/heads/main failed with HTTP 503.",
+    });
+    expect(requests).toBe(3);
+  });
+
+  test.each([
+    ["POST", 500],
+    ["PATCH", 503],
+    ["GET", 403],
+    ["GET", 404],
+    ["GET", 422],
+  ])(
+    "does not replay a %s request that fails with HTTP %i",
+    async (method, status) => {
+      let requests = 0;
+      const github = createGitHubClient(
+        "example/release-fixture",
+        "synthetic-release-token",
+        async () => {
+          requests++;
+          return Response.json({ message: "Failed request" }, { status });
+        },
+      );
+      await expect(github.request(method, "pulls")).rejects.toMatchObject({
+        status,
+      });
+      expect(requests).toBe(1);
+    },
+  );
+
   test("creates and updates a draft through serialized requests, including a concurrent commit conflict", async () => {
     const fixture = new Fixture();
     fixture.merge("feat: initial feature");

--- a/sdk/typescript/tests-ts/release-pr.test.ts
+++ b/sdk/typescript/tests-ts/release-pr.test.ts
@@ -435,7 +435,7 @@ class FakeGitHub {
 }
 
 describe("GitHub request transport", () => {
-  test("recovers from a temporary server error without duplicating paginated results", async () => {
+  test("recovers from an errored response body without duplicating paginated results", async () => {
     const pages: number[] = [];
     const github = createGitHubClient(
       "example/release-fixture",
@@ -445,10 +445,12 @@ describe("GitHub request transport", () => {
         const page = Number(new URL(url).searchParams.get("page"));
         pages.push(page);
         if (pages.length === 2) {
-          return Response.json(
-            { message: "Temporary failure" },
-            { status: 500 },
-          );
+          const body = new ReadableStream({
+            start(controller) {
+              controller.error(new Error("Synthetic response body failure"));
+            },
+          });
+          return new Response(body, { status: 500 });
         }
         return Response.json([{ number: page }], {
           headers:


### PR DESCRIPTION
## Summary

A temporary GitHub HTTP 500 while collecting release history aborts the rolling release updater. Retry temporary read failures so the job can recover without a manual rerun.

## Changes

- Retry GitHub GET requests returning HTTP 500, 502, 503, or 504 twice, with one- and two-second delays.
- Make failed-response cleanup best effort so an errored body stream cannot interrupt a read retry.
- Preserve pagination and the existing error status and message when retries are exhausted. Mutating requests and client errors retain their single-attempt behavior.
- Cover paginated read recovery, persistent server failures, and requests that must not be replayed.

## Testing

- Confirmed the new read-retry regression tests fail before the fix and pass afterward.
- GitHub request transport tests: 10 passed with seed `12345`.
- Full SDK suites in seeded and random order, hosted CI, and review results are tracked in the [validation report](https://github.com/openai/codex-security/pull/800#issuecomment-5521378202) for commit `17eb440ce719922e62e7c4231e4f073c5f580a0d`.
- SDK typechecking, formatting, Node syntax, and `git diff --check` passed.
- Live read-only release preview passed against current main and selected the expected next patch version.

## Risk and rollout

A persistent read failure takes up to three additional seconds of backoff before the existing error is reported. Release branch updates, PR creation, and comments retain their existing write behavior.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
