### PR TITLE
feat(sdk): pipeline dedupe with configurable concurrency

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1550,15 +1550,20 @@ codex-security dedupe --scan SCAN_ID --findings-url http://127.0.0.1:3000 --json
 
 Deduplication runs up to 8 jobs concurrently by default. Set `--concurrency N`
 to choose a positive integer, or `--concurrency 1` for serial execution. The SDK
-equivalent is `concurrency: N`. Each available worker takes the next queued job
-as soon as its current job finishes; it does not wait for a batch to finish.
-First, workers retrieve and screen finding neighborhoods with Luna. After all
-screenings finish, workers review the nominated pairs with Sol. Results are
-combined in input order so completion timing does not change the groups.
+equivalent is `concurrency: N`. Candidate neighborhoods are fetched first, with
+the same concurrency limit. Luna screenings and ready Sol pair reviews then use
+two queues sharing one worker pool, with at most 8 jobs running in total by
+default. Each available worker takes a ready job as soon as its current job
+finishes; it does not wait for a batch to finish.
+
+A Sol pair review becomes ready once every Luna screening covering that pair
+has finished and none voted `DISTINCT`. It can run while unrelated Luna
+screenings continue. Results are combined in input order so completion timing
+does not change the groups.
 
 If a job fails after its retries, queued jobs stop and already running jobs
 finish before the command reports the failure. No groups are posted from an
-incomplete review phase. To retain completed reviews across runs, use a
+incomplete review. To retain completed reviews across runs, use a
 `--workflow-id` as described below.
 
 The default scope is the saved scan's repository, identified by
@@ -1577,7 +1582,7 @@ import { deduplicateScan } from "@openai/codex-security";
 
 const result = await deduplicateScan("scan_example_001", {
   findingsUrl: "http://127.0.0.1:3000",
-  // concurrency: 8, // Maximum concurrent jobs per review phase; use 1 for serial.
+  // concurrency: 8, // Shared worker limit for Luna and Sol; use 1 for serial.
   // allRepositories: true, // Omit to search only this scan's repository.
   // signal: controller.signal,
 });
@@ -1721,7 +1726,7 @@ exponential backoff with jitter; HTTP retries honor `Retry-After`. Waiting to re
 occupies the job's concurrency slot.
 
 Cancellation, authentication or configuration errors, permanent HTTP errors, and
-required-source-access blockers are not retried. Exhausted retries fail the phase;
+required-source-access blockers are not retried. Exhausted retries fail deduplication;
 invalid or unfinished reviews are not cached. Completed checkpoints remain
 available when the workflow resumes.
 
@@ -1747,12 +1752,15 @@ use another workflow ID for a fresh review rather than changing that saved resul
 1. For each distinct finding ID in the scan, request
    `/v1/finding/{id}/potential-duplicates` with the selected repository or
    explicit all-repository scope. Use the complete stored anchor and
-   candidates returned by that request.
+   candidates returned by that request. Fetch all neighborhoods before starting
+   reviews so every pair's screening dependencies are known.
 2. Screen each nonempty neighborhood with `gpt-5.6-luna` at `xhigh` reasoning
    effort. The review covers every anchor-neighbor pair; nominations between
    neighbors are rejected.
 3. Independently review each nominated pair once with `gpt-5.6-sol` at `high`
