### PR TITLE
perf: speed up confirmed finding matching

### DIFF
--- a/sdk/typescript/src/scan-comparison.ts
+++ b/sdk/typescript/src/scan-comparison.ts
@@ -1258,18 +1258,16 @@ function validateComparison(
     ...[...new Set(findingIds.values())].map((findingId) => [findingId]),
   ]);
   if (enforceConfirmedIdentities) {
+    const occurrencesByFinding = Map.groupBy(
+      findingIds.keys(),
+      (occurrenceId) => findingIds.get(occurrenceId)!,
+    );
     for (const knownGroup of confirmedGroups) {
-      const knownFindingIds = new Set(knownGroup);
-      const knownBefore = input.before.filter(({ occurrenceId }) => {
-        const findingId = findingIds.get(occurrenceId);
-        return findingId !== undefined && knownFindingIds.has(findingId);
-      });
-      const knownAfter = input.after.filter(({ occurrenceId }) => {
-        const findingId = findingIds.get(occurrenceId);
-        return findingId !== undefined && knownFindingIds.has(findingId);
-      });
+      const knownOccurrences = knownGroup.flatMap(
+        (findingId) => occurrencesByFinding.get(findingId) ?? [],
+      );
       const matchedGroups = new Set(
-        [...knownBefore, ...knownAfter].flatMap(({ occurrenceId }) => {
+        knownOccurrences.flatMap((occurrenceId) => {
           const group =
             matchedBefore.get(occurrenceId) ?? matchedAfter.get(occurrenceId);
           return group === undefined ? [] : [group];
@@ -1278,13 +1276,13 @@ function validateComparison(
       if (
         matchedGroups.size > 1 ||
         (matchedGroups.size === 1 &&
-          [...knownBefore, ...knownAfter].some(
-            ({ occurrenceId }) =>
+          knownOccurrences.some(
+            (occurrenceId) =>
               !matchedBefore.has(occurrenceId) &&
               !matchedAfter.has(occurrenceId),
           )) ||
-        (knownBefore.length > 0 &&
-          knownAfter.length > 0 &&
+        (knownOccurrences.some((occurrenceId) => beforeIds.has(occurrenceId)) &&
+          knownOccurrences.some((occurrenceId) => afterIds.has(occurrenceId)) &&
           matchedGroups.size === 0)
       ) {
         throw new CodexSecurityError(

--- a/sdk/typescript/tests-ts/api-credentials.test.ts
+++ b/sdk/typescript/tests-ts/api-credentials.test.ts
@@ -630,7 +630,7 @@ process.exit(process.exitCode ?? 0);
       { pluginPath: PLUGIN_ROOT },
       {
         environment: {
-          ...process.env,
+          PATH: process.env["PATH"],
           NODE_OPTIONS: `--import=${pathToFileURL(script).href}`,
           CODEX_HOME: ambientHome,
           CODEX_SECURITY_STATE_DIR: stateDir,

--- a/sdk/typescript/tests-ts/cli-authentication.test.ts
+++ b/sdk/typescript/tests-ts/cli-authentication.test.ts
@@ -785,12 +785,10 @@ describe("CLI authentication", () => {
           'cli_auth_credentials_store = "file"\n',
         );
         const environment = {
-          ...process.env,
+          PATH: process.env["PATH"],
           HOME: userHome,
           USERPROFILE: userHome,
           CODEX_HOME: configuredHome,
-          OPENAI_API_KEY: undefined,
-          CODEX_API_KEY: undefined,
         };
         const run = (args: string[], input?: string): number | null =>
           spawnSync(
@@ -816,8 +814,9 @@ describe("CLI authentication", () => {
           {
             cwd: repository,
             env: {
-              ...process.env,
-              CODEX_HOME: undefined,
+              PATH: process.env["PATH"],
+              HOME: root,
+              USERPROFILE: root,
               Codex_Home: "   ",
             },
             encoding: "utf8",

--- a/sdk/typescript/tests-ts/publication-store.test.ts
+++ b/sdk/typescript/tests-ts/publication-store.test.ts
@@ -249,6 +249,7 @@ describe("read-only publication history", () => {
       destination: "linear" as const,
       teamId: "team-example",
       projectId: "project-example",
+      environment: fixture.environment,
     };
     const original = await prepareScanPublication(scanDirectory, options);
     seedPublicationScan(fixture, original);

--- a/sdk/typescript/tests-ts/publication.test.ts
+++ b/sdk/typescript/tests-ts/publication.test.ts
@@ -11,7 +11,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 import { prepareScanPublication } from "../src/publication.js";
 import type {
@@ -24,12 +24,17 @@ import { PLUGIN_ROOT } from "./plugin-root.js";
 
 const EXAMPLE = join(PLUGIN_ROOT, "examples", "completed-scan");
 const temporaryDirectories: string[] = [];
-const DESTINATION = {
-  destination: "linear",
-  teamId: "team_example",
-  projectId: "project_example",
-  uploadedAt: "2026-06-01T10:30:00Z",
-} as const;
+function publicationOptions(scanDirectory: string) {
+  return {
+    destination: "linear",
+    teamId: "team_example",
+    projectId: "project_example",
+    uploadedAt: "2026-06-01T10:30:00Z",
+    environment: {
+      CODEX_SECURITY_STATE_DIR: join(dirname(scanDirectory), "state"),
+    },
+  } as const;
+}
 
 afterEach(async () => {
   await Promise.all(
@@ -76,7 +81,7 @@ describe("scan publication preparation", () => {
 
     await expect(
       prepareScanPublication(scanDirectory, {
-        ...DESTINATION,
+        ...publicationOptions(scanDirectory),
         signal: controller.signal,
       }),
     ).rejects.toBe(reason);
@@ -86,7 +91,7 @@ describe("scan publication preparation", () => {
     const scanDirectory = await copyExample();
     await expect(
       prepareScanPublication(scanDirectory, {
-        ...DESTINATION,
+        ...publicationOptions(scanDirectory),
         expectedScanId: "another-scan",
       }),
     ).rejects.toThrow(
@@ -95,7 +100,7 @@ describe("scan publication preparation", () => {
     expect(
       (
         await prepareScanPublication(scanDirectory, {
-          ...DESTINATION,
+          ...publicationOptions(scanDirectory),
           expectedScanId: "scan_example_001",
         })
       ).scanId,
@@ -106,7 +111,7 @@ describe("scan publication preparation", () => {
     const scanDirectory = await copyExample();
     const publication = await prepareScanPublication(
       scanDirectory,
-      DESTINATION,
+      publicationOptions(scanDirectory),
     );
 
     expect(publication).toMatchObject({
@@ -183,7 +188,10 @@ describe("scan publication preparation", () => {
     await reseal(scanDirectory);
 
     const { description } = (
-      await prepareScanPublication(scanDirectory, DESTINATION)
+      await prepareScanPublication(
+        scanDirectory,
+        publicationOptions(scanDirectory),
+      )
     ).issues[0]!;
 
     const metadata = description.indexOf("**Scan ID:**");
@@ -221,7 +229,7 @@ describe("scan publication preparation", () => {
 
     const publication = await prepareScanPublication(
       join(alias, "scan"),
-      DESTINATION,
+      publicationOptions(scanDirectory),
     );
 
     expect(publication.scanDirectory).toBe(await realpath(scanDirectory));
@@ -246,7 +254,10 @@ describe("scan publication preparation", () => {
       await reseal(scanDirectory);
 
       const { description } = (
-        await prepareScanPublication(scanDirectory, DESTINATION)
+        await prepareScanPublication(
+          scanDirectory,
+          publicationOptions(scanDirectory),
+        )
       ).issues[0]!;
 
       expect(description).toContain(`**Coverage mode:** ${mode}`);
@@ -261,6 +272,7 @@ describe("scan publication preparation", () => {
       destination: "linear",
       teamId: "team_example",
       uploadedAt: "2026-06-01T10:30:00Z",
+      environment: publicationOptions(scanDirectory).environment,
     });
 
     expect(publication.destination).toEqual({
@@ -325,7 +337,10 @@ describe("scan publication preparation", () => {
     await reseal(scanDirectory);
 
     const { description } = (
-      await prepareScanPublication(scanDirectory, DESTINATION)
+      await prepareScanPublication(
+        scanDirectory,
+        publicationOptions(scanDirectory),
+      )
     ).issues[0]!;
 
     expect(description).toContain("**Root control:** `src/archive.py:12`");
@@ -362,7 +377,10 @@ describe("scan publication preparation", () => {
     await writeJson(manifestPath, manifest);
 
     const { description } = (
-      await prepareScanPublication(scanDirectory, DESTINATION)
+      await prepareScanPublication(
+        scanDirectory,
+        publicationOptions(scanDirectory),
+      )
     ).issues[0]!;
 
     expect(description).toContain(
@@ -385,7 +403,10 @@ describe("scan publication preparation", () => {
     await writeJson(manifestPath, manifest);
 
     const { description } = (
-      await prepareScanPublication(scanDirectory, DESTINATION)
+      await prepareScanPublication(
+        scanDirectory,
+        publicationOptions(scanDirectory),
+      )
     ).issues[0]!;
 
     expect(description).toContain("**Remote:** ssh://github.com/example/repo");
@@ -430,7 +451,10 @@ describe("scan publication preparation", () => {
     await reseal(scanDirectory);
 
     const { description } = (
-      await prepareScanPublication(scanDirectory, DESTINATION)
+      await prepareScanPublication(
+        scanDirectory,
+        publicationOptions(scanDirectory),
+      )
     ).issues[0]!;
 
     expect(description).toContain(
@@ -459,8 +483,12 @@ describe("scan publication preparation", () => {
       await writeJson(findingsPath, findings);
       await reseal(scanDirectory);
 
-      const issue = (await prepareScanPublication(scanDirectory, DESTINATION))
-        .issues[0]!;
+      const issue = (
+        await prepareScanPublication(
+          scanDirectory,
+          publicationOptions(scanDirectory),
+        )
+      ).issues[0]!;
       expect(issue.title).toStartWith(
         `[Codex Security][${severity.toUpperCase()}] `,
       );
@@ -478,7 +506,12 @@ describe("scan publication preparation", () => {
     await reseal(scanDirectory);
 
     expect(
-      (await prepareScanPublication(scanDirectory, DESTINATION)).issues,
+      (
+        await prepareScanPublication(
+          scanDirectory,
+          publicationOptions(scanDirectory),
+        )
+      ).issues,
     ).toEqual([]);
   });
 
@@ -490,7 +523,7 @@ describe("scan publication preparation", () => {
     await writeJson(findingsPath, findings);
 
     await expect(
-      prepareScanPublication(scanDirectory, DESTINATION),
+      prepareScanPublication(scanDirectory, publicationOptions(scanDirectory)),
     ).rejects.toThrow();
   });
 });

--- a/sdk/typescript/tests-ts/scan-comparison.property.test.ts
+++ b/sdk/typescript/tests-ts/scan-comparison.property.test.ts
@@ -49,6 +49,80 @@ function compare(
 }
 
 describe("finding-comparison invariants", () => {
+  test("keeps transitive identity groups separate across repeated occurrences", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(
+          fc.record({
+            before: fc.integer({ min: 0, max: 4 }),
+            after: fc.integer({ min: 0, max: 4 }),
+          }),
+          { minLength: 1, maxLength: 20 },
+        ),
+        async (counts) => {
+          const before = counts.flatMap((count, group) =>
+            Array.from({ length: count.before }, (_, occurrence) => ({
+              occurrenceId: `before-${group}-${occurrence}`,
+              findingId: `old-${group}`,
+            })),
+          );
+          const after = counts.flatMap((count, group) =>
+            Array.from({ length: count.after }, (_, occurrence) => ({
+              occurrenceId: `after-${group}-${occurrence}`,
+              findingId: `new-${group}`,
+            })),
+          );
+          const knownFindingGroups = counts.flatMap((_, group) => [
+            [`old-${group}`, `historical-${group}`],
+            [`historical-${group}`, `new-${group}`],
+          ]);
+          const expected = counts
+            .flatMap((count, group) =>
+              count.before > 0 && count.after > 0
+                ? [
+                    [
+                      Array.from(
+                        { length: count.before },
+                        (_, occurrence) => `before-${group}-${occurrence}`,
+                      ),
+                      Array.from(
+                        { length: count.after },
+                        (_, occurrence) => `after-${group}-${occurrence}`,
+                      ),
+                    ],
+                  ]
+                : [],
+            )
+            .sort();
+
+          for (const input of [
+            { before, after, knownFindingGroups },
+            {
+              before: [...before].reverse(),
+              after: [...after].reverse(),
+              knownFindingGroups: [...knownFindingGroups].reverse(),
+            },
+          ]) {
+            const result = await compare(input, {
+              matches: [],
+              uncertain: [],
+            });
+            expect(
+              result.matches
+                .map(({ beforeOccurrenceIds, afterOccurrenceIds }) => [
+                  [...beforeOccurrenceIds].sort(),
+                  [...afterOccurrenceIds].sort(),
+                ])
+                .sort(),
+            ).toEqual(expected);
+            expect(result.uncertain).toEqual([]);
+          }
+        },
+      ),
+      propertyOptions,
+    );
+  });
+
   test("preserves valid identities regardless of finding order", async () => {
     await fc.assert(
       fc.asyncProperty(identities, async (ids) => {


### PR DESCRIPTION
## Summary

Matching many distinct finding identities repeatedly scanned both occurrence lists for every confirmed group. Indexing occurrences by identity removes that quadratic validation work while preserving the existing grouping rules.

## Changes

- Index occurrences once and validate each confirmed identity group using its members.
- Add generated regression coverage for repeated occurrences, transitive aliases through absent historical identities, one-sided groups, and reordered inputs.
- Give publication fixtures their own state directories and credential fixtures explicit environments so ambient API keys and state paths cannot change test results.

## Testing

- Focused matching suite: 107 passed, 3 platform-specific skips; comparison properties ran with 1,000 cases each.
- Publication and credential tests under a synthetic ambient API key and unusable ambient database path: 86 passed across four files.
- Independent graph oracle: 1,000 generated cases; results equal main and remain correct with reversed input order.
- Built CLI: 8 checks passed, covering saved matches, cache reuse, comparison output, malformed responses, cancellation, missing artifacts, and unchanged sealed artifact hashes.
- SDK build, types, and formatting passed.
- Packed and installed-package checks passed, including public imports, types, CLI, lifecycle, bundled plugin files, MCP initialization, and dashboard assets.

Local Node.js 24 benchmark, median of three runs per case, using synthetic distinct identities and no model calls:

| Finding pairs | Main | This change |
| --- | ---: | ---: |
| 1,000 | 43 ms | 4 ms |
| 2,000 | 168 ms | 8 ms |
| 4,000 | 919 ms | 17 ms |
| 8,000 | 3,598 ms | 37 ms |

These measurements describe the deterministic identity-matching path; model latency is outside the benchmark.

## Risk and rollout

The added index uses memory proportional to the number of occurrences. Existing match validation, CLI behavior, stored comparisons, and sealed scan artifacts remain compatible. The environment changes apply only to tests. This can ship through the normal release process.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
