### PR TITLE
fix(cli): parse GitLab merge request URLs

### DIFF
--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -5418,7 +5418,7 @@ async function publishPatchBranch(
     );
     if (!url) {
       await run("git", ["push", "--set-upstream", "origin", branch]);
-      url = await run(
+      const createOutput = await run(
         command,
         gitlab
           ? [
@@ -5449,6 +5449,7 @@ async function publishPatchBranch(
               body,
             ],
       );
+      url = gitlab ? glabMergeRequestUrl(createOutput) : createOutput;
     }
     stderr.write(
       `${gitlab ? "Merge" : "Pull"} request: ${safePatchText(url)}\n`,
@@ -5460,6 +5461,14 @@ async function publishPatchBranch(
     );
     throw error;
   }
+}
+
+function glabMergeRequestUrl(output: string): string {
+  for (const line of output.split(/\r?\n/u).reverse()) {
+    const candidate = line.trim();
+    if (/^https?:\/\/\S+$/u.test(candidate)) return candidate;
+  }
+  throw new CodexSecurityError("glab did not return a merge request URL.");
 }
 
 function patchRemoteHost(remote: string): string | undefined {

--- a/sdk/typescript/tests-ts/cli-patch.test.ts
+++ b/sdk/typescript/tests-ts/cli-patch.test.ts
@@ -1467,7 +1467,10 @@ describe("scan and patch workflow", () => {
             }
             expect(command).toBe(client);
             publicationCommands.push(args);
-            return args[1] === "create" ? url : "";
+            if (args[1] !== "create") return "";
+            return client === "glab"
+              ? `!14 fix: patch verified security findings (codex-security/patch-scan-1)\n${url}`
+              : url;
           },
         },
         {


### PR DESCRIPTION
## Summary

`glab mr create` writes a merge request summary followed by the merge request URL. The patch workflow currently treats the complete stdout as the URL, so GitLab patch publication can persist and print a multiline value instead of a usable link.

## Changes

- extract the standalone HTTP(S) URL from `glab mr create` output
- report a clear publication error when the output has no URL
- exercise the GitLab path with the multiline format emitted by `glab`

## Testing

- `bun test --timeout 30000 --seed=12345 tests-ts` with Bun 1.3.14: 2415 passed, 43 skipped, 0 failed
- `bun test --timeout 30000 tests-ts/cli-patch.test.ts`: 42 passed, 0 failed
- `node sdk/typescript/scripts/generate-models.cjs --check`
- TypeScript checks for the SDK and MCP app
- Prettier check
- `git diff --check`

## Risk and rollout

Low risk. GitHub publication is unchanged. GitLab publication now stores the final standalone URL from the existing CLI output; output without a URL fails through the existing pull-request creation error path.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.