### PR TITLE
fix(cli): correct GitLab patch publication

### DIFF
--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -5387,6 +5387,9 @@ async function publishPatchBranch(
             gitlabHost.includes("://") ? gitlabHost : `https://${gitlabHost}`,
           ));
     const command = gitlab ? "glab" : "gh";
+    const gitlabRepository = remote.includes("://")
+      ? remote
+      : `ssh://${remote.replace(":", "/")}`;
     const existing = await run(
       command,
       gitlab
@@ -5399,7 +5402,7 @@ async function publishPatchBranch(
             "--output",
             "json",
             "--repo",
-            remote,
+            gitlabRepository,
           ]
         : [
             "pr",
@@ -5434,7 +5437,7 @@ async function publishPatchBranch(
               "create",
               "--draft",
               "--head",
-              remote,
+              gitlabRepository,
               "--source-branch",
               branch,
               "--title",
@@ -5443,7 +5446,7 @@ async function publishPatchBranch(
               body,
               "--yes",
               "--repo",
-              remote,
+              gitlabRepository,
             ]
           : [
               "pr",

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -5401,6 +5401,8 @@ async function publishPatchBranch(
             branch,
             "--output",
             "json",
+            "--jq",
+            "map({source_project_id, target_project_id, web_url})",
             "--repo",
             gitlabRepository,
           ]

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -5387,7 +5387,7 @@ async function publishPatchBranch(
             gitlabHost.includes("://") ? gitlabHost : `https://${gitlabHost}`,
           ));
     const command = gitlab ? "glab" : "gh";
-    let url = await run(
+    const existing = await run(
       command,
       gitlab
         ? [
@@ -5398,8 +5398,6 @@ async function publishPatchBranch(
             branch,
             "--output",
             "json",
-            "--jq",
-            ".[0].web_url // empty",
             "--repo",
             remote,
           ]
@@ -5416,6 +5414,16 @@ async function publishPatchBranch(
             ".[0].url // empty",
           ],
     );
+    let url = gitlab
+      ? (
+          JSON.parse(existing) as {
+            source_project_id: number;
+            target_project_id: number;
+            web_url: string;
+          }[]
+        ).find((mr) => mr.source_project_id === mr.target_project_id)
+          ?.web_url ?? ""
+      : existing;
     if (!url) {
       await run("git", ["push", "--set-upstream", "origin", branch]);
       url = await run(

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -5443,7 +5443,7 @@ async function publishPatchBranch(
               "--title",
               PATCH_PR_TITLE,
               "--description",
-              body,
+              body.replace(/^\//gmu, "\\/"),
               "--yes",
               "--repo",
               gitlabRepository,

--- a/sdk/typescript/tests-ts/cli-patch.test.ts
+++ b/sdk/typescript/tests-ts/cli-patch.test.ts
@@ -1524,6 +1524,8 @@ describe("scan and patch workflow", () => {
             "codex-security/patch-scan-1",
             "--output",
             "json",
+            "--jq",
+            "map({source_project_id, target_project_id, web_url})",
             "--repo",
             selector,
           ],
@@ -1597,11 +1599,10 @@ describe("scan and patch workflow", () => {
         },
       );
       expect(outcome.exitCode, outcome.stderr).toBe(0);
-      expect(publishedBody).toBe(
-        "Applies verified security fixes from a completed scan.\n\n## Patch risk assessment\n\nReview the patch.\n\n" +
-          (gitlab ? "\\/label ~reviewed" : "/label ~reviewed") +
-          "\n\nUse /tmp/example.",
+      expect(publishedBody).toContain(
+        gitlab ? "\n\\/label ~reviewed\n" : "\n/label ~reviewed\n",
       );
+      expect(publishedBody).toContain("Use /tmp/example.");
       expect(JSON.parse(outcome.stdout).patchRisk.report).toBe(summary);
     },
   );

--- a/sdk/typescript/tests-ts/cli-patch.test.ts
+++ b/sdk/typescript/tests-ts/cli-patch.test.ts
@@ -829,8 +829,6 @@ describe("scan and patch workflow", () => {
   test.each([
     ["github", "push"],
     ["github", "create"],
-    ["gitlab", "push"],
-    ["gitlab", "create"],
     ["gitlab", "missing client"],
   ])(
     "resumes %s publication after %s fails without patching again",
@@ -908,7 +906,20 @@ describe("scan and patch workflow", () => {
               failOnce = false;
               throw new Error("spawn glab ENOENT");
             }
-            if (args[1] === "list") return publishedUrl;
+            if (args[1] === "list")
+              return gitlab
+                ? JSON.stringify(
+                    publishedUrl
+                      ? [
+                          {
+                            source_project_id: 1,
+                            target_project_id: 1,
+                            web_url: publishedUrl,
+                          },
+                        ]
+                      : [],
+                  )
+                : publishedUrl;
             expect(args[1]).toBe("create");
             if (failure === "create" && failOnce) {
               failOnce = false;
@@ -1445,14 +1456,7 @@ describe("scan and patch workflow", () => {
           : "https://github.example.test/example/repository/pull/14";
       const publicationCommands: Array<readonly string[]> = [];
       const outcome = await runWorkflow(
-        [
-          "patch",
-          "--scan",
-          "scan-1",
-          "--assess-patch-risk",
-          "--create-pr",
-          "--json",
-        ],
+        ["patch", "--scan", "scan-1", "--create-pr", "--json"],
         {
           environment,
           onWorkbench: () => savedScan(result),
@@ -1467,14 +1471,7 @@ describe("scan and patch workflow", () => {
             }
             expect(command).toBe(client);
             publicationCommands.push(args);
-            return args[1] === "create" ? url : "";
-          },
-        },
-        {
-          configure: (current) => {
-            Object.assign(current, {
-              assessPatchRisk: async () => patchRiskAssessment(),
-            });
+            return args[1] === "create" ? url : client === "glab" ? "[]" : "";
           },
         },
       );
@@ -1494,8 +1491,6 @@ describe("scan and patch workflow", () => {
             "codex-security/patch-scan-1",
             "--output",
             "json",
-            "--jq",
-            ".[0].web_url // empty",
             "--repo",
             origin,
           ],
@@ -1510,7 +1505,7 @@ describe("scan and patch workflow", () => {
             "--title",
             "fix: patch verified security findings",
             "--description",
-            expect.stringContaining(patchRiskSummary()),
+            "Applies verified security fixes from a completed scan.",
             "--yes",
             "--repo",
             origin,
@@ -1524,6 +1519,58 @@ describe("scan and patch workflow", () => {
         scanId: "scan-1",
         pullRequest: { branch: "codex-security/patch-scan-1", url },
       });
+    },
+  );
+
+  test.each([false, true])(
+    "filters fork merge requests before reuse (same-project MR: %j)",
+    async (hasExisting) => {
+      const result = resultWithFindings(["high"]);
+      const url =
+        "https://gitlab.example.test/example/repository/-/merge_requests/14";
+      const forkUrl =
+        "https://gitlab.example.test/example/repository/-/merge_requests/15";
+      const commands: string[] = [];
+      const outcome = await runWorkflow(
+        ["patch", "--scan", "scan-1", "--create-pr", "--json"],
+        {
+          onWorkbench: () => savedScan(result),
+          onRepositoryCommand: (command, args) => {
+            if (command === "git") {
+              if (args[0] === "remote")
+                return "https://gitlab.com/example/repository.git";
+              if (args[0] === "push") commands.push("push");
+              return "";
+            }
+            expect(command).toBe("glab");
+            commands.push(args[1]!);
+            if (args[1] === "list")
+              return JSON.stringify([
+                {
+                  source_project_id: 2,
+                  target_project_id: 1,
+                  web_url: forkUrl,
+                },
+                ...(hasExisting
+                  ? [
+                      {
+                        source_project_id: 1,
+                        target_project_id: 1,
+                        web_url: url,
+                      },
+                    ]
+                  : []),
+              ]);
+            return url;
+          },
+        },
+      );
+      expect(outcome.exitCode).toBe(0);
+      expect(commands).toEqual(
+        hasExisting ? ["list"] : ["list", "push", "create"],
+      );
+      expect(JSON.parse(outcome.stdout).pullRequest.url).toBe(url);
+      expect(outcome.stderr).not.toContain(forkUrl);
     },
   );
 

--- a/sdk/typescript/tests-ts/cli-patch.test.ts
+++ b/sdk/typescript/tests-ts/cli-patch.test.ts
@@ -1421,34 +1421,67 @@ describe("scan and patch workflow", () => {
       "https://github.example.test/example/repository.git",
       { GITLAB_HOST: "gitlab.com" },
       "gh",
+      undefined,
     ],
-    ["https://gitlab.com/example/subgroup/repository.git", {}, "glab"],
-    ["git@gitlab.com:example/subgroup/repository.git", {}, "glab"],
-    ["ssh://git@gitlab.com:2222/example/subgroup/repository.git", {}, "glab"],
+    [
+      "https://gitlab.com/example/subgroup/repository.git",
+      {},
+      "glab",
+      undefined,
+    ],
+    [
+      "git@gitlab.com:example/subgroup/repository.git",
+      {},
+      "glab",
+      "ssh://git@gitlab.com/example/subgroup/repository.git",
+    ],
+    [
+      "gitlab.com:example/subgroup/repository.git",
+      {},
+      "glab",
+      "ssh://gitlab.com/example/subgroup/repository.git",
+    ],
+    [
+      "gitlab@gitlab.example.test:example/subgroup/repository.git",
+      { GITLAB_HOST: "gitlab.example.test" },
+      "glab",
+      "ssh://gitlab@gitlab.example.test/example/subgroup/repository.git",
+    ],
+    [
+      "ssh://git@gitlab.com:2222/example/subgroup/repository.git",
+      {},
+      "glab",
+      undefined,
+    ],
     [
       "git@gitlab.example.test:example/subgroup/repository.git",
       { GITLAB_HOST: "gitlab.example.test" },
       "glab",
+      "ssh://git@gitlab.example.test/example/subgroup/repository.git",
     ],
     [
       "https://gitlab.example.test/example/repository.git",
       { GITLAB_HOST: "https://gitlab.example.test" },
       "glab",
+      undefined,
     ],
     [
       "https://gitlab.example.test/example/repository.git",
       { GITLAB_URI: "https://gitlab.example.test" },
       "glab",
+      undefined,
     ],
     [
       "https://gitlab.example.test/example/repository.git",
       { GL_HOST: "gitlab.example.test" },
       "glab",
+      undefined,
     ],
-    ["https://gitlab.example.test/example/repository.git", {}, "gh"],
+    ["https://gitlab.example.test/example/repository.git", {}, "gh", undefined],
   ] as const)(
     "publishes saved-finding patches for origin %s with environment %j using %s",
-    async (origin, environment, client) => {
+    async (origin, environment, client, expectedSelector) => {
+      const selector = expectedSelector ?? origin;
       const result = resultWithFindings(["high"]);
       const url =
         client === "glab"
@@ -1492,14 +1525,14 @@ describe("scan and patch workflow", () => {
             "--output",
             "json",
             "--repo",
-            origin,
+            selector,
           ],
           [
             "mr",
             "create",
             "--draft",
             "--head",
-            origin,
+            selector,
             "--source-branch",
             "codex-security/patch-scan-1",
             "--title",
@@ -1508,7 +1541,7 @@ describe("scan and patch workflow", () => {
             "Applies verified security fixes from a completed scan.",
             "--yes",
             "--repo",
-            origin,
+            selector,
           ],
         ]);
       }

--- a/sdk/typescript/tests-ts/cli-patch.test.ts
+++ b/sdk/typescript/tests-ts/cli-patch.test.ts
@@ -1555,6 +1555,57 @@ describe("scan and patch workflow", () => {
     },
   );
 
+  test.each(["github", "gitlab"] as const)(
+    "keeps quick-action text in generated %s descriptions advisory",
+    async (provider) => {
+      const gitlab = provider === "gitlab";
+      const result = resultWithFindings(["high"]);
+      const summary =
+        "Review the patch.\n\n/label ~reviewed\n\nUse /tmp/example.";
+      let publishedBody = "";
+      const outcome = await runWorkflow(
+        [
+          "patch",
+          "--scan",
+          "scan-1",
+          "--assess-patch-risk",
+          "--create-pr",
+          "--json",
+        ],
+        {
+          onWorkbench: () => savedScan(result),
+          onRepositoryCommand: (command, args) => {
+            if (command === "git")
+              return args[0] === "remote"
+                ? `https://${provider}.com/example/repository.git`
+                : "";
+            expect(command).toBe(gitlab ? "glab" : "gh");
+            if (args[1] === "list") return gitlab ? "[]" : "";
+            publishedBody =
+              args[args.indexOf(gitlab ? "--description" : "--body") + 1]!;
+            return "https://example.test/review/1";
+          },
+        },
+        {
+          configure: (current) => {
+            Object.assign(current, {
+              assessPatchRisk: async () => ({
+                report: `<!-- codex-security:patch-risk-summary:start -->\n${summary}\n<!-- codex-security:patch-risk-summary:end -->`,
+              }),
+            });
+          },
+        },
+      );
+      expect(outcome.exitCode, outcome.stderr).toBe(0);
+      expect(publishedBody).toBe(
+        "Applies verified security fixes from a completed scan.\n\n## Patch risk assessment\n\nReview the patch.\n\n" +
+          (gitlab ? "\\/label ~reviewed" : "/label ~reviewed") +
+          "\n\nUse /tmp/example.",
+      );
+      expect(JSON.parse(outcome.stdout).patchRisk.report).toBe(summary);
+    },
+  );
+
   test.each([false, true])(
     "filters fork merge requests before reuse (same-project MR: %j)",
     async (hasExisting) => {


### PR DESCRIPTION
## Summary

Match GitLab patch merge requests by branch and project identity, normalize SSH repository selectors, and preserve generated descriptions as advisory text. This follows up on #814.

## Changes

- Reuse an existing merge request only when its source and target project IDs match. Request only those IDs and the URL from glab to avoid buffering full descriptions.
- Normalize SCP-style origins to explicit SSH URLs for glab source and target project selection.
- Escape quick-action text in GitLab descriptions while preserving the CLI report and GitHub body.
- Check the default body in the routing matrix and remove duplicate GitLab retry rows; retain missing-client recovery and repeated reuse coverage.

## Testing

- Focused CLI patch and patch-browser tests: 55 passed, 0 failed, including fork-only and fork-before-same-project results, SSH selectors, and description handling.
- `pnpm run types` and `pnpm run format` passed.
- A subprocess probe reproduced the buffer failure with 1.23 MB of MR metadata; projecting the required fields returned 4.5 KB and preserved the selected MR.
- GitLab API calls are mocked in regression tests; no live GitLab merge request was created during validation.

## Risk and rollout

The existing command syntax, defaults, JSON result, and GitHub publication arguments are unchanged. These changes apply to GitLab selection and publication through the existing `--create-pr` and `--resume-pr` paths.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
