### PR TITLE
feat(cli): create GitLab merge requests for verified patches

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1128,8 +1128,8 @@ assessment skill once on the completed patch. The assessment is advisory and
 does not change the patch or its merge state. Human-readable commands print the
 report after the patch results; saved-finding JSON output returns it as
 `patchRisk.report` in the same result object. When combined with `--create-pr`,
-the draft pull request body includes only the concise Markdown summary from the
-assessment; the validated JSON remains in the command result.
+the draft pull request or merge request body includes only the concise Markdown
+summary from the assessment; the validated JSON remains in the command result.
 
 ```bash
 npx @openai/codex-security validate "Possible SQL injection" --effort high
@@ -1151,11 +1151,25 @@ to select findings and add patch instructions. Results include a `patches`
 entry per finding with status `verified`, `no_change`, `blocked`, or `failed`.
 Verified and already-fixed findings no longer fail `--fail-on-severity`.
 
-`--create-pr` commits generated patch files and opens a draft PR with `gh`.
-Supplied-issue pull requests require a clean working tree before patching so
+`--create-pr` commits generated patch files and opens a draft GitHub pull request
+with `gh` or a draft GitLab merge request with `glab`. Install and authenticate
+the appropriate CLI first (`gh auth login` or `glab auth login`). GitLab.com is
+selected from the `origin` push URL, including SSH URLs and subgroup projects.
+For self-hosted GitLab, set `GITLAB_HOST` to the host in that URL and authenticate
+with `glab auth login --hostname HOST`. The existing `GITLAB_URI` and `GL_HOST`
+aliases are also accepted, in that order after `GITLAB_HOST`. Other hosts retain
+the GitHub workflow.
+
+```bash
+GITLAB_HOST=gitlab.example.com npx @openai/codex-security patch --scan SCAN_ID --create-pr
+```
+
+Both providers use the existing `pullRequest: { branch, url }` JSON result.
+Supplied-issue requests require a clean working tree before patching so
 existing work is never included. If publication fails, run the printed
 `patch --resume-pr BRANCH` command in the same repository. It reuses the saved
 commit without rerunning Codex, but refuses to publish if the branch changed.
+Use the same GitLab host setting when resuming a self-hosted merge request.
 
 To patch Linear issues, repeat `--linear-issue ISSUE` (ID or URL), or use
 `--linear-project "PROJECT"` with an optional native JSON `--linear-filter`.

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -323,7 +323,9 @@ const PROVIDER_OPTION = z
 const CREATE_PR_OPTION = z
   .boolean()
   .default(false)
-  .describe("Create a draft GitHub pull request after verified patches.");
+  .describe(
+    "Create a draft GitHub pull request or GitLab merge request after verified patches.",
+  );
 const ASSESS_PATCH_RISK_OPTION = z
   .boolean()
   .default(false)
@@ -1174,7 +1176,7 @@ interface CliDependencies {
     input?: string,
   ): Promise<number>;
   runRepositoryCommand(
-    command: "git" | "gh",
+    command: "git" | "gh" | "glab",
     args: readonly string[],
     repository: string,
     options?: { trim?: boolean; environment?: NodeJS.ProcessEnv },
@@ -5367,36 +5369,90 @@ async function publishPatchBranch(
   stderr: Writable,
   dependencies: CliDependencies,
 ): Promise<{ branch: string; url: string }> {
-  const run = (command: "git" | "gh", args: string[]) =>
+  const run = (command: "git" | "gh" | "glab", args: string[]) =>
     dependencies.runRepositoryCommand(command, args, repository);
   try {
-    let url = await run("gh", [
-      "pr",
-      "list",
-      "--head",
-      branch,
-      "--state",
-      "all",
-      "--json",
-      "url",
-      "--jq",
-      ".[0].url // empty",
-    ]);
+    const remote = await run("git", ["remote", "get-url", "--push", "origin"]);
+    const host = patchRemoteHost(remote);
+    const gitlabHost =
+      dependencies.environment["GITLAB_HOST"] ||
+      dependencies.environment["GITLAB_URI"] ||
+      dependencies.environment["GL_HOST"];
+    const gitlab =
+      host === "gitlab.com" ||
+      (host !== undefined &&
+        gitlabHost !== undefined &&
+        host ===
+          patchRemoteHost(
+            gitlabHost.includes("://") ? gitlabHost : `https://${gitlabHost}`,
+          ));
+    const command = gitlab ? "glab" : "gh";
+    let url = await run(
+      command,
+      gitlab
+        ? [
+            "mr",
+            "list",
+            "--all",
+            "--source-branch",
+            branch,
+            "--output",
+            "json",
+            "--jq",
+            ".[0].web_url // empty",
+            "--repo",
+            remote,
+          ]
+        : [
+            "pr",
+            "list",
+            "--head",
+            branch,
+            "--state",
+            "all",
+            "--json",
+            "url",
+            "--jq",
+            ".[0].url // empty",
+          ],
+    );
     if (!url) {
       await run("git", ["push", "--set-upstream", "origin", branch]);
-      url = await run("gh", [
-        "pr",
-        "create",
-        "--draft",
-        "--head",
-        branch,
-        "--title",
-        PATCH_PR_TITLE,
-        "--body",
-        body,
-      ]);
+      url = await run(
+        command,
+        gitlab
+          ? [
+              "mr",
+              "create",
+              "--draft",
+              "--head",
+              remote,
+              "--source-branch",
+              branch,
+              "--title",
+              PATCH_PR_TITLE,
+              "--description",
+              body,
+              "--yes",
+              "--repo",
+              remote,
+            ]
+          : [
+              "pr",
+              "create",
+              "--draft",
+              "--head",
+              branch,
+              "--title",
+              PATCH_PR_TITLE,
+              "--body",
+              body,
+            ],
+      );
     }
