### PR TITLE
fix(release): allow the built-in workflow token

### DIFF
--- a/.github/workflows/node-release-pr.yml
+++ b/.github/workflows/node-release-pr.yml
@@ -19,15 +19,46 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  preview:
+    if: >-
+      github.repository == 'openai/codex-security' && github.ref == 'refs/heads/main' &&
+      ((github.event_name == 'workflow_dispatch' && inputs.dry_run) ||
+      (github.event_name != 'workflow_dispatch' && vars.RELEASE_PR_ENABLED != 'true'))
+    name: preview draft release PR
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_PR_DRY_RUN: "true"
+
+    steps:
+      - name: Checkout main, never the release PR
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: "22.13.0"
+
+      - name: Preview the rolling release proposal
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node sdk/typescript/scripts/release-pr.mjs
+
   reconcile:
-    if: github.repository == 'openai/codex-security' && github.ref == 'refs/heads/main'
+    if: >-
+      github.repository == 'openai/codex-security' && github.ref == 'refs/heads/main' &&
+      ((github.event_name == 'workflow_dispatch' && !inputs.dry_run) ||
+      (github.event_name != 'workflow_dispatch' && vars.RELEASE_PR_ENABLED == 'true'))
     name: maintain draft release PR
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     env:
-      RELEASE_PR_DRY_RUN: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) || (github.event_name != 'workflow_dispatch' && vars.RELEASE_PR_ENABLED != 'true') }}
+      RELEASE_PR_DRY_RUN: "false"
 
     steps:
       - name: Checkout main, never the release PR
@@ -44,7 +75,7 @@ jobs:
 
       - name: Create repository-scoped release App token
         id: app-token
-        if: env.RELEASE_PR_DRY_RUN == 'false' && vars.RELEASE_APP_CLIENT_ID != ''
+        if: vars.RELEASE_APP_CLIENT_ID != ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}

--- a/.github/workflows/node-release-pr.yml
+++ b/.github/workflows/node-release-pr.yml
@@ -23,6 +23,9 @@ jobs:
     if: github.repository == 'openai/codex-security' && github.ref == 'refs/heads/main'
     name: maintain draft release PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       RELEASE_PR_DRY_RUN: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) || (github.event_name != 'workflow_dispatch' && vars.RELEASE_PR_ENABLED != 'true') }}
 
@@ -41,7 +44,7 @@ jobs:
 
       - name: Create repository-scoped release App token
         id: app-token
-        if: env.RELEASE_PR_DRY_RUN == 'false'
+        if: env.RELEASE_PR_DRY_RUN == 'false' && vars.RELEASE_APP_CLIENT_ID != ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -140,15 +140,24 @@ writes. Its JSON output includes the proposed files and any reason the
 updater would pause. After the workflow is on `main`, use its **Run workflow**
 form with **dry_run** enabled to test the hosted read-only path.
 
