### PR TITLE
fix(scan): include workflow files in diff inventories

### DIFF
--- a/plugins/codex-security/scripts/generate_in_scope_files.py
+++ b/plugins/codex-security/scripts/generate_in_scope_files.py
@@ -187,7 +187,7 @@ def generate_diff_in_scope_files(
 ) -> int:
     """Reuse the existing diff selection without generating previews or duplicate worklists."""
     sys.path.insert(0, str(Path(__file__).resolve().parent))
-    from generate_rank_input import git_changed_paths, path_is_excluded
+    from generate_rank_input import git_changed_paths, path_is_diff_excluded
     from rank_preview import (
         DEFAULT_PREVIEW_BYTES,
         TEXT_CODE_EXTENSIONS,
@@ -206,7 +206,7 @@ def generate_diff_in_scope_files(
         eligible = [
             (path, status)
             for path, status in changed
-            if not path_is_excluded(path.relative_to(repository))
+            if not path_is_diff_excluded(path.relative_to(repository))
             and path.suffix.lower() in TEXT_CODE_EXTENSIONS
         ]
         revision_paths = [

--- a/plugins/codex-security/scripts/generate_rank_input.py
+++ b/plugins/codex-security/scripts/generate_rank_input.py
@@ -293,6 +293,13 @@ def path_is_excluded(path: Path) -> bool:
     return path.name.endswith((".min.js", ".map"))
 
 
+def path_is_diff_excluded(path: Path) -> bool:
+    """Apply repository exclusions while retaining changed workflow files."""
+    if path.parts[:2] == (".github", "workflows"):
+        return False
+    return path_is_excluded(path)
+
+
 def windows_stream_component(path: Path) -> str | None:
     """Return the first NTFS alternate-data-stream component."""
 
@@ -683,7 +690,7 @@ def make_diff_rank_input(args: argparse.Namespace) -> None:
     changed = [
         (path, status)
         for path, status in git_changed_paths(repo, args.base, args.head, args.mode)
-        if not path_is_excluded(path.relative_to(repo))
+        if not path_is_diff_excluded(path.relative_to(repo))
         and path.suffix.lower() in TEXT_CODE_EXTENSIONS
     ]
     revision_paths = [

--- a/plugins/codex-security/tests/test_generate_in_scope_files.py
+++ b/plugins/codex-security/tests/test_generate_in_scope_files.py
@@ -359,6 +359,7 @@ def test_diff_inventory_keeps_changed_and_deleted_source_files(tmp_path: Path) -
     write_file(repository, "app/new handler.py", b"handler = True\n")
     write_file(repository, "app/binary.py", b"\x00\xff\x01")
     write_file(repository, "tests/demo.py", b"excluded = True\n")
+    write_file(repository, ".github/workflows/ci.yml", b"name: CI\n")
     (repository / "app/évidence.py").unlink()
     git(repository, "add", ".")
     git(repository, "commit", "-qm", "change")
@@ -374,6 +375,7 @@ def test_diff_inventory_keeps_changed_and_deleted_source_files(tmp_path: Path) -
 
     assert result.returncode == 0, result.stderr
     assert output.read_text(encoding="utf-8").splitlines() == [
+        ".github/workflows/ci.yml",
         "app/new handler.py",
         "app/routes.py",
         "app/évidence.py",
@@ -389,6 +391,7 @@ def test_diff_inventory_combines_staged_and_unstaged_changes(tmp_path: Path) -> 
     write_file(repository, "app/staged.py", b"staged = True\n")
     git(repository, "add", "app/staged.py")
     write_file(repository, "app/untracked.py", b"untracked = True\n")
+    write_file(repository, ".github/workflows/ci.yaml", b"name: CI\n")
     write_file(repository, "app/untracked-binary.py", b"\x00\xff\x01")
     index_only = write_file(repository, "app/index-only.py", b"index_only = True\n")
     git(repository, "add", "app/index-only.py")
@@ -404,6 +407,7 @@ def test_diff_inventory_combines_staged_and_unstaged_changes(tmp_path: Path) -> 
 
     assert result.returncode == 0, result.stderr
     assert output.read_text(encoding="utf-8").splitlines() == [
+        ".github/workflows/ci.yaml",
         "app/routes.py",
         "app/staged.py",
         "app/untracked.py",

--- a/plugins/codex-security/tests/test_generate_rank_input.py
+++ b/plugins/codex-security/tests/test_generate_rank_input.py
@@ -671,6 +671,8 @@ def test_make_diff_rank_input_for_revision_range(tmp_path: Path) -> None:
 
     (repo / "src" / "alpha.py").write_text("alpha = 2", encoding="utf-8")
     (repo / "src" / "beta.py").write_text("beta = 1", encoding="utf-8")
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    (repo / ".github" / "workflows" / "ci.yml").write_text("name: CI", encoding="utf-8")
     deleted_guard.unlink()
     (repo / "README.md").write_text("ignored", encoding="utf-8")
     git(repo, "add", ".")
@@ -693,6 +695,7 @@ def test_make_diff_rank_input_for_revision_range(tmp_path: Path) -> None:
 
     rows = read_jsonl(output)
     assert [row["path"] for row in rows] == [
+        ".github/workflows/ci.yml",
         "src/alpha.py",
         "src/beta.py",
         "src/deleted_guard.py",
@@ -799,6 +802,8 @@ def test_make_diff_rank_input_combines_staged_and_unstaged_patch(tmp_path: Path)
 
     (repo / "src" / "alpha.py").write_text("alpha = 2", encoding="utf-8")
     (repo / "src" / "beta.py").write_text("beta = 1", encoding="utf-8")
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    (repo / ".github" / "workflows" / "ci.yaml").write_text("name: CI", encoding="utf-8")
     git(repo, "add", "src/beta.py")
     output = tmp_path / "patch.jsonl"
 
@@ -814,7 +819,11 @@ def test_make_diff_rank_input_combines_staged_and_unstaged_patch(tmp_path: Path)
         str(output),
     )
 
-    assert [row["path"] for row in read_jsonl(output)] == ["src/alpha.py", "src/beta.py"]
+    assert [row["path"] for row in read_jsonl(output)] == [
+        ".github/workflows/ci.yaml",
+        "src/alpha.py",
+        "src/beta.py",
+    ]
 
 
 @pytest.mark.parametrize("mode", ["repo", "explicit-file", "revisions", "local-patch"])


### PR DESCRIPTION
## Summary

Fixes #819. Diff scans currently reuse repository-ranking exclusions, so a change under `.github/workflows` is silently omitted and a workflow-only diff can produce an empty review inventory.

## Changes

- Add a diff-specific exclusion predicate that retains `.github/workflows/**` while preserving the existing broad exclusions for repository ranking and all other excluded paths.
- Use the predicate in both canonical diff inventory generation and the legacy diff rank-input path.
- Cover committed revision diffs and local working-tree patches for both entry points, while retaining the existing assertions that unrelated excluded paths stay omitted.

## Testing

- `uv run --project plugins/codex-security --extra test pytest -q plugins/codex-security/tests/test_generate_rank_input.py plugins/codex-security/tests/test_generate_in_scope_files.py` — 87 passed.
- `uv run --project plugins/codex-security --extra test pytest -q plugins/codex-security/tests` — 1108 passed, 5 skipped, 110 subtests passed.
- Required Ruff check and format-check commands passed.
- `.github/scripts/check_plugin_source_compatibility.py` passed.

## Risk and rollout

The change only broadens explicit diff inventories to include text-code files under `.github/workflows`. Repository-wide ranking behavior and exclusions for tests, fixtures, generated files, and other `.github` content remain unchanged. No migration or rollout step is required.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
