### PR TITLE
fix(cli): report component scan progress headlessly

### DIFF
--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -125,7 +125,10 @@ import {
 import type { Finding, SeverityLevel } from "./models.js";
 import { runMultiscan } from "./multiscan.js";
 import { componentPlanSchema, planComponents } from "./component-plan.js";
-import { runComponentScans } from "./component-scan.js";
+import {
+  runComponentScans,
+  type ComponentScanEvent,
+} from "./component-scan.js";
 import {
   checkScanPublication,
   forceTerminatePublicationProcesses as terminatePublishers,
@@ -3466,6 +3469,7 @@ export async function main(
       async run({ args, options }) {
         const controller = new AbortController();
         let dashboard: ScanDashboard | null = null;
+        const componentNames = new Map<string, string>();
         const stopDashboard = (): void => {
           try {
             dashboard?.stop();
@@ -3560,10 +3564,20 @@ export async function main(
             createSecurity: dependencies.createSecurity,
             planComponents: dependencies.planComponents,
             matchFindings: dependencies.matchFindings,
-            onPlan: (components) => dashboard?.setComponents(components),
+            onPlan: (components) => {
+              for (const component of components)
+                componentNames.set(component.id, component.name);
+              dashboard?.setComponents(components);
+            },
             onScanEvent:
               dashboard === null
-                ? undefined
+                ? (event) => {
+                    const componentName =
+                      componentNames.get(event.componentId) ??
+                      event.componentId;
+                    const line = componentScanEventLine(componentName, event);
+                    if (line !== null) errorOutput.write(line);
+                  }
                 : (event) => dashboard?.recordComponentEvent(event),
             onDeduplicationStarted: () => {
               if (dashboard !== null)
@@ -7584,6 +7598,24 @@ function formatTokenUsage(usage: unknown): string | null {
       .filter((value): value is string => value !== null)
       .join(", ") || null
   );
+}
+
+function componentScanEventLine(
+  componentName: string,
+  event: ComponentScanEvent,
+): string | null {
+  if (event.type === "progress") {
+    const progress = event.value;
+    return `codex-security: ${componentName} ${scanPhase(progress.phase)} | Files: ${progress.filesCompleted.toLocaleString("en-US")}/${progress.filesTotal.toLocaleString("en-US")}\n`;
+  }
+  if (event.type !== "cost") return null;
+  const cost = event.value;
+  const tokens = formatTokenUsage({
+    input_tokens: cost.inputTokens,
+    cached_input_tokens: cost.cachedInputTokens,
+    output_tokens: cost.outputTokens,
+  });
+  return `codex-security: ${componentName} | ${tokens === null ? "" : `Tokens: ${tokens} | `}Cost: ${formatUsd(cost.estimatedUsd)}\n`;
 }
 
 function protectedRootErrorMessage(

--- a/sdk/typescript/tests-ts/component-scan.test.ts
+++ b/sdk/typescript/tests-ts/component-scan.test.ts
@@ -463,13 +463,19 @@ test.each(["dashboard", "headless", "ci"])(
             presentation === "ci" ? { CI: "true" } : { NO_COLOR: "1" },
         }),
         createSecurity: client(async (_repository, options) => {
-          expect(typeof options.onProgress).toBe(
-            presentation === "dashboard" ? "function" : "undefined",
-          );
+          expect(typeof options.onProgress).toBe("function");
           options.onProgress?.({
             phase: "validation",
             filesCompleted: 2,
             filesTotal: 2,
+          });
+          options.onCost?.({
+            model: "gpt-5.6",
+            inputTokens: 100,
+            cachedInputTokens: 10,
+            cacheWriteInputTokens: 0,
+            outputTokens: 20,
+            estimatedUsd: 0.00123,
           });
           return completed(options);
         }),
@@ -490,6 +496,14 @@ test.each(["dashboard", "headless", "ci"])(
         stderr.text().indexOf("Component scans:"),
       );
     } else expect(stderr.text()).toContain("apps/api completed");
+    if (presentation !== "dashboard") {
+      expect(stderr.text()).toContain(
+        "apps/api validating findings | Files: 2/2",
+      );
+      expect(stderr.text()).toContain(
+        "apps/api | Tokens: 100 input, 10 cached, 20 output | Cost: $0.00123",
+      );
+    }
     expect(
       [...signals.listeners.values()].every(
         (listeners) => listeners.size === 0,


### PR DESCRIPTION
## Summary

Headless and CI runs of `scan-components` now report per-component progress and estimated cost. Previously, those runs only printed component lifecycle transitions because scan observers were registered only when the interactive dashboard was active.

Fixes #803

## Changes

- Register a scan-event presenter when the interactive dashboard is unavailable.
- Use component names and existing formatting helpers to display scan phases, file counts, token usage, and estimated cost.
- Emit progress and cost events to stderr; suppress activity text and raw session events.
- Cover dashboard, headless, and CI presentation in the component-scan tests.

## Testing

Independent validation of commit `a33bbcf000c70d367a2a89cabba4d58b3dc4b9cd`:

- Five focused Bun tests passed: dashboard, headless, and CI presentation; component event forwarding and observer failures; dashboard cleanup on cancellation.
- `tsc --noEmit` passed.
- Prettier checks passed for both changed files.
- `git diff --check` passed.

The focused local tests use synthetic repositories and mocked scans.

## Risk and rollout

This adds progress and cost lines to headless stderr output, making long-running component scans easier to monitor. JSON results remain on stdout. The interactive dashboard continues to receive the existing scan events. No new command, flag, environment variable, or dependency is introduced. Suitable for a normal patch release.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
