### PR TITLE
fix(sdk): advance Linear pagination connections

### DIFF
--- a/sdk/typescript/src/linear.ts
+++ b/sdk/typescript/src/linear.ts
@@ -83,9 +83,12 @@ export async function importLinearIssues(options: {
         );
       }
 
-      const page = await projects.nodes[0]!.issues({ first: 50, filter });
-      while (page.pageInfo.hasNextPage) await page.fetchNext();
-      issues.push(...page.nodes);
+      let page = await projects.nodes[0]!.issues({ first: 50, filter });
+      while (true) {
+        issues.push(...page.nodes);
+        if (!page.pageInfo.hasNextPage) break;
+        page = await page.fetchNext();
+      }
       if (issues.length === 0) {
         throw new CodexSecurityError(
           `No open Linear issues matched project "${options.project}" and its filter.`,
@@ -114,8 +117,13 @@ export async function importLinearIssues(options: {
 
     const imports: ImportedIssue[] = [];
     for (const issue of issues) {
-      const comments = await issue.comments({ first: 50 });
-      while (comments.pageInfo.hasNextPage) await comments.fetchNext();
+      let comments = await issue.comments({ first: 50 });
+      const commentNodes = [];
+      while (true) {
+        commentNodes.push(...comments.nodes);
+        if (!comments.pageInfo.hasNextPage) break;
+        comments = await comments.fetchNext();
+      }
       imports.push({
         source: "linear",
         id: issue.identifier,
@@ -123,7 +131,7 @@ export async function importLinearIssues(options: {
         text: [
           `Title: ${issue.title}`,
           `<description>\n${issue.description ?? ""}\n</description>`,
-          ...comments.nodes.map(
+          ...commentNodes.map(
             ({ url, body }) => `<comment>\nURL: ${url}\n\n${body}\n</comment>`,
           ),
         ].join("\n\n"),

--- a/sdk/typescript/tests-ts/cli-skills.test.ts
+++ b/sdk/typescript/tests-ts/cli-skills.test.ts
@@ -20,20 +20,26 @@ function linearIssue(identifier: string, comments: string[] = []) {
     body,
     url: `https://linear.app/example/issue/${identifier}#comment-${index}`,
   }));
+  const nextPage = {
+    nodes: nodes.slice(1),
+    pageInfo: { hasNextPage: false },
+    async fetchNext() {
+      throw new Error("unexpected extra Linear comment page");
+    },
+  };
+  const firstPage = {
+    nodes: nodes.slice(0, 1),
+    pageInfo: { hasNextPage: nodes.length > 1 },
+    async fetchNext() {
+      return nextPage;
+    },
+  };
   return {
     identifier,
     title: `Fix ${identifier}`,
     description: `Synthetic evidence for ${identifier}`,
     url: `https://linear.app/example/issue/${identifier}`,
-    comments: async () => ({
-      nodes: nodes.slice(0, 1),
-      pageInfo: { hasNextPage: nodes.length > 1 },
-      async fetchNext() {
-        this.nodes.push(...nodes.slice(1));
-        this.pageInfo.hasNextPage = false;
-        return this;
-      },
-    }),
+    comments: async () => firstPage,
   };
 }
 
@@ -191,7 +197,7 @@ describe("CLI skill commands", () => {
                   description,
                 };
               },
-            } as ReturnType<LinearClientFactory>;
+            } as unknown as ReturnType<LinearClientFactory>;
           },
           onCodex: (_args, output, processEnvironment) => {
             inputs = JSON.parse(output!.appServer!.prompt.split("\n").at(-1)!);
@@ -308,16 +314,19 @@ describe("CLI skill commands", () => {
           environment: { LINEAR_ACCESS_TOKEN: "SYNTHETIC_OAUTH_TOKEN" },
           linearClient: ({ accessToken }) => {
             expect(accessToken).toBe("SYNTHETIC_OAUTH_TOKEN");
+            const nextPage = {
+              nodes: [linearIssue("SEC-124", ["Second issue comment"])],
+              pageInfo: { hasNextPage: false },
+              async fetchNext() {
+                throw new Error("unexpected extra Linear issue page");
+              },
+            };
             const page = {
               nodes: [linearIssue("SEC-123", ["First issue comment"])],
               pageInfo: { hasNextPage: true },
               async fetchNext() {
                 nextPages++;
-                this.nodes.push(
-                  linearIssue("SEC-124", ["Second issue comment"]),
-                );
-                this.pageInfo.hasNextPage = false;
-                return this;
+                return nextPage;
               },
             };
             return {


### PR DESCRIPTION
Fixes #516

## Reproduction

When a Linear project has more than one page of matching issues, the first connection reports `pageInfo.hasNextPage: true`, but `fetchNext()` returns the next connection. The current code discards that return value and keeps checking the first page, so the import can loop indefinitely.

The same discarded-connection pattern also affected paginated issue comments.

## Expected behavior

Advance through each returned Linear connection and import every page exactly once.

## Actual behavior

The project import repeatedly fetches from the original first page and never reaches the terminal page when the SDK returns a new connection object.

## Root cause

Both pagination loops awaited `fetchNext()` without assigning its returned connection, then read only the original connection's nodes.

## Fix

Consume the current page before assigning the connection returned by `fetchNext()`. Apply the same traversal to issue comments so imported evidence is complete.

## Validation

- `bun test --timeout 30000 ./tests-ts/cli-skills.test.ts`: 30 passed
- Added immutable multi-page project and comment fixtures that fail under the old implementation
- Prettier check: passed
- TypeScript `tsc --noEmit`: passed
- `git diff --check origin/main...HEAD`: passed

The branch was based on and tested against the latest upstream `main` at `f9b686a6`.