### PR TITLE
fix: require explicit requests for security fix verification

### DIFF
--- a/plugins/codex-security/skills/verify-fix/SKILL.md
+++ b/plugins/codex-security/skills/verify-fix/SKILL.md
@@ -1,9 +1,13 @@
 ---
 name: verify-fix
-description: Use when the user asks whether an existing security fix, patch, finding, or completed issue actually remediates the original vulnerability without modifying the repository. Do not use to validate candidate findings, implement patches, or run full repository scans.
+description: Use only when the user explicitly requests verification that a security fix remediates a reported vulnerability. Do not invoke automatically while implementing fixes, reviewing ordinary code changes, or running tests. Do not use for non-security fixes, candidate finding validation, or full repository scans.
 ---
 
 # Verify Fix
+
+## When to Use
+
+Invoke this skill only for an explicit request to verify a security fix, including a direct `$verify-fix` invocation. A request to implement a fix or run its tests does not by itself request this skill. For other tasks, follow the user's requested workflow and response format without applying this skill's JSON result contract.
 
 ## Objective
 


### PR DESCRIPTION
## Summary

The `verify-fix` skill can be selected for ordinary fix requests and impose its JSON result format. Restrict its trigger to explicit requests to verify that a security fix remediates a reported vulnerability.

## Changes

- Narrow the skill description to exclude automatic invocation during implementation, ordinary code review, and test runs.
- Clarify that other tasks retain the user's requested workflow and response format.

## Testing

- Ruff 0.16.1 check and format check: passed for the plugin and portable source-check scripts (run through `uv run --no-project --with ruff==0.16.1` because the default Python environment lacks Ruff).
- `python .github/scripts/check_plugin_source_compatibility.py`: passed.
- Skill creator `quick_validate.py` for `verify-fix`: passed.
- `git diff --check`: passed.
- Reviewed the trigger wording against implementation-only, test-only, non-security review, and explicit security-fix verification requests. Live model routing was not tested.

## Risk and rollout

Instruction-only change. The verification workflow, read-only boundary, and JSON result contract remain unchanged when the skill is requested. No CLI surface changes. Skill selection still depends on the model following the description and instructions.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
