### PR TITLE
fix(sdk): replace vulnerable ZIP extractor and update dependencies

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -72,7 +72,6 @@
     "@openai/codex": "0.149.1",
     "@openai/codex-sdk": "0.149.1",
     "ajv": "8.20.0",
-    "extract-zip": "2.0.1",
     "fast-uri": "3.1.6",
     "fflate": "0.8.3",
     "incur": "0.4.13",
@@ -82,7 +81,8 @@
     "pdfjs-dist": "6.2.108",
     "react": "19.2.4",
     "semver": "7.8.5",
-    "smol-toml": "1.6.1"
+    "smol-toml": "1.6.1",
+    "yauzl": "3.4.0"
   },
   "devDependencies": {
     "@openai/apps-sdk-ui": "0.2.2",
@@ -94,6 +94,7 @@
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@types/semver": "7.8.0",
+    "@types/yauzl": "3.4.0",
     "esbuild": "0.28.2",
     "fast-check": "4.9.0",
     "ink-testing-library": "4.0.0",

--- a/sdk/typescript/pnpm-lock.yaml
+++ b/sdk/typescript/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@openai/apps-sdk-ui@0.2.2>lodash': 4.18.1
+  typed-rest-client@2.3.1>qs: 6.16.0
+
 importers:
 
   .:
@@ -26,9 +30,6 @@ importers:
       ajv:
         specifier: 8.20.0
         version: 8.20.0
-      extract-zip:
-        specifier: 2.0.1
-        version: 2.0.1
       fast-uri:
         specifier: 3.1.6
         version: 3.1.6
@@ -59,6 +60,9 @@ importers:
       smol-toml:
         specifier: 1.6.1
         version: 1.6.1
+      yauzl:
+        specifier: 3.4.0
+        version: 3.4.0
     devDependencies:
       '@openai/apps-sdk-ui':
         specifier: 0.2.2
@@ -87,6 +91,9 @@ importers:
       '@types/semver':
         specifier: 7.8.0
         version: 7.8.0
+      '@types/yauzl':
+        specifier: 3.4.0
+        version: 3.4.0
       esbuild:
         specifier: 0.28.2
         version: 0.28.2
@@ -1595,8 +1602,8 @@ packages:
   '@tailwindcss/postcss@4.3.3':
     resolution: {integrity: sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==}
 
-  '@toon-format/toon@2.3.0':
-    resolution: {integrity: sha512-/Ew9etdRQKVMnm9fDaCG0JjyAOK/O7T0M97oum1aW4W+UR8ZhVVPBanIV7oWgHBiGlnVxV9M55PWQCHofDV07w==}
+  '@toon-format/toon@2.3.1':
+    resolution: {integrity: sha512-sWqEMeAJGMda9qRrfPKrX3C4c33CO9SJuvJzzrcBEn5sbDB+k6pSLkDsfN0rVnLQwR97MV3sDgVbcxQNsq8xVw==}
 
   '@types/bun@1.3.13':
     resolution: {integrity: sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw==}
@@ -1654,8 +1661,8 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+  '@types/yauzl@3.4.0':
+    resolution: {integrity: sha512-NRPn5w6h8dhcnmx3YIRQcqMywY/+nND/uOkJessedcrowO3C0AssHp3tMJpxKAwOhFOo0OV1y9VtsC5hbKKBAw==}
 
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
@@ -1719,9 +1726,6 @@ packages:
     resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   bun-types@1.3.13:
     resolution: {integrity: sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA==}
@@ -1854,9 +1858,6 @@ packages:
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
-  end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
-
   enhanced-resolve@5.24.5:
     resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
     engines: {node: '>=10.13.0'}
@@ -1911,11 +1912,6 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
-  extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
-
   fast-check@4.9.0:
     resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
     engines: {node: '>=12.17.0'}
@@ -1937,9 +1933,6 @@ packages:
 
   fault@1.0.4:
     resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
-
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1983,10 +1976,6 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
-
-  get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
 
   get-stream@9.0.1:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
@@ -2264,9 +2253,6 @@ packages:
   lodash.groupby@4.6.0:
     resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
@@ -2488,9 +2474,6 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
-
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
@@ -2558,14 +2541,11 @@ packages:
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
-  pump@3.0.4:
-    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
-
   pure-rand@8.4.2:
     resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   radix-ui@1.6.7:
@@ -2931,9 +2911,6 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-
   ws@8.21.3:
     resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
@@ -2954,8 +2931,9 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+  yauzl@3.4.0:
+    resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
+    engines: {node: '>=12'}
 
   yoctocolors@2.2.0:
     resolution: {integrity: sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==}
@@ -3552,7 +3530,7 @@ snapshots:
   '@openai/apps-sdk-ui@0.2.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.3.3)':
     dependencies:
       clsx: 2.1.1
-      lodash: 4.17.21
+      lodash: 4.18.1
       luxon: 3.7.1
       radix-ui: 1.6.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
@@ -4484,7 +4462,7 @@ snapshots:
       postcss: 8.5.23
       tailwindcss: 4.3.3
 
-  '@toon-format/toon@2.3.0': {}
+  '@toon-format/toon@2.3.1': {}
 
   '@types/bun@1.3.13':
     dependencies:
@@ -4540,10 +4518,9 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@types/yauzl@2.10.3':
+  '@types/yauzl@3.4.0':
     dependencies:
       '@types/node': 22.19.17
-    optional: true
 
   '@ungap/structured-clone@1.3.3': {}
 
@@ -4600,8 +4577,6 @@ snapshots:
       electron-to-chromium: 1.5.404
       node-releases: 2.0.53
       update-browserslist-db: 1.3.1(browserslist@4.28.8)
-
-  buffer-crc32@0.2.13: {}
 
   bun-types@1.3.13:
     dependencies:
@@ -4707,10 +4682,6 @@ snapshots:
 
   emoji-regex@10.6.0: {}
 
-  end-of-stream@1.4.5:
-    dependencies:
-      once: 1.4.0
-
   enhanced-resolve@5.24.5:
     dependencies:
       graceful-fs: 4.2.11
@@ -4784,16 +4755,6 @@ snapshots:
 
   extend@3.0.2: {}
 
-  extract-zip@2.0.1:
-    dependencies:
-      debug: 4.4.3
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
-
   fast-check@4.9.0:
     dependencies:
       pure-rand: 8.4.2
@@ -4815,10 +4776,6 @@ snapshots:
   fault@1.0.4:
     dependencies:
       format: 0.2.2
-
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -4857,10 +4814,6 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
-
-  get-stream@5.2.0:
-    dependencies:
-      pump: 3.0.4
 
   get-stream@9.0.1:
     dependencies:
@@ -4976,7 +4929,7 @@ snapshots:
       '@cfworker/json-schema': 4.1.1
       '@modelcontextprotocol/server': 2.0.0-beta.4
       '@scalar/openapi-types': 0.8.0
-      '@toon-format/toon': 2.3.0
+      '@toon-format/toon': 2.3.1
       tokenx: 1.3.0
       yaml: 2.9.0
       zod: 4.4.3
@@ -5148,8 +5101,6 @@ snapshots:
   lodash.debounce@4.0.8: {}
 
   lodash.groupby@4.6.0: {}
-
-  lodash@4.17.21: {}
 
   lodash@4.18.1: {}
 
@@ -5606,10 +5557,6 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
-
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
@@ -5666,15 +5613,11 @@ snapshots:
 
   property-information@7.2.0: {}
 
-  pump@3.0.4:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
-
   pure-rand@8.4.2: {}
 
-  qs@6.15.1:
+  qs@6.16.0:
     dependencies:
+      es-define-property: 1.0.1
       side-channel: 1.1.1
 
   radix-ui@1.6.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
@@ -6025,7 +5968,7 @@ snapshots:
     dependencies:
       des.js: 1.1.0
       js-md4: 0.3.2
-      qs: 6.15.1
+      qs: 6.16.0
       tunnel: 0.0.6
       underscore: 1.13.8
 
@@ -6141,18 +6084,15 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
-  wrappy@1.0.2: {}
-
   ws@8.21.3: {}
 
   yallist@3.1.1: {}
 
   yaml@2.9.0: {}
 
-  yauzl@2.10.0:
+  yauzl@3.4.0:
     dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
+      pend: 1.2.0
 
   yoctocolors@2.2.0: {}
 

--- a/sdk/typescript/pnpm-workspace.yaml
+++ b/sdk/typescript/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 allowBuilds:
   esbuild: false
+overrides:
+  '@openai/apps-sdk-ui@0.2.2>lodash': 4.18.1
+  'typed-rest-client@2.3.1>qs': 6.16.0

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import {
   chmodSync,
   constants,
+  createWriteStream,
   existsSync,
   readdirSync,
   type BigIntStats,
@@ -43,9 +44,10 @@ import {
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
+import { pipeline } from "node:stream/promises";
 import { crc32 } from "node:zlib";
 import { setTimeout as delay } from "node:timers/promises";
-import extractZip from "extract-zip";
+import { openPromise as openZip } from "yauzl";
 import { parse } from "smol-toml";
 import {
   CodexSecurityError,
@@ -2145,17 +2147,16 @@ export async function extractPluginZip(
     let expandedSize = 0;
     const paths = new Set<string>();
     const checksums: Array<{ path: string; checksum: number }> = [];
-    await extractZip(archivePath, {
-      dir: staging,
-      defaultDirMode: 0o700,
-      defaultFileMode: 0o600,
-      onEntry(entry, archive) {
+    const zip = await openZip(archivePath, { strictFileNames: true });
+    try {
+      for await (const entry of zip.eachEntry()) {
         throwIfSignalAborted(signal);
-        if (archive.entryCount > MAX_ZIP_ENTRIES) {
+        if (zip.entryCount > MAX_ZIP_ENTRIES) {
           throw new PluginBootstrapError(
-            `Plugin ZIP contains too many entries: ${archive.entryCount}.`,
+            `Plugin ZIP contains too many entries: ${zip.entryCount}.`,
           );
         }
+        if (entry.fileName.startsWith("__MACOSX/")) continue;
         const path = safeArchivePath(entry.fileName);
         const collisionKey = path.toLowerCase();
         if (paths.has(collisionKey)) {
@@ -2186,11 +2187,25 @@ export async function extractPluginZip(
           mode === 0o040000 ||
           (entry.versionMadeBy >>> 8 === 0 &&
             entry.externalFileAttributes === 16);
-        if (!directory) {
-          checksums.push({ path, checksum: entry.crc32 >>> 0 });
-        }
-      },
-    });
+        const output = join(staging, ...path.split("/"));
+        const entryMode = (entry.externalFileAttributes >>> 16) & 0xffff;
+        const permissions = (entryMode || (directory ? 0o700 : 0o600)) & 0o777;
+        await mkdir(directory ? output : dirname(output), {
+          recursive: true,
+          ...(directory ? { mode: permissions } : {}),
+        });
+        if (directory) continue;
+        const stream = await zip.openReadStreamPromise(entry);
+        await pipeline(
+          stream,
+          createWriteStream(output, { mode: permissions, flags: "wx" }),
+          { signal },
+        );
+        checksums.push({ path, checksum: entry.crc32 >>> 0 });
+      }
+    } finally {
+      zip.close();
+    }
     for (const { path, checksum } of checksums) {
       throwIfSignalAborted(signal);
       const bytes = await readFile(join(staging, ...path.split("/")));

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -1300,6 +1300,68 @@ describe("plugin runtime preparation", () => {
     );
   });
 
+  test("extracts ZIP directories and preserves executable file permissions", async () => {
+    const root = await temporaryDirectory();
+    const archive = join(root, "plugin.zip");
+    await writeFile(
+      archive,
+      zipSync({
+        "__MACOSX/._release": strToU8("metadata"),
+        "release/.codex-plugin/plugin.json": strToU8(
+          JSON.stringify({ name: "codex-security", version: "1.2.3" }),
+        ),
+        "release/unix-directory": [
+          new Uint8Array(),
+          { os: 3, attrs: 0o40700 << 16 },
+        ],
+        "release/dos-directory": [new Uint8Array(), { os: 0, attrs: 16 }],
+        "release/scripts/helper": [
+          strToU8("#!/bin/sh\n"),
+          { os: 3, attrs: 0o100755 << 16 },
+        ],
+      }),
+    );
+    const extracted = await extractPluginZip(archive, join(root, "extracted"));
+    expect((await stat(join(extracted, "unix-directory"))).isDirectory()).toBe(
+      true,
+    );
+    expect((await stat(join(extracted, "dos-directory"))).isDirectory()).toBe(
+      true,
+    );
+    expect(await readFile(join(extracted, "scripts/helper"), "utf8")).toBe(
+      "#!/bin/sh\n",
+    );
+    expect(existsSync(join(root, "extracted", "__MACOSX"))).toBe(false);
+    if (process.platform !== "win32") {
+      expect((await stat(join(extracted, "scripts/helper"))).mode & 0o777).toBe(
+        0o755 & ~process.umask(),
+      );
+    }
+  });
+
+  test("rejects ZIP symlinks before writing through them and cleans staging", async () => {
+    const root = await temporaryDirectory();
+    const outside = await temporaryDirectory();
+    const target = join(outside, "target.txt");
+    await writeFile(target, "unchanged");
+    const archive = join(root, "plugin.zip");
+    await writeFile(
+      archive,
+      zipSync({
+        "release/.codex-plugin/plugin.json": strToU8(
+          JSON.stringify({ name: "codex-security", version: "1.2.3" }),
+        ),
+        "release/link": [strToU8(outside), { os: 3, attrs: 0o120777 << 16 }],
+        "release/link/target.txt": strToU8("overwritten"),
+      }),
+    );
+    await expect(
+      extractPluginZip(archive, join(root, "extracted")),
+    ).rejects.toThrow("unsafe path");
+    expect(await readFile(target, "utf8")).toBe("unchanged");
+    expect(await readdir(root)).toEqual(["plugin.zip"]);
+  });
+
   test("honors cancellation while preparing a plugin ZIP", async () => {
     const root = await temporaryDirectory();
     const archive = join(root, "plugin.zip");


### PR DESCRIPTION
## Summary

The SDK dependency audit reports vulnerabilities in `extract-zip` and several transitive dependencies. Replace `extract-zip` with `yauzl` 3.4.0 for plugin ZIP extraction and resolve patched dependencies so both production and full SDK audits report no known vulnerabilities.

The existing ZIP symlink rejection already protects the CLI against the behavior described in [GHSA-jmr9-qjv8-65gv](https://github.com/advisories/GHSA-jmr9-qjv8-65gv); this change removes the affected package from the dependency tree.

## Changes

- Extract entries through `yauzl`'s async API and Node streams, retaining path, duplicate, symlink, size, and CRC checks, filename decoding, directory attributes, executable permissions, and macOS metadata handling.
- Add regression coverage for directory attributes and executable permissions, plus an external-target symlink followed by a file write and staging cleanup.
- Update the transitive `@toon-format/toon` resolution to 2.3.1. Scope overrides to the development packages that pin vulnerable `lodash` and `qs` versions.

## Testing

Validated on Linux with Node 24.18.0, Bun 1.3.14, pnpm 11.19.0, and `umask 022`:

- Focused ZIP tests before and after the extraction change: 10 passed.
- `pnpm run test --seed 12345`: 2,419 passed, 41 skipped, 0 failed.
- The additional default randomized full-suite run is in progress.
- `pnpm run types` and `pnpm run format`: passed.
- `pnpm audit` and `pnpm audit --prod`: no known vulnerabilities.
- `pnpm pack` and `node scripts/check-package.mjs <tarball>`: passed, including installed-package CLI, SDK, MCP, dashboard, and nested-worker checks.
- Fresh npm resolution of the packed artifact and `npm audit`: 0 vulnerabilities.

## Risk and rollout

The ZIP reader moves from the older `yauzl` version behind `extract-zip` to the current direct API. Archive compatibility and security behavior are covered by the focused tests; Windows-specific tests were skipped locally. The development dependency overrides are limited to the parent versions that pin vulnerable releases and should be revisited when those parents update their pins.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
