### PR TITLE
fix(cli): improve scan usage and cost reports

### DIFF
--- a/plugins/codex-security/tests/test_workbench_scan_history.py
+++ b/plugins/codex-security/tests/test_workbench_scan_history.py
@@ -349,7 +349,15 @@ def test_cli_scan_history_persists_per_scan_cost(tmp_path: Path) -> None:
         "cachedInputTokens": 200,
         "cacheWriteInputTokens": 0,
         "outputTokens": 30,
-        "estimatedUsd": 0.00625,
+        "estimatedUsd": 0.00488,
+        "cacheWriteInputTokensReported": False,
+        "pricing": {
+            "source": "https://developers.openai.com/api/docs/pricing",
+            "asOf": "2026-09-09",
+            "serviceTier": "standard",
+            "context": "short",
+            "usdPerMillionTokens": {"input": 4, "cacheRead": 0.4, "cacheWrite": 5, "output": 20},
+        },
     }
     scan = create_cli_scan(state_dir, tmp_path / "results", repository, cost=cost)
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -586,6 +586,9 @@ The token summary shows uncached input, cache reads, cache writes, output,
 and total tokens. Total tokens include all input plus output; cache reads and
 writes are subsets of input, not extra tokens. When cache-write usage is missing,
 the summary shows uncached input and cache writes as unavailable.
+The final summary preserves missing-data information from a matching session log.
+If the Codex runtime converts an omitted count to zero before recording it, the
+CLI cannot distinguish that zero from reported usage.
 
 JSON results, scan history, and bulk-scan receipts record the model, tokens,
 estimated cost, and `cost.pricing`: the price source, verification date, processing

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -582,10 +582,25 @@ Interactive scans show full-screen progress; CI, redirected output, and
 diagnostics to stderr. Add `--verbose` for diagnostics. Check logs for
 sensitive information before sharing them.
 
+The token summary shows uncached input, cache reads, cache writes, output,
+and total tokens. Total tokens include all input plus output; cache reads and
+writes are subsets of input, not extra tokens. When cache-write usage is missing,
+the summary shows uncached input and cache writes as unavailable.
+
 JSON results, scan history, and bulk-scan receipts record the model, tokens,
