### PR TITLE
feat(scan): import CSV findings as saved scans

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -439,6 +439,33 @@ Scans are report-only by default. Set `--fail-on-severity high` to exit with
 `1` if a completed scan finds high or critical issues. Incomplete scans exit
 with `2`, writing available results to stdout and a coverage warning to stderr.
 
+### Import a CSV as a saved scan
+
+```bash
+codex-security scan import --csv /path/to/findings.csv
+codex-security scans show <returned-scan-id>
+```
+
+The command imports a Codex Security findings CSV into local SQLite history and
+returns `scanId`, `scanDir`, and `findingCount`. It uses the same CSV parser as
+Cloud publication; the [findings CSV template](https://github.com/openai/codex-security/blob/main/examples/findings.csv)
+shows the required columns. `candidate_id` is optional. Quoted multiline fields
+are supported. Each row needs unique `finding_id` and `occurrence_id` values;
+rows describing the same issue remain separate findings.
+
+Each import creates a completed, sealed scan under the normal state directory
+(`CODEX_SECURITY_STATE_DIR` when set). The original CSV is retained in the
+adjacent `source/findings.csv` snapshot. This dataset has its own target and is
+not attached to the current repository. Use the returned scan ID to view or
+export it; repository-filtered history will not include it.
+
+Import performs no model calls, authentication, deduplication, or publication.
+Coverage is `unknown` and findings have `csv_import` provenance. Source IDs,
+status, close reason, and notes are retained as metadata; imported findings
+start open in local triage. Importing again creates a new scan and dataset;
+`scans rerun` directs you to import the CSV again. A repository directory named
+`import` can still be scanned using `scan ./import`.
+
 ### Generate mock scan results
 
 Use `--mock` to populate a Standard scan with synthetic test data in seconds,
@@ -888,7 +915,7 @@ npx @openai/codex-security publish scan --to cloud \
 ```
 
 The [findings CSV template](https://github.com/openai/codex-security/blob/main/examples/findings.csv)
-has the required columns; deep-scan exports may add `candidate_id`. `--csv`
+has the required columns; deep-scan exports may add `candidate_id`. For `publish scan`, `--csv`
 only supports Cloud and cannot be combined with scan IDs or directories.
 
 For artifacts outside local history, pass a directory or repeat `--scan-dir PATH`.

--- a/sdk/typescript/scripts/check-package.mjs
+++ b/sdk/typescript/scripts/check-package.mjs
@@ -172,6 +172,8 @@ const distFiles = new Set(
     "classify-scan-severity",
     "severity-store",
     "cloud-publish",
+    "findings-csv",
+    "scan-import",
     "codex-prompt",
     "component-plan",
     "component-scan",

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -2919,7 +2919,7 @@ export async function main(
       dependencies.addSignalListener("SIGTERM", onTerminate);
       try {
         return await importScanCsv(
-          resolve(dependencies.currentDirectory(), options.csv),
+          resolveCliPath(dependencies.currentDirectory(), options.csv),
           dependencies,
           controller.signal,
         );

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -63,6 +63,7 @@ import {
   type ScanOptions,
   type ScanPreflight,
 } from "./api.js";
+import { importScanCsv } from "./scan-import.js";
 import { accountStatus } from "./auth.js";
 import { publishScanToCustom } from "./custom-publish.js";
 import { deduplicateScanInternal } from "./deduplication/scan.js";
@@ -2891,6 +2892,48 @@ export async function main(
       }
     },
   });
+  const scanImports = Cli.create("scan", {
+    description: "Import a local scan.",
+  }).command("import", {
+    description:
+      "Import a findings CSV as a completed local scan without running analysis.",
+    destructive: true,
+    mcp: false,
+    options: z.object({
+      csv: optionValue("--csv").describe(
+        "Codex Security findings CSV to import.",
+      ),
+    }),
+    output: z
+      .object({
+        scanId: z.string(),
+        scanDir: z.string(),
+        findingCount: z.number().int(),
+      })
+      .optional(),
+    async run({ options }) {
+      const controller = new AbortController();
+      const onInterrupt = () => controller.abort("SIGINT");
+      const onTerminate = () => controller.abort("SIGTERM");
+      dependencies.addSignalListener("SIGINT", onInterrupt);
+      dependencies.addSignalListener("SIGTERM", onTerminate);
+      try {
+        return await importScanCsv(
+          resolve(dependencies.currentDirectory(), options.csv),
+          dependencies,
+          controller.signal,
+        );
+      } catch (error) {
+        const signal = controller.signal.reason;
+        exitCode = signal === "SIGINT" ? 130 : signal === "SIGTERM" ? 143 : 2;
+        errorOutput.write(`codex-security: ${errorMessage(error)}\n`);
+        return undefined;
+      } finally {
+        dependencies.removeSignalListener("SIGINT", onInterrupt);
+        dependencies.removeSignalListener("SIGTERM", onTerminate);
+      }
+    },
+  });
   const cli = Cli.create("codex-security", {
     description:
       "Draft security policies; run, import, validate, patch, verify fixes, export, and publish Codex Security findings.",
@@ -3096,6 +3139,7 @@ export async function main(
     })
     .command("scan", {
       description: "Run a Codex Security scan.",
+      hint: "Import saved findings: codex-security scan import --csv FILE",
       destructive: true,
       mcp: false,
       args: z.object({
@@ -4873,6 +4917,12 @@ export async function main(
       },
     });
 
+  // Incur mounts a root handler or a command group, so select the group for import.
+  const commandIndex = cliCommandIndex(argv);
+  if (argv[commandIndex] === "scan" && argv[commandIndex + 1] === "import") {
+    cli.command(scanImports);
+  }
+
   let notice: UpdateNotice | undefined;
   try {
     await cli.serve(
@@ -4958,6 +5008,11 @@ function scanArgumentsFromRecipe(
   if (recipe === undefined || !isJsonObject(recipe)) {
     throw new CodexSecurityError(
       "This scan does not have a saved launch recipe.",
+    );
+  }
+  if (recipe["importCsv"] === true) {
+    throw new CodexSecurityError(
+      "This scan was imported from CSV. Use scan import --csv FILE to import it again.",
     );
   }
   if (

--- a/sdk/typescript/src/cloud-publish.ts
+++ b/sdk/typescript/src/cloud-publish.ts
@@ -1,12 +1,16 @@
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { isAbsolute, join, posix } from "node:path";
+import { join } from "node:path";
 import { z } from "incur";
-import Papa from "papaparse";
 import { parse as parseToml } from "smol-toml";
 import { loadContract } from "./contract.js";
 import { AuthenticationRequiredError, CodexSecurityError } from "./errors.js";
+import {
+  CSV_TARGET_ID,
+  parseFindingsCsv,
+  csvRowFinding,
+} from "./findings-csv.js";
 import type { Finding, ScanManifest } from "./models.js";
 import {
   bundledPluginRoot,
@@ -19,7 +23,6 @@ import { VERSION } from "./version.js";
 
 const CLOUD_PUBLISH_URL =
   "https://chatgpt.com/backend-api/aardvark/cli/findings";
-const CSV_TARGET_ID = "codex-security-csv-import";
 const CHATGPT_LOGIN_REQUIRED =
   "Cloud publication requires a ChatGPT login already available to Codex Security. Run a scan or sign in with ChatGPT using Codex file credential storage, then retry.";
 
@@ -52,97 +55,6 @@ interface CloudPublicationDependencies {
   signal?: AbortSignal;
   dryRun?: boolean;
 }
-
-const EXPORTED_CSV_ESCAPE = /^'(?:[\t\r\n]|\s*[=+\-@＝＋－＠])/u;
-const csvFindingRowSchema = z
-  .object({
-    occurrence_id: z.string().regex(/^occ_[a-f0-9]{24}$/u, {
-      error: "has an invalid occurrence_id",
-    }),
-    finding_id: z.string().regex(/^csf_[a-f0-9]{24}$/u, {
-      error: "has an invalid finding_id",
-    }),
-    candidate_id: z
-      .string()
-      .optional()
-      .transform((value) =>
-        value === undefined || value.trim() === "" ? undefined : value,
-      ),
-    title: requiredCsvText("title"),
-    summary: requiredCsvText("summary"),
-    severity: z.enum(["critical", "high", "medium", "low", "informational"], {
-      error: "has an invalid severity",
-    }),
-    confidence: z.enum(["high", "medium", "low"], {
-      error: "has an invalid confidence",
-    }),
-    status: z.enum(["open", "closed"], {
-      error: "has an invalid status",
-    }),
-    close_reason: z
-      .union(
-        [
-          z.literal(""),
-          z.enum(["already_fixed", "wont_fix", "false_positive"]),
-        ],
-        { error: "has an invalid close_reason" },
-      )
-      .transform((value) => (value === "" ? undefined : value)),
-    note: z
-      .string()
-      .transform((value) => (value.trim() === "" ? undefined : value)),
-    remediation: requiredCsvText("remediation"),
-    path: z.string().refine(safeFindingPath, {
-      error: "has an invalid path",
-    }),
-    start_line: z
-      .string()
-      .refine(validCsvLine, { error: "has an invalid start_line" })
-      .transform(Number),
-    end_line: z
-      .string()
-      .refine((value) => value === "" || validCsvLine(value), {
-        error: "has an invalid end_line",
-      })
-      .transform((value) => (value === "" ? undefined : Number(value))),
-  })
-  .superRefine((row, context) => {
-    if (
-      (row.status === "open" && row.close_reason !== undefined) ||
-      (row.status === "closed" && row.close_reason === undefined)
-    ) {
-      context.addIssue({
-        code: "custom",
-        path: ["close_reason"],
-        message: "has an invalid close_reason",
-      });
-    }
-    if (
-      row.status === "closed" &&
-      (row.close_reason === "false_positive" ||
-        row.close_reason === "wont_fix") &&
-      row.note === undefined
-    ) {
-      context.addIssue({
-        code: "custom",
-        path: ["note"],
-        message: "requires a note for its close_reason",
-      });
-    }
-    if (row.end_line !== undefined && row.end_line < row.start_line) {
-      context.addIssue({
-        code: "custom",
-        path: ["end_line"],
-        message: "has end_line before start_line",
-      });
-    }
-  });
-type CsvFindingRow = z.infer<typeof csvFindingRowSchema>;
-type CsvColumn = keyof typeof csvFindingRowSchema.shape;
-const CSV_COLUMNS = Object.keys(csvFindingRowSchema.shape) as CsvColumn[];
-const REQUIRED_CSV_COLUMNS = CSV_COLUMNS.filter(
-  (column) => !csvFindingRowSchema.shape[column].isOptional(),
-);
 
 export async function publishScanToCloud(
   scanDirectory: string,
@@ -247,161 +159,6 @@ export async function publishFindingsCsvToCloud(
     ],
   };
   return publishCloudPayload(scan, findings, dependencies);
-}
-
-function parseFindingsCsv(source: string): CsvFindingRow[] {
-  const {
-    data: rows,
-    errors,
-    meta,
-  } = Papa.parse<Record<string, string>>(source, {
-    header: true,
-    delimiter: ",",
-    skipEmptyLines: "greedy",
-    transform: decodeExportedCsvCell,
-  });
-  const fieldMismatch = errors.find(
-    (error) => error.code === "TooFewFields" || error.code === "TooManyFields",
-  );
-  if (fieldMismatch?.row !== undefined) {
-    throw csvRowError(fieldMismatch.row + 2, "must match the header columns");
-  }
-  if (errors.length > 0) {
-    throw new CodexSecurityError(
-      `Findings CSV could not be parsed: ${errors[0]!.message}`,
-    );
-  }
-  const headers = meta.fields;
-  const allowed = new Set<string>(CSV_COLUMNS);
-  if (
-    headers === undefined ||
-    !REQUIRED_CSV_COLUMNS.every((name) => headers.includes(name)) ||
-    headers.some((name) => !allowed.has(name)) ||
-    new Set(headers).size !== headers.length
-  ) {
-    throw new CodexSecurityError(
-      `Findings CSV must use the Codex Security export columns: ${REQUIRED_CSV_COLUMNS.join(", ")} (candidate_id is optional).`,
-    );
-  }
-  if (rows.length === 0) {
-    throw new CodexSecurityError(
-      "Findings CSV must contain at least one finding.",
-    );
-  }
-
-  const findingIds = new Set<string>();
-  const occurrenceIds = new Set<string>();
-  return rows.map((record, index) => {
-    const rowNumber = index + 2;
-    const parsed = csvFindingRowSchema.safeParse(record);
-    if (!parsed.success) {
-      throw csvRowError(rowNumber, parsed.error.issues[0]!.message);
-    }
-    const row = parsed.data;
-    if (findingIds.has(row.finding_id)) {
-      throw csvRowError(rowNumber, "has a duplicate finding_id");
-    }
-    if (occurrenceIds.has(row.occurrence_id)) {
-      throw csvRowError(rowNumber, "has a duplicate occurrence_id");
-    }
-    findingIds.add(row.finding_id);
-    occurrenceIds.add(row.occurrence_id);
-    return row;
-  });
-}
-
-function decodeExportedCsvCell(value: string): string {
-  return EXPORTED_CSV_ESCAPE.test(value) ? value.slice(1) : value;
-}
-
-function csvRowFinding(row: CsvFindingRow, scanId: string): Finding {
-  const ruleId = "import.csv";
-  const anchor = row.finding_id;
-  const fingerprint = `codex-security/v1:sha256:${sha256(
-    ["codex-security/v1", CSV_TARGET_ID, ruleId, anchor, ""].join("\0"),
-  )}`;
-  const findingId = `csf_${sha256(fingerprint).slice(0, 24)}`;
-  const occurrenceId = `occ_${sha256([scanId, fingerprint].join("\0")).slice(
-    0,
-    24,
-  )}`;
-  return {
-    findingId,
-    occurrenceId,
-    ruleId,
-    identity: { anchor },
-    fingerprints: {
-      algorithm: "codex-security/v1",
-      primary: fingerprint,
-    },
-    title: row.title,
-    summary: row.summary,
-    severity: { level: row.severity },
-    confidence: {
-      level: row.confidence,
-      rationale: "Imported from a Codex Security findings CSV.",
-    },
-    taxonomy: { category: "imported", cwe: [] },
-    locations: [
-      {
-        path: row.path,
-        startLine: row.start_line,
-        ...(row.end_line === undefined ? {} : { endLine: row.end_line }),
-      },
-    ],
-    remediation: row.remediation,
-    validation: {
-      method: "Source-reported CSV import metadata",
-      status: row.status,
-      summary: [
-        `Source finding ID: ${row.finding_id}`,
-        `Source occurrence ID: ${row.occurrence_id}`,
-        `Source status: ${row.status}`,
-        ...(row.close_reason === undefined
-          ? []
-          : [`Source close reason: ${row.close_reason}`]),
-        ...(row.note === undefined ? [] : [`Source note: ${row.note}`]),
-      ].join("\n"),
-    },
-    provenance: { source: "csv_import" },
-    extensions: {
-      ...(row.candidate_id === undefined
-        ? {}
-        : { candidateId: row.candidate_id }),
-    },
-  };
-}
-
-function requiredCsvText(column: string) {
-  return z.string().refine((value) => value.trim().length > 0, {
-    error: `requires ${column}`,
-  });
-}
-
-function validCsvLine(value: string): boolean {
-  if (!/^[1-9]\d*$/u.test(value)) return false;
-  const line = Number(value);
-  return Number.isSafeInteger(line);
-}
-
-function safeFindingPath(value: string): boolean {
-  if (
-    value.trim().length === 0 ||
-    value === "." ||
-    isAbsolute(value) ||
-    /^[A-Za-z]:/u.test(value) ||
-    value.includes("\\") ||
-    /[\u0000-\u001F]/u.test(value) ||
-    value.split("/").includes("..")
-  ) {
-    return false;
-  }
-  const normalized = posix.normalize(value).replace(/\/+$/u, "");
-  return normalized !== "." && !normalized.startsWith("../");
-}
-
-function csvRowError(rowNumber: number, detail: string): CodexSecurityError {
-  return new CodexSecurityError(`Findings CSV row ${rowNumber} ${detail}.`);
 }
 
 function sha256(value: string): string {

--- a/sdk/typescript/src/findings-csv.ts
+++ b/sdk/typescript/src/findings-csv.ts
@@ -1,0 +1,258 @@
+import { createHash } from "node:crypto";
+import { isAbsolute, posix } from "node:path";
+import { z } from "incur";
+import Papa from "papaparse";
+import { CodexSecurityError } from "./errors.js";
+import type { Finding } from "./models.js";
+
+export const CSV_TARGET_ID = "codex-security-csv-import";
+
+const EXPORTED_CSV_ESCAPE = /^'(?:[\t\r\n]|\s*[=+\-@＝＋－＠])/u;
+const csvFindingRowSchema = z
+  .object({
+    occurrence_id: z.string().regex(/^occ_[a-f0-9]{24}$/u, {
+      error: "has an invalid occurrence_id",
+    }),
+    finding_id: z.string().regex(/^csf_[a-f0-9]{24}$/u, {
+      error: "has an invalid finding_id",
+    }),
+    candidate_id: z
+      .string()
+      .optional()
+      .transform((value) =>
+        value === undefined || value.trim() === "" ? undefined : value,
+      ),
+    title: requiredCsvText("title"),
+    summary: requiredCsvText("summary"),
+    severity: z.enum(["critical", "high", "medium", "low", "informational"], {
+      error: "has an invalid severity",
+    }),
+    confidence: z.enum(["high", "medium", "low"], {
+      error: "has an invalid confidence",
+    }),
+    status: z.enum(["open", "closed"], {
+      error: "has an invalid status",
+    }),
+    close_reason: z
+      .union(
+        [
+          z.literal(""),
+          z.enum(["already_fixed", "wont_fix", "false_positive"]),
+        ],
+        { error: "has an invalid close_reason" },
+      )
+      .transform((value) => (value === "" ? undefined : value)),
+    note: z
+      .string()
+      .transform((value) => (value.trim() === "" ? undefined : value)),
+    remediation: requiredCsvText("remediation"),
+    path: z.string().refine(safeFindingPath, {
+      error: "has an invalid path",
+    }),
+    start_line: z
+      .string()
+      .refine(validCsvLine, { error: "has an invalid start_line" })
+      .transform(Number),
+    end_line: z
+      .string()
+      .refine((value) => value === "" || validCsvLine(value), {
+        error: "has an invalid end_line",
+      })
+      .transform((value) => (value === "" ? undefined : Number(value))),
+  })
+  .superRefine((row, context) => {
+    if (
+      (row.status === "open" && row.close_reason !== undefined) ||
+      (row.status === "closed" && row.close_reason === undefined)
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["close_reason"],
+        message: "has an invalid close_reason",
+      });
+    }
+    if (
+      row.status === "closed" &&
+      (row.close_reason === "false_positive" ||
+        row.close_reason === "wont_fix") &&
+      row.note === undefined
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["note"],
+        message: "requires a note for its close_reason",
+      });
+    }
+    if (row.end_line !== undefined && row.end_line < row.start_line) {
+      context.addIssue({
+        code: "custom",
+        path: ["end_line"],
+        message: "has end_line before start_line",
+      });
+    }
+  });
+type CsvFindingRow = z.infer<typeof csvFindingRowSchema>;
+type CsvColumn = keyof typeof csvFindingRowSchema.shape;
+const CSV_COLUMNS = Object.keys(csvFindingRowSchema.shape) as CsvColumn[];
+const REQUIRED_CSV_COLUMNS = CSV_COLUMNS.filter(
+  (column) => !csvFindingRowSchema.shape[column].isOptional(),
+);
+
+export function parseFindingsCsv(source: string): CsvFindingRow[] {
+  const {
+    data: rows,
+    errors,
+    meta,
+  } = Papa.parse<Record<string, string>>(source, {
+    header: true,
+    delimiter: ",",
+    skipEmptyLines: "greedy",
+    transform: decodeExportedCsvCell,
+  });
+  const fieldMismatch = errors.find(
+    (error) => error.code === "TooFewFields" || error.code === "TooManyFields",
+  );
+  if (fieldMismatch?.row !== undefined) {
+    throw csvRowError(fieldMismatch.row + 2, "must match the header columns");
+  }
+  if (errors.length > 0) {
+    throw new CodexSecurityError(
+      `Findings CSV could not be parsed: ${errors[0]!.message}`,
+    );
+  }
+  const headers = meta.fields;
+  const allowed = new Set<string>(CSV_COLUMNS);
+  if (
+    headers === undefined ||
+    !REQUIRED_CSV_COLUMNS.every((name) => headers.includes(name)) ||
+    headers.some((name) => !allowed.has(name)) ||
+    new Set(headers).size !== headers.length
+  ) {
+    throw new CodexSecurityError(
+      `Findings CSV must use the Codex Security export columns: ${REQUIRED_CSV_COLUMNS.join(", ")} (candidate_id is optional).`,
+    );
+  }
+  if (rows.length === 0) {
+    throw new CodexSecurityError(
+      "Findings CSV must contain at least one finding.",
+    );
+  }
+
+  const findingIds = new Set<string>();
+  const occurrenceIds = new Set<string>();
+  return rows.map((record, index) => {
+    const rowNumber = index + 2;
+    const parsed = csvFindingRowSchema.safeParse(record);
+    if (!parsed.success) {
+      throw csvRowError(rowNumber, parsed.error.issues[0]!.message);
+    }
+    const row = parsed.data;
+    if (findingIds.has(row.finding_id)) {
+      throw csvRowError(rowNumber, "has a duplicate finding_id");
+    }
+    if (occurrenceIds.has(row.occurrence_id)) {
+      throw csvRowError(rowNumber, "has a duplicate occurrence_id");
+    }
+    findingIds.add(row.finding_id);
+    occurrenceIds.add(row.occurrence_id);
+    return row;
+  });
+}
+
+function decodeExportedCsvCell(value: string): string {
+  return EXPORTED_CSV_ESCAPE.test(value) ? value.slice(1) : value;
+}
+
+export function csvRowFinding(row: CsvFindingRow, scanId: string): Finding {
+  const ruleId = "import.csv";
+  const anchor = row.finding_id;
+  const fingerprint = `codex-security/v1:sha256:${sha256(
+    ["codex-security/v1", CSV_TARGET_ID, ruleId, anchor, ""].join("\0"),
+  )}`;
+  const findingId = `csf_${sha256(fingerprint).slice(0, 24)}`;
+  const occurrenceId = `occ_${sha256([scanId, fingerprint].join("\0")).slice(
+    0,
+    24,
+  )}`;
+  return {
+    findingId,
+    occurrenceId,
+    ruleId,
+    identity: { anchor },
+    fingerprints: {
+      algorithm: "codex-security/v1",
+      primary: fingerprint,
+    },
+    title: row.title,
+    summary: row.summary,
+    severity: { level: row.severity },
+    confidence: {
+      level: row.confidence,
+      rationale: "Imported from a Codex Security findings CSV.",
+    },
+    taxonomy: { category: "imported", cwe: [] },
+    locations: [
+      {
+        path: row.path,
+        startLine: row.start_line,
+        ...(row.end_line === undefined ? {} : { endLine: row.end_line }),
+      },
+    ],
+    remediation: row.remediation,
+    validation: {
+      method: "Source-reported CSV import metadata",
+      status: row.status,
+      summary: [
+        `Source finding ID: ${row.finding_id}`,
+        `Source occurrence ID: ${row.occurrence_id}`,
+        `Source status: ${row.status}`,
+        ...(row.close_reason === undefined
+          ? []
+          : [`Source close reason: ${row.close_reason}`]),
+        ...(row.note === undefined ? [] : [`Source note: ${row.note}`]),
+      ].join("\n"),
+    },
+    provenance: { source: "csv_import" },
+    extensions: {
+      ...(row.candidate_id === undefined
+        ? {}
+        : { candidateId: row.candidate_id }),
+    },
+  };
+}
+
+function requiredCsvText(column: string) {
+  return z.string().refine((value) => value.trim().length > 0, {
+    error: `requires ${column}`,
+  });
+}
+
+function validCsvLine(value: string): boolean {
+  if (!/^[1-9]\d*$/u.test(value)) return false;
+  const line = Number(value);
+  return Number.isSafeInteger(line);
+}
+
+function safeFindingPath(value: string): boolean {
+  if (
+    value.trim().length === 0 ||
+    value === "." ||
+    isAbsolute(value) ||
+    /^[A-Za-z]:/u.test(value) ||
+    value.includes("\\") ||
+    /[\u0000-\u001F]/u.test(value) ||
+    value.split("/").includes("..")
+  ) {
+    return false;
+  }
+  const normalized = posix.normalize(value).replace(/\/+$/u, "");
+  return normalized !== "." && !normalized.startsWith("../");
+}
+
+function csvRowError(rowNumber: number, detail: string): CodexSecurityError {
+  return new CodexSecurityError(`Findings CSV row ${rowNumber} ${detail}.`);
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}

--- a/sdk/typescript/src/scan-import.ts
+++ b/sdk/typescript/src/scan-import.ts
@@ -1,0 +1,131 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+import type { JsonObject } from "./config.js";
+import { CodexSecurityError, safeErrorMessage } from "./errors.js";
+import { csvRowFinding, parseFindingsCsv } from "./findings-csv.js";
+import {
+  codexSecurityStateDirectory,
+  preparePersistentOutputRoot,
+} from "./runtime.js";
+
+interface ImportDependencies {
+  environment: NodeJS.ProcessEnv;
+  runWorkbench(
+    args: readonly string[],
+    input?: string,
+    signal?: AbortSignal,
+  ): Promise<JsonObject>;
+}
+
+export async function importScanCsv(
+  csvPath: string,
+  dependencies: ImportDependencies,
+  signal?: AbortSignal,
+): Promise<{ scanId: string; scanDir: string; findingCount: number }> {
+  const source = await readFile(csvPath, { encoding: "utf8", signal });
+  const rows = parseFindingsCsv(source);
+  signal?.throwIfAborted();
+  const root = await preparePersistentOutputRoot(
+    codexSecurityStateDirectory(dependencies.environment),
+    "scans",
+    basename(csvPath),
+  );
+  const directory = await mkdtemp(join(root, "import-"));
+  // The imported dataset is its own target, independent of the caller's repository.
+  const repository = join(directory, "source");
+  const scanDir = join(directory, "scan");
+  await mkdir(repository, { mode: 0o700 });
+  await mkdir(scanDir, { mode: 0o700 });
+  await writeFile(join(repository, "findings.csv"), source, {
+    flag: "wx",
+    signal,
+  });
+  const workbench = dependencies.runWorkbench;
+  let scanId: string | undefined;
+  try {
+    const registration = await workbench(
+      [
+        "register-cli-scan",
+        "--repository",
+        repository,
+        "--scan-dir",
+        scanDir,
+        "--registration-json-stdin",
+      ],
+      JSON.stringify({
+        recipe: {
+          repository,
+          target: { kind: "repository", paths: [] },
+          mode: "standard",
+          config: {},
+          importCsv: true,
+        },
+      }),
+      signal,
+    );
+    if (typeof registration["scanId"] !== "string") {
+      throw new CodexSecurityError(
+        "CSV import registration did not return a scan ID.",
+      );
+    }
+    scanId = registration["scanId"];
+    const description =
+      "Findings imported from CSV. No security analysis was performed; source status is retained as metadata.";
+    const documents = {
+      "scan-manifest.json": {
+        scan: {
+          target: { kind: "directory_snapshot" },
+          scope: {
+            summary: description,
+            runtimeStatus: "imported",
+            limitations: [description],
+          },
+          extensions: { importCsv: true },
+        },
+      },
+      "findings.json": {
+        findings: rows.map((row) => {
+          const { findingId, occurrenceId, fingerprints, ...draft } =
+            csvRowFinding(row, scanId!);
+          return draft;
+        }),
+      },
+      "coverage.json": {
+        completeness: "unknown",
+        inventoryStrategy: "custom",
+        surfaces: rows.map((row) => ({
+          id: row.finding_id,
+          label: row.title,
+          disposition: "reported",
+          receiptRefs: [],
+        })),
+        explicitExclusions: [],
+        deferred: [],
+      },
+    };
+    for (const [name, document] of Object.entries(documents)) {
+      await writeFile(join(scanDir, name), `${JSON.stringify(document)}\n`, {
+        flag: "wx",
+        signal,
+      });
+    }
+    await workbench(
+      ["prepare-scan-completion", "--scan-id", scanId],
+      undefined,
+      signal,
+    );
+    await workbench(["complete-scan", "--scan-id", scanId], undefined, signal);
+    return { scanId, scanDir, findingCount: rows.length };
+  } catch (error) {
+    if (scanId !== undefined) {
+      await workbench([
+        "fail-scan",
+        "--scan-id",
+        scanId,
+        "--message",
+        safeErrorMessage(error),
+      ]).catch(() => undefined);
+    }
+    throw error;
+  }
+}

--- a/sdk/typescript/tests-ts/scan-import.test.ts
+++ b/sdk/typescript/tests-ts/scan-import.test.ts
@@ -1,0 +1,240 @@
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, expect, test } from "bun:test";
+import Papa from "papaparse";
+import { main } from "../src/cli.js";
+import { importScanCsv } from "../src/scan-import.js";
+import { loadContract } from "../src/contract.js";
+import { runWorkbench } from "../src/runtime.js";
+import { capture, dependencies, FakeSignals } from "./cli-fixtures.js";
+import { PLUGIN_ROOT } from "./plugin-root.js";
+
+const roots: string[] = [];
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+function csv(count = 2) {
+  return Papa.unparse(
+    Array.from({ length: count }, (_, index) => ({
+      occurrence_id: `occ_${index.toString(16).padStart(24, "0")}`,
+      finding_id: `csf_${index.toString(16).padStart(24, "0")}`,
+      candidate_id: `source-${index}`,
+      title: "Same reported issue",
+      summary:
+        'A quoted "report", with a newline.\n' +
+        "Details. ".repeat(index === 0 ? 18000 : 1),
+      severity: "high",
+      confidence: "medium",
+      status: index === 0 ? "closed" : "open",
+      close_reason: index === 0 ? "wont_fix" : "",
+      note: index === 0 ? "Source closed this report." : "",
+      remediation: "Check access before returning the record.",
+      path: "src/example.ts",
+      start_line: "10",
+      end_line: "11",
+    })),
+  );
+}
+
+async function fixture(source = csv()) {
+  const root = await mkdtemp(
+    join(await realpath(tmpdir()), "scan-import-test-"),
+  );
+  roots.push(root);
+  const repository = join(root, "caller");
+  await mkdir(repository);
+  const csvPath = join(repository, "findings.csv");
+  await writeFile(csvPath, source);
+  const environment = {
+    PATH: process.env["PATH"],
+    SystemRoot: process.env["SystemRoot"],
+    CODEX_HOME: join(root, "home"),
+    CODEX_SECURITY_STATE_DIR: join(root, "state"),
+  };
+  const python = Bun.which("python3") ?? Bun.which("python");
+  expect(python).not.toBeNull();
+  const workbench: Parameters<typeof importScanCsv>[1]["runWorkbench"] = (
+    args,
+    input,
+    signal,
+  ) =>
+    runWorkbench(
+      { python: python!, pluginRoot: PLUGIN_ROOT, environment, signal },
+      args,
+      input,
+    );
+  return { root, repository, csvPath, environment, workbench, source };
+}
+
+test("scan import saves 5000 distinct rows in SQLite and seals ordinary scan artifacts", async () => {
+  const { repository, csvPath, environment, workbench, source } = await fixture(
+    csv(5000),
+  );
+  const output = capture();
+  const errors = capture();
+  expect(
+    await main(
+      ["scan", "import", "--csv", "findings.csv", "--json"],
+      output.stream,
+      errors.stream,
+      dependencies({
+        currentDirectory: repository,
+        environment,
+        onWorkbench: workbench,
+        onRun: () => {
+          throw new Error("Import started analysis");
+        },
+      }),
+    ),
+    errors.text(),
+  ).toBe(0);
+  expect(errors.text()).toBe("");
+  const result = JSON.parse(output.text());
+  expect(result.findingCount).toBe(5000);
+  const contract = await loadContract(result.scanDir, {
+    pluginRoot: PLUGIN_ROOT,
+  });
+  expect(contract.manifest.scan.status).toBe("completed");
+  expect(contract.manifest.scan.target.kind).toBe("directory_snapshot");
+  expect(contract.coverage.completeness).toBe("unknown");
+  const findings = contract.findings.findings;
+  expect(findings).toHaveLength(5000);
+  expect(new Set(findings.map((finding) => finding.findingId)).size).toBe(5000);
+  expect(new Set(findings.map((finding) => finding.occurrenceId)).size).toBe(
+    5000,
+  );
+  const closed = findings.find(
+    (finding) => finding.extensions?.["candidateId"] === "source-0",
+  )!;
+  expect(closed.summary).toBe(
+    Papa.parse<Record<string, string>>(source, { header: true }).data[0]![
+      "summary"
+    ]!,
+  );
+  expect(closed.provenance).toEqual({ source: "csv_import" });
+  expect(closed.validation?.status).toBe("closed");
+  expect(closed.validation?.summary).toContain("Source close reason: wont_fix");
+  const sourceDir = join(dirname(result.scanDir), "source");
+  expect(await readFile(join(sourceDir, "findings.csv"), "utf8")).toBe(source);
+  expect(await readFile(csvPath, "utf8")).toBe(source);
+  expect(await readdir(repository)).toEqual(["findings.csv"]);
+  const history = await workbench(["list-scans", "--repository", sourceDir]);
+  expect(history["scans"]).toHaveLength(1);
+  expect(
+    (await workbench(["list-scans", "--repository", repository]))["scans"],
+  ).toHaveLength(0);
+  const indexed = await workbench(["get-scan", "--scan-id", result.scanId]);
+  expect(indexed["scan"]).toMatchObject({
+    findingCount: 5000,
+    progress: { status: "complete" },
+  });
+  const rerunErrors = capture();
+  expect(
+    await main(
+      ["scans", "rerun", result.scanId],
+      capture().stream,
+      rerunErrors.stream,
+      dependencies({ onWorkbench: workbench }),
+    ),
+  ).toBe(2);
+  expect(rerunErrors.text()).toContain("scan import --csv");
+}, 120_000);
+
+test("invalid CSV is rejected before registering a scan or creating state", async () => {
+  const { root, csvPath, environment } = await fixture("title\nIncomplete\n");
+  await expect(
+    importScanCsv(csvPath, {
+      environment,
+      runWorkbench: async () => {
+        throw new Error("Unexpected workbench call");
+      },
+    }),
+  ).rejects.toThrow("export columns");
+  expect(await readdir(root)).toEqual(["caller"]);
+});
+
+test("a failed import leaves a terminal failed scan", async () => {
+  const { csvPath, environment, workbench } = await fixture();
+  let scanId: string | undefined;
+  await expect(
+    importScanCsv(csvPath, {
+      environment,
+      runWorkbench: async (args, input, signal) => {
+        if (args[0] === "prepare-scan-completion")
+          throw new Error("Completion failed");
+        const result = await workbench(args, input, signal);
+        if (args[0] === "register-cli-scan")
+          scanId = result["scanId"] as string;
+        return result;
+      },
+    }),
+  ).rejects.toThrow("Completion failed");
+  const scan = await workbench(["get-scan", "--scan-id", scanId!]);
+  expect(scan["scan"]).toMatchObject({ progress: { status: "failed" } });
+});
+
+test("scan import exposes its CSV option in help and schema and requires it", async () => {
+  for (const flag of ["--help", "--schema"]) {
+    const output = capture();
+    expect(
+      await main(
+        ["scan", "import", flag],
+        output.stream,
+        capture().stream,
+        dependencies(),
+      ),
+    ).toBe(0);
+    expect(output.text()).toContain("csv");
+  }
+  expect(
+    await main(
+      ["scan", "import"],
+      capture().stream,
+      capture().stream,
+      dependencies(),
+    ),
+  ).not.toBe(0);
+});
+
+test("canceling CSV completion marks the scan failed and removes signal listeners", async () => {
+  const { csvPath, environment, workbench } = await fixture();
+  const signals = new FakeSignals();
+  let scanId: string | undefined;
+  const exitCode = await main(
+    ["scan", "import", "--csv", csvPath],
+    capture().stream,
+    capture().stream,
+    dependencies({
+      environment,
+      signals,
+      onWorkbench: async (args, input, signal) => {
+        if (args[0] === "prepare-scan-completion") {
+          signals.emit("SIGINT");
+          signal!.throwIfAborted();
+        }
+        const result = await workbench(args, input, signal);
+        if (args[0] === "register-cli-scan")
+          scanId = result["scanId"] as string;
+        return result;
+      },
+    }),
+  );
+  expect(exitCode).toBe(130);
+  const scan = await workbench(["get-scan", "--scan-id", scanId!]);
+  expect(scan["scan"]).toMatchObject({ progress: { status: "failed" } });
+  expect(
+    [...signals.listeners.values()].every((listeners) => listeners.size === 0),
+  ).toBe(true);
+});


### PR DESCRIPTION
## Summary

Adds `codex-security scan import --csv FILE` to import existing findings into local SQLite history as a completed, sealed scan without running security analysis.

## Changes

- Reuse the existing Cloud CSV schema, parser, and finding conversion without changing their behavior.
- Retain the CSV in its own managed directory snapshot and use normal scan registration, completion, and indexing. Distinct row IDs remain separate findings even when their descriptions match.
- Record `csv_import` provenance and unknown coverage. Preserve source IDs, status, close reason, and notes as metadata; local triage starts open.
- Add CLI help, input/output schemas, documentation, package entries, and integration coverage for 5,000 rows, multiline fields, failure, and cancellation. Imported scans direct reruns back to CSV import.

## Testing

- Full SDK suite in an isolated temporary directory: 2,611 passed, 48 skipped, 0 failed.
- Final focused CSV import and CLI tests: 159 passed, including a real 5,000-row SQLite import, seal verification, long multiline fields, and cancellation.
- Existing Cloud publication and mock-scan regression coverage passed.
- Type checks, formatting, production build, and built CLI schema check: passed.
- npm archive checks: passed, 446 entries. Installed-package smoke checks passed for the CLI, public SDK, bundled plugin, native helpers, and dashboard.

## Risk and rollout

The new `scan import` subcommand reserves the positional name `import`; scan a repository with that name using `scan ./import`. Existing scan flags, `--mock`, and top-level `import github` retain their behavior. Each import creates a separate dataset and scan, independent of the current repository. No new dependencies or database migrations.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