-    stderr.write(`Pull request: ${safePatchText(url)}\n`);
+    stderr.write(
+      `${gitlab ? "Merge" : "Pull"} request: ${safePatchText(url)}\n`,
+    );
     return { branch, url };
   } catch (error) {
     stderr.write(
@@ -5404,6 +5460,11 @@ async function publishPatchBranch(
     );
     throw error;
   }
+}
+
+function patchRemoteHost(remote: string): string | undefined {
+  if (remote.includes("://")) return new URL(remote).hostname.toLowerCase();
+  return /^(?:[^@/]+@)?([^:/]+):[^/]/u.exec(remote)?.[1]?.toLowerCase();
 }
 
 async function resumePatchPullRequest(
@@ -5484,10 +5545,10 @@ async function createPatchPullRequest(
 
   const branch = `codex-security/patch-${patchId.replaceAll(/[^a-z\d._-]/giu, "-")}`;
   const body = patchPullRequestBody(patchRiskSummary, introduction);
-  const run = (command: "git" | "gh", args: string[]) =>
+  const run = (command: "git", args: string[]) =>
     dependencies.runRepositoryCommand(command, args, repository);
   stderr.write(
-    "Creating a draft GitHub pull request for verified patches...\n",
+    "Creating a draft pull request or merge request for verified patches...\n",
   );
   await run("git", ["switch", "-c", branch]);
   await run("git", ["--literal-pathspecs", "add", "--", ...files]);

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -5545,14 +5545,14 @@ async function createPatchPullRequest(
 
   const branch = `codex-security/patch-${patchId.replaceAll(/[^a-z\d._-]/giu, "-")}`;
   const body = patchPullRequestBody(patchRiskSummary, introduction);
-  const run = (command: "git", args: string[]) =>
-    dependencies.runRepositoryCommand(command, args, repository);
+  const run = (args: string[]) =>
+    dependencies.runRepositoryCommand("git", args, repository);
   stderr.write(
     "Creating a draft pull request or merge request for verified patches...\n",
   );
-  await run("git", ["switch", "-c", branch]);
-  await run("git", ["--literal-pathspecs", "add", "--", ...files]);
-  await run("git", [
+  await run(["switch", "-c", branch]);
+  await run(["--literal-pathspecs", "add", "--", ...files]);
+  await run([
     "--literal-pathspecs",
     "commit",
     "--only",
@@ -5561,14 +5561,9 @@ async function createPatchPullRequest(
     "--",
     ...files,
   ]);
-  const commit = await run("git", ["rev-parse", "HEAD"]);
-  await run("git", ["config", "--local", patchCommitKey(branch), commit]);
-  await run("git", [
-    "config",
-    "--local",
-    patchPullRequestBodyKey(branch),
-    body,
-  ]);
+  const commit = await run(["rev-parse", "HEAD"]);
+  await run(["config", "--local", patchCommitKey(branch), commit]);
+  await run(["config", "--local", patchPullRequestBodyKey(branch), body]);
   return publishPatchBranch(repository, branch, body, stderr, dependencies);
 }
 

--- a/sdk/typescript/src/patch-tui.tsx
+++ b/sdk/typescript/src/patch-tui.tsx
@@ -652,7 +652,7 @@ export function PatchTui({
         <Text color={createPullRequest ? success : muted}>
           {createPullRequest ? "[✓]" : "[ ]"}
         </Text>
-        {" Create draft GitHub pull request after patching "}
+        {" Create draft pull request or merge request after patching "}
         <Text dimColor>(r toggle)</Text>
       </Text>
 

--- a/sdk/typescript/tests-ts/cli-patch.test.ts
+++ b/sdk/typescript/tests-ts/cli-patch.test.ts
@@ -656,192 +656,256 @@ describe("scan and patch workflow", () => {
     );
   });
 
-  test("publishes only verified patch files and preserves unrelated staged changes", async () => {
-    const directory = await mkdtemp(join(tmpdir(), "codex-security-patch-pr-"));
-    const repository = join(directory, "repository");
-    const remote = join(directory, "remote.git");
-    const url = "https://github.example.test/example/repository/pull/15";
-    const result = resultWithFindings(["high", "medium"]);
-    result.findings.findings[0]!.title = "Synthetic private finding";
-    const expectedPullRequestBody = [
-      "Applies verified security fixes from a completed scan.",
-      "",
-      "## Patch risk assessment",
-      "",
-      patchRiskSummary(),
-    ].join("\n");
-    let pullRequestArguments: readonly string[] = [];
-    const githubCommands: string[][] = [];
-    await mkdir(join(repository, "src"), { recursive: true });
-    const git = (...args: string[]) =>
-      execFileSync("git", args, {
-        cwd: repository,
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"],
-      }).trim();
+  test.each(["github", "gitlab"])(
+    "publishes only verified patch files to %s and preserves unrelated staged changes",
+    async (provider) => {
+      const directory = await mkdtemp(
+        join(tmpdir(), "codex-security-patch-pr-"),
+      );
+      const repository = join(directory, "repository");
+      const remote = join(directory, "remote.git");
+      const gitlab = provider === "gitlab";
+      const origin = "git@gitlab.com:example/subgroup/repository.git";
+      const url = gitlab
+        ? "https://gitlab.com/example/subgroup/repository/-/merge_requests/15"
+        : "https://github.example.test/example/repository/pull/15";
+      const result = resultWithFindings(["high", "medium"]);
+      result.findings.findings[0]!.title = "Synthetic private finding";
+      const expectedPullRequestBody = [
+        "Applies verified security fixes from a completed scan.",
+        "",
+        "## Patch risk assessment",
+        "",
+        patchRiskSummary(),
+      ].join("\n");
+      let pullRequestArguments: readonly string[] = [];
+      const publicationCommands: string[][] = [];
+      await mkdir(join(repository, "src"), { recursive: true });
+      const git = (...args: string[]) =>
+        execFileSync("git", args, {
+          cwd: repository,
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+        }).trim();
 
-    try {
-      git("init", "--initial-branch=main");
-      git("config", "user.name", "Synthetic User");
-      git("config", "user.email", "synthetic@example.test");
-      git("config", "commit.gpgsign", "false");
-      await writeFile(join(repository, "src", "finding-1.ts"), "unsafe\n");
-      await writeFile(join(repository, "unrelated.ts"), "original\n");
-      git("add", "--", ".");
-      git("commit", "-m", "Initial synthetic checkout");
-      git("init", "--bare", remote);
-      git("remote", "add", "origin", remote);
-      git("push", "--set-upstream", "origin", "main");
-      await writeFile(join(repository, "unrelated.ts"), "staged separately\n");
-      git("add", "--", "unrelated.ts");
+      try {
+        git("init", "--initial-branch=main");
+        git("config", "user.name", "Synthetic User");
+        git("config", "user.email", "synthetic@example.test");
+        git("config", "commit.gpgsign", "false");
+        await writeFile(join(repository, "src", "finding-1.ts"), "unsafe\n");
+        await writeFile(join(repository, "unrelated.ts"), "original\n");
+        git("add", "--", ".");
+        git("commit", "-m", "Initial synthetic checkout");
+        git("init", "--bare", remote);
+        git("remote", "add", "origin", remote);
+        git("push", "--set-upstream", "origin", "main");
+        await writeFile(
+          join(repository, "unrelated.ts"),
+          "staged separately\n",
+        );
+        git("add", "--", "unrelated.ts");
 
-      const outcome = await runWorkflow(
-        [
-          "patch",
-          "--scan",
-          "scan",
-          "--severity",
-          "high",
-          "--assess-patch-risk",
-          "--create-pr",
-          "--json",
-        ],
-        {
-          currentDirectory: repository,
-          result,
-          onWorkbench: () => ({
-            scan: {
-              scanId: "scan",
-              targetPath: repository,
-              findings: result.findings.findings as unknown as JsonObject[],
-            },
-          }),
-          onCodex: async (args, output) => {
-            if (
-              output?.appServer?.prompt.includes(
-                "$codex-security:assess-patch-risk",
-              )
-            ) {
-              expect(output.command).toBe("patch");
-              expect(output.appServer?.sandbox).toBe("read-only");
-              expect(output.appServer?.prompt).toContain(
-                "<!-- codex-security:patch-risk-summary:start -->",
+        const outcome = await runWorkflow(
+          [
+            "patch",
+            "--scan",
+            "scan",
+            "--severity",
+            "high",
+            "--assess-patch-risk",
+            "--create-pr",
+            "--json",
+          ],
+          {
+            currentDirectory: repository,
+            result,
+            onWorkbench: () => ({
+              scan: {
+                scanId: "scan",
+                targetPath: repository,
+                findings: result.findings.findings as unknown as JsonObject[],
+              },
+            }),
+            onCodex: async (args, output) => {
+              if (
+                output?.appServer?.prompt.includes(
+                  "$codex-security:assess-patch-risk",
+                )
+              ) {
+                expect(output.command).toBe("patch");
+                expect(output.appServer?.sandbox).toBe("read-only");
+                expect(output.appServer?.prompt).toContain(
+                  "<!-- codex-security:patch-risk-summary:start -->",
+                );
+                expect(output.appServer?.prompt).toContain(
+                  "<!-- codex-security:patch-risk-summary:end -->",
+                );
+                const artifact = JSON.parse(
+                  output
+                    .appServer!.prompt.split("\n")
+                    .find((line) => line.startsWith('{"path":'))!,
+                ) as {
+                  path: string;
+                  sourceType: string;
+                  changedFiles: string[];
+                  sha256: string;
+                };
+                const patch = await readFile(artifact.path);
+                expect(artifact.sourceType).toBe("patch_file");
+                expect(artifact.changedFiles).toEqual(["src/finding-1.ts"]);
+                expect(patch.toString()).toEndWith("+fixed  \n");
+                expect(createHash("sha256").update(patch).digest("hex")).toBe(
+                  artifact.sha256,
+                );
+                output.stdout.write(patchRiskAssessment().report);
+                return 0;
+              }
+              await writeFile(
+                join(repository, "src", "finding-1.ts"),
+                "fixed  \n",
               );
-              expect(output.appServer?.prompt).toContain(
-                "<!-- codex-security:patch-risk-summary:end -->",
-              );
-              const artifact = JSON.parse(
-                output
-                  .appServer!.prompt.split("\n")
-                  .find((line) => line.startsWith('{"path":'))!,
-              ) as {
-                path: string;
-                sourceType: string;
-                changedFiles: string[];
-                sha256: string;
-              };
-              const patch = await readFile(artifact.path);
-              expect(artifact.sourceType).toBe("patch_file");
-              expect(artifact.changedFiles).toEqual(["src/finding-1.ts"]);
-              expect(patch.toString()).toEndWith("+fixed  \n");
-              expect(createHash("sha256").update(patch).digest("hex")).toBe(
-                artifact.sha256,
-              );
-              output.stdout.write(patchRiskAssessment().report);
+              completePatches(args, output);
               return 0;
-            }
-            await writeFile(
-              join(repository, "src", "finding-1.ts"),
-              "fixed  \n",
-            );
-            completePatches(args, output);
-            return 0;
+            },
+            onRepositoryCommand: (
+              command,
+              args,
+              workingDirectory,
+              commandOptions,
+            ) => {
+              expect(workingDirectory).toBe(repository);
+              if (command === "git") {
+                if (gitlab && args[0] === "remote") {
+                  expect(args).toEqual([
+                    "remote",
+                    "get-url",
+                    "--push",
+                    "origin",
+                  ]);
+                  return origin;
+                }
+                const result = execFileSync("git", args, {
+                  cwd: repository,
+                  encoding: "utf8",
+                  env: { ...process.env, ...commandOptions?.environment },
+                  stdio: ["ignore", "pipe", "pipe"],
+                });
+                return commandOptions?.trim === false ? result : result.trim();
+              }
+              expect(command).toBe(gitlab ? "glab" : "gh");
+              publicationCommands.push([...args]);
+              if (args[1] === "list") return "";
+              pullRequestArguments = args;
+              return url;
+            },
           },
-          onRepositoryCommand: (
-            command,
-            args,
-            workingDirectory,
-            commandOptions,
-          ) => {
-            expect(workingDirectory).toBe(repository);
-            if (command === "git") {
-              const result = execFileSync("git", args, {
-                cwd: repository,
-                encoding: "utf8",
-                env: { ...process.env, ...commandOptions?.environment },
-                stdio: ["ignore", "pipe", "pipe"],
-              });
-              return commandOptions?.trim === false ? result : result.trim();
-            }
-            githubCommands.push([...args]);
-            if (args[1] === "list") return "";
-            pullRequestArguments = args;
-            return url;
-          },
-        },
-      );
+        );
 
-      expect(outcome.exitCode, outcome.stderr).toBe(0);
-      expect(git("branch", "--show-current")).toBe("codex-security/patch-scan");
-      expect(git("show", "--format=", "--name-only", "HEAD")).toBe(
-        "src/finding-1.ts",
-      );
-      expect(git("diff", "--cached", "--name-only")).toBe("unrelated.ts");
-      expect(git("rev-parse", "HEAD")).toBe(
-        git("rev-parse", "origin/codex-security/patch-scan"),
-      );
-      expect(pullRequestArguments).toEqual([
-        "pr",
-        "create",
-        "--draft",
-        "--head",
-        "codex-security/patch-scan",
-        "--title",
-        "fix: patch verified security findings",
-        "--body",
-        expectedPullRequestBody,
-      ]);
-      expect(
-        git(
-          "config",
-          "--get",
-          "branch.codex-security/patch-scan.codexSecurityPatchPullRequestBody",
-        ),
-      ).toBe(expectedPullRequestBody);
-      expect(pullRequestArguments.at(-1)).not.toContain("schemaVersion");
-      expect(pullRequestArguments.at(-1)).not.toContain(
-        "codex-security:patch-risk-summary",
-      );
-      expect(JSON.stringify(pullRequestArguments)).not.toContain(
-        "Synthetic private finding",
-      );
-      expect(githubCommands.some((args) => args[1] === "comment")).toBe(false);
-      expect(JSON.parse(outcome.stdout)).toMatchObject({
-        pullRequest: { branch: "codex-security/patch-scan", url },
-        patchRisk: { report: patchRiskReport() },
-      });
-      expect(outcome.stdout).not.toContain("codex-security:patch-risk-summary");
-    } finally {
-      await rm(directory, { recursive: true, force: true });
-    }
-  });
+        expect(outcome.exitCode, outcome.stderr).toBe(0);
+        expect(git("branch", "--show-current")).toBe(
+          "codex-security/patch-scan",
+        );
+        expect(git("show", "--format=", "--name-only", "HEAD")).toBe(
+          "src/finding-1.ts",
+        );
+        expect(git("diff", "--cached", "--name-only")).toBe("unrelated.ts");
+        expect(git("rev-parse", "HEAD")).toBe(
+          git("rev-parse", "origin/codex-security/patch-scan"),
+        );
+        expect(pullRequestArguments).toEqual(
+          gitlab
+            ? [
+                "mr",
+                "create",
+                "--draft",
+                "--head",
+                origin,
+                "--source-branch",
+                "codex-security/patch-scan",
+                "--title",
+                "fix: patch verified security findings",
+                "--description",
+                expectedPullRequestBody,
+                "--yes",
+                "--repo",
+                origin,
+              ]
+            : [
+                "pr",
+                "create",
+                "--draft",
+                "--head",
+                "codex-security/patch-scan",
+                "--title",
+                "fix: patch verified security findings",
+                "--body",
+                expectedPullRequestBody,
+              ],
+        );
+        expect(
+          git(
+            "config",
+            "--get",
+            "branch.codex-security/patch-scan.codexSecurityPatchPullRequestBody",
+          ),
+        ).toBe(expectedPullRequestBody);
+        const body =
+          pullRequestArguments[
+            pullRequestArguments.indexOf(gitlab ? "--description" : "--body") +
+              1
+          ];
+        expect(body).not.toContain("schemaVersion");
+        expect(body).not.toContain("codex-security:patch-risk-summary");
+        expect(JSON.stringify(pullRequestArguments)).not.toContain(
+          "Synthetic private finding",
+        );
+        expect(publicationCommands.some((args) => args[1] === "comment")).toBe(
+          false,
+        );
+        expect(outcome.stderr).toContain(
+          `${gitlab ? "Merge" : "Pull"} request: ${url}`,
+        );
+        expect(JSON.parse(outcome.stdout)).toMatchObject({
+          pullRequest: { branch: "codex-security/patch-scan", url },
+          patchRisk: { report: patchRiskReport() },
+        });
+        expect(outcome.stdout).not.toContain(
+          "codex-security:patch-risk-summary",
+        );
+      } finally {
+        await rm(directory, { recursive: true, force: true });
+      }
+    },
+  );
 
-  test.each(["push", "create"])(
-    "resumes publication after %s fails without patching again",
-    async (failure) => {
+  test.each([
+    ["github", "push"],
+    ["github", "create"],
+    ["gitlab", "push"],
+    ["gitlab", "create"],
+    ["gitlab", "missing client"],
+  ])(
+    "resumes %s publication after %s fails without patching again",
+    async (provider, failure) => {
       const directory = await mkdtemp(
         join(tmpdir(), "codex-security-pr-retry-"),
       );
       const repository = join(directory, "repository");
       const remote = join(directory, "remote.git");
       const branch = "codex-security/patch-scan-1";
-      const url = "https://github.example.test/example/repository/pull/16";
+      const gitlab = provider === "gitlab";
+      const origin = "https://gitlab.com/example/subgroup/repository.git";
+      const url = gitlab
+        ? "https://gitlab.com/example/subgroup/repository/-/merge_requests/16"
+        : "https://github.example.test/example/repository/pull/16";
       const result = resultWithFindings(["high"]);
       let modelCalls = 0;
       let pushCalls = 0;
       let created = 0;
       let failOnce = true;
       let publishedUrl = "";
+      const clients = new Set<string>();
       await mkdir(join(repository, "src"), { recursive: true });
       const git = (...args: string[]) =>
         execFileSync("git", args, {
@@ -880,6 +944,10 @@ describe("scan and patch workflow", () => {
           },
           onRepositoryCommand: (command, args) => {
             if (command === "git") {
+              if (gitlab && args[0] === "remote") {
+                expect(args).toEqual(["remote", "get-url", "--push", "origin"]);
+                return origin;
+              }
               if (args[0] === "push") {
                 pushCalls += 1;
                 if (failure === "push" && failOnce) {
@@ -889,7 +957,42 @@ describe("scan and patch workflow", () => {
               }
               return git(...args);
             }
-            if (args[1] === "list") return publishedUrl;
+            clients.add(command);
+            if (failure === "missing client" && failOnce) {
+              failOnce = false;
+              throw new Error("spawn glab ENOENT");
+            }
+            if (args[1] === "list") {
+              expect(args).toEqual(
+                gitlab
+                  ? [
+                      "mr",
+                      "list",
+                      "--all",
+                      "--source-branch",
+                      branch,
+                      "--output",
+                      "json",
+                      "--jq",
+                      ".[0].web_url // empty",
+                      "--repo",
+                      origin,
+                    ]
+                  : [
+                      "pr",
+                      "list",
+                      "--head",
+                      branch,
+                      "--state",
+                      "all",
+                      "--json",
+                      "url",
+                      "--jq",
+                      ".[0].url // empty",
+                    ],
+              );
+              return publishedUrl;
+            }
             expect(args[1]).toBe("create");
             if (failure === "create" && failOnce) {
               failOnce = false;
@@ -907,6 +1010,10 @@ describe("scan and patch workflow", () => {
         );
         expect(first.exitCode).toBe(2);
         expect(first.stderr).toContain(`patch --resume-pr ${branch}`);
+        if (failure === "missing client") {
+          expect(first.stderr).toContain("spawn glab ENOENT");
+          expect(pushCalls).toBe(0);
+        }
         const commit = git("rev-parse", "HEAD");
         expect(
           git("config", "--get", `branch.${branch}.codexSecurityPatchCommit`),
@@ -925,6 +1032,7 @@ describe("scan and patch workflow", () => {
           pullRequest: { branch, url },
         });
         expect(modelCalls).toBe(1);
+        expect([...clients]).toEqual([gitlab ? "glab" : "gh"]);
         expect(created).toBe(1);
         expect(git("rev-parse", "HEAD")).toBe(commit);
         expect(git("rev-parse", `origin/${branch}`)).toBe(commit);
@@ -1382,28 +1490,89 @@ describe("scan and patch workflow", () => {
     });
   });
 
-  test("creates a draft pull request for verified saved-finding patches", async () => {
-    const result = resultWithFindings(["high"]);
-    const url = "https://github.example.test/example/repository/pull/14";
-    let repository = "";
-    const outcome = await runWorkflow(
-      ["patch", "--scan", "scan-1", "--create-pr", "--json"],
-      {
-        onWorkbench: () => savedScan(result),
-        onRepositoryCommand: (command, args, target) => {
-          repository = target;
-          return command === "gh" && args[1] === "create" ? url : "";
+  test.each([
+    [
+      "https://github.example.test/example/repository.git",
+      { GITLAB_HOST: "gitlab.com" },
+      "gh",
+    ],
+    ["https://gitlab.com/example/subgroup/repository.git", {}, "glab"],
+    ["git@gitlab.com:example/subgroup/repository.git", {}, "glab"],
+    ["ssh://git@gitlab.com:2222/example/subgroup/repository.git", {}, "glab"],
+    [
+      "git@gitlab.example.test:example/subgroup/repository.git",
+      { GITLAB_HOST: "gitlab.example.test" },
+      "glab",
+    ],
+    [
+      "https://gitlab.example.test/example/repository.git",
+      { GITLAB_HOST: "https://gitlab.example.test" },
+      "glab",
+    ],
+    [
+      "https://gitlab.example.test/example/repository.git",
+      { GITLAB_URI: "https://gitlab.example.test" },
+      "glab",
+    ],
+    [
+      "https://gitlab.example.test/example/repository.git",
+      { GL_HOST: "gitlab.example.test" },
+      "glab",
+    ],
+    ["https://gitlab.example.test/example/repository.git", {}, "gh"],
+  ] as const)(
+    "publishes saved-finding patches for origin %s with environment %j using %s",
+    async (origin, environment, client) => {
+      const result = resultWithFindings(["high"]);
+      const url =
+        client === "glab"
+          ? "https://gitlab.example.test/example/repository/-/merge_requests/14"
+          : "https://github.example.test/example/repository/pull/14";
+      let repository = "";
+      const publicationCommands: Array<{
+        command: string;
+        args: readonly string[];
+      }> = [];
+      const outcome = await runWorkflow(
+        ["patch", "--scan", "scan-1", "--create-pr", "--json"],
+        {
+          environment,
+          onWorkbench: () => savedScan(result),
+          onRepositoryCommand: (command, args, target) => {
+            repository = target;
+            if (command === "git") {
+              if (args[0] === "remote") {
+                expect(args).toEqual(["remote", "get-url", "--push", "origin"]);
+                return origin;
+              }
+              return "";
+            }
+            publicationCommands.push({ command, args });
+            return args[1] === "create" ? url : "";
+          },
         },
-      },
-    );
+      );
 
-    expect(outcome.exitCode).toBe(0);
-    expect(repository).toBe(SAVED_REPOSITORY);
-    expect(JSON.parse(outcome.stdout)).toMatchObject({
-      scanId: "scan-1",
-      pullRequest: { branch: "codex-security/patch-scan-1", url },
-    });
-  });
+      expect(outcome.exitCode).toBe(0);
+      expect(repository).toBe(SAVED_REPOSITORY);
+      expect(publicationCommands.map(({ command }) => command)).toEqual([
+        client,
+        client,
+      ]);
+      if (client === "glab") {
+        for (const { args } of publicationCommands) {
+          expect(args.slice(-2)).toEqual(["--repo", origin]);
+        }
+      }
+      expect(outcome.stderr).toContain(
+        `${client === "glab" ? "Merge" : "Pull"} request: ${url}`,
+      );
+      expect(JSON.parse(outcome.stdout)).toMatchObject({
+        scanId: "scan-1",
+        pullRequest: { branch: "codex-security/patch-scan-1", url },
+      });
+    },
+  );
 
   test("redacts credentials when saved-finding pull request creation fails", async () => {
     const result = resultWithFindings(["high"]);

--- a/sdk/typescript/tests-ts/cli-patch.test.ts
+++ b/sdk/typescript/tests-ts/cli-patch.test.ts
@@ -656,228 +656,175 @@ describe("scan and patch workflow", () => {
     );
   });
 
-  test.each(["github", "gitlab"])(
-    "publishes only verified patch files to %s and preserves unrelated staged changes",
-    async (provider) => {
-      const directory = await mkdtemp(
-        join(tmpdir(), "codex-security-patch-pr-"),
-      );
-      const repository = join(directory, "repository");
-      const remote = join(directory, "remote.git");
-      const gitlab = provider === "gitlab";
-      const origin = "git@gitlab.com:example/subgroup/repository.git";
-      const url = gitlab
-        ? "https://gitlab.com/example/subgroup/repository/-/merge_requests/15"
-        : "https://github.example.test/example/repository/pull/15";
-      const result = resultWithFindings(["high", "medium"]);
-      result.findings.findings[0]!.title = "Synthetic private finding";
-      const expectedPullRequestBody = [
-        "Applies verified security fixes from a completed scan.",
-        "",
-        "## Patch risk assessment",
-        "",
-        patchRiskSummary(),
-      ].join("\n");
-      let pullRequestArguments: readonly string[] = [];
-      const publicationCommands: string[][] = [];
-      await mkdir(join(repository, "src"), { recursive: true });
-      const git = (...args: string[]) =>
-        execFileSync("git", args, {
-          cwd: repository,
-          encoding: "utf8",
-          stdio: ["ignore", "pipe", "pipe"],
-        }).trim();
+  test("publishes only verified patch files and preserves unrelated staged changes", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "codex-security-patch-pr-"));
+    const repository = join(directory, "repository");
+    const remote = join(directory, "remote.git");
+    const url = "https://github.example.test/example/repository/pull/15";
+    const result = resultWithFindings(["high", "medium"]);
+    result.findings.findings[0]!.title = "Synthetic private finding";
+    const expectedPullRequestBody = [
+      "Applies verified security fixes from a completed scan.",
+      "",
+      "## Patch risk assessment",
+      "",
+      patchRiskSummary(),
+    ].join("\n");
+    let pullRequestArguments: readonly string[] = [];
+    const githubCommands: string[][] = [];
+    await mkdir(join(repository, "src"), { recursive: true });
+    const git = (...args: string[]) =>
+      execFileSync("git", args, {
+        cwd: repository,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      }).trim();
 
-      try {
-        git("init", "--initial-branch=main");
-        git("config", "user.name", "Synthetic User");
-        git("config", "user.email", "synthetic@example.test");
-        git("config", "commit.gpgsign", "false");
-        await writeFile(join(repository, "src", "finding-1.ts"), "unsafe\n");
-        await writeFile(join(repository, "unrelated.ts"), "original\n");
-        git("add", "--", ".");
-        git("commit", "-m", "Initial synthetic checkout");
-        git("init", "--bare", remote);
-        git("remote", "add", "origin", remote);
-        git("push", "--set-upstream", "origin", "main");
-        await writeFile(
-          join(repository, "unrelated.ts"),
-          "staged separately\n",
-        );
-        git("add", "--", "unrelated.ts");
+    try {
+      git("init", "--initial-branch=main");
+      git("config", "user.name", "Synthetic User");
+      git("config", "user.email", "synthetic@example.test");
+      git("config", "commit.gpgsign", "false");
+      await writeFile(join(repository, "src", "finding-1.ts"), "unsafe\n");
+      await writeFile(join(repository, "unrelated.ts"), "original\n");
+      git("add", "--", ".");
+      git("commit", "-m", "Initial synthetic checkout");
+      git("init", "--bare", remote);
+      git("remote", "add", "origin", remote);
+      git("push", "--set-upstream", "origin", "main");
+      await writeFile(join(repository, "unrelated.ts"), "staged separately\n");
+      git("add", "--", "unrelated.ts");
 
-        const outcome = await runWorkflow(
-          [
-            "patch",
-            "--scan",
-            "scan",
-            "--severity",
-            "high",
-            "--assess-patch-risk",
-            "--create-pr",
-            "--json",
-          ],
-          {
-            currentDirectory: repository,
-            result,
-            onWorkbench: () => ({
-              scan: {
-                scanId: "scan",
-                targetPath: repository,
-                findings: result.findings.findings as unknown as JsonObject[],
-              },
-            }),
-            onCodex: async (args, output) => {
-              if (
-                output?.appServer?.prompt.includes(
-                  "$codex-security:assess-patch-risk",
-                )
-              ) {
-                expect(output.command).toBe("patch");
-                expect(output.appServer?.sandbox).toBe("read-only");
-                expect(output.appServer?.prompt).toContain(
-                  "<!-- codex-security:patch-risk-summary:start -->",
-                );
-                expect(output.appServer?.prompt).toContain(
-                  "<!-- codex-security:patch-risk-summary:end -->",
-                );
-                const artifact = JSON.parse(
-                  output
-                    .appServer!.prompt.split("\n")
-                    .find((line) => line.startsWith('{"path":'))!,
-                ) as {
-                  path: string;
-                  sourceType: string;
-                  changedFiles: string[];
-                  sha256: string;
-                };
-                const patch = await readFile(artifact.path);
-                expect(artifact.sourceType).toBe("patch_file");
-                expect(artifact.changedFiles).toEqual(["src/finding-1.ts"]);
-                expect(patch.toString()).toEndWith("+fixed  \n");
-                expect(createHash("sha256").update(patch).digest("hex")).toBe(
-                  artifact.sha256,
-                );
-                output.stdout.write(patchRiskAssessment().report);
-                return 0;
-              }
-              await writeFile(
-                join(repository, "src", "finding-1.ts"),
-                "fixed  \n",
+      const outcome = await runWorkflow(
+        [
+          "patch",
+          "--scan",
+          "scan",
+          "--severity",
+          "high",
+          "--assess-patch-risk",
+          "--create-pr",
+          "--json",
+        ],
+        {
+          currentDirectory: repository,
+          result,
+          onWorkbench: () => ({
+            scan: {
+              scanId: "scan",
+              targetPath: repository,
+              findings: result.findings.findings as unknown as JsonObject[],
+            },
+          }),
+          onCodex: async (args, output) => {
+            if (
+              output?.appServer?.prompt.includes(
+                "$codex-security:assess-patch-risk",
+              )
+            ) {
+              expect(output.command).toBe("patch");
+              expect(output.appServer?.sandbox).toBe("read-only");
+              expect(output.appServer?.prompt).toContain(
+                "<!-- codex-security:patch-risk-summary:start -->",
               );
-              completePatches(args, output);
+              expect(output.appServer?.prompt).toContain(
+                "<!-- codex-security:patch-risk-summary:end -->",
+              );
+              const artifact = JSON.parse(
+                output
+                  .appServer!.prompt.split("\n")
+                  .find((line) => line.startsWith('{"path":'))!,
+              ) as {
+                path: string;
+                sourceType: string;
+                changedFiles: string[];
+                sha256: string;
+              };
+              const patch = await readFile(artifact.path);
+              expect(artifact.sourceType).toBe("patch_file");
+              expect(artifact.changedFiles).toEqual(["src/finding-1.ts"]);
+              expect(patch.toString()).toEndWith("+fixed  \n");
+              expect(createHash("sha256").update(patch).digest("hex")).toBe(
+                artifact.sha256,
+              );
+              output.stdout.write(patchRiskAssessment().report);
               return 0;
-            },
-            onRepositoryCommand: (
-              command,
-              args,
-              workingDirectory,
-              commandOptions,
-            ) => {
-              expect(workingDirectory).toBe(repository);
-              if (command === "git") {
-                if (gitlab && args[0] === "remote") {
-                  expect(args).toEqual([
-                    "remote",
-                    "get-url",
-                    "--push",
-                    "origin",
-                  ]);
-                  return origin;
-                }
-                const result = execFileSync("git", args, {
-                  cwd: repository,
-                  encoding: "utf8",
-                  env: { ...process.env, ...commandOptions?.environment },
-                  stdio: ["ignore", "pipe", "pipe"],
-                });
-                return commandOptions?.trim === false ? result : result.trim();
-              }
-              expect(command).toBe(gitlab ? "glab" : "gh");
-              publicationCommands.push([...args]);
-              if (args[1] === "list") return "";
-              pullRequestArguments = args;
-              return url;
-            },
+            }
+            await writeFile(
+              join(repository, "src", "finding-1.ts"),
+              "fixed  \n",
+            );
+            completePatches(args, output);
+            return 0;
           },
-        );
+          onRepositoryCommand: (
+            command,
+            args,
+            workingDirectory,
+            commandOptions,
+          ) => {
+            expect(workingDirectory).toBe(repository);
+            if (command === "git") {
+              const result = execFileSync("git", args, {
+                cwd: repository,
+                encoding: "utf8",
+                env: { ...process.env, ...commandOptions?.environment },
+                stdio: ["ignore", "pipe", "pipe"],
+              });
+              return commandOptions?.trim === false ? result : result.trim();
+            }
+            githubCommands.push([...args]);
+            if (args[1] === "list") return "";
+            pullRequestArguments = args;
+            return url;
+          },
+        },
+      );
 
-        expect(outcome.exitCode, outcome.stderr).toBe(0);
-        expect(git("branch", "--show-current")).toBe(
-          "codex-security/patch-scan",
-        );
-        expect(git("show", "--format=", "--name-only", "HEAD")).toBe(
-          "src/finding-1.ts",
-        );
-        expect(git("diff", "--cached", "--name-only")).toBe("unrelated.ts");
-        expect(git("rev-parse", "HEAD")).toBe(
-          git("rev-parse", "origin/codex-security/patch-scan"),
-        );
-        expect(pullRequestArguments).toEqual(
-          gitlab
-            ? [
-                "mr",
-                "create",
-                "--draft",
-                "--head",
-                origin,
-                "--source-branch",
-                "codex-security/patch-scan",
-                "--title",
-                "fix: patch verified security findings",
-                "--description",
-                expectedPullRequestBody,
-                "--yes",
-                "--repo",
-                origin,
-              ]
-            : [
-                "pr",
-                "create",
-                "--draft",
-                "--head",
-                "codex-security/patch-scan",
-                "--title",
-                "fix: patch verified security findings",
-                "--body",
-                expectedPullRequestBody,
-              ],
-        );
-        expect(
-          git(
-            "config",
-            "--get",
-            "branch.codex-security/patch-scan.codexSecurityPatchPullRequestBody",
-          ),
-        ).toBe(expectedPullRequestBody);
-        const body =
-          pullRequestArguments[
-            pullRequestArguments.indexOf(gitlab ? "--description" : "--body") +
-              1
-          ];
-        expect(body).not.toContain("schemaVersion");
-        expect(body).not.toContain("codex-security:patch-risk-summary");
-        expect(JSON.stringify(pullRequestArguments)).not.toContain(
-          "Synthetic private finding",
-        );
-        expect(publicationCommands.some((args) => args[1] === "comment")).toBe(
-          false,
-        );
-        expect(outcome.stderr).toContain(
-          `${gitlab ? "Merge" : "Pull"} request: ${url}`,
-        );
-        expect(JSON.parse(outcome.stdout)).toMatchObject({
-          pullRequest: { branch: "codex-security/patch-scan", url },
-          patchRisk: { report: patchRiskReport() },
-        });
-        expect(outcome.stdout).not.toContain(
-          "codex-security:patch-risk-summary",
-        );
-      } finally {
-        await rm(directory, { recursive: true, force: true });
-      }
-    },
-  );
+      expect(outcome.exitCode, outcome.stderr).toBe(0);
+      expect(git("branch", "--show-current")).toBe("codex-security/patch-scan");
+      expect(git("show", "--format=", "--name-only", "HEAD")).toBe(
+        "src/finding-1.ts",
+      );
+      expect(git("diff", "--cached", "--name-only")).toBe("unrelated.ts");
+      expect(git("rev-parse", "HEAD")).toBe(
+        git("rev-parse", "origin/codex-security/patch-scan"),
+      );
+      expect(pullRequestArguments).toEqual([
+        "pr",
+        "create",
+        "--draft",
+        "--head",
+        "codex-security/patch-scan",
+        "--title",
+        "fix: patch verified security findings",
+        "--body",
+        expectedPullRequestBody,
+      ]);
+      expect(
+        git(
+          "config",
+          "--get",
+          "branch.codex-security/patch-scan.codexSecurityPatchPullRequestBody",
+        ),
+      ).toBe(expectedPullRequestBody);
+      expect(pullRequestArguments.at(-1)).not.toContain("schemaVersion");
+      expect(pullRequestArguments.at(-1)).not.toContain(
+        "codex-security:patch-risk-summary",
+      );
+      expect(JSON.stringify(pullRequestArguments)).not.toContain(
+        "Synthetic private finding",
+      );
+      expect(githubCommands.some((args) => args[1] === "comment")).toBe(false);
+      expect(JSON.parse(outcome.stdout)).toMatchObject({
+        pullRequest: { branch: "codex-security/patch-scan", url },
+        patchRisk: { report: patchRiskReport() },
+      });
+      expect(outcome.stdout).not.toContain("codex-security:patch-risk-summary");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
 
   test.each([
     ["github", "push"],
@@ -905,7 +852,6 @@ describe("scan and patch workflow", () => {
       let created = 0;
       let failOnce = true;
       let publishedUrl = "";
-      const clients = new Set<string>();
       await mkdir(join(repository, "src"), { recursive: true });
       const git = (...args: string[]) =>
         execFileSync("git", args, {
@@ -957,42 +903,12 @@ describe("scan and patch workflow", () => {
               }
               return git(...args);
             }
-            clients.add(command);
+            expect(command).toBe(gitlab ? "glab" : "gh");
             if (failure === "missing client" && failOnce) {
               failOnce = false;
               throw new Error("spawn glab ENOENT");
             }
-            if (args[1] === "list") {
-              expect(args).toEqual(
-                gitlab
-                  ? [
-                      "mr",
-                      "list",
-                      "--all",
-                      "--source-branch",
-                      branch,
-                      "--output",
-                      "json",
-                      "--jq",
-                      ".[0].web_url // empty",
-                      "--repo",
-                      origin,
-                    ]
-                  : [
-                      "pr",
-                      "list",
-                      "--head",
-                      branch,
-                      "--state",
-                      "all",
-                      "--json",
-                      "url",
-                      "--jq",
-                      ".[0].url // empty",
-                    ],
-              );
-              return publishedUrl;
-            }
+            if (args[1] === "list") return publishedUrl;
             expect(args[1]).toBe("create");
             if (failure === "create" && failOnce) {
               failOnce = false;
@@ -1032,7 +948,6 @@ describe("scan and patch workflow", () => {
           pullRequest: { branch, url },
         });
         expect(modelCalls).toBe(1);
-        expect([...clients]).toEqual([gitlab ? "glab" : "gh"]);
         expect(created).toBe(1);
         expect(git("rev-parse", "HEAD")).toBe(commit);
         expect(git("rev-parse", `origin/${branch}`)).toBe(commit);
@@ -1528,18 +1443,21 @@ describe("scan and patch workflow", () => {
         client === "glab"
           ? "https://gitlab.example.test/example/repository/-/merge_requests/14"
           : "https://github.example.test/example/repository/pull/14";
-      let repository = "";
-      const publicationCommands: Array<{
-        command: string;
-        args: readonly string[];
-      }> = [];
+      const publicationCommands: Array<readonly string[]> = [];
       const outcome = await runWorkflow(
-        ["patch", "--scan", "scan-1", "--create-pr", "--json"],
+        [
+          "patch",
+          "--scan",
+          "scan-1",
+          "--assess-patch-risk",
+          "--create-pr",
+          "--json",
+        ],
         {
           environment,
           onWorkbench: () => savedScan(result),
           onRepositoryCommand: (command, args, target) => {
-            repository = target;
+            expect(target).toBe(SAVED_REPOSITORY);
             if (command === "git") {
               if (args[0] === "remote") {
                 expect(args).toEqual(["remote", "get-url", "--push", "origin"]);
@@ -1547,22 +1465,57 @@ describe("scan and patch workflow", () => {
               }
               return "";
             }
-            publicationCommands.push({ command, args });
+            expect(command).toBe(client);
+            publicationCommands.push(args);
             return args[1] === "create" ? url : "";
+          },
+        },
+        {
+          configure: (current) => {
+            Object.assign(current, {
+              assessPatchRisk: async () => patchRiskAssessment(),
+            });
           },
         },
       );
 
       expect(outcome.exitCode).toBe(0);
-      expect(repository).toBe(SAVED_REPOSITORY);
-      expect(publicationCommands.map(({ command }) => command)).toEqual([
-        client,
-        client,
+      expect(publicationCommands.map((args) => args[1])).toEqual([
+        "list",
+        "create",
       ]);
       if (client === "glab") {
-        for (const { args } of publicationCommands) {
-          expect(args.slice(-2)).toEqual(["--repo", origin]);
-        }
+        expect(publicationCommands).toEqual([
+          [
+            "mr",
+            "list",
+            "--all",
+            "--source-branch",
+            "codex-security/patch-scan-1",
+            "--output",
+            "json",
+            "--jq",
+            ".[0].web_url // empty",
+            "--repo",
+            origin,
+          ],
+          [
+            "mr",
+            "create",
+            "--draft",
+            "--head",
+            origin,
+            "--source-branch",
+            "codex-security/patch-scan-1",
+            "--title",
+            "fix: patch verified security findings",
+            "--description",
+            expect.stringContaining(patchRiskSummary()),
+            "--yes",
+            "--repo",
+            origin,
+          ],
+        ]);
       }
       expect(outcome.stderr).toContain(
         `${client === "glab" ? "Merge" : "Pull"} request: ${url}`,

--- a/sdk/typescript/tests-ts/patch-tui.test.ts
+++ b/sdk/typescript/tests-ts/patch-tui.test.ts
@@ -101,7 +101,7 @@ describe("interactive patch finding browser", () => {
     expect(app.lastFrame()).toContain("PATCH INSTRUCTIONS");
     expect(app.lastFrame()).toContain("Add instructions for this finding.");
     expect(app.lastFrame()).toContain(
-      "[ ] Create draft GitHub pull request after patching",
+      "[ ] Create draft pull request or merge request after patching",
     );
     expect(app.lastFrame()).toContain("3/3 selected");
     expect(app.lastFrame()).toContain("SUMMARY");
@@ -316,12 +316,12 @@ describe("interactive patch finding browser", () => {
     );
 
     expect(app.lastFrame()).toContain(
-      "[ ] Create draft GitHub pull request after patching",
+      "[ ] Create draft pull request or merge request after patching",
     );
     app.stdin.write("r");
     await settle();
     expect(app.lastFrame()).toContain(
-      "[✓] Create draft GitHub pull request after patching",
+      "[✓] Create draft pull request or merge request after patching",
     );
     app.stdin.write("\r");
     await settle();


### PR DESCRIPTION
## Summary

`patch --create-pr` currently invokes GitHub's CLI for every repository. It now creates a draft GitLab merge request with `glab` when the origin push URL identifies GitLab.

## Changes

- Support GitLab.com and self-hosted GitLab through the existing `GITLAB_HOST` setting (including glab's `GITLAB_URI` and `GL_HOST` aliases).
- Bind the merge request's source and target projects to the origin push URL, including SSH remotes and subgroup paths.
- Reuse verified patch commits, patch-risk summaries, and `patch --resume-pr` recovery. Preserve the `pullRequest: { branch, url }` JSON result and existing GitHub arguments.
- Update command help, the interactive patch browser, documentation, and publication/retry regression tests.

## Testing

- `bun test --timeout 30000 tests-ts/cli-patch.test.ts --seed 12345`: 42 passed, 0 failed.
- `pnpm run types` and `pnpm run format` passed.
- Hosted CI is running for the updated commit.

## Risk and rollout

The existing `--create-pr` and `--resume-pr` syntax and defaults are unchanged. GitLab requires an installed, authenticated `glab`; self-hosted repositories also require the matching GitLab host setting when creating or resuming publication. Other hosts retain the GitHub workflow. GitLab API calls are mocked in regression tests; no live merge request was created during validation.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.

