### PR TITLE
fix(scan): accept a UTF-8 byte order mark in imported findings JSON

### DIFF
--- a/sdk/typescript/src/findings-import.ts
+++ b/sdk/typescript/src/findings-import.ts
@@ -116,7 +116,9 @@ export async function parseImportedFindings(
 
   let payload: unknown;
   try {
-    payload = JSON.parse(source);
+    // Exported findings files often start with a UTF-8 byte order mark, which
+    // the CSV parser already skips.
+    payload = JSON.parse(source.replace(/^\uFEFF/u, ""));
   } catch (error) {
     throw new CodexSecurityError("Findings JSON could not be parsed.", {
       cause: error,

--- a/sdk/typescript/tests-ts/findings-import.test.ts
+++ b/sdk/typescript/tests-ts/findings-import.test.ts
@@ -8,6 +8,14 @@ import {
 import type { Finding, FindingsDocument } from "../src/models.js";
 import { PLUGIN_ROOT } from "./plugin-root.js";
 
+const BYTE_ORDER_MARK = "\uFEFF";
+const CSV_SOURCE =
+  "occurrence_id,finding_id,title,summary,severity,confidence,status," +
+  "close_reason,note,remediation,path,start_line,end_line\r\n" +
+  "occ_000000000000000000000001,csf_000000000000000000000001," +
+  "Reported CSV import issue,Reported summary,high,high,open,,," +
+  "Validate archive entry destinations.,src/extract.ts,41,44\r\n";
+
 async function sourceDocument(): Promise<FindingsDocument> {
   return JSON.parse(
     await readFile(
@@ -35,6 +43,24 @@ describe("findings import formats", () => {
     expect(
       await parseImportedFindings('{"findings":[]}', "json", PLUGIN_ROOT),
     ).toEqual([]);
+  });
+
+  test("accepts a UTF-8 byte order mark in either import format", async () => {
+    const document = await sourceDocument();
+    expect(
+      await parseImportedFindings(
+        `${BYTE_ORDER_MARK}${JSON.stringify(document)}`,
+        "json",
+        PLUGIN_ROOT,
+      ),
+    ).toEqual(document.findings);
+    const csv = await parseImportedFindings(
+      `${BYTE_ORDER_MARK}${CSV_SOURCE}`,
+      "csv",
+      PLUGIN_ROOT,
+    );
+    expect(csv).toHaveLength(1);
+    expect(csv[0]!.title).toBe("Reported CSV import issue");
   });
 
   test("binds separate source occurrences and retains source metadata without following report paths", async () => {


### PR DESCRIPTION
## Summary

`codex-security scan import --json FILE` fails on a findings document whose file
starts with a UTF-8 byte order mark, even though the document itself is valid:

```
$ codex-security scan import --json findings-with-bom.json --dry-run
codex-security: Findings JSON could not be parsed.
```

The same command's CSV branch accepts the identical mark, because the CSV parser
skips it. So the same export, written by a tool that emits a byte order mark,
imports as CSV and is rejected as JSON. The error text also points at the wrong
thing: the JSON parses fine once the mark is removed.

Reproduced against `main` with the bundled mock scan on Windows:

```
codex-security scan ../demo --mock --headless
codex-security export --export-format json --output rt.json
node -e "const fs=require('node:fs');fs.writeFileSync('bom.json',Buffer.concat([Buffer.from([0xEF,0xBB,0xBF]),fs.readFileSync('rt.json')]))"
codex-security scan import --json bom.json --dry-run   # before: Findings JSON could not be parsed.
codex-security scan import --csv  bom.csv  --dry-run   # before: findingCount: 12
```

After the change the JSON invocation reports `findingCount: 12`, matching CSV.

## Changes

- `parseImportedFindings` skips a single leading U+FEFF before `JSON.parse`.
  Only the text handed to the parser changes; the retained source bytes,
  the `artifacts/import/source.json` copy, and the digest that names the
  retained import directory are all still the original file bytes.
- Regression test covering both import formats with a leading byte order mark.

## Testing

Run from `sdk/typescript`.

Before the change, the new test fails:

```
$ bun test --timeout 30000 ./tests-ts/findings-import.test.ts
CodexSecurityError: Findings JSON could not be parsed.
      at parseImportedFindings (.../src/findings-import.ts:121:11)
SyntaxError: JSON Parse error: Unrecognized token '<U+FEFF>'
(fail) findings import formats > accepts a UTF-8 byte order mark in either import format
 3 pass
 1 fail
```

After the change:

```
$ bun test --timeout 30000 ./tests-ts/findings-import.test.ts
 4 pass
 0 fail
 20 expect() calls
```

Wider run of the import, export and publish suites, same command before and
after the change:

```
$ bun test --timeout 60000 ./tests-ts/findings-import.test.ts ./tests-ts/import-scan.test.ts \
    ./tests-ts/cli-scan-import.test.ts ./tests-ts/cloud-publish.test.ts ./tests-ts/cli-export.test.ts
before: 86 pass, 4 skip, 6 fail
after:  87 pass, 4 skip, 6 fail
```

The six failures are identical before and after and are local environment
limits on this Windows host, not related to this change: five need
`symlink()`, which needs elevation or Developer Mode, and one asserts on
credential-home ACL ancestry.

Also run: `pnpm run format` (clean) and `tsc --noEmit` (clean).

## Risk and rollout

Behavior change is limited to JSON input that previously always failed, so no
input that used to import can import differently. Bytes written to the retained
import directory and to the scan's `artifacts/import/` copy are untouched, so
the import digest and provenance are unchanged. A byte order mark anywhere other
than the first character is still a parse error. No public CLI surface changes.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