-   reasoning effort. Only accepted pairs contribute to duplicate groups.
+   reasoning effort after all Luna screenings covering that pair finish without
+   a `DISTINCT` decision. Luna and ready Sol jobs share the configured worker
+   pool and can run together. Only accepted pairs contribute to duplicate groups.
 4. Group accepted duplicate pairs transitively unless a Luna or Sol `DISTINCT`
    decision contradicts the resulting component. Contradicted components are
    split deterministically, preferring legal subgroups that preserve more

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1548,14 +1548,27 @@ change scan artifacts.
 codex-security dedupe --scan SCAN_ID --findings-url http://127.0.0.1:3000 --json
 ```
 
+Deduplication runs up to 8 jobs concurrently by default. Set `--concurrency N`
+to choose a positive integer, or `--concurrency 1` for serial execution. The SDK
+equivalent is `concurrency: N`. Each available worker takes the next queued job
+as soon as its current job finishes; it does not wait for a batch to finish.
+First, workers retrieve and screen finding neighborhoods with Luna. After all
+screenings finish, workers review the nominated pairs with Sol. Results are
+combined in input order so completion timing does not change the groups.
+
+If a job fails after its retries, queued jobs stop and already running jobs
+finish before the command reports the failure. No groups are posted from an
+incomplete review phase. To retain completed reviews across runs, use a
+`--workflow-id` as described below.
+
 The default scope is the saved scan's repository, identified by
 `scan.target.targetId` in its manifest. Add `--all-repositories` to search the
 entire stored corpus explicitly; the flag defaults to false. The SDK has the
 equivalent optional `allRepositories: true` setting. This narrows the previous
 preview's implicit all-repository behavior.
 
-Both `--scan` and `--findings-url` are required, with no implicit scan or service
-URL. As with `publish scan --scan`, the selector accepts a full ID, unique
+Provide `--findings-url` and either `--scan` or `--workflow-id`, with no implicit
+scan or service URL. As with `publish scan --scan`, the scan selector accepts a full ID, unique
 prefix, or `latest` for the current repository. The saved scan must be complete
 and its sealed artifacts must be available.
 
@@ -1564,6 +1577,7 @@ import { deduplicateScan } from "@openai/codex-security";
 
 const result = await deduplicateScan("scan_example_001", {
   findingsUrl: "http://127.0.0.1:3000",
+  // concurrency: 8, // Maximum concurrent jobs per review phase; use 1 for serial.
   // allRepositories: true, // Omit to search only this scan's repository.
   // signal: controller.signal,
 });
@@ -1579,6 +1593,7 @@ import { deduplicateScanDirectory } from "@openai/codex-security";
 const result = await deduplicateScanDirectory("/path/to/completed-scan", {
   repository: "/path/to/repository",
   findingsUrl: "http://127.0.0.1:3000",
+  // concurrency: 8,
   // expectedScanId: "scan_example_001",
   // allRepositories: true,
   // signal: controller.signal,
@@ -1661,8 +1676,9 @@ scan. Existing output-directory and archive safeguards still apply to scan retri
 
 Publication and dedupe can use the workflow ID in place of `--scan`; an explicit
 scan selector must identify that same scan. A workflow can also begin at custom
-publication of a completed scan. Dedupe still requires local scan history to locate
-the approved source checkout. For a workflow, dedupe first completes publication
+publication of a completed scan. The CLI and `deduplicateScan` require local scan
+history to locate the approved source checkout; `deduplicateScanDirectory` uses
+the supplied repository. For a workflow, dedupe first completes publication
 if its receipt is missing. `--all-repositories` retains its existing default of
 false. Changing a workflow's scan, destination, or bound scope is an error: choose
 a different workflow ID. Use one coordinating process per workflow.
@@ -1682,6 +1698,12 @@ A completed `dedupe --workflow-id` returns its saved result without repeating
 reviews or group writes. A publication whose acknowledgement was lost is retried
 using the service's existing idempotent upsert.
 
+Concurrent jobs save their validated reviews independently. Resuming with the
+same workflow ID reuses completed reviews and retries unfinished jobs. The
+concurrency setting is not part of a review's checkpoint identity, so it is safe
+to change `--concurrency` when resuming. Cancellation stops active reviews and
+leaves their completed checkpoints available for the next run.
+
 Each validated screening and pair review is checkpointed locally,
 including DISTINCT decisions. Screening checkpoints retain pair recommendations
 and rationales under host-assigned pair slots bound to the original records.
@@ -1691,8 +1713,17 @@ must satisfy the Finding schema and preserve the canonical finding ID. Validatio
 still happens through `review_validator.submit_decisions`; invalid submissions
 are corrected in the same review conversation. A completed turn without an
 accepted submission receives one corrective turn in that same conversation.
-Transport, model, cancellation, and accepted `submit_error` failures are terminal.
-Invalid or unfinished reviews are not cached.
+If formatting remains invalid, the job retries in a fresh review session.
+Explicit transient Codex failures and unexpected process exits also retry, with
+at most three fresh sessions per review. Transient findings-service failures, including
+rate limits and network errors, receive up to three request attempts. Retries use
+exponential backoff with jitter; HTTP retries honor `Retry-After`. Waiting to retry
+occupies the job's concurrency slot.
+
+Cancellation, authentication or configuration errors, permanent HTTP errors, and
+required-source-access blockers are not retried. Exhausted retries fail the phase;
+invalid or unfinished reviews are not cached. Completed checkpoints remain
+available when the workflow resumes.
 
 Checkpoints bind to the exact original records and ordering, approved source path,
 Git revision and current file contents (including ignored files), repository scope,

--- a/sdk/typescript/scripts/check-package.mjs
+++ b/sdk/typescript/scripts/check-package.mjs
@@ -211,6 +211,7 @@ const distFiles = new Set(
     "server/api",
     "deduplication/codex-review",
     "deduplication/checkpointed-review",
+    "deduplication/retry",
     "deduplication/deduplication",
     "finding-retrieval",
     "finding-workflow",

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -65,6 +65,7 @@ import {
 } from "./api.js";
 import { accountStatus } from "./auth.js";
 import { publishScanToCustom } from "./custom-publish.js";
+import { DEFAULT_DEDUPE_CONCURRENCY } from "./deduplication/deduplication.js";
 import { deduplicateScanInternal } from "./deduplication/scan.js";
 import {
   classifyScanSeverityInternal,
@@ -264,6 +265,7 @@ const EXPORT_DEFAULT_OUTPUTS = {
 const VALUE_OPTIONS = new Set([
   "--port",
   "--workflow-id",
+  "--concurrency",
   "--auth",
   "--safety-identifier",
   "--path",
@@ -3557,6 +3559,14 @@ export async function main(
       destructive: true,
       mcp: false,
       options: z.object({
+        concurrency: z
+          .number()
+          .int()
+          .positive()
+          .default(DEFAULT_DEDUPE_CONCURRENCY)
+          .describe(
+            "Maximum concurrent dedupe jobs per phase; use 1 for serial execution.",
+          ),
         workflowId: optionValue("--workflow-id")
           .optional()
           .describe(
@@ -3609,6 +3619,7 @@ export async function main(
             scanId,
             {
               findingsUrl: options.findingsUrl,
+              concurrency: options.concurrency,
               ...(options.workflowId === undefined
                 ? {}
                 : { workflowId: options.workflowId }),

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -3565,7 +3565,7 @@ export async function main(
           .positive()
           .default(DEFAULT_DEDUPE_CONCURRENCY)
           .describe(
-            "Maximum concurrent dedupe jobs per phase; use 1 for serial execution.",
+            "Maximum concurrent dedupe jobs across Luna and Sol; use 1 for serial execution.",
           ),
         workflowId: optionValue("--workflow-id")
           .optional()

--- a/sdk/typescript/src/deduplication/codex-review.ts
+++ b/sdk/typescript/src/deduplication/codex-review.ts
@@ -39,6 +39,7 @@ import {
   reviewSubmissionInstructions,
   sourceReviewInstructions,
 } from "./deduplication-prompts.js";
+import { retryDelay, waitForRetry } from "./retry.js";
 
 const reviewErrorSchema = z
   .object({ reason: z.string().trim().min(1) })
@@ -58,6 +59,7 @@ class ReviewAttemptError extends Error {
     public readonly category: DeduplicationReviewFailureCategory,
     message: string,
     public readonly supportReason: string,
+    public readonly retryable = false,
   ) {
     super(message);
   }
@@ -72,7 +74,10 @@ type StartCodex = (
 interface Message {
   id?: string | number;
   method?: string;
-  error?: { message: string };
+  error?: {
+    message: string;
+    data?: { codexErrorInfo?: unknown };
+  };
   result?: {
     thread?: { id: string; ephemeral: boolean; path: string | null };
     turn?: { id: string };
@@ -80,11 +85,41 @@ interface Message {
   params?: {
     threadId: string;
     turnId?: string;
-    turn?: { id: string; status: string; error?: { message: string } | null };
+    turn?: {
+      id: string;
+      status: string;
+      error?: { message: string; codexErrorInfo?: unknown } | null;
+    };
     tool?: string;
     namespace?: string | null;
     arguments?: unknown;
   };
+}
+
+function transientCodexError(info: unknown): boolean {
+  if (
+    info === "usageLimitExceeded" ||
+    info === "serverOverloaded" ||
+    info === "internalServerError"
+  )
+    return true;
+  if (info === null || typeof info !== "object") return false;
+  for (const variant of [
+    "httpConnectionFailed",
+    "responseStreamConnectionFailed",
+    "responseStreamDisconnected",
+    "responseTooManyFailedAttempts",
+  ]) {
+    const detail = (info as Record<string, unknown>)[variant];
+    if (detail === null || typeof detail !== "object") continue;
+    const status = (detail as { httpStatusCode?: unknown }).httpStatusCode;
+    return (
+      status === null ||
+      (typeof status === "number" &&
+        [408, 429, 500, 502, 503, 504].includes(status))
+    );
+  }
+  return false;
 }
 
 export class CodexReviewRunner {
@@ -93,12 +128,33 @@ export class CodexReviewRunner {
     private readonly startCodex: StartCodex = spawn,
     private readonly signal?: AbortSignal,
     private readonly workingDirectory: string = process.cwd(),
+    private readonly retry: {
+      wait?: typeof waitForRetry;
+      random?: () => number;
+    } = {},
   ) {}
 
   async run<T>(review: CodexReview<T>): Promise<T> {
-    const state = { attempts: 1 };
+    const state = { attempts: 0 };
     try {
-      return await this.runSession(review, state);
+      for (let session = 1; ; session++) {
+        state.attempts++;
+        try {
+          return await this.runSession(review, state);
+        } catch (error) {
+          this.signal?.throwIfAborted();
+          if (
+            session >= 3 ||
+            !(error instanceof ReviewAttemptError) ||
+            !error.retryable
+          )
+            throw error;
+          await (this.retry.wait ?? waitForRetry)(
+            retryDelay(session, this.retry.random),
+            this.signal,
+          );
+        }
+      }
     } catch (error) {
       this.signal?.throwIfAborted();
       const category =
@@ -200,8 +256,20 @@ export class CodexReviewRunner {
       const closed = new Promise<void>((resolve) =>
         child.once("close", () => resolve()),
       );
-      child.once("error", () => undefined);
-      child.stdin.on("error", () => undefined);
+      const lines = createInterface({
+        input: child.stdout,
+        crlfDelay: Infinity,
+      });
+      let processError: Error | undefined;
+      let inputError: Error | undefined;
+      child.once("error", (error) => {
+        processError = error;
+        lines.close();
+      });
+      child.stdin.on("error", (error) => {
+        inputError = error;
+        lines.close();
+      });
       child.stderr.resume();
       const send = (message: object) =>
         child.stdin.write(`${JSON.stringify(message)}\n`);
@@ -278,8 +346,10 @@ export class CodexReviewRunner {
       let turnId: string | undefined;
       let accepted: T | undefined;
       let validationFailure: string | undefined;
+      let turns = 0;
       const startTurn = (prompt: string) => {
         this.signal?.throwIfAborted();
+        turns++;
         turnId = undefined;
         validationFailure = undefined;
         send({
@@ -302,15 +372,17 @@ export class CodexReviewRunner {
             capabilities: { experimentalApi: true },
           },
         });
-        for await (const line of createInterface({
-          input: child.stdout,
-          crlfDelay: Infinity,
-        })) {
+        for await (const line of lines) {
           let message: Message;
           try {
             message = JSON.parse(line) as Message;
           } catch {
-            throw new Error("Codex returned malformed JSON");
+            throw new ReviewAttemptError(
+              "transport",
+              "Codex returned malformed JSON",
+              "Codex review transport failed.",
+              true,
+            );
           }
           const params = message.params;
           if (message.id !== undefined && message.method !== undefined) {
@@ -376,6 +448,7 @@ export class CodexReviewRunner {
               "transport",
               message.error?.message ?? "Codex rejected the review request",
               "Codex rejected the review request.",
+              transientCodexError(message.error.data?.codexErrorInfo),
             );
           } else if (message.id === 1) {
             send({ method: "initialized" });
@@ -419,10 +492,11 @@ export class CodexReviewRunner {
                 params.turn.error?.message ??
                   `Codex review turn ${params.turn.status}`,
                 "Codex review turn failed.",
+                transientCodexError(params.turn.error?.codexErrorInfo),
               );
             }
             if (accepted === undefined) {
-              if (state.attempts === 1) {
+              if (turns === 1) {
                 state.attempts++;
                 startTurn(
                   `Continue the original assigned review in this conversation. No submission was accepted.${validationFailure ? ` The last submission was rejected: ${validationFailure}` : ""} ${reviewSubmissionInstructions}`,
@@ -434,19 +508,28 @@ export class CodexReviewRunner {
                   "validation",
                   `Review validation failed: ${validationFailure}`,
                   "The submitted review failed semantic validation.",
+                  true,
                 );
               }
               throw new ReviewAttemptError(
                 "no-submission",
                 "Codex did not submit a validated review",
                 "Codex did not submit a validated review.",
+                true,
               );
             }
             return accepted;
           }
         }
-        throw new Error("Codex exited before completing the review");
+        if (processError) throw processError;
+        throw new ReviewAttemptError(
+          "transport",
+          inputError?.message ?? "Codex exited before completing the review",
+          "Codex review transport failed.",
+          true,
+        );
       } finally {
+        lines.close();
         child.stdin.end();
         if (child.exitCode === null) child.kill();
         await closed;

--- a/sdk/typescript/src/deduplication/deduplication.ts
+++ b/sdk/typescript/src/deduplication/deduplication.ts
@@ -1,10 +1,53 @@
 import type { Finding } from "../models.js";
 import type { FindingNeighborhood } from "../finding-retrieval.js";
+import { CodexSecurityError } from "../errors.js";
 import {
   pairKey,
   screeningPairSlot,
   type DeduplicationReviewer,
 } from "./deduplication-reviewer.js";
+
+export const DEFAULT_DEDUPE_CONCURRENCY = 8;
+
+export function deduplicationConcurrency(
+  concurrency = DEFAULT_DEDUPE_CONCURRENCY,
+): number {
+  if (!Number.isSafeInteger(concurrency) || concurrency < 1)
+    throw new CodexSecurityError(
+      "concurrency must be a positive safe integer.",
+    );
+  return concurrency;
+}
+
+async function mapConcurrent<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  operation: (item: T) => Promise<R>,
+  signal?: AbortSignal,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  let failure: { error: unknown } | undefined;
+  async function worker(): Promise<void> {
+    while (failure === undefined) {
+      try {
+        signal?.throwIfAborted();
+        const index = next++;
+        if (index >= items.length) return;
+        results[index] = await operation(items[index]!);
+      } catch (error) {
+        failure ??= { error };
+      }
+    }
+  }
+  // Drain started jobs so successful reviews can finish saving their checkpoints.
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, worker),
+  );
+  signal?.throwIfAborted();
+  if (failure !== undefined) throw failure.error;
+  return results;
+}
 
 export interface DeduplicationResult {
   uniqueFindingIds: string[];
@@ -179,22 +222,37 @@ export class FindingDeduplicator {
     },
     private readonly reviewer: DeduplicationReviewer,
     private readonly signal?: AbortSignal,
+    private readonly concurrency = DEFAULT_DEDUPE_CONCURRENCY,
   ) {}
 
   async run(findingIds: readonly string[]): Promise<DeduplicationResult> {
     this.signal?.throwIfAborted();
+    const concurrency = deduplicationConcurrency(this.concurrency);
     const ids = [...new Set(findingIds)];
     const findings = new Map<string, Finding>();
     const nominated = new Map<string, [string, string]>();
     const rejected = new Map<string, [string, string]>();
-    for (const id of ids) {
+    const screenings = await mapConcurrent(
+      ids,
+      concurrency,
+      async (id) => {
+        const result = await this.candidates.potentialDuplicates(id);
+        this.signal?.throwIfAborted();
+        const neighborhood = [result.finding, ...result.potentialDuplicates];
+        const screening =
+          neighborhood.length < 2
+            ? undefined
+            : await this.reviewer.screen(neighborhood);
+        return { neighborhood, screening };
+      },
+      this.signal,
+    );
+    // Reduce in input order: completion order must not change grouping ties.
+    for (const { neighborhood, screening } of screenings) {
       this.signal?.throwIfAborted();
-      const result = await this.candidates.potentialDuplicates(id);
-      const neighborhood = [result.finding, ...result.potentialDuplicates];
       for (const finding of neighborhood)
         findings.set(finding.findingId, finding);
-      if (neighborhood.length < 2) continue;
-      const screening = await this.reviewer.screen(neighborhood);
+      if (screening === undefined) continue;
       for (let index = 0; index < neighborhood.length - 1; index++) {
         const decision = screening.decisions[screeningPairSlot(index)]!;
         const pair: [string, string] = [
@@ -212,10 +270,18 @@ export class FindingDeduplicator {
     }
 
     const supported: [string, string][] = [];
-    for (const pair of nominated.values()) {
+    const pairs = [...nominated.values()];
+    const decisions = await mapConcurrent(
+      pairs,
+      concurrency,
+      async (pair) =>
+        (await this.reviewer.reviewPair(pair.map((id) => findings.get(id)!)))
+          .decision,
+      this.signal,
+    );
+    for (const [index, pair] of pairs.entries()) {
       this.signal?.throwIfAborted();
-      const originals = pair.map((id) => findings.get(id)!);
-      if ((await this.reviewer.reviewPair(originals)).decision === "SAME") {
+      if (decisions[index] === "SAME") {
         supported.push(pair);
       } else {
         rejected.set(pairKey(pair), pair);

--- a/sdk/typescript/src/deduplication/deduplication.ts
+++ b/sdk/typescript/src/deduplication/deduplication.ts
@@ -19,34 +19,46 @@ export function deduplicationConcurrency(
   return concurrency;
 }
 
-async function mapConcurrent<T, R>(
-  items: readonly T[],
+type Job = () => Promise<void>;
+
+async function runQueued(
+  pending: Job[],
+  ready: Job[],
   concurrency: number,
-  operation: (item: T) => Promise<R>,
   signal?: AbortSignal,
-): Promise<R[]> {
-  const results = new Array<R>(items.length);
-  let next = 0;
+): Promise<void> {
   let failure: { error: unknown } | undefined;
-  async function worker(): Promise<void> {
-    while (failure === undefined) {
+  await new Promise<void>((resolve) => {
+    let running = 0;
+    async function run(job: Job): Promise<void> {
       try {
-        signal?.throwIfAborted();
-        const index = next++;
-        if (index >= items.length) return;
-        results[index] = await operation(items[index]!);
+        await job();
       } catch (error) {
         failure ??= { error };
+      } finally {
+        running--;
+        pump();
       }
     }
-  }
-  // Drain started jobs so successful reviews can finish saving their checkpoints.
-  await Promise.all(
-    Array.from({ length: Math.min(concurrency, items.length) }, worker),
-  );
+    function pump(): void {
+      while (
+        failure === undefined &&
+        !signal?.aborted &&
+        running < concurrency
+      ) {
+        const job = ready.shift() ?? pending.shift();
+        if (job === undefined) break;
+        running++;
+        void run(job);
+      }
+      // An active producer can still enqueue work. After failure, drain active
+      // jobs so successful reviews can finish saving their checkpoints.
+      if (running === 0) resolve();
+    }
+    pump();
+  });
   signal?.throwIfAborted();
   if (failure !== undefined) throw failure.error;
-  return results;
 }
 
 export interface DeduplicationResult {
@@ -230,62 +242,88 @@ export class FindingDeduplicator {
     const concurrency = deduplicationConcurrency(this.concurrency);
     const ids = [...new Set(findingIds)];
     const findings = new Map<string, Finding>();
-    const nominated = new Map<string, [string, string]>();
-    const rejected = new Map<string, [string, string]>();
-    const screenings = await mapConcurrent(
-      ids,
-      concurrency,
-      async (id) => {
+    const neighborhoods = new Array<Finding[]>(ids.length);
+    await runQueued(
+      ids.map((id, index) => async () => {
         const result = await this.candidates.potentialDuplicates(id);
         this.signal?.throwIfAborted();
-        const neighborhood = [result.finding, ...result.potentialDuplicates];
-        const screening =
-          neighborhood.length < 2
-            ? undefined
-            : await this.reviewer.screen(neighborhood);
-        return { neighborhood, screening };
-      },
+        neighborhoods[index] = [result.finding, ...result.potentialDuplicates];
+      }),
+      [],
+      concurrency,
       this.signal,
     );
-    // Reduce in input order: completion order must not change grouping ties.
-    for (const { neighborhood, screening } of screenings) {
+    const pairs = new Map<
+      string,
+      {
+        ids: [string, string];
+        remaining: number;
+        rejected: boolean;
+        decision?: "SAME" | "DISTINCT";
+      }
+    >();
+    // Freeze records, insertion order, and the last nominating anchor's pair
+    // orientation before reviews run, preserving grouping and checkpoint inputs.
+    for (const neighborhood of neighborhoods) {
       this.signal?.throwIfAborted();
       for (const finding of neighborhood)
         findings.set(finding.findingId, finding);
-      if (screening === undefined) continue;
-      for (let index = 0; index < neighborhood.length - 1; index++) {
-        const decision = screening.decisions[screeningPairSlot(index)]!;
+      for (const neighbor of neighborhood.slice(1)) {
         const pair: [string, string] = [
           neighborhood[0]!.findingId,
-          neighborhood[index + 1]!.findingId,
+          neighbor.findingId,
         ];
         const key = pairKey(pair);
-        if (decision.decision === "SAME") {
-          if (!rejected.has(key)) nominated.set(key, pair);
+        const state = pairs.get(key);
+        if (state === undefined) {
+          pairs.set(key, { ids: pair, remaining: 1, rejected: false });
         } else {
-          rejected.set(key, pair);
-          nominated.delete(key);
+          state.ids = pair;
+          state.remaining++;
         }
       }
     }
 
+    const ready: Job[] = [];
+    const pending = neighborhoods
+      .filter((neighborhood) => neighborhood.length > 1)
+      .map((neighborhood) => async () => {
+        const screening = await this.reviewer.screen(neighborhood);
+        this.signal?.throwIfAborted();
+        for (let index = 0; index < neighborhood.length - 1; index++) {
+          const key = pairKey([
+            neighborhood[0]!.findingId,
+            neighborhood[index + 1]!.findingId,
+          ]);
+          const state = pairs.get(key)!;
+          if (
+            screening.decisions[screeningPairSlot(index)]!.decision ===
+            "DISTINCT"
+          )
+            state.rejected = true;
+          state.remaining--;
+          // Wait for every screening of this pair: a later DISTINCT veto must
+          // prevent verification, including a verification that could fail.
+          if (state.remaining === 0 && !state.rejected) {
+            ready.push(async () => {
+              state.decision = (
+                await this.reviewer.reviewPair(
+                  state.ids.map((id) => findings.get(id)!),
+                )
+              ).decision;
+            });
+          }
+        }
+      });
+    await runQueued(pending, ready, concurrency, this.signal);
+
+    // Completion order must not change grouping ties.
     const supported: [string, string][] = [];
-    const pairs = [...nominated.values()];
-    const decisions = await mapConcurrent(
-      pairs,
-      concurrency,
-      async (pair) =>
-        (await this.reviewer.reviewPair(pair.map((id) => findings.get(id)!)))
-          .decision,
-      this.signal,
-    );
-    for (const [index, pair] of pairs.entries()) {
+    const rejected: [string, string][] = [];
+    for (const state of pairs.values()) {
       this.signal?.throwIfAborted();
-      if (decisions[index] === "SAME") {
-        supported.push(pair);
-      } else {
-        rejected.set(pairKey(pair), pair);
-      }
+      if (state.decision === "SAME") supported.push(state.ids);
+      else rejected.push(state.ids);
     }
 
     const adjacent = new Map<string, Set<string>>();
@@ -325,7 +363,7 @@ export class FindingDeduplicator {
       componentByFinding.get(id)?.members.push(id);
     for (const pair of supported)
       componentByFinding.get(pair[0])!.supported.push(pair);
-    for (const pair of rejected.values()) {
+    for (const pair of rejected) {
       const component = componentByFinding.get(pair[0]);
       if (component && component === componentByFinding.get(pair[1]))
         component.rejected.push(pair);

--- a/sdk/typescript/src/deduplication/retry.ts
+++ b/sdk/typescript/src/deduplication/retry.ts
@@ -1,0 +1,18 @@
+import { setTimeout } from "node:timers/promises";
+
+export function retryDelay(attempt: number, random = Math.random): number {
+  return 1_000 * 2 ** (attempt - 1) * (1 + random());
+}
+
+export async function waitForRetry(
+  delayMs: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  signal?.throwIfAborted();
+  try {
+    await setTimeout(delayMs, undefined, { signal });
+  } catch (error) {
+    signal?.throwIfAborted();
+    throw error;
+  }
+}

--- a/sdk/typescript/src/deduplication/scan.ts
+++ b/sdk/typescript/src/deduplication/scan.ts
@@ -40,7 +40,7 @@ export interface DeduplicateScanOptions {
   findingsUrl: string;
   /** Search all repositories instead of the scan's targetId. Defaults to false. */
   allRepositories?: boolean;
-  /** Maximum concurrent jobs in each deduplication phase. Defaults to 8. */
+  /** Shared concurrency limit for deduplication jobs. Defaults to 8. */
   concurrency?: number;
   signal?: AbortSignal;
 }

--- a/sdk/typescript/src/deduplication/scan.ts
+++ b/sdk/typescript/src/deduplication/scan.ts
@@ -12,6 +12,7 @@ import {
 import { CodexReviewRunner } from "./codex-review.js";
 import {
   FindingDeduplicator,
+  deduplicationConcurrency,
   type DeduplicationResult,
 } from "./deduplication.js";
 import {
@@ -39,6 +40,8 @@ export interface DeduplicateScanOptions {
   findingsUrl: string;
   /** Search all repositories instead of the scan's targetId. Defaults to false. */
   allRepositories?: boolean;
+  /** Maximum concurrent jobs in each deduplication phase. Defaults to 8. */
+  concurrency?: number;
   signal?: AbortSignal;
 }
 
@@ -84,6 +87,7 @@ export async function deduplicateScanDirectoryInternal(
   dependencies: DeduplicateScanDependencies = {},
 ): Promise<DeduplicateScanResult> {
   options.signal?.throwIfAborted();
+  deduplicationConcurrency(options.concurrency);
   const repository = await normalizeRepository(
     options.repository,
     options.signal,
@@ -106,6 +110,7 @@ export async function deduplicateScanInternal(
   dependencies: DeduplicateScanDependencies = {},
 ): Promise<DeduplicateScanResult> {
   options.signal?.throwIfAborted();
+  deduplicationConcurrency(options.concurrency);
   const environment = dependencies.environment ?? process.env;
   const pluginRoot = await bundledPluginRoot();
   const scan = await resolveCompletedScan(scanId, {
@@ -242,6 +247,7 @@ async function deduplicateResolvedScan(
       dependencies.reviewer ??
         new CodexDeduplicationReviewer(checkpoints ?? runner),
       options.signal,
+      options.concurrency,
     );
     const reviewed = await deduplicator.run(
       contract.findings.findings.map((finding) => finding.findingId),

--- a/sdk/typescript/src/findings-client.ts
+++ b/sdk/typescript/src/findings-client.ts
@@ -1,4 +1,5 @@
 import { CodexSecurityError } from "./errors.js";
+import { retryDelay, waitForRetry } from "./deduplication/retry.js";
 import type { Finding } from "./models.js";
 import type {
   FindingNeighborhood,
@@ -10,11 +11,32 @@ export type FindingsRequest = (
   init: RequestInit,
 ) => Promise<Response>;
 
+class FindingsHttpError extends CodexSecurityError {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly retryAfter: string | null,
+  ) {
+    super(message);
+  }
+}
+
+function isRetryable(error: unknown): boolean {
+  if (error instanceof FindingsHttpError)
+    return [408, 429, 500, 502, 503, 504].includes(error.status);
+  // Fetch rejects network failures with TypeError; JSON truncation can produce SyntaxError.
+  return error instanceof TypeError || error instanceof SyntaxError;
+}
+
 export class FindingsClient {
   constructor(
     private readonly url: string,
     private readonly signal?: AbortSignal,
     private readonly request: FindingsRequest = fetch,
+    private readonly retries: {
+      wait?: typeof waitForRetry;
+      random?: () => number;
+    } = {},
   ) {}
 
   async potentialDuplicates(
@@ -27,17 +49,22 @@ export class FindingsClient {
     if (scope.allRepositories === true)
       url.searchParams.set("allRepositories", "true");
     else url.searchParams.set("repositoryId", scope.repositoryId);
-    const response = await this.request(url, { signal: this.signal });
-    if (!response.ok) {
-      throw new CodexSecurityError(
-        `Potential-duplicates lookup for ${findingId} failed (HTTP ${response.status}).${
-          response.status === 404
-            ? " Import the finding with its repositoryId through POST /v1/bulk/findings before deduplicating."
-            : ""
-        }`,
-      );
-    }
-    return (await response.json()) as FindingNeighborhood;
+    return await this.retry(async () => {
+      const response = await this.request(url, { signal: this.signal });
+      if (!response.ok) {
+        await response.body?.cancel().catch(() => undefined);
+        throw new FindingsHttpError(
+          `Potential-duplicates lookup for ${findingId} failed (HTTP ${response.status}).${
+            response.status === 404
+              ? " Import the finding with its repositoryId through POST /v1/bulk/findings before deduplicating."
+              : ""
+          }`,
+          response.status,
+          response.headers.get("Retry-After"),
+        );
+      }
+      return (await response.json()) as FindingNeighborhood;
+    });
   }
 
   async publish(
@@ -64,7 +91,29 @@ export class FindingsClient {
 
   async storeDedupeGroups(groups: readonly string[][]): Promise<void> {
     if (groups.length === 0) return;
-    await this.post("v1/dedupe-groups", { groups });
+    await this.retry(() => this.post("v1/dedupe-groups", { groups }));
+  }
+
+  private async retry<T>(operation: () => Promise<T>): Promise<T> {
+    for (let attempt = 1; ; attempt++) {
+      this.signal?.throwIfAborted();
+      try {
+        return await operation();
+      } catch (error) {
+        this.signal?.throwIfAborted();
+        if (attempt === 3 || !isRetryable(error)) throw error;
+        let delay = retryDelay(attempt, this.retries.random);
+        if (error instanceof FindingsHttpError && error.retryAfter !== null) {
+          const seconds = Number(error.retryAfter);
+          const serverDelay = Number.isFinite(seconds)
+            ? seconds * 1000
+            : Date.parse(error.retryAfter) - Date.now();
+          if (Number.isFinite(serverDelay))
+            delay = Math.max(delay, serverDelay);
+        }
+        await (this.retries.wait ?? waitForRetry)(delay, this.signal);
+      }
+    }
   }
 
   private endpoint(path: string): URL {
@@ -79,8 +128,11 @@ export class FindingsClient {
       signal: this.signal,
     });
     if (!response.ok) {
-      throw new CodexSecurityError(
+      await response.body?.cancel().catch(() => undefined);
+      throw new FindingsHttpError(
         `Findings API POST /${path} failed (HTTP ${response.status}).`,
+        response.status,
+        response.headers.get("Retry-After"),
       );
     }
     return await response.json();

--- a/sdk/typescript/tests-ts/cli-dedupe.test.ts
+++ b/sdk/typescript/tests-ts/cli-dedupe.test.ts
@@ -77,6 +77,7 @@ test.each([false, true])(
       expect(scanId).toBe("latest");
       expect(options).toEqual({
         findingsUrl: "http://127.0.0.1:3000",
+        concurrency: 8,
         allRepositories,
         signal: expect.any(AbortSignal),
       });
@@ -95,6 +96,95 @@ test.each([false, true])(
     expect(stderr.text()).toBe("");
   },
 );
+
+test.each([
+  { flags: ["--concurrency", "1"], expected: 1 },
+  { flags: ["--concurrency", "3"], expected: 3 },
+  { flags: ["--concurrency=3"], expected: 3 },
+])("dedupe forwards configured concurrency %j", async ({ flags, expected }) => {
+  const deps = dependencies();
+  let called = false;
+  deps.deduplicateScan = async (scanId, options) => {
+    called = true;
+    expect(options.concurrency).toBe(expected);
+    return {
+      scanId,
+      uniqueFindingIds: [],
+      duplicateGroups: [],
+      deduplicationStatus: "completed",
+    };
+  };
+  expect(
+    await main([...args, ...flags], capture().stream, capture().stream, deps),
+  ).toBe(0);
+  expect(called).toBe(true);
+});
+
+test.each(["0", "-1", "1.5", "NaN", "Infinity", "9007199254740992"])(
+  "dedupe rejects invalid concurrency %s before calling the SDK",
+  async (value) => {
+    const deps = dependencies();
+    let called = false;
+    deps.deduplicateScan = async () => {
+      called = true;
+      throw new Error("Invalid concurrency must not reach the SDK");
+    };
+    const stderr = capture();
+    expect(
+      await main(
+        [...args, "--concurrency", value],
+        capture().stream,
+        stderr.stream,
+        deps,
+      ),
+    ).toBe(2);
+    expect(stderr.text()).toContain("concurrency");
+    expect(called).toBe(false);
+  },
+);
+
+test("dedupe requires a value for concurrency", async () => {
+  const stderr = capture();
+  expect(
+    await main(
+      [...args, "--concurrency"],
+      capture().stream,
+      stderr.stream,
+      dependencies(),
+    ),
+  ).toBe(2);
+  expect(stderr.text()).toContain("Missing value for flag: --concurrency");
+});
+
+test("dedupe help and schema expose concurrency and its default", async () => {
+  const help = capture();
+  expect(
+    await main(
+      ["dedupe", "--help"],
+      help.stream,
+      capture().stream,
+      dependencies(),
+    ),
+  ).toBe(0);
+  expect(help.text()).toContain("--concurrency");
+  expect(help.text()).toContain("serial execution");
+
+  const schema = capture();
+  expect(
+    await main(
+      ["dedupe", "--schema", "--format", "json"],
+      schema.stream,
+      capture().stream,
+      dependencies(),
+    ),
+  ).toBe(0);
+  expect(
+    JSON.parse(schema.text()).options.properties.concurrency,
+  ).toMatchObject({
+    type: "integer",
+    default: 8,
+  });
+});
 
 test("dedupe requires both explicit inputs and reports SDK failures", async () => {
   const deps = dependencies();

--- a/sdk/typescript/tests-ts/codex-review.test.ts
+++ b/sdk/typescript/tests-ts/codex-review.test.ts
@@ -20,6 +20,7 @@ import { checkpointWorkbench } from "./support/workbench-fakes.js";
 import { resolveCodexCommand } from "../src/runtime.js";
 import { environmentEntry } from "../src/scan-comparison.js";
 import { runTestInSubprocess } from "./support/test-subprocess.js";
+import { retryDelay, waitForRetry } from "../src/deduplication/retry.js";
 
 const fixture = fileURLToPath(
   new URL("fixtures/codex-review.mjs", import.meta.url),
@@ -28,6 +29,11 @@ const fixture = fileURLToPath(
 const failureReasons: Record<string, string> = {
   "text-only": "Codex did not submit a validated review",
   "failed-turn": "Rate limit exceeded",
+  "server-error": "Provider temporarily unavailable",
+  "connection-error": "Provider stream disconnected",
+  "unauthorized-turn": "Authentication required",
+  "bad-request-turn": "Invalid model configuration",
+  "unknown-turn": "Unknown model failure",
   "request-error": "Authentication required",
   "credential-error": "[redacted]",
   "invalid-json": "Codex returned malformed JSON",
@@ -42,6 +48,32 @@ const failureReasons: Record<string, string> = {
     "Required review check could not be completed: Required source revision could not be read.",
   exit: "Codex exited before completing the review",
 };
+const retriedFailures = new Set([
+  "text-only",
+  "failed-turn",
+  "server-error",
+  "connection-error",
+  "invalid-json",
+  "invalid-submission",
+  "exit",
+]);
+const recoveredScenarios: Record<string, string> = {
+  "recover-rate-limit": "failed-turn",
+  "recover-server-error": "server-error",
+  "recover-connection-error": "connection-error",
+  "recover-process-exit": "exit",
+  "recover-invalid-json": "invalid-json",
+  "recover-invalid-submission": "invalid-submission",
+  "recover-no-submission": "text-only",
+};
+const modelFailures = new Set([
+  "failed-turn",
+  "server-error",
+  "connection-error",
+  "unauthorized-turn",
+  "bad-request-turn",
+  "unknown-turn",
+]);
 
 const transportCases: {
   scenario: string;
@@ -69,7 +101,9 @@ const transportCases: {
     "correction",
     "incomplete-content",
     "optional-lookup-failure",
+    ...Object.keys(recoveredScenarios),
     ...Object.keys(failureReasons),
+    "cancel-backoff",
     "cancel",
   ].map((scenario) => ({ scenario })),
   {
@@ -119,6 +153,9 @@ for (const {
     let starts = 0;
     let directory: string | undefined;
     let args: readonly string[] = [];
+    const delays: number[] = [];
+    const recovery = recoveredScenarios[scenario];
+    const sessions = retriedFailures.has(scenario) ? 3 : recovery ? 2 : 1;
     const controller = new AbortController();
     try {
       const auth = {
@@ -177,7 +214,18 @@ for (const {
           expect(environmentEntry(options.env!, "CODEX_HOME")).toBe(modelHome);
           child = spawn(
             process.execPath,
-            [fixture, scenario, transcript, checkout],
+            [
+              fixture,
+              recovery
+                ? starts === 1
+                  ? recovery
+                  : "accepted-no-replay"
+                : scenario === "cancel-backoff"
+                  ? "exit"
+                  : scenario,
+              transcript,
+              checkout,
+            ],
             options,
           );
           if (scenario === "cancel")
@@ -192,6 +240,16 @@ for (const {
         },
         controller.signal,
         checkout,
+        {
+          random: () => 0,
+          wait: async (delay, signal) => {
+            delays.push(delay);
+            if (scenario === "cancel-backoff") {
+              controller.abort("synthetic cancellation");
+              await waitForRetry(delay, signal);
+            }
+          },
+        },
       );
       let validations = 0;
       const checkpoints = checkpointWorkbench("blocked-review", {
@@ -233,6 +291,7 @@ for (const {
         },
       });
       if (
+        recovery ||
         [
           "correction",
           "retry-correction",
@@ -242,9 +301,15 @@ for (const {
       ) {
         expect(await result).toEqual({ decision: "SAME" });
         expect(validations).toBe(
-          ["text-only-correction", "accepted-no-replay"].includes(scenario)
-            ? 1
-            : 2,
+          recovery
+            ? recovery === "invalid-submission"
+              ? 3
+              : modelFailures.has(recovery)
+                ? 2
+                : 1
+            : ["text-only-correction", "accepted-no-replay"].includes(scenario)
+              ? 1
+              : 2,
         );
       } else if (
         ["incomplete-content", "optional-lookup-failure"].includes(scenario)
@@ -253,7 +318,9 @@ for (const {
           decision: scenario === "incomplete-content" ? "DISTINCT" : "SAME",
         });
         expect(validations).toBe(1);
-      } else if (["cancel", "cancel-continuation"].includes(scenario)) {
+      } else if (
+        ["cancel", "cancel-continuation", "cancel-backoff"].includes(scenario)
+      ) {
         await expect(result).rejects.toBe("synthetic cancellation");
       } else {
         const failure = await result.catch((error: unknown) => error);
@@ -280,16 +347,17 @@ for (const {
               ? "validation"
               : scenario === "text-only"
                 ? "no-submission"
-                : scenario === "failed-turn" || reportsBlocker
+                : modelFailures.has(scenario) || reportsBlocker
                   ? "model"
                   : "transport",
-          attempts: [
-            "invalid-submission",
-            "text-only",
-            "required-source-error-after-text",
-          ].includes(scenario)
-            ? 2
-            : 1,
+          attempts:
+            ([
+              "invalid-submission",
+              "text-only",
+              "required-source-error-after-text",
+            ].includes(scenario)
+              ? 2
+              : 1) * sessions,
           reason:
             scenario === "credential-error"
               ? "[redacted]"
@@ -297,7 +365,7 @@ for (const {
                 ? "The submitted review failed semantic validation."
                 : scenario === "text-only"
                   ? "Codex did not submit a validated review."
-                  : scenario === "failed-turn"
+                  : modelFailures.has(scenario)
                     ? "Codex review turn failed."
                     : reportsBlocker
                       ? "A required review check could not be completed."
@@ -311,16 +379,24 @@ for (const {
         expect(supportBundle).not.toContain("review-thread");
         expect(validations).toBe(
           scenario === "invalid-submission"
-            ? 2
-            : ["failed-turn", "required-source-error-after-verdict"].includes(
-                  scenario,
-                )
-              ? 1
+            ? 2 * sessions
+            : modelFailures.has(scenario) ||
+                scenario === "required-source-error-after-verdict"
+              ? sessions
               : 0,
         );
         if (reportsBlocker) expect(checkpoints.saved).toHaveLength(0);
       }
-      expect(starts).toBe(1);
+      expect(starts).toBe(sessions);
+      expect(delays).toEqual(
+        scenario === "cancel-backoff"
+          ? [1000]
+          : sessions === 3
+            ? [1000, 2000]
+            : sessions === 2
+              ? [1000]
+              : [],
+      );
       if (commandAuth) {
         expect(args).not.toContain('cli_auth_credentials_store="ephemeral"');
         const providers = parse(
@@ -360,22 +436,26 @@ for (const {
         );
         expect(
           messages.filter((message) => message.method === "thread/start"),
-        ).toHaveLength(1);
+        ).toHaveLength(sessions);
         expect(
           messages.filter((message) => message.method === "turn/start"),
         ).toHaveLength(
-          [
-            "invalid-submission",
-            "text-only",
-            "retry-correction",
-            "text-only-correction",
-            "cancel-continuation",
-            "required-source-error-after-text",
-          ].includes(scenario)
-            ? 2
-            : ["request-error", "credential-error"].includes(scenario)
-              ? 0
-              : 1,
+          recovery
+            ? ["invalid-submission", "text-only"].includes(recovery)
+              ? 3
+              : 2
+            : ([
+                "invalid-submission",
+                "text-only",
+                "retry-correction",
+                "text-only-correction",
+                "cancel-continuation",
+                "required-source-error-after-text",
+              ].includes(scenario)
+                ? 2
+                : ["request-error", "credential-error"].includes(scenario)
+                  ? 0
+                  : 1) * sessions,
         );
         expect(loginRequest?.params?.apiKey).toBe(
           commandAuth ? undefined : "synthetic-review-key",
@@ -482,4 +562,50 @@ test("environment lookups preserve platform case rules and exact-key precedence"
   expect(environmentEntry({ ...aliases, CODEX_HOME: "" }, "CODEX_HOME")).toBe(
     "",
   );
+});
+
+test("retry backoff grows exponentially with jitter and preserves cancellation", async () => {
+  expect(retryDelay(1, () => 0.25)).toBe(1250);
+  expect(retryDelay(2, () => 0.75)).toBe(3500);
+  const controller = new AbortController();
+  const waiting = waitForRetry(60_000, controller.signal);
+  controller.abort("synthetic backoff cancellation");
+  await expect(waiting).rejects.toBe("synthetic backoff cancellation");
+});
+
+test("a missing Codex executable is not retried", async () => {
+  const root = await mkdtemp(join(tmpdir(), "codex-review-missing-command-"));
+  let starts = 0;
+  const delays: number[] = [];
+  try {
+    await writeFile(join(root, "config.toml"), "");
+    const runner = new CodexReviewRunner(
+      { CODEX_HOME: root, OPENAI_API_KEY: "synthetic-review-key" },
+      (_command, args, options) => {
+        starts++;
+        return spawn(join(root, "missing-executable"), args, options);
+      },
+      undefined,
+      root,
+      {
+        wait: async (delay) => {
+          delays.push(delay);
+        },
+      },
+    );
+    await expect(
+      runner.run({
+        stage: "pair-review",
+        model: "gpt-5.6-sol",
+        effort: "high",
+        prompt: "Review synthetic reports",
+        schema: {},
+        validate: (value) => value,
+      }),
+    ).rejects.toThrow("ENOENT");
+    expect(starts).toBe(1);
+    expect(delays).toEqual([]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });

--- a/sdk/typescript/tests-ts/finding-deduplication.test.ts
+++ b/sdk/typescript/tests-ts/finding-deduplication.test.ts
@@ -171,15 +171,289 @@ test.each(["screening", "pair-review"])(
     gates[0]!.resolve();
     const parallel = await result;
     expect(peak).toBe(2);
-    expect(phases).toEqual([
-      ...entries.map(() => "screening"),
-      ...entries.map(() => "pair-review"),
-    ]);
+    expect(phases.filter((phase) => phase === "screening")).toHaveLength(4);
+    expect(phases.filter((phase) => phase === "pair-review")).toHaveLength(4);
     expect(parallel).toEqual(
       await new FindingDeduplicator(candidates, reviewer, undefined, 1).run(
         ids,
       ),
     );
+  },
+);
+
+test("ready pairs take free slots before pending screenings and share the concurrency cap", async () => {
+  const entries = [entry(1), entry(2), entry(3)];
+  const neighbor = entry(4);
+  const ids = entries.map((finding) => finding.findingId);
+  const nominations = new Set(
+    ids.map((id) => pairKey([id, neighbor.findingId])),
+  );
+  const screeningGates = entries.map(() => deferred<void>());
+  const screeningStarts = entries.map(() => deferred<void>());
+  const pairGates = entries.map(() => deferred<void>());
+  const pairStarts = entries.map(() => deferred<void>());
+  const events: string[] = [];
+  let active = 0;
+  let peak = 0;
+  const hold = async (index: number, stage: "screen" | "pair") => {
+    events.push(`${stage}:${index}`);
+    peak = Math.max(peak, ++active);
+    (stage === "screen" ? screeningStarts : pairStarts)[index]!.resolve();
+    await (stage === "screen" ? screeningGates : pairGates)[index]!.promise;
+    active--;
+  };
+  const result = new FindingDeduplicator(
+    {
+      async potentialDuplicates(id) {
+        return {
+          finding: entries[ids.indexOf(id)]!,
+          potentialDuplicates: [neighbor],
+        };
+      },
+    },
+    {
+      async screen(findings) {
+        await hold(ids.indexOf(findings[0]!.findingId), "screen");
+        return screening(findings, nominations);
+      },
+      async reviewPair(findings) {
+        await hold(ids.indexOf(findings[0]!.findingId), "pair");
+        return same(findings);
+      },
+    },
+    undefined,
+    2,
+  ).run(ids);
+  try {
+    await Promise.all(
+      screeningStarts.slice(0, 2).map((start) => start.promise),
+    );
+    screeningGates[0]!.resolve();
+    await pairStarts[0]!.promise;
+    expect(events).toEqual(["screen:0", "screen:1", "pair:0"]);
+    expect(active).toBe(2);
+    pairGates[0]!.resolve();
+    await screeningStarts[2]!.promise;
+    screeningGates[1]!.resolve();
+    await pairStarts[1]!.promise;
+    expect(active).toBe(2);
+    pairGates[1]!.resolve();
+    screeningGates[2]!.resolve();
+    await pairStarts[2]!.promise;
+    pairGates[2]!.resolve();
+    expect((await result).duplicateGroups).toEqual([
+      [...ids, neighbor.findingId],
+    ]);
+    expect(peak).toBe(2);
+    expect(events).toEqual([
+      "screen:0",
+      "screen:1",
+      "pair:0",
+      "screen:2",
+      "pair:1",
+      "pair:2",
+    ]);
+  } finally {
+    for (const gate of [...screeningGates, ...pairGates]) gate.resolve();
+    await result.catch(() => undefined);
+  }
+});
+
+test("a pair waits for its delayed reciprocal screening and honors a DISTINCT veto", async () => {
+  const entries = [entry(1), entry(2)];
+  const ids = entries.map((finding) => finding.findingId);
+  const gates = entries.map(() => deferred<void>());
+  const started = entries.map(() => deferred<void>());
+  const finished = deferred<void>();
+  const reviewed: string[] = [];
+  const result = new FindingDeduplicator(
+    candidates(entries),
+    {
+      async screen(findings) {
+        const index = ids.indexOf(findings[0]!.findingId);
+        started[index]!.resolve();
+        await gates[index]!.promise;
+        if (index === 0) finished.resolve();
+        return screening(
+          findings,
+          index === 0 ? new Set([pairKey(ids)]) : new Set(),
+        );
+      },
+      async reviewPair(findings) {
+        reviewed.push(pairKey(findings.map((finding) => finding.findingId)));
+        return same(findings);
+      },
+    },
+    undefined,
+    2,
+  ).run(ids);
+  try {
+    await Promise.all(started.map((start) => start.promise));
+    gates[0]!.resolve();
+    await finished.promise;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(reviewed).toEqual([]);
+    gates[1]!.resolve();
+    expect(await result).toEqual({
+      uniqueFindingIds: ids,
+      duplicateGroups: [],
+      deduplicationStatus: "completed",
+    });
+    expect(reviewed).toEqual([]);
+  } finally {
+    for (const gate of gates) gate.resolve();
+    await result.catch(() => undefined);
+  }
+});
+
+test("reverse completion preserves pair orientation and the final input-order finding records", async () => {
+  const entries = [entry(1), entry(2), entry(3)];
+  const ids = entries.map((finding) => finding.findingId);
+  const finalA = {
+    ...entry(1),
+    title: "Final candidate record",
+    severity: { ...entry(1).severity, level: "critical" as const },
+  };
+  const finalB = { ...entry(2), title: "Later anchor record" };
+  const neighborhoods = [
+    { finding: entries[0]!, potentialDuplicates: [entries[1]!] },
+    {
+      finding: finalB,
+      potentialDuplicates: [
+        { ...entries[0]!, title: "Intermediate candidate record" },
+      ],
+    },
+    { finding: entries[2]!, potentialDuplicates: [finalA] },
+  ];
+  const lookupStarts = entries.map(() => deferred<void>());
+  const lookupGates = entries.map(() => deferred<void>());
+  const screenStarts = entries.map(() => deferred<void>());
+  const screenGates = entries.map(() => deferred<void>());
+  const pairStarted = deferred<void>();
+  const reviewed: Finding[][] = [];
+  const result = new FindingDeduplicator(
+    {
+      async potentialDuplicates(id) {
+        const index = ids.indexOf(id);
+        lookupStarts[index]!.resolve();
+        await lookupGates[index]!.promise;
+        return neighborhoods[index]!;
+      },
+    },
+    {
+      async screen(findings) {
+        const index = ids.indexOf(findings[0]!.findingId);
+        screenStarts[index]!.resolve();
+        await screenGates[index]!.promise;
+        return screening(findings, new Set([pairKey(ids.slice(0, 2))]));
+      },
+      async reviewPair(findings) {
+        reviewed.push([...findings]);
+        pairStarted.resolve();
+        return same(findings);
+      },
+    },
+    undefined,
+    3,
+  ).run(ids);
+  try {
+    await Promise.all(lookupStarts.map((start) => start.promise));
+    for (const gate of [...lookupGates].reverse()) {
+      gate.resolve();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    await Promise.all(screenStarts.map((start) => start.promise));
+    screenGates[1]!.resolve();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(reviewed).toEqual([]);
+    screenGates[0]!.resolve();
+    await pairStarted.promise;
+    expect(reviewed).toEqual([[finalB, finalA]]);
+    screenGates[2]!.resolve();
+    expect(await result).toEqual({
+      uniqueFindingIds: [ids[0]!, ids[2]!],
+      duplicateGroups: [ids.slice(0, 2)],
+      deduplicationStatus: "completed",
+    });
+  } finally {
+    for (const gate of [...lookupGates, ...screenGates]) gate.resolve();
+    await result.catch(() => undefined);
+  }
+});
+
+test.each(["screen", "pair", "cancel"])(
+  "%s failure drains mixed active reviews and stops both pending queues",
+  async (failureStage) => {
+    const entries = [entry(1), entry(2), entry(3)];
+    const neighbors = [entry(4), entry(5)];
+    const ids = entries.map((finding) => finding.findingId);
+    const starts: string[] = [];
+    const completed: string[] = [];
+    const screenGate = deferred<void>();
+    const pairGate = deferred<void>();
+    const pairStarted = deferred<void>();
+    const controller = new AbortController();
+    const failure = new Error("Synthetic mixed-stage failure");
+    const result = new FindingDeduplicator(
+      {
+        async potentialDuplicates(id) {
+          return {
+            finding: entries[ids.indexOf(id)]!,
+            potentialDuplicates: neighbors,
+          };
+        },
+      },
+      {
+        async screen(findings) {
+          const index = ids.indexOf(findings[0]!.findingId);
+          starts.push(`screen:${index}`);
+          if (index === 1) await screenGate.promise;
+          completed.push(`screen:${index}`);
+          return screening(
+            findings,
+            new Set(
+              neighbors.map((neighbor) =>
+                pairKey([findings[0]!.findingId, neighbor.findingId]),
+              ),
+            ),
+          );
+        },
+        async reviewPair(findings) {
+          starts.push("pair");
+          pairStarted.resolve();
+          await pairGate.promise;
+          completed.push("pair");
+          return same(findings);
+        },
+      },
+      controller.signal,
+      2,
+    ).run(ids);
+    let settled = false;
+    const observed = result.catch((error: unknown) => {
+      settled = true;
+      return error;
+    });
+    try {
+      await pairStarted.promise;
+      expect(starts).toEqual(["screen:0", "screen:1", "pair"]);
+      if (failureStage === "screen") screenGate.reject(failure);
+      else if (failureStage === "pair") pairGate.reject(failure);
+      else controller.abort(failure);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(settled).toBe(false);
+      screenGate.resolve();
+      pairGate.resolve();
+      expect(await observed).toBe(failure);
+      expect(starts).toEqual(["screen:0", "screen:1", "pair"]);
+      expect(completed).toContain("screen:0");
+      if (failureStage !== "screen") expect(completed).toContain("screen:1");
+      if (failureStage !== "pair") expect(completed).toContain("pair");
+    } finally {
+      screenGate.resolve();
+      pairGate.resolve();
+      await observed;
+    }
   },
 );
 
@@ -282,15 +556,8 @@ test("reviews nominated pairs once and groups non-conflicting accepted pairs by 
   });
   expect(new Set(reviewedPairs)).toEqual(nominations);
   expect(reviewedPairs).toHaveLength(3);
-  expect(phases).toEqual([
-    "screen",
-    "screen",
-    "screen",
-    "screen",
-    "pair",
-    "pair",
-    "pair",
-  ]);
+  expect(phases.filter((phase) => phase === "screen")).toHaveLength(4);
+  expect(phases.filter((phase) => phase === "pair")).toHaveLength(3);
 });
 
 test("groups accepted neighbors transitively without screening them as anchors", async () => {

--- a/sdk/typescript/tests-ts/finding-deduplication.test.ts
+++ b/sdk/typescript/tests-ts/finding-deduplication.test.ts
@@ -101,6 +101,149 @@ function screening(
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((yes, no) => {
+    resolve = yes;
+    reject = no;
+  });
+  return { promise, resolve, reject };
+}
+
+test.each(["screening", "pair-review"])(
+  "%s fills each free slot immediately and preserves serial grouping",
+  async (stage) => {
+    const entries = [entry(1), entry(2), entry(3), entry(4)];
+    const neighbor = entry(5);
+    const ids = entries.map((finding) => finding.findingId);
+    const nominations = new Set(
+      ids.map((id) => pairKey([id, neighbor.findingId])),
+    );
+    const candidates = {
+      async potentialDuplicates(id: string) {
+        return {
+          finding: entries[ids.indexOf(id)]!,
+          potentialDuplicates: [neighbor],
+        };
+      },
+    };
+    const gates = entries.map(() => deferred<void>());
+    const started = entries.map(() => deferred<void>());
+    const starts: number[] = [];
+    const phases: string[] = [];
+    let active = 0;
+    let peak = 0;
+    const hold = async (findings: readonly Finding[]) => {
+      const index = ids.indexOf(findings[0]!.findingId);
+      starts.push(index);
+      peak = Math.max(peak, ++active);
+      started[index]!.resolve();
+      await gates[index]!.promise;
+      active--;
+    };
+    const reviewer: DeduplicationReviewer = {
+      async screen(findings) {
+        phases.push("screening");
+        if (stage === "screening") await hold(findings);
+        return screening(findings, nominations);
+      },
+      async reviewPair(findings) {
+        phases.push("pair-review");
+        if (stage === "pair-review") await hold(findings);
+        return same(findings);
+      },
+    };
+    const result = new FindingDeduplicator(
+      candidates,
+      reviewer,
+      undefined,
+      2,
+    ).run(ids);
+    await Promise.all([started[0]!.promise, started[1]!.promise]);
+    expect(starts).toEqual([0, 1]);
+    gates[1]!.resolve();
+    await started[2]!.promise;
+    expect(starts).toEqual([0, 1, 2]);
+    gates[2]!.resolve();
+    await started[3]!.promise;
+    gates[3]!.resolve();
+    gates[0]!.resolve();
+    const parallel = await result;
+    expect(peak).toBe(2);
+    expect(phases).toEqual([
+      ...entries.map(() => "screening"),
+      ...entries.map(() => "pair-review"),
+    ]);
+    expect(parallel).toEqual(
+      await new FindingDeduplicator(candidates, reviewer, undefined, 1).run(
+        ids,
+      ),
+    );
+  },
+);
+
+test("terminal failure drains started reviews without starting queued jobs", async () => {
+  const entries = [entry(1), entry(2), entry(3)];
+  const gates = entries.map(() => deferred<void>());
+  const started = entries.map(() => deferred<void>());
+  const calls: string[] = [];
+  const failure = new Error("Synthetic review failure");
+  const result = new FindingDeduplicator(
+    candidates(entries),
+    {
+      async screen(findings) {
+        const index = entries.findIndex(
+          (entry) => entry.findingId === findings[0]!.findingId,
+        );
+        calls.push(findings[0]!.findingId);
+        started[index]!.resolve();
+        await gates[index]!.promise;
+        return screening(findings, new Set());
+      },
+      async reviewPair() {
+        throw new Error("Pair review must not start after screening failure");
+      },
+    },
+    undefined,
+    2,
+  ).run(entries.map((entry) => entry.findingId));
+  let settled = false;
+  const observed = result.catch((error: unknown) => {
+    settled = true;
+    return error;
+  });
+  await Promise.all([started[0]!.promise, started[1]!.promise]);
+  gates[0]!.reject(failure);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  expect(settled).toBe(false);
+  gates[1]!.resolve();
+  expect(await observed).toBe(failure);
+  expect(calls).toEqual(entries.slice(0, 2).map((entry) => entry.findingId));
+});
+
+test("SDK rejects invalid concurrency before reading scan artifacts or history", async () => {
+  for (const concurrency of [
+    0,
+    -1,
+    1.5,
+    NaN,
+    Infinity,
+    Number.MAX_SAFE_INTEGER + 1,
+  ]) {
+    const options = { findingsUrl: "http://synthetic.test", concurrency };
+    await expect(deduplicateScanInternal("synthetic", options)).rejects.toThrow(
+      "concurrency must be a positive safe integer",
+    );
+    await expect(
+      deduplicateScanDirectoryInternal("unused", {
+        ...options,
+        repository: "unused",
+      }),
+    ).rejects.toThrow("concurrency must be a positive safe integer");
+  }
+});
+
 test("reviews nominated pairs once and groups non-conflicting accepted pairs by severity", async () => {
   const entries = [entry(1), entry(2), entry(3), entry(4)];
   entries[1]!.severity.level = "critical";

--- a/sdk/typescript/tests-ts/finding-workflow-integration.test.ts
+++ b/sdk/typescript/tests-ts/finding-workflow-integration.test.ts
@@ -391,6 +391,7 @@ test.each(["screen", "pair"])(
     const options = {
       workflowId: `reviews-${interruptAt}`,
       findingsUrl: "http://synthetic.test",
+      concurrency: 1,
     };
     const calls: string[] = [];
     let interrupted = false;
@@ -487,6 +488,178 @@ test.each(["screen", "pair"])(
   },
 );
 
+test.each(["screening", "pair-review"] as const)(
+  "drains concurrent %s checkpoints after failure and resumes with different concurrency",
+  async (failedStage) => {
+    const { scanDir, environment, document, history } = await fixture();
+    const manifestPath = join(scanDir, "scan-manifest.json");
+    const manifest = JSON.parse(
+      await readFile(manifestPath, "utf8"),
+    ) as ScanManifest;
+    const digest = (value: string) =>
+      createHash("sha256").update(value).digest("hex");
+    document.findings = Array.from({ length: 4 }, (_value, index) => {
+      const finding = structuredClone(document.findings[0]!);
+      finding.identity.instance = `concurrent-${index}`;
+      const fingerprint = `codex-security/v1:sha256:${digest(
+        [
+          "codex-security/v1",
+          manifest.scan.target.targetId,
+          finding.ruleId,
+          finding.identity.anchor,
+          finding.identity.instance,
+        ].join("\0"),
+      )}`;
+      return {
+        ...finding,
+        findingId: `csf_${digest(fingerprint).slice(0, 24)}`,
+        occurrenceId: `occ_${digest([document.scanId, fingerprint].join("\0")).slice(0, 24)}`,
+        fingerprints: { ...finding.fingerprints, primary: fingerprint },
+        title: `Synthetic concurrent finding ${index}`,
+      };
+    });
+    const content = JSON.stringify(document);
+    await writeFile(join(scanDir, "findings.json"), content);
+    manifest.scan.artifacts!.find(
+      (artifact) => artifact.path === "findings.json",
+    )!.sha256 = createHash("sha256").update(content).digest("hex");
+    await writeFile(manifestPath, JSON.stringify(manifest));
+
+    const options = {
+      workflowId: `concurrent-${failedStage}`,
+      findingsUrl: "http://synthetic.test",
+      concurrency: 2,
+    };
+    const started = Promise.withResolvers<void>();
+    const failed = Promise.withResolvers<void>();
+    const sibling = Promise.withResolvers<void>();
+    const attempts = new Map<string, number>();
+    const events: string[] = [];
+    const interruptedKeys: string[] = [];
+    let interrupt = true;
+    let groupWrites = 0;
+    const reviewRunner = {
+      async run<T>(review: CodexReview<T>): Promise<T> {
+        const originals = JSON.parse(
+          review.prompt.slice(review.prompt.lastIndexOf("\n\n") + 2),
+        ).findings as Finding[];
+        const key = `${review.stage}:${originals.map((finding) => finding.findingId).join(",")}`;
+        attempts.set(key, (attempts.get(key) ?? 0) + 1);
+        if (interrupt && review.stage === failedStage) {
+          interruptedKeys.push(key);
+          if (interruptedKeys.length === 1) await failed.promise;
+          else if (interruptedKeys.length === 2) {
+            started.resolve();
+            await sibling.promise;
+          }
+        }
+        return review.validate(
+          review.stage === "screening"
+            ? {
+                decisions: Object.fromEntries(
+                  originals
+                    .slice(1)
+                    .map((_finding, index) => [
+                      screeningPairSlot(index),
+                      { ...sameRecommendation },
+                    ]),
+                ),
+              }
+            : merged(originals),
+        );
+      },
+    };
+    const dependencies = {
+      environment,
+      reviewRunner,
+      runWorkbench: async (args: readonly string[], input?: string) => {
+        const payload = input ? JSON.parse(input) : {};
+        if (payload.action === "fail") events.push("workflow-failed");
+        const response = await history(args, input);
+        if (
+          payload.action === "save-review" &&
+          payload.binding.stage === failedStage
+        )
+          events.push("checkpoint-saved");
+        return response;
+      },
+      fetch: async (url: URL) => {
+        if (url.pathname.endsWith("/bulk/findings"))
+          return Response.json(
+            document.findings.map((finding) => finding.findingId),
+          );
+        if (url.pathname.endsWith("/dedupe-groups")) {
+          groupWrites++;
+          return Response.json([]);
+        }
+        const id = decodeURIComponent(url.pathname.split("/").at(-2)!);
+        return Response.json({
+          finding: document.findings.find(
+            (finding) => finding.findingId === id,
+          ),
+          potentialDuplicates: document.findings.filter(
+            (finding) => finding.findingId !== id,
+          ),
+        });
+      },
+    };
+    const failure = new Error("Synthetic concurrent failure");
+    const first = deduplicateScanInternal(
+      document.scanId,
+      options,
+      dependencies,
+    ).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    try {
+      await Promise.race([
+        started.promise,
+        first.then((error) => {
+          throw error ?? new Error("Dedupe completed before reviews started");
+        }),
+      ]);
+      events.push("model-failed");
+      failed.reject(failure);
+      await new FindingWorkflow(options.workflowId, environment).get();
+    } finally {
+      sibling.resolve();
+    }
+    expect(await first).toBe(failure);
+    expect(interruptedKeys).toHaveLength(2);
+    expect(events).toEqual([
+      "model-failed",
+      "checkpoint-saved",
+      "workflow-failed",
+    ]);
+    expect(groupWrites).toBe(0);
+    expect(
+      (await new FindingWorkflow(options.workflowId, environment).get())?.stages
+        .dedupe,
+    ).toMatchObject({ status: "failed" });
+
+    interrupt = false;
+    const result = await deduplicateScanInternal(
+      document.scanId,
+      { ...options, concurrency: 1 },
+      dependencies,
+    );
+    expect(result.duplicateGroups).toEqual([
+      document.findings.map((finding) => finding.findingId).sort(),
+    ]);
+    expect(groupWrites).toBe(1);
+    expect(attempts.get(interruptedKeys[0]!)).toBe(2);
+    expect(attempts.get(interruptedKeys[1]!)).toBe(1);
+    expect(attempts.size).toBe(10);
+    for (const [key, count] of attempts)
+      expect(count).toBe(key === interruptedKeys[0] ? 2 : 1);
+    expect(
+      (await new FindingWorkflow(options.workflowId, environment).get())?.stages
+        .dedupe,
+    ).toEqual({ status: "completed", result });
+  },
+);
+
 test("replays an unacknowledged group write after migrating its workflow database", async () => {
   const { environment, document, history } = await fixture();
   const originals = [
@@ -530,9 +703,9 @@ test("replays an unacknowledged group write after migrating its workflow databas
     });
     expect(saved.pendingWrite).toEqual(JSON.parse(init.body as string));
     bodies.push(init.body as string);
-    return bodies.length === 1
-      ? new Response("incomplete acknowledgement", { status: 201 })
-      : Response.json([]);
+    if (bodies.length === 1)
+      throw new Error("Synthetic interrupted acknowledgement");
+    return Response.json([]);
   };
   await expect(
     deduplicateScanInternal(document.scanId, options, {

--- a/sdk/typescript/tests-ts/finding-workflow-integration.test.ts
+++ b/sdk/typescript/tests-ts/finding-workflow-integration.test.ts
@@ -54,6 +54,44 @@ async function fixture() {
   return { ...value, history, workbenchOptions };
 }
 
+async function fixtureWithFindings(count: number) {
+  const value = await fixture();
+  const { scanDir, document } = value;
+  const manifestPath = join(scanDir, "scan-manifest.json");
+  const manifest = JSON.parse(
+    await readFile(manifestPath, "utf8"),
+  ) as ScanManifest;
+  const digest = (text: string) =>
+    createHash("sha256").update(text).digest("hex");
+  document.findings = Array.from({ length: count }, (_value, index) => {
+    const finding = structuredClone(document.findings[0]!);
+    finding.identity.instance = `concurrent-${index}`;
+    const fingerprint = `codex-security/v1:sha256:${digest(
+      [
+        "codex-security/v1",
+        manifest.scan.target.targetId,
+        finding.ruleId,
+        finding.identity.anchor,
+        finding.identity.instance,
+      ].join("\0"),
+    )}`;
+    return {
+      ...finding,
+      findingId: `csf_${digest(fingerprint).slice(0, 24)}`,
+      occurrenceId: `occ_${digest([document.scanId, fingerprint].join("\0")).slice(0, 24)}`,
+      fingerprints: { ...finding.fingerprints, primary: fingerprint },
+      title: `Synthetic concurrent finding ${index}`,
+    };
+  });
+  const content = JSON.stringify(document);
+  await writeFile(join(scanDir, "findings.json"), content);
+  manifest.scan.artifacts!.find(
+    (artifact) => artifact.path === "findings.json",
+  )!.sha256 = digest(content);
+  await writeFile(manifestPath, JSON.stringify(manifest));
+  return value;
+}
+
 async function restoreLegacyWorkflow(
   environment: NodeJS.ProcessEnv,
   state: object,
@@ -491,40 +529,7 @@ test.each(["screen", "pair"])(
 test.each(["screening", "pair-review"] as const)(
   "drains concurrent %s checkpoints after failure and resumes with different concurrency",
   async (failedStage) => {
-    const { scanDir, environment, document, history } = await fixture();
-    const manifestPath = join(scanDir, "scan-manifest.json");
-    const manifest = JSON.parse(
-      await readFile(manifestPath, "utf8"),
-    ) as ScanManifest;
-    const digest = (value: string) =>
-      createHash("sha256").update(value).digest("hex");
-    document.findings = Array.from({ length: 4 }, (_value, index) => {
-      const finding = structuredClone(document.findings[0]!);
-      finding.identity.instance = `concurrent-${index}`;
-      const fingerprint = `codex-security/v1:sha256:${digest(
-        [
-          "codex-security/v1",
-          manifest.scan.target.targetId,
-          finding.ruleId,
-          finding.identity.anchor,
-          finding.identity.instance,
-        ].join("\0"),
-      )}`;
-      return {
-        ...finding,
-        findingId: `csf_${digest(fingerprint).slice(0, 24)}`,
-        occurrenceId: `occ_${digest([document.scanId, fingerprint].join("\0")).slice(0, 24)}`,
-        fingerprints: { ...finding.fingerprints, primary: fingerprint },
-        title: `Synthetic concurrent finding ${index}`,
-      };
-    });
-    const content = JSON.stringify(document);
-    await writeFile(join(scanDir, "findings.json"), content);
-    manifest.scan.artifacts!.find(
-      (artifact) => artifact.path === "findings.json",
-    )!.sha256 = createHash("sha256").update(content).digest("hex");
-    await writeFile(manifestPath, JSON.stringify(manifest));
-
+    const { environment, document, history } = await fixtureWithFindings(4);
     const options = {
       workflowId: `concurrent-${failedStage}`,
       findingsUrl: "http://synthetic.test",
@@ -659,6 +664,118 @@ test.each(["screening", "pair-review"] as const)(
     ).toEqual({ status: "completed", result });
   },
 );
+
+test("resumes a saved Sol review after overlapping Luna work fails", async () => {
+  const { environment, document, history } = await fixtureWithFindings(3);
+  const options = {
+    workflowId: "overlapping-reviews",
+    findingsUrl: "http://synthetic.test",
+    concurrency: 2,
+  };
+  const failedAnchor = document.findings[2]!.findingId;
+  const lunaStarted = Promise.withResolvers<void>();
+  const solSaved = Promise.withResolvers<void>();
+  const failure = new Error("Synthetic later screening failure");
+  const calls = new Map<string, number>();
+  const events: string[] = [];
+  let interrupt = true;
+  let failedReviewKey: string | undefined;
+  let groupWrites = 0;
+  const dependencies = {
+    environment,
+    reviewRunner: {
+      async run<T>(review: CodexReview<T>): Promise<T> {
+        const originals = JSON.parse(
+          review.prompt.slice(review.prompt.lastIndexOf("\n\n") + 2),
+        ).findings as Finding[];
+        const key = `${review.stage}:${originals.map((finding) => finding.findingId).join(",")}`;
+        calls.set(key, (calls.get(key) ?? 0) + 1);
+        if (
+          interrupt &&
+          review.stage === "screening" &&
+          originals[0]!.findingId === failedAnchor
+        ) {
+          failedReviewKey = key;
+          events.push("luna-pending");
+          lunaStarted.resolve();
+          await solSaved.promise;
+          events.push("luna-failed");
+          throw failure;
+        }
+        if (interrupt && review.stage === "pair-review")
+          await lunaStarted.promise;
+        return review.validate(
+          review.stage === "screening"
+            ? {
+                decisions: Object.fromEntries(
+                  originals
+                    .slice(1)
+                    .map((_finding, index) => [
+                      screeningPairSlot(index),
+                      { ...sameRecommendation },
+                    ]),
+                ),
+              }
+            : merged(originals),
+        );
+      },
+    },
+    runWorkbench: async (args: readonly string[], input?: string) => {
+      const response = await history(args, input);
+      const payload = input ? JSON.parse(input) : {};
+      if (
+        interrupt &&
+        payload.action === "save-review" &&
+        payload.binding.stage === "pair-review"
+      ) {
+        events.push("sol-saved");
+        solSaved.resolve();
+      }
+      return response;
+    },
+    fetch: async (url: URL) => {
+      if (url.pathname.endsWith("/bulk/findings"))
+        return Response.json(
+          document.findings.map((finding) => finding.findingId),
+        );
+      if (url.pathname.endsWith("/dedupe-groups")) {
+        groupWrites++;
+        return Response.json([]);
+      }
+      const id = decodeURIComponent(url.pathname.split("/").at(-2)!);
+      return Response.json({
+        finding: document.findings.find((finding) => finding.findingId === id),
+        potentialDuplicates: document.findings.filter(
+          (finding) => finding.findingId !== id,
+        ),
+      });
+    },
+  };
+  await expect(
+    deduplicateScanInternal(document.scanId, options, dependencies),
+  ).rejects.toThrow(failure.message);
+  expect(events).toEqual(["luna-pending", "sol-saved", "luna-failed"]);
+  expect(groupWrites).toBe(0);
+  expect(calls.size).toBe(4);
+
+  interrupt = false;
+  const result = await deduplicateScanInternal(
+    document.scanId,
+    { ...options, concurrency: 1 },
+    dependencies,
+  );
+  expect(result.duplicateGroups).toEqual([
+    document.findings.map((finding) => finding.findingId).sort(),
+  ]);
+  expect(groupWrites).toBe(1);
+  expect(calls.size).toBe(6);
+  for (const [key, count] of calls)
+    expect(count).toBe(key === failedReviewKey ? 2 : 1);
+  expect(
+    (await new FindingWorkflow(options.workflowId, environment).get())?.stages
+      .dedupe,
+  ).toEqual({ status: "completed", result });
+});
 
 test("replays an unacknowledged group write after migrating its workflow database", async () => {
   const { environment, document, history } = await fixture();

--- a/sdk/typescript/tests-ts/finding-workflow-publication.test.ts
+++ b/sdk/typescript/tests-ts/finding-workflow-publication.test.ts
@@ -382,9 +382,9 @@ test.each(["before-post", "before-write", "lost-ack", "lost-completion"])(
         pendingWrite: JSON.parse(init.body as string),
       });
       bodies.push(init.body as string);
-      if (bodies.length === 1 && failure === "before-write")
+      if (bodies.length <= 3 && failure === "before-write")
         return new Response("", { status: 503 });
-      if (bodies.length === 1 && failure === "lost-ack")
+      if (bodies.length <= 3 && failure === "lost-ack")
         return new Response("incomplete acknowledgement", { status: 201 });
       return Response.json([]);
     };
@@ -400,7 +400,13 @@ test.each(["before-post", "before-write", "lost-ack", "lost-completion"])(
     expect(
       await deduplicateScanInternal(document.scanId, options, dependencies),
     ).toEqual(result);
-    expect(bodies).toHaveLength(failure === "before-post" ? 1 : 2);
+    expect(bodies).toHaveLength(
+      failure === "before-post"
+        ? 1
+        : failure === "before-write" || failure === "lost-ack"
+          ? 4
+          : 2,
+    );
     expect(new Set(bodies).size).toBe(1);
     expect(reviews).toBe(2);
     expect(lookups).toBe(1);

--- a/sdk/typescript/tests-ts/findings-client-retry.test.ts
+++ b/sdk/typescript/tests-ts/findings-client-retry.test.ts
@@ -1,0 +1,182 @@
+import { expect, test } from "bun:test";
+import { FindingsClient } from "../src/findings-client.js";
+
+const scope = { repositoryId: "synthetic-repository" };
+const neighborhood = {
+  finding: { findingId: "synthetic" },
+  potentialDuplicates: [],
+};
+
+test("lookup retries rate limits and honors Retry-After before continuing", async () => {
+  let requests = 0;
+  const delays: number[] = [];
+  const client = new FindingsClient(
+    "http://synthetic.test",
+    undefined,
+    async () => {
+      requests++;
+      return requests === 1
+        ? new Response("busy", {
+            status: 429,
+            headers: { "Retry-After": "12" },
+          })
+        : Response.json(neighborhood);
+    },
+    {
+      wait: async (delay) => {
+        delays.push(delay);
+      },
+      random: () => 0,
+    },
+  );
+  expect(
+    (await client.potentialDuplicates("synthetic", scope)).finding.findingId,
+  ).toBe("synthetic");
+  expect(requests).toBe(2);
+  expect(delays).toEqual([12000]);
+});
+
+test("lookup retries network and truncated JSON responses within the attempt budget", async () => {
+  let requests = 0;
+  const delays: number[] = [];
+  const client = new FindingsClient(
+    "http://synthetic.test",
+    undefined,
+    async () => {
+      requests++;
+      if (requests === 1) throw new TypeError("fetch failed");
+      if (requests === 2) return new Response('{"finding":');
+      return Response.json(neighborhood);
+    },
+    {
+      wait: async (delay) => {
+        delays.push(delay);
+      },
+      random: () => 0,
+    },
+  );
+  expect(
+    (await client.potentialDuplicates("synthetic", scope)).finding.findingId,
+  ).toBe("synthetic");
+  expect(requests).toBe(3);
+  expect(delays).toHaveLength(2);
+  expect(delays[1]!).toBeGreaterThan(delays[0]!);
+});
+
+test.each([400, 401, 403, 404, 409, 501])(
+  "lookup does not retry HTTP %i",
+  async (status) => {
+    let requests = 0;
+    const client = new FindingsClient(
+      "http://synthetic.test",
+      undefined,
+      async () => {
+        requests++;
+        return new Response("failed", { status });
+      },
+      {
+        wait: async () => {
+          throw new Error("Unexpected retry");
+        },
+      },
+    );
+    await expect(
+      client.potentialDuplicates("synthetic", scope),
+    ).rejects.toThrow(`HTTP ${status}`);
+    expect(requests).toBe(1);
+  },
+);
+
+test.each([408, 429, 500, 502, 503, 504])(
+  "lookup stops after three HTTP %i failures",
+  async (status) => {
+    let requests = 0;
+    let waits = 0;
+    const client = new FindingsClient(
+      "http://synthetic.test",
+      undefined,
+      async () => {
+        requests++;
+        return new Response("unavailable", { status });
+      },
+      {
+        wait: async () => {
+          waits++;
+        },
+      },
+    );
+    await expect(
+      client.potentialDuplicates("synthetic", scope),
+    ).rejects.toThrow(`HTTP ${status}`);
+    expect(requests).toBe(3);
+    expect(waits).toBe(2);
+  },
+);
+
+test("group write retries the identical payload after a lost acknowledgement", async () => {
+  const bodies: unknown[] = [];
+  const groups = [["synthetic-a", "synthetic-b"]];
+  const client = new FindingsClient(
+    "http://synthetic.test",
+    undefined,
+    async (_url, init) => {
+      bodies.push(init.body);
+      if (bodies.length === 1) throw new TypeError("fetch failed");
+      return Response.json({ groups });
+    },
+    { wait: async () => {} },
+  );
+  await client.storeDedupeGroups(groups);
+  expect(bodies).toEqual([
+    JSON.stringify({ groups }),
+    JSON.stringify({ groups }),
+  ]);
+});
+
+test("cancellation interrupts a pending retry and prevents another request", async () => {
+  const controller = new AbortController();
+  let requests = 0;
+  const client = new FindingsClient(
+    "http://synthetic.test",
+    controller.signal,
+    async () => {
+      requests++;
+      return new Response("busy", { status: 429 });
+    },
+    {
+      wait: async () => {
+        controller.abort("synthetic cancellation");
+      },
+    },
+  );
+  await expect(client.potentialDuplicates("synthetic", scope)).rejects.toBe(
+    "synthetic cancellation",
+  );
+  expect(requests).toBe(1);
+});
+
+test("Retry-After accepts an HTTP date", async () => {
+  const until = "Fri, 01 Jan 2100 00:00:00 GMT";
+  let requests = 0;
+  let delay = 0;
+  const client = new FindingsClient(
+    "http://synthetic.test",
+    undefined,
+    async () => {
+      requests++;
+      return requests === 1
+        ? new Response("busy", {
+            status: 503,
+            headers: { "Retry-After": until },
+          })
+        : Response.json(neighborhood);
+    },
+    {
+      wait: async (value) => {
+        delay = value;
+      },
+    },
+  );
+  await client.potentialDuplicates("synthetic", scope);
+  expect(delay).toBeGreaterThan(24 * 60 * 60 * 1000);
+});

--- a/sdk/typescript/tests-ts/fixtures/codex-review.mjs
+++ b/sdk/typescript/tests-ts/fixtures/codex-review.mjs
@@ -3,6 +3,32 @@ import { appendFileSync } from "node:fs";
 import { createInterface } from "node:readline";
 
 const [scenario, transcript, checkout] = process.argv.slice(2);
+const turnFailures = {
+  "failed-turn": {
+    message: "Rate limit exceeded",
+    codexErrorInfo: "usageLimitExceeded",
+  },
+  "server-error": {
+    message: "Provider temporarily unavailable",
+    codexErrorInfo: { httpConnectionFailed: { httpStatusCode: 503 } },
+  },
+  "connection-error": {
+    message: "Provider stream disconnected",
+    codexErrorInfo: { responseStreamDisconnected: { httpStatusCode: null } },
+  },
+  "unauthorized-turn": {
+    message: "Authentication required",
+    codexErrorInfo: { httpConnectionFailed: { httpStatusCode: 401 } },
+  },
+  "bad-request-turn": {
+    message: "Invalid model configuration",
+    codexErrorInfo: "badRequest",
+  },
+  "unknown-turn": {
+    message: "Unknown model failure",
+    codexErrorInfo: "other",
+  },
+};
 let turns = 0;
 let turnId;
 const send = (message) => process.stdout.write(`${JSON.stringify(message)}\n`);
@@ -199,11 +225,10 @@ for await (const line of createInterface({ input: process.stdin })) {
     assert.equal(message.result.success, true);
     if (scenario === "accepted-no-replay") {
       submit("late-submission", { decision: "UNKNOWN" });
-    } else if (scenario === "failed-turn") {
+    } else if (turnFailures[scenario]) {
       process.stderr.write("Synthetic provider failure with private details\n");
       complete("failed", {
-        message: "Rate limit exceeded",
-        codexErrorInfo: "usageLimitExceeded",
+        ...turnFailures[scenario],
         additionalDetails: "Synthetic private response data",
       });
     } else complete();


### PR DESCRIPTION
## Summary

Deduplication waits for each candidate lookup and review in sequence, then waits for every Luna screening before starting Sol verification. Use a configurable worker pool so independent reviews run concurrently and ready Sol pairs can overlap with unrelated Luna screenings. Completed workflow checkpoints survive failures and restarts.

## Changes

- Add `dedupe --concurrency N` and SDK `concurrency` options for saved-scan and scan-directory deduplication. Both default to `8`, accept positive safe integers, and support `1` for serial execution.
- Fetch candidate neighborhoods concurrently, then run two queues sharing one pool: pending Luna screenings and ready Sol pair reviews. Refill free slots immediately, preferring ready Sol work. The configured limit applies across both models combined.
- Wait for every Luna screening covering a pair before verifying it, preserving `DISTINCT` vetoes. Preserve input-order finding records, pair prompts, and grouping results regardless of completion order.
- Retry transient candidate lookups and idempotent group writes up to three attempts, and transient or invalid Codex reviews up to three fresh sessions. Use exponential backoff with jitter and honor HTTP `Retry-After`; retain the corrective turn for invalid submissions.
- Stop both queues after a terminal failure and drain active jobs so successful reviews can save checkpoints. Preserve cancellation. Existing workflow IDs reuse completed Luna and Sol reviews even when concurrency changes; incomplete runs do not publish groups.
- Update CLI help, SDK documentation, package inventory, and regression tests for scheduling, retries, failure draining, and durable resume.

## Testing

- Seeded full SDK suite: **2,669 passed, 48 skipped, 0 failed** (seed `12345`).
- Focused deduplication tests: **27 passed**. Focused SQLite checkpoint/resume tests: **3 passed**.
- A disposable differential check matched the previous serial implementation across **500 generated scenarios**, including exact Luna and Sol review inputs and grouping results.
- `pnpm run types`, `pnpm run format`, and `pnpm run build` passed. Built CLI help describes the shared limit and default; `git diff --check` passed.
- Installed-package smoke was not rerun for this scheduler update. The earlier local attempt reached smoke installation and failed with the registry error `ETARGET: No matching version found for fast-uri@3.1.6` for the existing dependency.

## Risk and rollout

The default changes from serial execution to eight concurrent jobs, increasing simultaneous service requests and Codex processes. Use `--concurrency 1` or SDK `concurrency: 1` for serial operation, or lower the count to fit available capacity. Retry backoff occupies its worker slot; retries can add model usage.

Candidate retrieval completes before model scheduling so pair dependencies and review inputs are stable. Sol work overlaps with unrelated Luna work, but throughput still depends on available capacity, review durations, and pair dependencies. Live-service latency improvements have not been benchmarked.

Result shapes, model settings, repository scope, validation rules, and checkpoint identities remain unchanged. Durable resume still requires `--workflow-id` or SDK `workflowId`. No database migration is needed.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
