### PR TITLE
release: bump Codex Security to 0.1.26

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,74 +1,33 @@
-<!-- release-version: 0.1.25 -->
+<!-- release-version: 0.1.26 -->
 
 ## Highlights
 
-- Preserve confirmed finding identities across scans and comparisons, and show
-  related findings with their reasons while keeping distinct findings separate.
-  Large comparisons now use bounded batches without truncating finding text;
-  inputs that cannot fit leave matching explicitly incomplete.
-- Improve deduplication with separate screening and pair reviews, validated
-  pair assignments, and groups that respect explicit `DISTINCT` decisions.
-  Invalid submissions receive one corrective turn; blocked reviews fail without
-  recording a verdict. `DeduplicationReviewError` exposes structured, sanitized
-  failure details. The SDK also adds `deduplicateScanDirectory` for complete,
-  sealed scans outside local history.
-- Generate synthetic Standard scan results with `scan --mock` or the SDK's
-  `mock: true`, without authentication or model calls. Mock results support
-  normal reports, exports, history, and reruns. See
-  [mock scans](https://github.com/openai/codex-security/blob/npm-v0.1.25/sdk/typescript/README.md#generate-mock-scan-results).
-- Increase a running scan's total budget from the interactive dashboard when
-  usage reaches 80% of its limit, or use the SDK's `onBudgetApproaching`
-  callback. The existing limit remains enforced until an increase is saved.
-  See [scan cost limits](https://github.com/openai/codex-security/blob/npm-v0.1.25/sdk/typescript/README.md#progress-and-cost).
-- Recognize existing Codex authentication in CLI and SDK login status. SDK
-  scans, comparisons, and deduplication reviews now honor native command-auth
-  providers, including renewable tokens.
-- Configure the findings service's full embeddings endpoint with
-  `CODEX_SECURITY_EMBEDDINGS_URL`. The new `@openai/codex-security/server`
-  exports support embedding credentials supplied by a callback before each
-  HTTP batch. See
-  [embeddings and storage](https://github.com/openai/codex-security/blob/npm-v0.1.25/sdk/typescript/README.md#embeddings-and-storage).
-- Include PowerShell module (`.psm1`) and data (`.psd1`) files in scan
-  inventories, and recognize BOM-marked UTF-16 source files as text.
-- Preserve scoped scan and component-plan inventories after directory renames
-  that change only letter casing on case-insensitive filesystems.
-- Support long Codex executable paths on Windows, including nested Deep Scan
-  workers, and retry credential snapshots for another `Get-Acl` path-not-found
-  race when a descendant disappears during inspection.
-- Honor case-insensitive Windows environment variable names during finding
-  deduplication, so configured API credentials and private configuration paths
-  are used consistently.
-- Stream tracked binary diffs when hashing repository snapshots, reducing
-  memory use while preserving the existing digest format.
-- Include complete OCI metadata in container image labels and multiarchitecture
-  annotations, with documentation pinned to the source commit and image
-  verification commands in the release workflow summary. See
-  [container metadata and verification](https://github.com/openai/codex-security/blob/npm-v0.1.25/docker/README.md#image-metadata-and-verification).
+- Classify finding severity with custom rubrics and supporting context through
+  the CLI and SDK. Saved assessments can be reused for Linear publication
+  without changing the original findings or sealed scan artifacts. See
+  [severity classification](https://github.com/openai/codex-security/blob/npm-v0.1.26/sdk/typescript/README.md#classify-finding-severity).
+- Match repeated findings across scan history, preserving confirmed identities
+  and related-finding relationships. Automatic matching restores batching, and
+  confirmed-finding lookups are faster.
+- Open draft GitLab merge requests for verified patches with the existing
+  `--create-pr` option, including self-hosted GitLab. See
+  [patch publication](https://github.com/openai/codex-security/blob/npm-v0.1.26/sdk/typescript/README.md#validate-and-patch-findings).
+- Report component scan progress in headless runs and exclude replayed usage
+  events with identical timestamps from scan budgets.
+- Preserve analytics settings in finding workflows and allow 120 seconds for
+  the bundled plugin's MCP server to start.
+- Require an explicit request before invoking the security fix verification
+  skill during other work.
 
 ## Upgrade notes
 
-- Mock mode is opt-in and saves clearly marked synthetic findings in local
-  history; use a separate `CODEX_SECURITY_STATE_DIR` for disposable test data.
-  It supports Standard scans only and does not audit the repository.
-- Interactive budget increases are unavailable in CI, JSON/JSONL, headless,
-  and verbose modes. Existing cost limits continue to apply in those modes.
-- The embeddings URL defaults to the existing OpenAI endpoint. A configured
-  endpoint receives finding inputs and the bearer credential and must support
-  the OpenAI embeddings format. Embeddings credentials remain separate from
-  Codex ChatGPT sign-in.
-- Local history applies an automatic database index migration. Completed scan
-  artifacts remain unchanged.
-- Source builds now use repository-pinned pnpm 11.19.0, including MCP app
-  dependencies, whose configuration requires a seven-day minimum release age.
-  From the repository root, run
-  `pnpm --dir plugins/codex-security/mcp-app install --frozen-lockfile`.
-  See
-  [running without Docker](https://github.com/openai/codex-security/blob/npm-v0.1.25/sdk/typescript/README.md#running-without-docker).
-- Container publication remains separate from npm publication. Existing stable
-  container tags are not updated in place.
-
-Build and CI updates also improve package verification, portable Python checks,
-Windows fixtures, and test scheduling. Documentation clarifies portable
-environment-variable guidance and safe examples.
+- GitLab patch publication requires an installed and authenticated `glab` CLI.
+  For self-hosted GitLab, configure the host as described in the patch
+  publication documentation above.
+- Severity classification is opt-in. Without a rubric, it inherits the
+  finding's existing severity without a model call.
+- With `--max-cost`, automatic history matching makes at most one extra model
+  call. If matching needs more context, the completed scan is retained and a
+  warning directs you to run `scans match --all` explicitly.
 
 The categorized list below contains the individual changes.

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-security",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "TypeScript SDK and CLI for Codex Security",
   "license": "Apache-2.0",
   "author": "OpenAI",


### PR DESCRIPTION
## Summary

Prepare Codex Security 0.1.26 for release.

## Changes

- Bump `sdk/typescript/package.json` from 0.1.25 to 0.1.26. The lockfile does not record the root package version.
- Replace the previous release summary with 0.1.26 highlights and upgrade notes covering severity classification, finding-history matching, GitLab patch publication, and workflow fixes.

## Testing

- Release-note validation for 0.1.26 passed.
- Focused release automation, release PR, and release-cut workflow tests passed.
- Prettier checks for both changed files passed.
- `git diff --check` passed.
- Full SDK tests and build were not run locally for this version-and-documentation-only change; hosted CI will validate the PR.

## Risk and rollout

This PR changes release metadata and documentation only. Merging the version bump starts the existing release process after CI succeeds; npm and GitHub publication retain their existing gates. No CLI syntax or defaults change in this PR.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
