### PR TITLE
fix(multiscan): persist scan warnings in receipts

### DIFF
--- a/sdk/typescript/src/multiscan.ts
+++ b/sdk/typescript/src/multiscan.ts
@@ -56,6 +56,7 @@ interface MultiscanReceipt extends MultiscanTask {
   cost?: ScanCost;
   error?: string;
   warning?: string;
+  warnings?: string[];
 }
 
 export interface MultiscanOptions {
@@ -166,6 +167,16 @@ async function runCampaign(
         receipt.outputDir === selectedArtifactOutput) &&
       (await hasArtifacts(artifactOutput))
     ) {
+      if (receipt.status !== "failed") {
+        for (const warning of receipt.warnings ?? []) {
+          notifyProgress(options, {
+            repository: task.id,
+            status: receipt.status,
+            attempt: receipt.attempt,
+            warning,
+          });
+        }
+      }
       if (receipt.status === "completed") {
         completed += 1;
         continue;
@@ -228,6 +239,7 @@ async function runCampaign(
         notifyProgress(options, { ...progress, status: "started" });
         let failure: string | undefined;
         let warning: string | undefined;
+        const runWarnings: string[] = [];
         let coverage: CoverageDocument["completeness"] | undefined;
         let cost: Readonly<ScanCost> | null = null;
         let exhaustedBudget = false;
@@ -272,12 +284,14 @@ async function runCampaign(
             ...(options.maxCostUsd === undefined
               ? {}
               : { maxCostUsd: options.maxCostUsd }),
-            onWarning: (warning) =>
+            onWarning: (warning) => {
+              runWarnings.push(warning);
               notifyProgress(options, {
                 ...progress,
                 status: "started",
                 warning,
-              }),
+              });
+            },
             ...(options.signal === undefined ? {} : { signal: options.signal }),
           });
           cost = result.cost;
@@ -317,6 +331,7 @@ async function runCampaign(
             ...(cost === null ? {} : { cost }),
             ...(failure === undefined ? {} : { error: failure }),
             ...(warning === undefined ? {} : { warning }),
+            ...(runWarnings.length === 0 ? {} : { warnings: runWarnings }),
           })}\n`,
         );
         notifyProgress(options, {

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -369,6 +369,7 @@ describe("multiscan", () => {
         paths,
         client(async (_repository, scanOptions = {}) => {
           scanOptions.onWarning?.("Could not run post-scan instructions.");
+          scanOptions.onWarning?.("Repository changed during the scan.");
           return await completedScan(scanOptions.outputDir!);
         }),
         { onProgress: (event) => progress.push(event) },
@@ -382,6 +383,45 @@ describe("multiscan", () => {
       status: "started",
       warning: "Could not run post-scan instructions.",
     });
+    expect(await results(summary.resultsPath)).toMatchObject([
+      {
+        id: "follow-up-warning",
+        status: "completed",
+        warnings: [
+          "Could not run post-scan instructions.",
+          "Repository changed during the scan.",
+        ],
+      },
+    ]);
+
+    const resumedProgress: typeof progress = [];
+    const resumed = await runMultiscan(
+      options(
+        paths,
+        client(async () => Promise.reject(new Error("must not rerun"))),
+        {
+          onProgress: (event) => resumedProgress.push(event),
+        },
+      ),
+    );
+
+    expect(resumed).toMatchObject({ completed: 1, skipped: 1, failed: 0 });
+    expect(resumedProgress).toEqual(
+      expect.arrayContaining([
+        {
+          repository: "follow-up-warning",
+          attempt: 1,
+          status: "completed",
+          warning: "Could not run post-scan instructions.",
+        },
+        {
+          repository: "follow-up-warning",
+          attempt: 1,
+          status: "completed",
+          warning: "Repository changed during the scan.",
+        },
+      ]),
+    );
   });
 
   test.each([false, true])(


### PR DESCRIPTION
## Summary

Preserve bulk-scan run warnings in the durable `results.jsonl` ledger so successful repositories do not lose warning evidence after the live progress event has passed.

Part of #248. Follow-up #973 tracks surfacing persisted run warnings in the campaign summary.

Current `main` already forwards `security.run()` warnings to live progress. This PR closes the persistence/replay gap: a completed scan can now retain its run warnings in the receipt and surface them again when a completed/incomplete receipt is reused on campaign resume.

## Changes

- collect every warning emitted by `security.run()` for an attempt;
- write non-empty warnings to the attempt receipt as `warnings` while keeping the existing singular coverage `warning` field compatible;
- replay persisted warnings through `onProgress` when a completed/incomplete receipt is reused on campaign resume;
- extend the warning regression to verify multiple warnings survive the ledger and a resume does not rerun the repository.

## Testing

After rebasing onto current `main`:
- `tsc --noEmit` — passed
- Prettier check on both changed files — passed
- `git diff --check` — passed
- Bun is not installed in the local rebase environment, so the focused Bun suite could not be rerun locally. The pre-rebase focused suite was independently verified by review as 52 passed, 1 skip, 0 failed, and the rebased test conflict applied cleanly.

## Risk and rollout

Low. The ledger change is additive and older receipts without `warnings` remain readable. Scan status, retry behavior, coverage handling, policy-failure accounting, recovery behavior, and live warning delivery are unchanged. Resumed campaigns gain warning replay for receipts that include the new field.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
