### PR TITLE
test: synchronize patch browser input with React updates

### DIFF
--- a/sdk/typescript/tests-ts/patch-tui.test.ts
+++ b/sdk/typescript/tests-ts/patch-tui.test.ts
@@ -4,7 +4,7 @@ import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { cleanup, render } from "ink-testing-library";
-import { createElement } from "react";
+import { act, createElement } from "react";
 import type { Finding, SeverityLevel } from "../src/index.js";
 import { PatchTui, type PatchSelection } from "../src/patch-tui.js";
 import { fakeResult } from "./cli-fixtures.js";
@@ -80,8 +80,23 @@ function findings(severities: readonly SeverityLevel[]): Finding[] {
   return result.findings.findings;
 }
 
-async function settle(): Promise<void> {
-  await new Promise<void>((resolve) => setTimeout(resolve, 60));
+async function pressKey(
+  app: ReturnType<typeof render>,
+  input: string,
+): Promise<void> {
+  const environment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+  const previous = environment.IS_REACT_ACT_ENVIRONMENT;
+  environment.IS_REACT_ACT_ENVIRONMENT = true;
+  try {
+    await act(async () => {
+      app.stdin.write(input);
+    });
+  } finally {
+    if (previous === undefined) delete environment.IS_REACT_ACT_ENVIRONMENT;
+    else environment.IS_REACT_ACT_ENVIRONMENT = previous;
+  }
 }
 
 describe("interactive patch finding browser", () => {
@@ -112,11 +127,9 @@ describe("interactive patch finding browser", () => {
     expect(app.lastFrame()).not.toContain('"rationale"');
 
     const frames = [app.lastFrame() ?? ""];
-    app.stdin.write("\t");
-    await settle();
+    await pressKey(app, "\t");
     for (let page = 0; page < 12; page += 1) {
-      app.stdin.write("\u001B[6~");
-      await settle();
+      await pressKey(app, "\u001B[6~");
       frames.push(app.lastFrame() ?? "");
     }
 
@@ -200,8 +213,7 @@ describe("interactive patch finding browser", () => {
 
       const frames = [app.lastFrame() ?? ""];
       for (let page = 0; page < 12; page += 1) {
-        app.stdin.write("\u001B[6~");
-        await settle();
+        await pressKey(app, "\u001B[6~");
         frames.push(app.lastFrame() ?? "");
       }
       const reviewed = frames.join("\n");
@@ -234,18 +246,15 @@ describe("interactive patch finding browser", () => {
       }),
     );
 
-    app.stdin.write("2");
-    await settle();
+    await pressKey(app, "2");
     expect(app.lastFrame()).toContain("1/3 selected");
     expect(app.lastFrame()).toContain("high and above");
 
-    app.stdin.write("\u001B[B ");
-    await settle();
+    await pressKey(app, "\u001B[B ");
     expect(app.lastFrame()).toContain("2/3 selected");
     expect(app.lastFrame()).toContain("custom");
 
-    app.stdin.write("\r");
-    await settle();
+    await pressKey(app, "\r");
     expect(selected).toEqual([
       { severity: "medium", occurrenceIds: ["occ_1", "occ_2"] },
     ]);
@@ -262,36 +271,27 @@ describe("interactive patch finding browser", () => {
       }),
     );
 
-    app.stdin.write("i");
-    await settle();
+    await pressKey(app, "i");
     expect(app.lastFrame()).toContain("Enter save");
 
-    app.stdin.write("Use the shared 2FA helper, not a new dependency.");
-    await settle();
+    await pressKey(app, "Use the shared 2FA helper, not a new dependency.");
     expect(app.lastFrame()).toContain("Use the shared 2FA helper");
     expect(app.lastFrame()).toContain("2/2 selected");
 
-    app.stdin.write("\r");
-    await settle();
+    await pressKey(app, "\r");
     expect(app.lastFrame()).toContain("PATCH INSTRUCTIONS");
     expect(app.lastFrame()).toContain("Use the shared 2FA helper");
     expect(app.lastFrame()).toContain("✎");
     expect(app.lastFrame()?.match(/PATCH INSTRUCTIONS/gu)).toHaveLength(1);
 
-    app.stdin.write("\u001B[B");
-    await settle();
-    app.stdin.write("i");
-    await settle();
-    app.stdin.write("Keep the existing middleware.");
-    await settle();
-    app.stdin.write("\r");
-    await settle();
+    await pressKey(app, "\u001B[B");
+    await pressKey(app, "i");
+    await pressKey(app, "Keep the existing middleware.");
+    await pressKey(app, "\r");
     expect(app.lastFrame()).toContain("Keep the existing middleware.");
 
-    app.stdin.write(" ");
-    await settle();
-    app.stdin.write("\r");
-    await settle();
+    await pressKey(app, " ");
+    await pressKey(app, "\r");
 
     expect(selected).toEqual([
       {
@@ -318,13 +318,11 @@ describe("interactive patch finding browser", () => {
     expect(app.lastFrame()).toContain(
       "[ ] Create draft pull request or merge request after patching",
     );
-    app.stdin.write("r");
-    await settle();
+    await pressKey(app, "r");
     expect(app.lastFrame()).toContain(
       "[✓] Create draft pull request or merge request after patching",
     );
-    app.stdin.write("\r");
-    await settle();
+    await pressKey(app, "\r");
 
     expect(selected).toEqual([
       {
@@ -346,25 +344,17 @@ describe("interactive patch finding browser", () => {
       }),
     );
 
-    app.stdin.write("i");
-    await settle();
-    app.stdin.write("Discard this guidance.");
-    await settle();
-    app.stdin.write("\u001B");
-    await settle();
+    await pressKey(app, "i");
+    await pressKey(app, "Discard this guidance.");
+    await pressKey(app, "\u001B");
     expect(selected).toEqual([]);
     expect(app.lastFrame()).not.toContain("Discard this guidance.");
 
-    app.stdin.write("i");
-    await settle();
-    app.stdin.write("x");
-    await settle();
-    app.stdin.write("\u007F");
-    await settle();
-    app.stdin.write("\r");
-    await settle();
-    app.stdin.write("\r");
-    await settle();
+    await pressKey(app, "i");
+    await pressKey(app, "x");
+    await pressKey(app, "\u007F");
+    await pressKey(app, "\r");
+    await pressKey(app, "\r");
 
     expect(selected).toEqual([{ severity: "high", occurrenceIds: ["occ_1"] }]);
   });
@@ -381,12 +371,10 @@ describe("interactive patch finding browser", () => {
         }),
       );
       if (input === "\r") {
-        app.stdin.write("n");
-        await settle();
+        await pressKey(app, "n");
         expect(app.lastFrame()).toContain("0/1 selected");
       }
-      app.stdin.write(input);
-      await settle();
+      await pressKey(app, input);
       expect(selected).toEqual([null]);
       app.unmount();
     }


### PR DESCRIPTION
## Summary

The patch-browser test can render a changed selection before React installs its updated input handler. On a busy runner, submitting the selection then reads the previous state and fails CI.

## Changes

- Wrap simulated key presses in awaited React `act` calls so rendering and effects finish before the next input or assertion.
- Replace the fixed 60 ms waits across the interactive patch-browser tests and restore React's test-environment setting after each call.
- Keep the existing selection, navigation, editing, and cancellation assertions.

## Testing

- Bun 1.3.14: all 9 patch-browser tests passed with the failing CI seed `2498037115`.
- The previously failing selection test passed 100 consecutive runs with that seed.
- `pnpm --dir sdk/typescript run types` passed.
- `pnpm --dir sdk/typescript run format` passed.
- `pnpm --dir sdk/typescript run build:ci` passed.
- `git diff --check` passed.
- `pnpm run test --seed 12345`: 2,454 passed, 53 skipped, and 0 failed.
- [Hosted CI](https://github.com/openai/codex-security/actions/runs/34360317968) passed with 42 successful jobs, including Linux, macOS, and Windows tests.
- Codex code and security reviews completed without findings on commit `7647fadd1f90e12ea0b342baa683fb8d2375676d`.

## Risk and rollout

This changes test synchronization only. Runtime behavior and the public CLI are unchanged. Hosted CI validated the tests on Linux, macOS, and Windows.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
