### PR TITLE
fix: reduce deduplication pair review effort to high

### DIFF
--- a/docker/fixtures/mock-reviews.mjs
+++ b/docker/fixtures/mock-reviews.mjs
@@ -57,7 +57,10 @@ const server = createServer(async (request, response) => {
         body.model,
         stage === "screen" ? "gpt-5.6-luna" : "gpt-5.6-sol",
       );
-      assert.equal(body.reasoning.effort, "xhigh");
+      assert.equal(
+        body.reasoning.effort,
+        stage === "screen" ? "xhigh" : "high",
+      );
       const tools = body.input
         .filter((entry) => entry.type === "additional_tools")
         .flatMap((entry) => entry.tools);

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1560,7 +1560,7 @@ use another workflow ID for a fresh review rather than changing that saved resul
 2. Screen each nonempty neighborhood with `gpt-5.6-luna` at `xhigh` reasoning
    effort. The review covers every anchor-neighbor pair; nominations between
    neighbors are rejected.
-3. Independently review each nominated pair once with `gpt-5.6-sol` at `xhigh`
+3. Independently review each nominated pair once with `gpt-5.6-sol` at `high`
    reasoning effort. Only accepted pairs contribute to duplicate groups.
 4. Group accepted duplicate pairs transitively unless a Luna or Sol `DISTINCT`
    decision contradicts the resulting component. Contradicted components are

--- a/sdk/typescript/src/deduplication/deduplication-reviewer.ts
+++ b/sdk/typescript/src/deduplication/deduplication-reviewer.ts
@@ -161,7 +161,7 @@ export class CodexDeduplicationReviewer implements DeduplicationReviewer {
     return await this.runner.run({
       stage: "pair-review",
       model: "gpt-5.6-sol",
-      effort: "xhigh",
+      effort: "high",
       prompt: pairReviewPrompt(findings),
       schema: {
         type: "object",

--- a/sdk/typescript/tests-ts/finding-deduplication.test.ts
+++ b/sdk/typescript/tests-ts/finding-deduplication.test.ts
@@ -596,8 +596,8 @@ test("keeps recommendation-only screening independent from complete pair reviews
     calls.map(({ stage, model, effort }) => [stage, model, effort]),
   ).toEqual([
     ["screening", "gpt-5.6-luna", "xhigh"],
-    ["pair-review", "gpt-5.6-sol", "xhigh"],
-    ["pair-review", "gpt-5.6-sol", "xhigh"],
+    ["pair-review", "gpt-5.6-sol", "high"],
+    ["pair-review", "gpt-5.6-sol", "high"],
   ]);
   expect(calls[0]!.prompt).toContain(JSON.stringify({ findings }));
   expect(calls[1]!.prompt).toContain(


### PR DESCRIPTION
## Summary

Reduce the reasoning effort for Sol pairwise duplicate comparisons from `xhigh` to `high`.

## Changes

- Set `gpt-5.6-sol` pair reviews to `high` reasoning effort.
- Update the existing model/effort assertions, Docker smoke-test mock, and deduplication documentation.

## Testing

- Focused deduplication tests: 17 passed.
- Docker mock request check: accepts Luna `xhigh` screening and Sol `high` pair reviews; fixture formatting passed.
- `pnpm run types`: passed.
- `pnpm run format`: passed.
- `pnpm run test --seed 12345`: 2,400 passed, 41 skipped, one unrelated authentication test failed because ambient API-key authentication overrides its expected ChatGPT login. That test passed with `OPENAI_API_KEY` and `CODEX_API_KEY` unset.
- `pnpm run test` with ambient API-key variables unset: 2,401 passed, 41 skipped, zero failures (seed `3693900373`).

## Risk and rollout

Pair-review decisions may differ with lower reasoning effort. Luna screening remains at `xhigh`; models, prompts, schemas, and CLI syntax are unchanged. Pair-review checkpoints include reasoning effort, so prior `xhigh` checkpoints will not be reused for new `high` requests.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
