### PR TITLE
fix(runtime): reuse unchanged plugins across concurrent scans

### DIFF
--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -2467,7 +2467,11 @@ export async function bootstrapPlugin(
       : await pluginMetadata(join(marketplace, "plugins", PLUGIN_NAME)).catch(
           () => null,
         );
-  if (staged?.version !== version) {
+  const stagedRoot = join(marketplace, "plugins", PLUGIN_NAME);
+  const stagedMatches =
+    staged?.version === version &&
+    (await pluginContentsMatch(root, stagedRoot, options.signal));
+  if (!stagedMatches) {
     if (existing !== null) {
       await rm(marketplace, { recursive: true, force: true });
     }
@@ -2479,22 +2483,62 @@ export async function bootstrapPlugin(
       throw error;
     },
   );
-  const marketplaces = parse(config)["marketplaces"];
+  const configuration = parse(config);
+  const marketplaces = configuration["marketplaces"];
   const registration = isRecord(marketplaces)
     ? marketplaces[MARKETPLACE_NAME]
     : undefined;
-  if (
-    !isRecord(registration) ||
-    registration["source_type"] !== "local" ||
-    typeof registration["source"] !== "string" ||
-    !(await sameFile(registration["source"], marketplace))
-  ) {
+  const registered =
+    isRecord(registration) &&
+    registration["source_type"] === "local" &&
+    typeof registration["source"] === "string" &&
+    (await sameFile(registration["source"], marketplace));
+  if (!registered) {
     await run(
       command,
       ["plugin", "marketplace", "add", marketplace],
       environment,
       options.signal,
     );
+  }
+  // The startup lock serializes bootstraps, but other scans can still be using
+  // the installed tree. Even a same-version `plugin add` replaces that tree
+  // and leaves their MCP coordinators with a deleted working directory.
+  const installRecord = join(marketplace, "installed-plugin.json");
+  const previous: unknown = await readFile(installRecord, "utf8")
+    .then((value) => JSON.parse(value) as unknown)
+    .catch((error: unknown) => {
+      if (nodeErrorCode(error) === "ENOENT" || error instanceof SyntaxError)
+        return null;
+      throw error;
+    });
+  const plugins = configuration["plugins"];
+  const plugin = isRecord(plugins)
+    ? plugins[`${PLUGIN_NAME}@${MARKETPLACE_NAME}`]
+    : undefined;
+  if (
+    stagedMatches &&
+    registered &&
+    isRecord(plugin) &&
+    plugin["enabled"] === true &&
+    isRecord(previous) &&
+    typeof previous["installedPath"] === "string" &&
+    previous["version"] === version &&
+    (await pluginContentsMatch(
+      root,
+      previous["installedPath"],
+      options.signal,
+      true,
+    ))
+  ) {
+    return {
+      pluginRoot: root,
+      marketplaceRoot: marketplace,
+      installedRoot: previous["installedPath"],
+      marketplaceName: MARKETPLACE_NAME,
+      name,
+      version,
+    };
   }
   const output = await run(
     command,
@@ -2520,6 +2564,11 @@ export async function bootstrapPlugin(
       "Codex plugin install did not return the selected plugin path and version.",
     );
   }
+  await writeFile(
+    installRecord,
+    JSON.stringify({ installedPath: installed["installedPath"], version }),
+    { mode: 0o600, signal: options.signal },
+  );
   return {
     pluginRoot: root,
     marketplaceRoot: marketplace,
@@ -2528,6 +2577,58 @@ export async function bootstrapPlugin(
     name,
     version,
   };
+}
+
+async function pluginContentsMatch(
+  source: string,
+  destination: string,
+  signal?: AbortSignal,
+  allowExtraFiles = false,
+): Promise<boolean> {
+  throwIfSignalAborted(signal);
+  const sourceMetadata = await lstat(source);
+  const destinationMetadata = await lstat(destination).catch(
+    (error: unknown) => {
+      if (["ENOENT", "ENOTDIR"].includes(nodeErrorCode(error) ?? ""))
+        return null;
+      throw error;
+    },
+  );
+  if (destinationMetadata === null) return false;
+  if (sourceMetadata.isFile() && destinationMetadata.isFile()) {
+    if (
+      sourceMetadata.size !== destinationMetadata.size ||
+      (sourceMetadata.mode & 0o111) !== (destinationMetadata.mode & 0o111)
+    )
+      return false;
+    const [sourceBytes, destinationBytes] = await Promise.all([
+      readFile(source, { signal }),
+      readFile(destination, { signal }),
+    ]);
+    return sourceBytes.equals(destinationBytes);
+  }
+  if (!sourceMetadata.isDirectory() || !destinationMetadata.isDirectory())
+    return false;
+  const entries = await readdir(source);
+  // An installed plugin can accumulate runtime files such as __pycache__.
+  // Only the pristine marketplace copy must have exactly the source entries.
+  if (
+    !allowExtraFiles &&
+    entries.length !== (await readdir(destination)).length
+  )
+    return false;
+  for (const entry of entries) {
+    if (
+      !(await pluginContentsMatch(
+        join(source, entry),
+        join(destination, entry),
+        signal,
+        allowExtraFiles,
+      ))
+    )
+      return false;
+  }
+  return true;
 }
 
 export async function pluginMetadata(

--- a/sdk/typescript/tests-ts/runtime.test.ts
+++ b/sdk/typescript/tests-ts/runtime.test.ts
@@ -1668,6 +1668,188 @@ describe("plugin runtime preparation", () => {
     ]);
   });
 
+  test("keeps an active coordinator's cwd usable across same-version bootstraps", async () => {
+    const root = await temporaryDirectory();
+    const selected = await plugin(root);
+    const home = join(root, "home");
+    const output = join(root, "output");
+    await mkdir(home);
+    await mkdir(output);
+    const environment = {
+      PATH: process.env["PATH"],
+      SystemRoot: process.env["SystemRoot"],
+      WINDIR: process.env["WINDIR"],
+      HOME: home,
+      USERPROFILE: home,
+      CODEX_HOME: home,
+      TMPDIR: root,
+      TMP: root,
+      TEMP: root,
+    };
+    const codexCommand = resolveCodexCommand(environment);
+    const options = { codexCommand, environment };
+    const first = await bootstrapPlugin(home, selected, options);
+    const identity = await stat(first.installedRoot, { bigint: true });
+    // The coordinator stays alive in the installed directory while a second
+    // scan bootstraps. Its later worker inherits that cwd even with --cd.
+    const coordinator = childProcess.spawn(
+      process.execPath,
+      [
+        "-e",
+        `
+          const { spawnSync } = require("node:child_process");
+          process.stdin.once("data", () => {
+            const result = spawnSync(${JSON.stringify(codexCommand.command)},
+              ["exec", "--skip-git-repo-check", "--cd", ${JSON.stringify(output)}],
+              { input: "", encoding: "utf8", timeout: 10000 });
+            console.log(JSON.stringify({ status: result.status, stderr: result.stderr, error: result.error?.message }));
+          });
+          console.log("ready");
+        `,
+      ],
+      { cwd: first.installedRoot, env: environment, stdio: "pipe" },
+    );
+    const completion = once(coordinator, "close");
+    try {
+      await once(coordinator.stdout, "data");
+      const second = await bootstrapPlugin(home, selected, options);
+      expect(second.installedRoot).toBe(first.installedRoot);
+      const current = await stat(second.installedRoot, { bigint: true });
+      expect([current.dev, current.ino]).toEqual([identity.dev, identity.ino]);
+      let output = "";
+      coordinator.stdout.setEncoding("utf8").on("data", (chunk: string) => {
+        output += chunk;
+      });
+      coordinator.stdin.end("start worker\n");
+      expect((await completion)[0]).toBe(0);
+      const result = JSON.parse(output) as {
+        status: number;
+        stderr: string;
+        error?: string;
+      };
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      // Empty stdin stops before authentication or any model request.
+      expect(result.stderr).toContain("No prompt provided via stdin");
+      expect(result.stderr).not.toContain("os error 2");
+    } finally {
+      coordinator.kill();
+      await completion;
+    }
+  });
+
+  test.each([
+    "unchanged contents",
+    "runtime-generated files",
+    "relocated source",
+    "changed source file",
+    "removed source file",
+    "missing installed directory",
+    "missing installed helper",
+    "changed installed helper",
+    "disabled plugin",
+    "missing marketplace registration",
+    "interrupted install record",
+  ])("bootstraps a cached plugin with %s", async (change) => {
+    const root = await temporaryDirectory();
+    let selected = await plugin(root);
+    const home = join(root, "home");
+    const marketplace = join(home, "sdk-marketplace");
+    // Codex owns the cache layout; only its returned path identifies the install.
+    const installed = join(home, "codex-managed-install");
+    const configPath = join(home, "config.toml");
+    await mkdir(home);
+    let installs = 0;
+    const registration = `[marketplaces.codex-security-sdk]\nsource_type = "local"\nsource = ${JSON.stringify(marketplace)}\n`;
+    const configuration = `${registration}\n[plugins."codex-security@codex-security-sdk"]\nenabled = true\n`;
+    const options = {
+      codexCommand: { command: "/codex" },
+      runCodex: async (_command: unknown, args: readonly string[]) => {
+        if (args[1] === "marketplace") {
+          await writeFile(configPath, registration);
+          return "";
+        }
+        installs += 1;
+        await rm(installed, { recursive: true, force: true });
+        await fsPromises.cp(
+          join(marketplace, "plugins", "codex-security"),
+          installed,
+          { recursive: true },
+        );
+        await writeFile(configPath, configuration);
+        return JSON.stringify({ installedPath: installed, version: "1.2.3" });
+      },
+    };
+    await bootstrapPlugin(home, selected, options);
+
+    switch (change) {
+      case "runtime-generated files":
+        await mkdir(join(installed, "scripts", "__pycache__"));
+        await writeFile(
+          join(installed, "scripts", "__pycache__", "helper.pyc"),
+          "generated",
+        );
+        break;
+      case "relocated source":
+        selected = await plugin(join(root, "relocated"));
+        break;
+      case "changed source file":
+        await writeFile(
+          join(selected, "scripts", "helper.py"),
+          "print('hi')\n",
+        );
+        break;
+      case "removed source file":
+        await rm(join(selected, "scripts", "helper.py"));
+        break;
+      case "missing installed directory":
+        await rm(installed, { recursive: true });
+        break;
+      case "missing installed helper":
+        await rm(join(installed, "scripts", "helper.py"));
+        break;
+      case "changed installed helper":
+        await writeFile(
+          join(installed, "scripts", "helper.py"),
+          "print('no')\n",
+        );
+        break;
+      case "disabled plugin":
+        await writeFile(
+          configPath,
+          configuration.replace("enabled = true", "enabled = false"),
+        );
+        break;
+      case "missing marketplace registration":
+        await writeFile(configPath, "");
+        break;
+      case "interrupted install record":
+        await writeFile(join(marketplace, "installed-plugin.json"), "{");
+        break;
+    }
+
+    const result = await bootstrapPlugin(home, selected, options);
+    expect(result.installedRoot).toBe(installed);
+    expect(result.pluginRoot).toBe(selected);
+    expect(installs).toBe(
+      [
+        "unchanged contents",
+        "runtime-generated files",
+        "relocated source",
+      ].includes(change)
+        ? 1
+        : 2,
+    );
+    if (change === "removed source file") {
+      expect(existsSync(join(installed, "scripts", "helper.py"))).toBe(false);
+    } else {
+      expect(
+        await readFile(join(installed, "scripts", "helper.py"), "utf8"),
+      ).toBe(await readFile(join(selected, "scripts", "helper.py"), "utf8"));
+    }
+    expect(await readFile(configPath, "utf8")).toBe(configuration);
+  });
+
   test("does not preserve a different marketplace when numeric identities collide", async () => {
     const root = await temporaryDirectory();
     const home = join(root, "home");


### PR DESCRIPTION
## Summary

Starting another same-version scan currently runs `codex plugin add` again,
replacing the directory used by an active MCP coordinator. A later worker
inherits the deleted working directory and fails with `os error 2`, even when
its thread specifies `workingDirectory`.

Reuse a verified unchanged installation so concurrent scans can continue
starting workers. This preserves the parallel ChatGPT scanning enabled by #440
and keeps shared startup mutations under the existing lock. Fixes #824.

## Changes

- Retain the installation path returned by Codex and reuse it when registration,
  source, and installed contents match.
- Refresh changed custom plugin contents even when the version is unchanged;
  continue repairing missing files and registration.
- Add a real-process regression for an active coordinator and focused coverage
  for reuse, runtime-generated files, relocated sources, and repair.

## Testing

- The new process regression fails on the unmodified base and passes with the fix.
- The compiled runtime passes an isolated Node/Codex SDK reproduction with both
  the released and current plugin payloads. Empty prompts avoid model requests.
- Focused runtime tests: 167 passed, 21 platform skips, 0 failures.
- Build, type checks, formatting, and `git diff --check`: passed.
- Full isolated SDK suite: 2,427 passed, 43 skipped, 0 failed, across 119 files
  (seed `1529161043`). The initial sandboxed run hit environment restrictions;
  all affected tests passed after isolating the test home and allowing local
  server/process checks, before the successful complete rerun.

## Risk and rollout

The change preserves parallel scanning and uses the existing startup lock.
It adds an internal installation record without changing public CLI options or
dependency versions. Content checks read the plugin payload during bootstrap.

This addresses repeated installation of identical contents. Upgrades, custom
plugin changes, repairs, and older SDK processes can still replace an active
installation. An older installation without the record is installed normally
once. Finish existing scans before switching builds; protecting active scans
through actual replacements is a separate follow-up.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
