### PR TITLE
fix(ci): budget package installation and verification

### DIFF
--- a/sdk/typescript/scripts/package-smoke-timeouts.mjs
+++ b/sdk/typescript/scripts/package-smoke-timeouts.mjs
@@ -3,6 +3,7 @@ export function packageSmokeTimeouts(platform = process.platform) {
 
   return {
     commandTimeoutMs,
-    processTimeoutMs: commandTimeoutMs + 30_000,
+    // Installation and verification run sequentially; allow both plus cleanup.
+    processTimeoutMs: commandTimeoutMs * 2 + 30_000,
   };
 }

--- a/sdk/typescript/tests-ts/package-smoke-timeouts.test.ts
+++ b/sdk/typescript/tests-ts/package-smoke-timeouts.test.ts
@@ -12,30 +12,26 @@ const { packageSmokeTimeouts } = (await import(
 )) as PackageSmokeTimeouts;
 
 describe("npm package smoke timeouts", () => {
-  test("preserves the existing timeout on Linux and macOS", () => {
+  test("preserves the command timeout on Linux and macOS", () => {
     for (const platform of ["linux", "darwin"] as const) {
-      expect(packageSmokeTimeouts(platform)).toEqual({
-        commandTimeoutMs: 120_000,
-        processTimeoutMs: 150_000,
-      });
+      expect(packageSmokeTimeouts(platform).commandTimeoutMs).toBe(120_000);
     }
   });
 
   test("allows the Windows npm install to complete", () => {
-    expect(packageSmokeTimeouts("win32")).toEqual({
-      commandTimeoutMs: 180_000,
-      processTimeoutMs: 210_000,
-    });
+    expect(packageSmokeTimeouts("win32").commandTimeoutMs).toBe(180_000);
   });
 
-  test("keeps the parent smoke timeout above the command timeout", () => {
-    for (const platform of ["linux", "darwin", "win32"] as const) {
+  test.each(["linux", "darwin", "win32"] as const)(
+    "allows installation and verification to each use a command budget on %s",
+    (platform) => {
       const { commandTimeoutMs, processTimeoutMs } =
         packageSmokeTimeouts(platform);
 
-      expect(processTimeoutMs).toBe(commandTimeoutMs + 30_000);
-    }
-  });
+      const remainingAfterInstallation = processTimeoutMs - commandTimeoutMs;
+      expect(remainingAfterInstallation).toBeGreaterThan(commandTimeoutMs);
+    },
+  );
 
   test("uses the active runtime platform by default", () => {
     expect(packageSmokeTimeouts()).toEqual(


### PR DESCRIPTION
## Summary

The installed-package smoke deadline includes npm installation and all subsequent verification, but it only budgets one command plus 30 seconds. In [this Windows Node 24 run](https://github.com/openai/codex-security/actions/runs/34286485486/job/102265183248), installation took about 168 seconds and the parent stopped the still-progressing checks at 210 seconds. Cache and download timing can therefore decide whether valid verification finishes.

## Changes

- Budget one command allowance for installation, another for verification, and 30 seconds for cleanup.
- Set the total deadline to 390 seconds on Windows and 270 seconds on Linux and macOS. Individual commands retain their existing 180-second and 120-second limits.
- Cover the remaining verification allowance after installation on all three platforms.

## Testing

- Regression before the fix: all three platform budget cases failed.
- Focused timeout tests after the fix: 6 passed.
- SDK typecheck, formatting, and `git diff --check`: passed.
- Full seeded and randomized SDK checks are running in separate checkouts. Final results will be recorded in a PR comment.

## Risk and rollout

This changes test infrastructure. A stalled full smoke run can take up to three extra minutes on Windows or two extra minutes on Linux and macOS before the parent stops it. Individual subprocess limits and the CI job deadline continue to bound failures. The change takes effect when merged.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