-and estimated cost. Estimates use
-[standard API token prices](https://developers.openai.com/api/docs/models/compare),
-including cached input and cache writes, but exclude fees and surcharges.
+estimated cost, and `cost.pricing`: the price source, verification date, processing
+tier, context category, and rates in USD per million tokens. Estimates use
+[standard, short-context API prices](https://developers.openai.com/api/docs/pricing),
+including cache reads and writes. They exclude long-context and other processing
+tier adjustments, fees, and surcharges. GPT-5.5 and GPT-6 Astra are supported;
+models without known prices show an unavailable estimate.
+
+For compatibility, `cacheWriteInputTokens` remains the reported token subtotal.
+`cacheWriteInputTokensReported: false` means at least one included usage record
+did not report cache writes. Raw usage uses `cache_write_input_tokens_reported`.
+In that case, the estimate prices unclassified input at the ordinary input rate;
+it may undercount cache-write charges. Older saved records lack this distinction
+and the saved pricing basis.
 
 `--max-cost USD` stops the scan and its workers when estimated cost exceeds
 the limit, though in-flight requests can finish above it. If deep-scan

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -99,6 +99,7 @@ import {
   type JsonValue,
 } from "./config.js";
 import { formatUsd, type ScanCost } from "./cost.js";
+import { formatTokenUsage, scanCostUsage } from "./cost-model.js";
 import {
   CodexSecurityError,
   ConfigurationError,
@@ -6842,11 +6843,7 @@ async function executeScan(
         );
       }
       if (runningCost !== null) {
-        const tokens = formatTokenUsage({
-          input_tokens: runningCost.inputTokens,
-          cached_input_tokens: runningCost.cachedInputTokens,
-          output_tokens: runningCost.outputTokens,
-        });
+        const tokens = formatTokenUsage(scanCostUsage(runningCost));
         if (tokens !== null) details.push(`Tokens: ${tokens}`);
         details.push(`Cost: ${formatUsd(runningCost.estimatedUsd)}`);
       }
@@ -6914,11 +6911,7 @@ async function executeScan(
         }
         progress?.stopTimer();
         if (maxCostUsd === undefined) {
-          const tokens = formatTokenUsage({
-            input_tokens: cost.inputTokens,
-            cached_input_tokens: cost.cachedInputTokens,
-            output_tokens: cost.outputTokens,
-          });
+          const tokens = formatTokenUsage(scanCostUsage(cost));
           progress?.stage(
             `${tokens === null ? "" : `Tokens: ${tokens}. `}Estimated cost: ${formatUsd(cost.estimatedUsd)} USD.`,
           );
@@ -7670,41 +7663,15 @@ function printScanSummary(
   if (tokenSummary !== null) {
     errorOutput.write(`  ${paint("TOKENS", 1)}    ${tokenSummary}\n`);
   }
-  if (result.cost !== null) {
-    errorOutput.write(
-      `  ${paint("COST", 1)}      ${formatUsd(result.cost.estimatedUsd)}\n`,
-    );
-  }
+  errorOutput.write(
+    `  ${paint("COST", 1)}      ${result.cost === null ? "unavailable (model pricing or usage missing)" : `${formatUsd(result.cost.estimatedUsd)} (standard, short context)`}\n`,
+  );
   errorOutput.write(
     `  ${paint("RESULTS", 1)}   ${errorMessage(result.scanDir)}\n`,
   );
   if (deepScanStop?.nextStep !== undefined) {
     errorOutput.write(`\n  ${deepScanStop.nextStep}\n`);
   }
-}
-
-function formatTokenUsage(usage: unknown): string | null {
-  if (usage === null || typeof usage !== "object") return null;
-  const values = usage as Record<string, unknown>;
-  return (
-    (
-      [
-        ["input_tokens", "input"],
-        ["cached_input_tokens", "cached"],
-        ["output_tokens", "output"],
-      ] as const
-    )
-      .map(([key, label]) => {
-        const value = values[key];
-        return typeof value === "number" &&
-          Number.isSafeInteger(value) &&
-          value >= 0
-          ? `${value.toLocaleString("en-US")} ${label}`
-          : null;
-      })
-      .filter((value): value is string => value !== null)
-      .join(", ") || null
-  );
 }
 
 function componentScanEventLine(
@@ -7717,11 +7684,7 @@ function componentScanEventLine(
   }
   if (event.type !== "cost") return null;
   const cost = event.value;
-  const tokens = formatTokenUsage({
-    input_tokens: cost.inputTokens,
-    cached_input_tokens: cost.cachedInputTokens,
-    output_tokens: cost.outputTokens,
-  });
+  const tokens = formatTokenUsage(scanCostUsage(cost));
   return `codex-security: ${componentName} | ${tokens === null ? "" : `Tokens: ${tokens} | `}Cost: ${formatUsd(cost.estimatedUsd)}\n`;
 }
 

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -99,7 +99,7 @@ import {
   type JsonValue,
 } from "./config.js";
 import { formatUsd, type ScanCost } from "./cost.js";
-import { formatTokenUsage, scanCostUsage } from "./cost-model.js";
+import { formatScanCostTokens, formatTokenUsage } from "./cost-model.js";
 import {
   CodexSecurityError,
   ConfigurationError,
@@ -6843,8 +6843,7 @@ async function executeScan(
         );
       }
       if (runningCost !== null) {
-        const tokens = formatTokenUsage(scanCostUsage(runningCost));
-        if (tokens !== null) details.push(`Tokens: ${tokens}`);
+        details.push(`Tokens: ${formatScanCostTokens(runningCost)}`);
         details.push(`Cost: ${formatUsd(runningCost.estimatedUsd)}`);
       }
       return details.length === 0 ? stage : `${stage} | ${details.join(" | ")}`;
@@ -6911,9 +6910,8 @@ async function executeScan(
         }
         progress?.stopTimer();
         if (maxCostUsd === undefined) {
-          const tokens = formatTokenUsage(scanCostUsage(cost));
           progress?.stage(
-            `${tokens === null ? "" : `Tokens: ${tokens}. `}Estimated cost: ${formatUsd(cost.estimatedUsd)} USD.`,
+            `Tokens: ${formatScanCostTokens(cost)}. Estimated cost: ${formatUsd(cost.estimatedUsd)} USD.`,
           );
         } else {
           progress?.stage(
@@ -7663,9 +7661,11 @@ function printScanSummary(
   if (tokenSummary !== null) {
     errorOutput.write(`  ${paint("TOKENS", 1)}    ${tokenSummary}\n`);
   }
-  errorOutput.write(
-    `  ${paint("COST", 1)}      ${result.cost === null ? "unavailable (model pricing or usage missing)" : `${formatUsd(result.cost.estimatedUsd)} (standard, short context)`}\n`,
-  );
+  const costSummary =
+    result.cost === null
+      ? "unavailable (model pricing or usage missing)"
+      : `${formatUsd(result.cost.estimatedUsd)} (standard, short context)`;
+  errorOutput.write(`  ${paint("COST", 1)}      ${costSummary}\n`);
   errorOutput.write(
     `  ${paint("RESULTS", 1)}   ${errorMessage(result.scanDir)}\n`,
   );
@@ -7684,8 +7684,7 @@ function componentScanEventLine(
   }
   if (event.type !== "cost") return null;
   const cost = event.value;
-  const tokens = formatTokenUsage(scanCostUsage(cost));
-  return `codex-security: ${componentName} | ${tokens === null ? "" : `Tokens: ${tokens} | `}Cost: ${formatUsd(cost.estimatedUsd)}\n`;
+  return `codex-security: ${componentName} | Tokens: ${formatScanCostTokens(cost)} | Cost: ${formatUsd(cost.estimatedUsd)}\n`;
 }
 
 function protectedRootErrorMessage(

--- a/sdk/typescript/src/cost-model.ts
+++ b/sdk/typescript/src/cost-model.ts
@@ -38,11 +38,9 @@ export interface ScanTokenUsage {
 }
 
 const MODEL_PRICING_NANODOLLARS: Readonly<Record<string, ModelPricing>> = {
-  // https://developers.openai.com/api/docs/models/gpt-5.5
   // GPT-5.5 has no additional cache-write charge.
   "gpt-5.5": [5_000, 500, 5_000, 30_000],
   "gpt-5.5-2026-04-23": [5_000, 500, 5_000, 30_000],
-  // https://developers.openai.com/api/docs/pricing
   "gpt-6-astra": [10_000, 1_000, 12_500, 50_000],
   "gpt-5.6": [4_000, 400, 5_000, 20_000],
   "gpt-5.6-sol": [4_000, 400, 5_000, 20_000],
@@ -148,10 +146,7 @@ export function estimateScanCost(
   };
 }
 
-export function formatTokenUsage(
-  value: unknown,
-  formatCount = (count: number) => count.toLocaleString("en-US"),
-): string | null {
+export function formatTokenUsage(value: unknown): string | null {
   const usage = tokenUsage(value);
   if (usage === null) return null;
   const writes =
@@ -173,23 +168,19 @@ export function formatTokenUsage(
   )
     .map(
       ([count, label]) =>
-        `${count === null ? "unavailable" : formatCount(count)} ${label}`,
+        `${count === null ? "unavailable" : count.toLocaleString("en-US")} ${label}`,
     )
     .join(", ");
 }
 
-export function scanCostUsage(cost: Readonly<ScanCost>): ScanTokenUsage {
-  return {
+export function formatScanCostTokens(cost: Readonly<ScanCost>): string {
+  return formatTokenUsage({
     input_tokens: cost.inputTokens,
     cached_input_tokens: cost.cachedInputTokens,
     cache_write_input_tokens: cost.cacheWriteInputTokens,
-    ...(cost.cacheWriteInputTokensReported === false
-      ? { cache_write_input_tokens_reported: false }
-      : {}),
+    cache_write_input_tokens_reported: cost.cacheWriteInputTokensReported,
     output_tokens: cost.outputTokens,
-    reasoning_output_tokens: 0,
-    total_tokens: cost.inputTokens + cost.outputTokens,
-  };
+  })!;
 }
 
 export function formatUsd(value: number): string {

--- a/sdk/typescript/src/cost-model.ts
+++ b/sdk/typescript/src/cost-model.ts
@@ -3,8 +3,21 @@ export interface ScanCost {
   inputTokens: number;
   cachedInputTokens: number;
   cacheWriteInputTokens: number;
+  cacheWriteInputTokensReported?: boolean;
   outputTokens: number;
   estimatedUsd: number;
+  pricing?: {
+    source: string;
+    asOf: string;
+    serviceTier: "standard";
+    context: "short";
+    usdPerMillionTokens: {
+      input: number;
+      cacheRead: number;
+      cacheWrite: number;
+      output: number;
+    };
+  };
 }
 
 type ModelPricing = readonly [
@@ -18,18 +31,25 @@ export interface ScanTokenUsage {
   input_tokens: number;
   cached_input_tokens: number;
   cache_write_input_tokens: number;
+  cache_write_input_tokens_reported?: boolean;
   output_tokens: number;
   reasoning_output_tokens: number;
   total_tokens: number;
 }
 
 const MODEL_PRICING_NANODOLLARS: Readonly<Record<string, ModelPricing>> = {
-  "gpt-5.6": [5_000, 500, 6_250, 30_000],
-  "gpt-5.6-sol": [5_000, 500, 6_250, 30_000],
+  // https://developers.openai.com/api/docs/models/gpt-5.5
+  // GPT-5.5 has no additional cache-write charge.
+  "gpt-5.5": [5_000, 500, 5_000, 30_000],
+  "gpt-5.5-2026-04-23": [5_000, 500, 5_000, 30_000],
+  // https://developers.openai.com/api/docs/pricing
+  "gpt-6-astra": [10_000, 1_000, 12_500, 50_000],
+  "gpt-5.6": [4_000, 400, 5_000, 20_000],
+  "gpt-5.6-sol": [4_000, 400, 5_000, 20_000],
   "gpt-5.6-terra": [2_000, 200, 2_500, 12_000],
   "gpt-5.6-luna": [200, 20, 250, 1_200],
   // https://developers.openai.com/api/docs/pricing#cyber-models
-  "gpt-daybreak-blue-latest": [5_000, 500, 6_250, 30_000],
+  "gpt-daybreak-blue-latest": [4_000, 400, 5_000, 20_000],
   "gpt-daybreak-red-latest": [12_500, 1_250, 15_625, 75_000],
 };
 
@@ -65,6 +85,10 @@ export function tokenUsage(value: unknown): ScanTokenUsage | null {
     input_tokens: input,
     cached_input_tokens: cached,
     cache_write_input_tokens: cacheWrite,
+    ...(value["cache_write_input_tokens_reported"] === false ||
+    (canonicalCacheWrite == null && legacyCacheWrite == null)
+      ? { cache_write_input_tokens_reported: false }
+      : {}),
     output_tokens: output,
     reasoning_output_tokens: reasoning,
     total_tokens: input + output,
@@ -102,8 +126,69 @@ export function estimateScanCost(
     inputTokens,
     cachedInputTokens,
     cacheWriteInputTokens,
+    ...(normalized.cache_write_input_tokens_reported === false
+      ? { cacheWriteInputTokensReported: false }
+      : {}),
     outputTokens,
     estimatedUsd: nanodollars / 1_000_000_000,
+    pricing: {
+      source: pricingModel.startsWith("gpt-5.5")
+        ? "https://developers.openai.com/api/docs/models/gpt-5.5"
+        : "https://developers.openai.com/api/docs/pricing",
+      asOf: "2026-09-09",
+      serviceTier: "standard",
+      context: "short",
+      usdPerMillionTokens: {
+        input: inputRate / 1_000,
+        cacheRead: cachedInputRate / 1_000,
+        cacheWrite: cacheWriteInputRate / 1_000,
+        output: outputRate / 1_000,
+      },
+    },
+  };
+}
+
+export function formatTokenUsage(
+  value: unknown,
+  formatCount = (count: number) => count.toLocaleString("en-US"),
+): string | null {
+  const usage = tokenUsage(value);
+  if (usage === null) return null;
+  const writes =
+    usage.cache_write_input_tokens_reported === false
+      ? null
+      : usage.cache_write_input_tokens;
+  const uncached =
+    writes === null
+      ? null
+      : usage.input_tokens - usage.cached_input_tokens - writes;
+  return (
+    [
+      [uncached, "uncached input"],
+      [usage.cached_input_tokens, "cache reads"],
+      [writes, "cache writes"],
+      [usage.output_tokens, "output"],
+      [usage.total_tokens, "total"],
+    ] as const
+  )
+    .map(
+      ([count, label]) =>
+        `${count === null ? "unavailable" : formatCount(count)} ${label}`,
+    )
+    .join(", ");
+}
+
+export function scanCostUsage(cost: Readonly<ScanCost>): ScanTokenUsage {
+  return {
+    input_tokens: cost.inputTokens,
+    cached_input_tokens: cost.cachedInputTokens,
+    cache_write_input_tokens: cost.cacheWriteInputTokens,
+    ...(cost.cacheWriteInputTokensReported === false
+      ? { cache_write_input_tokens_reported: false }
+      : {}),
+    output_tokens: cost.outputTokens,
+    reasoning_output_tokens: 0,
+    total_tokens: cost.inputTokens + cost.outputTokens,
   };
 }
 

--- a/sdk/typescript/src/cost.ts
+++ b/sdk/typescript/src/cost.ts
@@ -300,9 +300,13 @@ export class ScanCostTracker {
         }
         this.#reportWorkerProgress(session);
       }
+      const receipt = usages.get(threadId);
       if (
         session.usage !== null &&
-        session.usage.total_tokens > (usages.get(threadId)?.total_tokens ?? -1)
+        (session.usage.total_tokens > (receipt?.total_tokens ?? -1) ||
+          // The SDK inserts zero when the final receipt omits cache writes.
+          (session.usage.total_tokens === receipt?.total_tokens &&
+            receipt.cache_write_input_tokens === 0))
       ) {
         usages.set(threadId, session.usage);
       }

--- a/sdk/typescript/src/cost.ts
+++ b/sdk/typescript/src/cost.ts
@@ -116,7 +116,7 @@ export class ScanCostTracker {
   #timer: NodeJS.Timeout | null = null;
   #pending: Promise<void> = Promise.resolve();
   #snapshot: ScanCostSnapshot = { usage: null, cost: null };
-  #lastCost: number | null = null;
+  #lastCost: string | null = null;
   #highestFilesCompleted = 0;
   #expectedFilesTotal: number | undefined;
 
@@ -362,8 +362,10 @@ export class ScanCostTracker {
   }
 
   #reportCost(cost: ScanCost | null): void {
-    if (cost === null || cost.estimatedUsd === this.#lastCost) return;
-    this.#lastCost = cost.estimatedUsd;
+    if (cost === null) return;
+    const signature = JSON.stringify(cost);
+    if (signature === this.#lastCost) return;
+    this.#lastCost = signature;
     this.#options.onCost?.(cost);
   }
 }
@@ -799,6 +801,10 @@ function addTokenUsage(
       previous.cached_input_tokens + next.cached_input_tokens,
     cache_write_input_tokens:
       previous.cache_write_input_tokens + next.cache_write_input_tokens,
+    ...(previous.cache_write_input_tokens_reported === false ||
+    next.cache_write_input_tokens_reported === false
+      ? { cache_write_input_tokens_reported: false }
+      : {}),
     output_tokens: previous.output_tokens + next.output_tokens,
     reasoning_output_tokens:
       previous.reasoning_output_tokens + next.reasoning_output_tokens,
@@ -816,6 +822,10 @@ function subtractTokenUsage(
       usage.cached_input_tokens - inherited.cached_input_tokens,
     cache_write_input_tokens:
       usage.cache_write_input_tokens - inherited.cache_write_input_tokens,
+    ...(usage.cache_write_input_tokens_reported === false ||
+    inherited.cache_write_input_tokens_reported === false
+      ? { cache_write_input_tokens_reported: false }
+      : {}),
     output_tokens: usage.output_tokens - inherited.output_tokens,
     reasoning_output_tokens:
       usage.reasoning_output_tokens - inherited.reasoning_output_tokens,

--- a/sdk/typescript/src/scan-dashboard.ts
+++ b/sdk/typescript/src/scan-dashboard.ts
@@ -9,11 +9,7 @@ import type {
   ComponentScanResult,
 } from "./component-scan.js";
 import { formatUsd, type ScanCost, type ScanSessionEvent } from "./cost.js";
-import {
-  estimateScanCost,
-  formatTokenUsage,
-  scanCostUsage,
-} from "./cost-model.js";
+import { estimateScanCost, formatScanCostTokens } from "./cost-model.js";
 import type { ScanActivity } from "./scan-activity.js";
 import type { ScanMode } from "./targets.js";
 import { scanPhaseLabel, type ScanProgress } from "./worker-progress.js";
@@ -826,7 +822,7 @@ export class ScanDashboard {
     const tokens =
       this.#cost === null
         ? "waiting for usage"
-        : formatTokenUsage(scanCostUsage(this.#cost), formatCount)!;
+        : formatScanCostTokens(this.#cost);
     return wrapActivity("  TOKENS   ", tokens, this.#width());
   }
 

--- a/sdk/typescript/src/scan-dashboard.ts
+++ b/sdk/typescript/src/scan-dashboard.ts
@@ -9,6 +9,11 @@ import type {
   ComponentScanResult,
 } from "./component-scan.js";
 import { formatUsd, type ScanCost, type ScanSessionEvent } from "./cost.js";
+import {
+  estimateScanCost,
+  formatTokenUsage,
+  scanCostUsage,
+} from "./cost-model.js";
 import type { ScanActivity } from "./scan-activity.js";
 import type { ScanMode } from "./targets.js";
 import { scanPhaseLabel, type ScanProgress } from "./worker-progress.js";
@@ -562,14 +567,15 @@ export class ScanDashboard {
       this.#files === null
         ? "waiting for inventory"
         : `${formatCount(this.#files.filesCompleted)} / ${formatCount(this.#files.filesTotal)} reviewed`;
-    const tokens =
-      this.#cost === null
-        ? "waiting for usage"
-        : `${formatCount(this.#cost.inputTokens)} in · ${formatCount(this.#cost.cachedInputTokens)} cached · ${formatCount(this.#cost.outputTokens)} out`;
     const cost =
       this.#cost === null
         ? this.#options.maxCostUsd === undefined
-          ? "waiting for usage"
+          ? estimateScanCost(this.#options.model?.model, {
+              input_tokens: 0,
+              output_tokens: 0,
+            }) === null
+            ? "unavailable (model pricing missing)"
+            : "waiting for usage"
           : `— / ${formatUsd(this.#options.maxCostUsd)}`
         : `${formatUsd(this.#cost.estimatedUsd)}${this.#options.maxCostUsd === undefined ? "" : ` / ${formatUsd(this.#options.maxCostUsd)} · ${budgetBar(this.#cost.estimatedUsd, this.#options.maxCostUsd)}`}`;
 
@@ -618,7 +624,7 @@ export class ScanDashboard {
             ...(this.#options.mode === "deep"
               ? []
               : [`  STAGE    ${this.#stage}`, `  FILES    ${files}`]),
-            `  TOKENS   ${tokens}`,
+            ...this.#tokenLines(),
             `  COST     ${cost}`,
             ...(this.#budget === null
               ? []
@@ -803,13 +809,25 @@ export class ScanDashboard {
       1,
       (this.#stream.rows ?? 24) -
         FIXED_SCREEN_ROWS -
-        (this.#budget === null ? 0 : 2) +
+        (this.#budget === null ? 0 : 2) -
+        (this.#options.presentation === "publication" ||
+        this.#options.presentation === "verification"
+          ? 0
+          : this.#tokenLines().length - 1) +
         (this.#options.presentation === "publication"
           ? 2
           : this.#options.mode === "deep"
             ? 2
             : 0),
     );
+  }
+
+  #tokenLines(): string[] {
+    const tokens =
+      this.#cost === null
+        ? "waiting for usage"
+        : formatTokenUsage(scanCostUsage(this.#cost), formatCount)!;
+    return wrapActivity("  TOKENS   ", tokens, this.#width());
   }
 
   #activityLines(width: number): DashboardActivityLine[] {

--- a/sdk/typescript/tests-ts/api-events.test.ts
+++ b/sdk/typescript/tests-ts/api-events.test.ts
@@ -108,13 +108,13 @@ describe("one-shot scan events", () => {
       model: "gpt-5.6-sol",
       finalResponse: "scan complete",
     });
-    expect(result.cost).toEqual({
+    expect(result.cost).toMatchObject({
       model: "gpt-5.6-sol",
       inputTokens: 10,
       cachedInputTokens: 2,
       cacheWriteInputTokens: 0,
       outputTokens: 3,
-      estimatedUsd: 0.000131,
+      estimatedUsd: 0.0000928,
     });
   });
 

--- a/sdk/typescript/tests-ts/api.test.ts
+++ b/sdk/typescript/tests-ts/api.test.ts
@@ -3898,6 +3898,8 @@ describe("CodexSecurity orchestration", () => {
   });
 
   const pricedModels = [
+    "gpt-5.5",
+    "gpt-6-astra",
     "gpt-5.6-terra",
     "gpt-daybreak-blue-latest",
     "gpt-daybreak-red-latest",
@@ -4183,10 +4185,10 @@ describe("CodexSecurity orchestration", () => {
     await Promise.all([mkdir(repository), mkdir(codexHome), mkdir(scanDir)]);
     const approvals = new Map<number, () => void>();
     const firstApproval = new Promise<void>((resolve) =>
-      approvals.set(0.01, resolve),
+      approvals.set(0.008, resolve),
     );
     const secondApproval = new Promise<void>((resolve) =>
-      approvals.set(0.02, resolve),
+      approvals.set(0.016, resolve),
     );
     const requests: number[] = [];
     const commands: Array<readonly string[]> = [];
@@ -4248,7 +4250,7 @@ describe("CodexSecurity orchestration", () => {
     const keepAlive = setTimeout(() => {}, 10_000);
     try {
       const result = await client.run(repository, {
-        maxCostUsd: 0.005,
+        maxCostUsd: 0.004,
         signal: AbortSignal.timeout(5_000),
         onBudgetApproaching: ({ maxCostUsd, signal }) => {
           requests.push(maxCostUsd);
@@ -4261,15 +4263,15 @@ describe("CodexSecurity orchestration", () => {
       });
       expect(result.cost).toMatchObject({
         inputTokens: 2_600,
-        estimatedUsd: 0.013,
+        estimatedUsd: 0.0104,
       });
       expect(starts).toBe(1);
-      expect(requests).toEqual([0.005, 0.01]);
+      expect(requests).toEqual([0.004, 0.008]);
       expect(
         commands
           .filter(([command]) => command === "set-scan-cost-limit")
           .map((args) => args.at(-1)),
-      ).toEqual(["0.01", "0.02"]);
+      ).toEqual(["0.008", "0.016"]);
       expect(commands.some(([command]) => command === "fail-scan")).toBe(false);
       expect(budgetSignal?.aborted).toBe(true);
     } finally {
@@ -4380,7 +4382,7 @@ describe("CodexSecurity orchestration", () => {
       const keepAlive = setTimeout(() => {}, 10_000);
       try {
         const scan = client.run(repository, {
-          maxCostUsd: 0.005,
+          maxCostUsd: 0.004,
           signal: AbortSignal.any([
             controller.signal,
             AbortSignal.timeout(5_000),
@@ -4390,9 +4392,9 @@ describe("CodexSecurity orchestration", () => {
             budgetSignal = signal;
             requested();
             if (scenario === "declined") return undefined;
-            if (scenario === "invalid") return 0.005;
+            if (scenario === "invalid") return 0.004;
             if (scenario === "save-failed" || scenario === "saving")
-              return 0.02;
+              return 0.016;
             return lateAnswer;
           },
           onCost: (cost, limit) => {
@@ -4403,20 +4405,20 @@ describe("CodexSecurity orchestration", () => {
         });
         if (scenario === "completed")
           await expect(scan).resolves.toMatchObject({
-            cost: { estimatedUsd: 0.0045 },
+            cost: { estimatedUsd: 0.0036 },
           });
         else if (scenario === "canceled")
           await expect(scan).rejects.toBeInstanceOf(ScanInterruptedError);
         else
           await expect(scan).rejects.toMatchObject({
             name: ScanCostLimitExceededError.name,
-            maxCostUsd: 0.005,
-            cost: { estimatedUsd: 0.01 },
+            maxCostUsd: 0.004,
+            cost: { estimatedUsd: 0.008 },
           });
-        answer(0.02);
+        answer(0.016);
         await new Promise((resolve) => setImmediate(resolve));
         expect(requestCount).toBe(1);
-        expect(reportedLimit).toBe(0.005);
+        expect(reportedLimit).toBe(0.004);
         expect(budgetSignal?.aborted).toBe(true);
         expect(
           commands.filter(([command]) => command === "set-scan-cost-limit"),
@@ -4445,14 +4447,11 @@ describe("CodexSecurity orchestration", () => {
     const commands: Array<readonly string[]> = [];
     const costs: number[] = [];
     let turns = 0;
-    const cost = {
-      model: "gpt-5.6-sol",
-      inputTokens: 1_250,
-      cachedInputTokens: 200,
-      cacheWriteInputTokens: 0,
-      outputTokens: 30,
-      estimatedUsd: 0.00625,
-    };
+    const cost = estimateScanCost("gpt-5.6-sol", {
+      input_tokens: 1_250,
+      cached_input_tokens: 200,
+      output_tokens: 30,
+    })!;
     const client = new TestClient(
       {},
       {
@@ -4529,14 +4528,14 @@ describe("CodexSecurity orchestration", () => {
     try {
       await expect(
         client.run(repository, {
-          maxCostUsd: 0.005,
+          maxCostUsd: 0.004,
           postScanPrompt: "Record the scan cost.",
           onCost: (cost) => costs.push(cost.estimatedUsd),
           signal: AbortSignal.timeout(5_000),
         }),
       ).rejects.toMatchObject({
         name: ScanCostLimitExceededError.name,
-        maxCostUsd: 0.005,
+        maxCostUsd: 0.004,
         scanDir,
         cost,
       });
@@ -4544,7 +4543,7 @@ describe("CodexSecurity orchestration", () => {
       clearTimeout(keepEventLoopAlive);
     }
     expect(turns).toBe(1);
-    expect(costs.at(-1)).toBe(0.00625);
+    expect(costs.at(-1)).toBe(0.00488);
     expect(commands[1]).toEqual([
       "get-scan-feedback",
       "--scan-id",
@@ -4562,7 +4561,7 @@ describe("CodexSecurity orchestration", () => {
       "--scan-id",
       "scan_example_001",
       "--message",
-      `Scan stopped: estimated cost $0.00625 exceeded the $0.005 limit; partial output remains at ${scanDir}.`,
+      `Scan stopped: estimated cost $0.00488 exceeded the $0.004 limit; partial output remains at ${scanDir}.`,
       "--cost-json",
       JSON.stringify(cost),
     ]);
@@ -4672,7 +4671,7 @@ describe("CodexSecurity orchestration", () => {
       try {
         const result = client.run(repository, {
           mode: "deep",
-          maxCostUsd: 0.005,
+          maxCostUsd: 0.004,
           postScanPrompt: "Do not spend another model turn.",
           onWarning: (warning) => warnings.push(warning),
           signal: AbortSignal.timeout(5_000),
@@ -4693,9 +4692,9 @@ describe("CodexSecurity orchestration", () => {
           expect(recovered.coverage.completeness).toBe(completion);
           expect(recovered.findings.findings).toHaveLength(1);
           expect(recovered.threadId).toBe("scan-thread");
-          expect(recovered.cost?.estimatedUsd).toBe(0.00625);
+          expect(recovered.cost?.estimatedUsd).toBe(0.00488);
           expect(warnings).toEqual([
-            `Scan stopped: estimated cost $0.00625 exceeded the $0.005 limit; partial output remains at ${scanDir}.`,
+            `Scan stopped: estimated cost $0.00488 exceeded the $0.004 limit; partial output remains at ${scanDir}.`,
           ]);
           expect(commands.some((args) => args[0] === "fail-scan")).toBe(false);
         }

--- a/sdk/typescript/tests-ts/cli-deep-scan-summary.test.ts
+++ b/sdk/typescript/tests-ts/cli-deep-scan-summary.test.ts
@@ -104,9 +104,9 @@ describe("deep scan completion summary", () => {
           throw new Error("The exceeded cost limit is already known");
         },
       },
-      ["--mode", "deep", "--max-cost", "0.005"],
+      ["--mode", "deep", "--max-cost", "0.004"],
     );
-    expect(text).toContain("Reached the $0.005 cost limit");
+    expect(text).toContain("Reached the $0.004 cost limit");
     expect(text).toContain("higher --max-cost");
     expect(text).not.toContain("--max-discovery-runs");
   });

--- a/sdk/typescript/tests-ts/cli.test.ts
+++ b/sdk/typescript/tests-ts/cli.test.ts
@@ -1990,7 +1990,7 @@ describe("CLI", () => {
         "Scan phase: reviewing files (2 workers).",
       );
       expect(stderr.text()).toContain(
-        "Running scan: reviewing files | Workers: 2/2 | Files: 3/8 | Tokens: 1,250 input, 200 cached, 30 output | Cost: $0.00625",
+        "Running scan: reviewing files | Workers: 2/2 | Files: 3/8 | Tokens: unavailable uncached input, 200 cache reads, unavailable cache writes, 30 output, 1,280 total | Cost: $0.00488",
       );
       expect(stderr.text()).not.toContain("CODEX SECURITY");
       expect(stderr.text()).not.toContain("\u001B");
@@ -2198,7 +2198,9 @@ describe("CLI", () => {
     expect(text).toContain("3 / 1,258 reviewed");
     expect(text).not.toContain("opened");
     expect(text).not.toContain("3 / 6 active");
-    expect(text).toContain("17,985 in · 10,496 cached · 236 out");
+    expect(text.replace(/\s+/gu, " ")).toContain(
+      "unavailable uncached input, 10,496 cache reads, unavailable cache writes, 236 output, 18,221 total",
+    );
     expect(text).toContain("/ $2.00");
     expect(stderr.text()).toContain("\u001B[?1049h");
     expect(stderr.text()).toContain("\u001B[?1049l");
@@ -4255,8 +4257,8 @@ describe("CLI", () => {
         "  FINDINGS  1 (1 high)",
         "  COVERAGE  complete",
         "  ELAPSED   6m 37s",
-        "  TOKENS    1,250 input, 200 cached, 30 output",
-        "  COST      $0.00625",
+        "  TOKENS    unavailable uncached input, 200 cache reads, unavailable cache writes, 30 output, 1,280 total",
+        "  COST      $0.00488 (standard, short context)",
         "  RESULTS   /tmp/scan",
       ].join("\n"),
     );
@@ -4710,12 +4712,12 @@ describe("CLI", () => {
     ).toBe(0);
     expect(JSON.parse(stdout.text())).toEqual(result.toJSON());
     expect(stderr.text()).toContain(
-      "Tokens: 1,250 input, 200 cached, 30 output. Estimated cost: $0.00625 USD.",
+      "Tokens: unavailable uncached input, 200 cache reads, unavailable cache writes, 30 output, 1,280 total. Estimated cost: $0.00488 USD.",
     );
     expect(stderr.text()).toContain("Scan phase: reviewing files (0/8 files).");
     expect(stderr.text()).toContain("Scan phase: reviewing files (3/8 files).");
     expect(stderr.text()).toContain(
-      "Running scan: reviewing files | Workers: 4/6 | Files: 3/8 | Tokens: 1,250 input, 200 cached, 30 output | Cost: $0.00625",
+      "Running scan: reviewing files | Workers: 4/6 | Files: 3/8 | Tokens: unavailable uncached input, 200 cache reads, unavailable cache writes, 30 output, 1,280 total | Cost: $0.00488",
     );
   });
 
@@ -4786,9 +4788,9 @@ describe("CLI", () => {
     expect(stderr.text()).toContain("COVERAGE  complete");
     expect(stderr.text()).toContain("ELAPSED   1s");
     expect(stderr.text()).toContain(
-      "TOKENS    1,250 input, 200 cached, 30 output",
+      "TOKENS    unavailable uncached input, 200 cache reads, unavailable cache writes, 30 output, 1,280 total",
     );
-    expect(stderr.text()).toContain("COST      $0.00625");
+    expect(stderr.text()).toContain("COST      $0.00488");
     expect(stderr.text()).toContain(`REPORT    ${result.reportPath}`);
     expect(stderr.text()).toContain("RESULTS   /tmp/scan");
     expect(stderr.text()).not.toContain("Next:");
@@ -4849,7 +4851,7 @@ describe("CLI", () => {
       ),
     ).toBe(0);
     expect(JSON.parse(stdout.text())).toEqual(result.toJSON());
-    expect(stderr.text()).toContain("Estimated cost: $0.00625 of $0.01 limit");
+    expect(stderr.text()).toContain("Estimated cost: $0.00488 of $0.01 limit");
   });
 
   test("includes cache-write tokens in verbose cost diagnostics", async () => {
@@ -4887,26 +4889,26 @@ describe("CLI", () => {
 
     expect(
       await main(
-        ["scan", ".", "--verbose", "--json", "--max-cost", "0.005"],
+        ["scan", ".", "--verbose", "--json", "--max-cost", "0.004"],
         stdout.stream,
         stderr.stream,
         dependencies({
           onTurn: (_repository, options) => {
             (options as ScanOptions).onOutputDirReady?.("/tmp/scan");
-            throw new ScanCostLimitExceededError(0.005, cost, "/tmp/scan");
+            throw new ScanCostLimitExceededError(0.004, cost, "/tmp/scan");
           },
         }),
       ),
     ).toBe(2);
     expect(stdout.text()).toBe("");
     expect(stderr.text()).toContain(
-      "Scan stopped: estimated cost $0.00625 exceeded the $0.005 limit; partial output remains at /tmp/scan.",
+      "Scan stopped: estimated cost $0.00488 exceeded the $0.004 limit; partial output remains at /tmp/scan.",
     );
     expect(stderr.text()).toMatch(
-      /scan\.configuration[^\n]*max_cost_usd=0\.005/u,
+      /scan\.configuration[^\n]*max_cost_usd=0\.004/u,
     );
     expect(stderr.text()).toContain(
-      'scan.failed classification="cost_limit_exceeded" partial_output=true max_cost_usd=0.005 estimated_usd=0.00625',
+      'scan.failed classification="cost_limit_exceeded" partial_output=true max_cost_usd=0.004 estimated_usd=0.00488',
     );
   });
 
@@ -4920,7 +4922,7 @@ describe("CLI", () => {
 
     expect(
       await main(
-        ["scan", ".", "--json", "--max-cost", "0.00625"],
+        ["scan", ".", "--json", "--max-cost", "0.00488"],
         stdout.stream,
         capture().stream,
         dependencies({ result }),

--- a/sdk/typescript/tests-ts/component-scan.test.ts
+++ b/sdk/typescript/tests-ts/component-scan.test.ts
@@ -501,7 +501,7 @@ test.each(["dashboard", "headless", "ci"])(
         "apps/api validating findings | Files: 2/2",
       );
       expect(stderr.text()).toContain(
-        "apps/api | Tokens: 100 input, 10 cached, 20 output | Cost: $0.00123",
+        "apps/api | Tokens: 90 uncached input, 10 cache reads, 0 cache writes, 20 output, 120 total | Cost: $0.00123",
       );
     }
     expect(

--- a/sdk/typescript/tests-ts/cost-model.property.test.ts
+++ b/sdk/typescript/tests-ts/cost-model.property.test.ts
@@ -4,11 +4,14 @@ import { estimateScanCost, formatUsd, tokenUsage } from "../src/cost-model.js";
 import { propertyOptions } from "./support/property.js";
 
 const rates = [
-  ["gpt-5.6", 5000n, 500n, 6250n, 30000n],
-  ["gpt-5.6-sol", 5000n, 500n, 6250n, 30000n],
+  ["gpt-5.5", 5000n, 500n, 5000n, 30000n],
+  ["gpt-5.5-2026-04-23", 5000n, 500n, 5000n, 30000n],
+  ["gpt-6-astra", 10000n, 1000n, 12500n, 50000n],
+  ["gpt-5.6", 4000n, 400n, 5000n, 20000n],
+  ["gpt-5.6-sol", 4000n, 400n, 5000n, 20000n],
   ["gpt-5.6-terra", 2000n, 200n, 2500n, 12000n],
   ["gpt-5.6-luna", 200n, 20n, 250n, 1200n],
-  ["gpt-daybreak-blue-latest", 5000n, 500n, 6250n, 30000n],
+  ["gpt-daybreak-blue-latest", 4000n, 400n, 5000n, 20000n],
   ["gpt-daybreak-red-latest", 12500n, 1250n, 15625n, 75000n],
 ] as const;
 const count = fc.integer({ min: 0, max: 1_000_000_000 });
@@ -66,7 +69,7 @@ describe("cost-model invariants", () => {
             BigInt(parts.written) * writeRate +
             BigInt(parts.output) * outputRate;
           for (const selected of [model, `openai.${model}`]) {
-            expect(estimateScanCost(selected, tokens)).toEqual({
+            expect(estimateScanCost(selected, tokens)).toMatchObject({
               model: selected,
               inputTokens: tokens.input_tokens,
               cachedInputTokens: parts.cached,
@@ -170,7 +173,7 @@ describe("cost-model invariants", () => {
       fc.property(
         fc.integer({ min: 0, max: Number.MAX_SAFE_INTEGER }),
         (input) => {
-          const nanos = BigInt(input) * 5000n;
+          const nanos = BigInt(input) * 4000n;
           const result = estimateScanCost("gpt-5.6-sol", {
             input_tokens: input,
             output_tokens: 0,

--- a/sdk/typescript/tests-ts/cost.test.ts
+++ b/sdk/typescript/tests-ts/cost.test.ts
@@ -16,6 +16,7 @@ import {
   type ScanSessionEvent,
 } from "../src/cost.js";
 import type { ScanActivity } from "../src/scan-activity.js";
+import { formatTokenUsage, tokenUsage } from "../src/cost-model.js";
 import { readScanLogs } from "../src/scan-logs.js";
 import { sessionParentThreadId } from "../src/scan-sessions.js";
 import type { ScanProgress } from "../src/worker-progress.js";
@@ -181,6 +182,65 @@ test.each([
 });
 
 describe("scan cost", () => {
+  test("shows distinct token categories without adding cached input twice", () => {
+    expect(
+      formatTokenUsage({
+        input_tokens: 120,
+        cached_input_tokens: 30,
+        cache_write_tokens: 12,
+        output_tokens: 15,
+      }),
+    ).toBe(
+      "78 uncached input, 30 cache reads, 12 cache writes, 15 output, 135 total",
+    );
+  });
+
+  test("distinguishes missing cache writes from a reported zero", () => {
+    const usage = {
+      input_tokens: 120,
+      cached_input_tokens: 30,
+      output_tokens: 15,
+    };
+    expect(formatTokenUsage(tokenUsage(usage))).toBe(
+      "unavailable uncached input, 30 cache reads, unavailable cache writes, 15 output, 135 total",
+    );
+    expect(formatTokenUsage({ ...usage, cache_write_input_tokens: 0 })).toBe(
+      "90 uncached input, 30 cache reads, 0 cache writes, 15 output, 135 total",
+    );
+    expect(estimateScanCost("gpt-6-astra", usage)).toMatchObject({
+      cacheWriteInputTokens: 0,
+      cacheWriteInputTokensReported: false,
+    });
+  });
+
+  test("includes the price source and rates with each estimate", () => {
+    const cost = estimateScanCost("gpt-6-astra", {
+      input_tokens: 1_000_000,
+      cached_input_tokens: 200_000,
+      cache_write_input_tokens: 300_000,
+      output_tokens: 100_000,
+    });
+    expect(cost).toEqual({
+      model: "gpt-6-astra",
+      inputTokens: 1_000_000,
+      cachedInputTokens: 200_000,
+      cacheWriteInputTokens: 300_000,
+      outputTokens: 100_000,
+      estimatedUsd: 13.95,
+      pricing: {
+        source: "https://developers.openai.com/api/docs/pricing",
+        asOf: "2026-09-09",
+        serviceTier: "standard",
+        context: "short",
+        usdPerMillionTokens: {
+          input: 10,
+          cacheRead: 1,
+          cacheWrite: 12.5,
+          output: 50,
+        },
+      },
+    });
+  });
   test.each([
     [{ cache_write_tokens: 15 }, 15],
     [{ cache_write_input_tokens: 0, cache_write_tokens: 15 }, 15],
@@ -233,8 +293,8 @@ describe("scan cost", () => {
   test("uses published GPT-5.6 model rates", () => {
     const usage = { input_tokens: 1_000_000, output_tokens: 1_000_000 };
 
-    expect(estimateScanCost("gpt-5.6", usage)?.estimatedUsd).toBe(35);
-    expect(estimateScanCost("gpt-5.6-sol", usage)?.estimatedUsd).toBe(35);
+    expect(estimateScanCost("gpt-5.6", usage)?.estimatedUsd).toBe(24);
+    expect(estimateScanCost("gpt-5.6-sol", usage)?.estimatedUsd).toBe(24);
     expect(estimateScanCost("gpt-5.6-terra", usage)?.estimatedUsd).toBe(14);
     expect(estimateScanCost("gpt-5.6-luna", usage)?.estimatedUsd).toBe(1.4);
   });
@@ -243,9 +303,9 @@ describe("scan cost", () => {
     const usage = { input_tokens: 1_000_000, output_tokens: 1_000_000 };
 
     for (const [model, expectedUsd] of [
-      ["openai.gpt-5.6", 35],
-      ["openai.gpt-5.6-sol", 35],
-      ["openai.gpt-daybreak-blue-latest", 35],
+      ["openai.gpt-5.6", 24],
+      ["openai.gpt-5.6-sol", 24],
+      ["openai.gpt-daybreak-blue-latest", 24],
       ["openai.gpt-daybreak-red-latest", 87.5],
       ["openai.gpt-5.6-terra", 14],
       ["openai.gpt-5.6-luna", 1.4],
@@ -261,7 +321,10 @@ describe("scan cost", () => {
 
   test("uses current input, cache, and output rates", () => {
     for (const [model, input, cached, write, output] of [
-      ["gpt-daybreak-blue-latest", 5, 0.5, 6.25, 30],
+      ["gpt-5.5", 5, 0.5, 5, 30],
+      ["gpt-5.5-2026-04-23", 5, 0.5, 5, 30],
+      ["gpt-6-astra", 10, 1, 12.5, 50],
+      ["gpt-daybreak-blue-latest", 4, 0.4, 5, 20],
       ["gpt-daybreak-red-latest", 12.5, 1.25, 15.625, 75],
       ["gpt-5.6-terra", 2, 0.2, 2.5, 12],
       ["gpt-5.6-luna", 0.2, 0.02, 0.25, 1.2],
@@ -302,13 +365,13 @@ describe("scan cost", () => {
         cached_input_tokens: 200,
         output_tokens: 30,
       }),
-    ).toEqual({
+    ).toMatchObject({
       model: "gpt-5.6-sol",
       inputTokens: 1_250,
       cachedInputTokens: 200,
       cacheWriteInputTokens: 0,
       outputTokens: 30,
-      estimatedUsd: 0.00625,
+      estimatedUsd: 0.00488,
     });
   });
 
@@ -320,7 +383,7 @@ describe("scan cost", () => {
         cache_write_input_tokens: 200,
         output_tokens: 10,
       })?.estimatedUsd,
-    ).toBe(0.0051);
+    ).toBe(0.00404);
   });
 
   test("preserves legacy cache writes after SDK normalization adds zero", () => {
@@ -332,7 +395,7 @@ describe("scan cost", () => {
         cache_write_tokens: 200,
         output_tokens: 10,
       }),
-    ).toMatchObject({ cacheWriteInputTokens: 200, estimatedUsd: 0.0051 });
+    ).toMatchObject({ cacheWriteInputTokens: 200, estimatedUsd: 0.00404 });
   });
 
   test("ignores impossible legacy cache writes while retaining canonical usage", () => {
@@ -344,7 +407,7 @@ describe("scan cost", () => {
         cache_write_tokens: 1_001,
         output_tokens: 10,
       }),
-    ).toMatchObject({ cacheWriteInputTokens: 0, estimatedUsd: 0.00485 });
+    ).toMatchObject({ cacheWriteInputTokens: 0, estimatedUsd: 0.00384 });
   });
 
   test("does not double-charge reasoning tokens included in output", () => {
@@ -354,7 +417,7 @@ describe("scan cost", () => {
         output_tokens: 10,
         reasoning_output_tokens: 9,
       })?.estimatedUsd,
-    ).toBe(0.0053);
+    ).toBe(0.0042);
   });
 
   test("does not invent prices for unknown models or incomplete usage", () => {
@@ -382,6 +445,69 @@ describe("scan cost", () => {
 });
 
 describe("live scan cost tracking", () => {
+  test("retains reported write charges when another worker omits cache writes", async () => {
+    const home = await codexHome();
+    await writeSession(home, "scan-thread", {
+      input_tokens: 100,
+      cached_input_tokens: 20,
+      output_tokens: 10,
+    });
+    await writeSession(
+      home,
+      "worker-thread",
+      {
+        input_tokens: 200,
+        cached_input_tokens: 40,
+        cache_write_input_tokens: 50,
+        output_tokens: 20,
+      },
+      "scan-thread",
+    );
+    const tracker = new ScanCostTracker({
+      codexHome: home,
+      model: "gpt-6-astra",
+    });
+    tracker.start("scan-thread");
+    const snapshot = await tracker.stop();
+    expect(snapshot.usage).toMatchObject({
+      input_tokens: 300,
+      cache_write_input_tokens: 50,
+      cache_write_input_tokens_reported: false,
+      total_tokens: 330,
+    });
+    expect(snapshot.cost).toMatchObject({
+      cacheWriteInputTokens: 50,
+      cacheWriteInputTokensReported: false,
+      estimatedUsd: 0.004085,
+    });
+    expect(formatTokenUsage(snapshot.usage)).toContain(
+      "unavailable cache writes",
+    );
+  });
+
+  test("reports newly available cache writes even when the dollar amount is unchanged", async () => {
+    const home = await codexHome();
+    const updates: unknown[] = [];
+    const tracker = new ScanCostTracker({
+      codexHome: home,
+      model: "gpt-5.5",
+      onCost: (cost) => updates.push(cost),
+    });
+    tracker.start("scan-thread");
+    tracker.recordUsage(
+      { input_tokens: 100, output_tokens: 10 },
+      "scan-thread",
+    );
+    await tracker.refresh();
+    tracker.recordUsage(
+      { input_tokens: 100, cache_write_input_tokens: 0, output_tokens: 10 },
+      "scan-thread",
+    );
+    await tracker.stop();
+    expect(updates).toHaveLength(2);
+    expect(updates[0]).toHaveProperty("cacheWriteInputTokensReported", false);
+    expect(updates[1]).not.toHaveProperty("cacheWriteInputTokensReported");
+  });
   test("coalesces overlapping polling ticks and bounds final work", async () => {
     const home = await codexHome();
     await writeSession(home, "scan-thread", {
@@ -473,13 +599,13 @@ describe("live scan cost tracking", () => {
     tracker.start("scan-thread");
 
     try {
-      await expect(reportedCost).resolves.toEqual({
+      await expect(reportedCost).resolves.toMatchObject({
         model: "gpt-5.6-sol",
         inputTokens: 1_250,
         cachedInputTokens: 200,
         cacheWriteInputTokens: 0,
         outputTokens: 30,
-        estimatedUsd: 0.00625,
+        estimatedUsd: 0.00488,
       });
     } finally {
       await tracker.stop();
@@ -529,7 +655,7 @@ describe("live scan cost tracking", () => {
     await tracker.refresh();
     await tracker.refresh();
 
-    expect(await tracker.stop()).toEqual({
+    expect(await tracker.stop()).toMatchObject({
       usage: {
         input_tokens: 1_250,
         cached_input_tokens: 150,
@@ -544,7 +670,7 @@ describe("live scan cost tracking", () => {
         cachedInputTokens: 150,
         cacheWriteInputTokens: 200,
         outputTokens: 15,
-        estimatedUsd: 0.006275,
+        estimatedUsd: 0.00496,
       },
     });
     expect(
@@ -883,7 +1009,7 @@ describe("live scan cost tracking", () => {
         input_tokens: 1_250,
         output_tokens: 12,
       });
-      expect(snapshot.cost?.estimatedUsd).toBe(0.00661);
+      expect(snapshot.cost?.estimatedUsd).toBe(0.00524);
       const included = [
         ...new Set(events.map(({ threadId }) => threadId)),
       ].sort();
@@ -1068,7 +1194,7 @@ describe("live scan cost tracking", () => {
       });
       tracker.start("scan-thread");
 
-      expect(await tracker.stop()).toEqual({
+      expect(await tracker.stop()).toMatchObject({
         usage: {
           input_tokens: 1_300,
           cached_input_tokens: 650,
@@ -1156,9 +1282,9 @@ describe("live scan cost tracking", () => {
       trackedUsage: tracked.usage,
       estimatedUsd: tracked.cost?.estimatedUsd,
       python,
-    }).toEqual({
+    }).toMatchObject({
       trackedUsage: ownedSdkUsage,
-      estimatedUsd: 0.0008,
+      estimatedUsd: 0.0006,
       python: {
         usage: ownedPythonUsage,
         warnings: [],
@@ -1957,7 +2083,7 @@ describe("live scan cost tracking", () => {
     });
     await appendFile(path, `${latest}\n${latest}\n`);
 
-    expect((await tracker.stop()).cost).toEqual({
+    expect((await tracker.stop()).cost).toMatchObject({
       model: "gpt-5.6-terra",
       inputTokens: 250,
       cachedInputTokens: 0,
@@ -2049,7 +2175,7 @@ describe("live scan cost tracking", () => {
 
     await tracker.stop();
 
-    expect(updates).toEqual([0.00625]);
+    expect(updates).toEqual([0.00488]);
   });
 
   test.each([undefined, 100, 1_000, 1_500])(
@@ -2093,7 +2219,7 @@ describe("live scan cost tracking", () => {
     const usage = { input_tokens: 1_000, output_tokens: 20 };
     tracker.start("scan-thread");
 
-    expect(await tracker.stop(usage)).toEqual({
+    expect(await tracker.stop(usage)).toMatchObject({
       usage: {
         ...usage,
         cached_input_tokens: 0,

--- a/sdk/typescript/tests-ts/cost.test.ts
+++ b/sdk/typescript/tests-ts/cost.test.ts
@@ -290,74 +290,6 @@ describe("scan cost", () => {
     },
   );
 
-  test("uses published GPT-5.6 model rates", () => {
-    const usage = { input_tokens: 1_000_000, output_tokens: 1_000_000 };
-
-    expect(estimateScanCost("gpt-5.6", usage)?.estimatedUsd).toBe(24);
-    expect(estimateScanCost("gpt-5.6-sol", usage)?.estimatedUsd).toBe(24);
-    expect(estimateScanCost("gpt-5.6-terra", usage)?.estimatedUsd).toBe(14);
-    expect(estimateScanCost("gpt-5.6-luna", usage)?.estimatedUsd).toBe(1.4);
-  });
-
-  test("uses canonical OpenAI pricing for Amazon Bedrock model identifiers", () => {
-    const usage = { input_tokens: 1_000_000, output_tokens: 1_000_000 };
-
-    for (const [model, expectedUsd] of [
-      ["openai.gpt-5.6", 24],
-      ["openai.gpt-5.6-sol", 24],
-      ["openai.gpt-daybreak-blue-latest", 24],
-      ["openai.gpt-daybreak-red-latest", 87.5],
-      ["openai.gpt-5.6-terra", 14],
-      ["openai.gpt-5.6-luna", 1.4],
-    ] as const) {
-      expect(estimateScanCost(model, usage)).toMatchObject({
-        model,
-        estimatedUsd: expectedUsd,
-      });
-    }
-
-    expect(estimateScanCost("openai.unknown-model", usage)).toBeNull();
-  });
-
-  test("uses current input, cache, and output rates", () => {
-    for (const [model, input, cached, write, output] of [
-      ["gpt-5.5", 5, 0.5, 5, 30],
-      ["gpt-5.5-2026-04-23", 5, 0.5, 5, 30],
-      ["gpt-6-astra", 10, 1, 12.5, 50],
-      ["gpt-daybreak-blue-latest", 4, 0.4, 5, 20],
-      ["gpt-daybreak-red-latest", 12.5, 1.25, 15.625, 75],
-      ["gpt-5.6-terra", 2, 0.2, 2.5, 12],
-      ["gpt-5.6-luna", 0.2, 0.02, 0.25, 1.2],
-    ] as const) {
-      expect(
-        estimateScanCost(model, {
-          input_tokens: 1_000_000,
-          output_tokens: 0,
-        })?.estimatedUsd,
-      ).toBe(input);
-      expect(
-        estimateScanCost(model, {
-          input_tokens: 1_000_000,
-          cached_input_tokens: 1_000_000,
-          output_tokens: 0,
-        })?.estimatedUsd,
-      ).toBe(cached);
-      expect(
-        estimateScanCost(model, {
-          input_tokens: 1_000_000,
-          cache_write_input_tokens: 1_000_000,
-          output_tokens: 0,
-        })?.estimatedUsd,
-      ).toBe(write);
-      expect(
-        estimateScanCost(model, {
-          input_tokens: 0,
-          output_tokens: 1_000_000,
-        })?.estimatedUsd,
-      ).toBe(output);
-    }
-  });
-
   test("charges cached input at its discounted rate", () => {
     expect(
       estimateScanCost("gpt-5.6-sol", {
@@ -423,6 +355,7 @@ describe("scan cost", () => {
   test("does not invent prices for unknown models or incomplete usage", () => {
     for (const [model, usage] of [
       ["unknown-model", { input_tokens: 1, output_tokens: 1 }],
+      ["openai.unknown-model", { input_tokens: 1, output_tokens: 1 }],
       ["gpt-5.6-sol", null],
       ["gpt-5.6-sol", {}],
       ["gpt-5.6-sol", { input_tokens: -1, output_tokens: 1 }],

--- a/sdk/typescript/tests-ts/cost.test.ts
+++ b/sdk/typescript/tests-ts/cost.test.ts
@@ -9,6 +9,7 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, parse, sep } from "node:path";
+import { Codex } from "@openai/codex-sdk";
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   estimateScanCost,
@@ -378,6 +379,67 @@ describe("scan cost", () => {
 });
 
 describe("live scan cost tracking", () => {
+  test.each([
+    [undefined, undefined],
+    [0, 0],
+    [12, undefined],
+    [undefined, 12],
+  ] as const)(
+    "preserves cache-write usage through SDK normalization: log %p, receipt %p",
+    async (writes, receiptWrites) => {
+      const home = await codexHome();
+      const usage = {
+        input_tokens: 120,
+        cached_input_tokens: 30,
+        output_tokens: 15,
+        ...(writes === undefined ? {} : { cache_write_input_tokens: writes }),
+      };
+      await writeSession(home, "scan-thread", usage);
+      const thread = new Codex({
+        codexPathOverride: process.execPath,
+      }).startThread();
+      const executable = thread as unknown as {
+        _exec: { run(): AsyncGenerator<string> };
+      };
+      executable._exec.run = async function* () {
+        yield JSON.stringify({
+          type: "thread.started",
+          thread_id: "scan-thread",
+        });
+        yield JSON.stringify({
+          type: "turn.completed",
+          usage: { ...usage, cache_write_input_tokens: receiptWrites },
+        });
+      };
+      const receipt = (await thread.run("Scan the repository.")).usage;
+      expect(receipt?.cache_write_input_tokens).toBe(receiptWrites ?? 0);
+      const tracker = new ScanCostTracker({
+        codexHome: home,
+        model: "gpt-6-astra",
+      });
+      tracker.start("scan-thread");
+      const running = await tracker.refresh();
+      const completed = await tracker.stop(receipt);
+
+      expect(formatTokenUsage(running.usage)).toContain(
+        `${writes ?? "unavailable"} cache writes`,
+      );
+      const expectedWrites = receiptWrites ?? writes;
+      expect(completed.cost).toMatchObject({
+        inputTokens: 120,
+        cachedInputTokens: 30,
+        cacheWriteInputTokens: expectedWrites ?? 0,
+        outputTokens: 15,
+      });
+      expect(completed.cost?.cacheWriteInputTokensReported).toBe(
+        expectedWrites === undefined ? false : undefined,
+      );
+      expect(formatTokenUsage(completed.usage)).toContain(
+        `${expectedWrites ?? "unavailable"} cache writes`,
+      );
+    },
+  );
+
   test("retains reported write charges when another worker omits cache writes", async () => {
     const home = await codexHome();
     await writeSession(home, "scan-thread", {

--- a/sdk/typescript/tests-ts/result.test.ts
+++ b/sdk/typescript/tests-ts/result.test.ts
@@ -100,7 +100,7 @@ describe("ScanResult", () => {
       },
     });
 
-    expect(result.cost?.estimatedUsd).toBe(0.00625);
+    expect(result.cost?.estimatedUsd).toBe(0.00488);
     expect(result.toJSON()["cost"]).toEqual(result.cost);
   });
 

--- a/sdk/typescript/tests-ts/scan-dashboard.test.ts
+++ b/sdk/typescript/tests-ts/scan-dashboard.test.ts
@@ -567,7 +567,9 @@ describe("live scan dashboard", () => {
     expect(text).toContain("0 / 1,258 reviewed");
     expect(text).not.toContain("opened");
     expect(text).not.toContain("3 / 6 active");
-    expect(text).toContain("17,985 in · 10,496 cached · 236 out");
+    expect(text.replace(/\s+/gu, " ")).toContain(
+      "unavailable uncached input, 10,496 cache reads, unavailable cache writes, 236 output, 18,221 total",
+    );
     expect(text).toContain("/ $2.00");
     expect(stderr.text()).toContain("\u001B[?1049h");
     expect(stderr.text()).toContain("\u001B[?1049l");
@@ -620,7 +622,7 @@ describe("live scan dashboard", () => {
     expect(frame).not.toContain("FILES");
     expect(frame).not.toContain("inspecting repository files");
     expect(frame).not.toContain("0 / 1,258 reviewed");
-    expect(frame).toContain("worker 1 · Reviewed source file 1");
+    expect(frame).toContain("worker 1 · Reviewed source file 2");
     expect(frame).toContain("worker 1 · Reviewed source file 6");
     expect(frame).toContain("TOKENS");
     expect(frame).toContain("COST");


### PR DESCRIPTION
## Summary

Scan summaries omitted cache-write and total token counts. Missing cache-write usage appeared as zero, and some model prices were missing or outdated. This change shows the full token breakdown and records the prices used for each estimate.

## Changes

- Show uncached input, cache reads, cache writes, output, and total tokens. Mark missing cache-write counts and the derived uncached count as unavailable.
- Add GPT-5.5 and GPT-6 Astra prices. Update GPT-5.6, Sol, and Daybreak Blue prices. Show unavailable cost when prices or usage are missing.
- Save the price source, date, tier, context category, and rates with each estimate. Preserve known cache-write charges when other workers omit that data.
- Keep cache-write data from matching session logs when the completion receipt contains a default zero.
- Wrap longer dashboard summaries and document the estimate limits.

## Testing

- TypeScript full suite: 2,423 passed, 43 skipped, 0 failed, with isolated test state.
- The seeded full run hit one timeout in the unchanged 4,096-file copy test. That test passed on its own on retry.
- Focused accounting, SDK event, CLI, and dashboard tests: 344 passed, including four cases through the real SDK parser.
- Scan-history Python tests: 26 passed.
- Type checks and formatting checks passed.
- Plugin Ruff checks, Ruff format checks, and portable source checks passed.
- Git whitespace check passed.

## Risk and rollout

The added result fields are optional for compatibility with older saved results. Estimates use standard short-context prices. Missing cache-write data can understate cost. Updated prices also change when existing cost limits stop a scan. If the Codex runtime converts omitted cache-write counts to zero before logging them, the CLI cannot recover that distinction.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