-To test writes, configure a GitHub App installed on this repository
-with **Contents: write** and **Pull requests: write**, set the
-`RELEASE_APP_CLIENT_ID` repository variable and `RELEASE_APP_PRIVATE_KEY`
-secret, then manually dispatch the workflow with **dry_run** disabled.
-This permits a single write run while automatic updates remain disabled.
-Review the resulting draft, its hosted CI, and the Codex review request.
-The workflow requests an App token scoped to this repository so CI on the
-bot's PR does not need the approval required for PR events created by
-`GITHUB_TOKEN`. See [GitHub's token documentation](https://docs.github.com/en/actions/concepts/security/github_token).
+To test writes, enable **Allow GitHub Actions to create and approve pull requests**
+under the repository's **Settings → Actions → General → Workflow permissions**,
+then manually dispatch the workflow with **dry_run** disabled. This permits a
+single write run while automatic updates remain disabled. The workflow uses
+the repository's `GITHUB_TOKEN` with **Contents: write** and **Pull requests: write**
+by default; no separate App credentials are required.
+
+Review the resulting draft and select **Approve workflows to run** in its merge
+box to start hosted CI. GitHub requires this approval for PRs created or updated
+with `GITHUB_TOKEN`. Check the Codex review on the current head as well, and
+request it manually if the automated request has not started a review.
+
+For CI to start without this approval, optionally configure a GitHub App
+installed on this repository with **Contents: write** and **Pull requests: write**.
+Set the `RELEASE_APP_CLIENT_ID` repository variable and `RELEASE_APP_PRIVATE_KEY`
+secret. When the Client ID is configured, write runs request an App token scoped
+to this repository; a missing or invalid private key fails the run. Previews
+always use `GITHUB_TOKEN`. See [GitHub's token documentation](https://docs.github.com/en/actions/concepts/security/github_token).
 
 After the manual write run is verified, set the `RELEASE_PR_ENABLED`
 repository variable to `true` to allow updates after pushes to `main`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -145,7 +145,8 @@ under the repository's **Settings → Actions → General → Workflow permissio
 then manually dispatch the workflow with **dry_run** disabled. This permits a
 single write run while automatic updates remain disabled. The workflow uses
 the repository's `GITHUB_TOKEN` with **Contents: write** and **Pull requests: write**
-by default; no separate App credentials are required.
+by default; no separate App credentials are required. Preview runs use a separate
+job with read-only permissions for both scopes.
 
 Review the resulting draft and select **Approve workflows to run** in its merge
 box to start hosted CI. GitHub requires this approval for PRs created or updated

--- a/sdk/typescript/tests-ts/release-pr.test.ts
+++ b/sdk/typescript/tests-ts/release-pr.test.ts
@@ -633,6 +633,41 @@ describe("GitHub request transport", () => {
 
 describe("release workflow controls", () => {
   test.each([
+    { dryRun: "false", clientId: "", createsAppToken: false },
+    { dryRun: "false", clientId: "synthetic-app-id", createsAppToken: true },
+    { dryRun: "true", clientId: "", createsAppToken: false },
+    { dryRun: "true", clientId: "synthetic-app-id", createsAppToken: false },
+  ])(
+    "selects authentication for dry_run=$dryRun with client ID '$clientId'",
+    ({ dryRun, clientId, createsAppToken }) => {
+      const { jobs } = Bun.YAML.parse(workflow) as {
+        jobs: {
+          reconcile: {
+            permissions?: Record<string, string>;
+            steps: { id?: string; if?: string }[];
+          };
+        };
+      };
+      const appToken = jobs.reconcile.steps.find(
+        (step) => step.id === "app-token",
+      )!;
+      const evaluate = new Function("env", "vars", `return (${appToken.if});`);
+      expect(
+        evaluate(
+          { RELEASE_PR_DRY_RUN: dryRun },
+          { RELEASE_APP_CLIENT_ID: clientId },
+        ),
+      ).toBe(createsAppToken);
+      if (dryRun === "false" && !createsAppToken) {
+        expect(jobs.reconcile.permissions).toMatchObject({
+          contents: "write",
+          "pull-requests": "write",
+        });
+      }
+    },
+  );
+
+  test.each([
     { event: "push", enabled: undefined, dryRun: undefined, expected: true },
     { event: "push", enabled: "false", dryRun: undefined, expected: true },
     { event: "push", enabled: "true", dryRun: undefined, expected: false },

--- a/sdk/typescript/tests-ts/release-pr.test.ts
+++ b/sdk/typescript/tests-ts/release-pr.test.ts
@@ -632,6 +632,19 @@ describe("GitHub request transport", () => {
 });
 
 describe("release workflow controls", () => {
+  const { permissions, jobs } = Bun.YAML.parse(workflow) as {
+    permissions: Record<string, string>;
+    jobs: Record<
+      string,
+      {
+        if: string;
+        permissions?: Record<string, string>;
+        env: { RELEASE_PR_DRY_RUN: string };
+        steps: { id?: string; if?: string }[];
+      }
+    >;
+  };
+
   test.each([
     { dryRun: "false", clientId: "", createsAppToken: false },
     { dryRun: "false", clientId: "synthetic-app-id", createsAppToken: true },
@@ -640,30 +653,22 @@ describe("release workflow controls", () => {
   ])(
     "selects authentication for dry_run=$dryRun with client ID '$clientId'",
     ({ dryRun, clientId, createsAppToken }) => {
-      const { jobs } = Bun.YAML.parse(workflow) as {
-        jobs: {
-          reconcile: {
-            permissions?: Record<string, string>;
-            steps: { id?: string; if?: string }[];
-          };
-        };
-      };
-      const appToken = jobs.reconcile.steps.find(
-        (step) => step.id === "app-token",
+      const job = Object.values(jobs).find(
+        ({ env }) => env.RELEASE_PR_DRY_RUN === dryRun,
       )!;
-      const evaluate = new Function("env", "vars", `return (${appToken.if});`);
-      expect(
-        evaluate(
-          { RELEASE_PR_DRY_RUN: dryRun },
-          { RELEASE_APP_CLIENT_ID: clientId },
-        ),
-      ).toBe(createsAppToken);
-      if (dryRun === "false" && !createsAppToken) {
-        expect(jobs.reconcile.permissions).toMatchObject({
-          contents: "write",
-          "pull-requests": "write",
-        });
-      }
+      const appToken = job.steps.find((step) => step.id === "app-token");
+      const evaluate = new Function(
+        "vars",
+        `return (${appToken?.if ?? "false"});`,
+      );
+      expect(evaluate({ RELEASE_APP_CLIENT_ID: clientId })).toBe(
+        createsAppToken,
+      );
+      const access = dryRun === "true" ? "read" : "write";
+      expect(job.permissions ?? permissions).toEqual({
+        contents: access,
+        "pull-requests": access,
+      });
     },
   );
 
@@ -704,22 +709,26 @@ describe("release workflow controls", () => {
   ])(
     "selects preview mode for $event with enabled=$enabled and dry_run=$dryRun",
     ({ event, enabled, dryRun, expected }) => {
-      const expression = workflow.match(
-        /RELEASE_PR_DRY_RUN: \$\{\{ (.+) \}\}/u,
-      )![1]!;
-      const evaluate = new Function(
-        "github",
-        "inputs",
-        "vars",
-        `return (${expression});`,
-      );
-      expect(
-        evaluate(
-          { event_name: event },
+      const selectedJobs = Object.values(jobs).filter((job) => {
+        const evaluate = new Function(
+          "github",
+          "inputs",
+          "vars",
+          `return (${job.if});`,
+        );
+        return evaluate(
+          {
+            event_name: event,
+            repository: "openai/codex-security",
+            ref: "refs/heads/main",
+          },
           { dry_run: dryRun },
           { RELEASE_PR_ENABLED: enabled },
-        ),
-      ).toBe(expected);
+        );
+      });
+      expect(selectedJobs.map((job) => job.env.RELEASE_PR_DRY_RUN)).toEqual([
+        String(expected),
+      ]);
     },
   );
 });


### PR DESCRIPTION
## Summary

Release write runs fail when a separate GitHub App is not configured. Use the repository's built-in workflow token by default and retain the App option for CI that starts without maintainer approval.

## Changes

- Give only the release writer job Contents and Pull requests write permissions; previews run in a separate read-only job.
- Create an App token only when its Client ID is configured and the run can write.
- Document the built-in token setup, CI approval step, and optional App configuration.
- Cover preview and write runs with and without App configuration.

## Testing

- Release-updater tests: 68 passed.
- `pnpm run types`: passed.
- `pnpm run format`: passed.
- Prettier check of the changed workflow, documentation, and test: passed.
- `actionlint .github/workflows/node-release-pr.yml`: passed.
- `git diff --check`: passed.

Full SDK suite results and hosted checks are recorded in the validation comment.

## Risk and rollout

Only a write run's temporary token receives repository Contents and Pull requests write access. Preview credentials remain read-only, including when automatic updates are disabled. Both jobs continue to run the code from main. PRs created or updated with the built-in token require a maintainer to approve their CI runs; configured Apps retain unattended CI. See [GitHub's token behavior](https://docs.github.com/en/actions/concepts/security/github_token).

After merging, run one manual write with `dry_run=false`, review its draft and checks, then set `RELEASE_PR_ENABLED=true` to enable updates after pushes to main. Release merging and publication continue through the existing review process.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
