### PR TITLE
fix(scan): include CommonJS and TypeScript module extensions in scan inventories

### DIFF
--- a/plugins/codex-security/scripts/rank_preview.py
+++ b/plugins/codex-security/scripts/rank_preview.py
@@ -17,10 +17,12 @@ TEXT_CODE_EXTENSIONS = {
     ".c",
     ".cc",
     ".cfg",
+    ".cjs",
     ".clj",
     ".cpp",
     ".cs",
     ".css",
+    ".cts",
     ".cue",
     ".cxx",
     ".dart",
@@ -41,6 +43,7 @@ TEXT_CODE_EXTENSIONS = {
     ".lua",
     ".mjs",
     ".mm",
+    ".mts",
     ".php",
     ".proto",
     ".ps1",
@@ -62,7 +65,7 @@ TEXT_CODE_EXTENSIONS = {
     ".yml",
 }
 
-JAVASCRIPT_EXTENSIONS = {".js", ".jsx", ".mjs", ".ts", ".tsx", ".vue"}
+JAVASCRIPT_EXTENSIONS = {".cjs", ".cts", ".js", ".jsx", ".mjs", ".mts", ".ts", ".tsx", ".vue"}
 JAVA_LIKE_EXTENSIONS = {".c", ".cc", ".cpp", ".cs", ".cxx", ".h", ".hpp", ".java", ".mm"}
 BRACE_LANGUAGE_EXTENSIONS = {
     *JAVASCRIPT_EXTENSIONS,

--- a/plugins/codex-security/tests/test_generate_in_scope_files.py
+++ b/plugins/codex-security/tests/test_generate_in_scope_files.py
@@ -380,6 +380,44 @@ def test_diff_inventory_keeps_changed_and_deleted_source_files(tmp_path: Path) -
     ]
 
 
+def test_diff_inventory_keeps_every_javascript_module_extension(tmp_path: Path) -> None:
+    repository = make_repository(tmp_path)
+    git(repository, "add", ".")
+    git(repository, "commit", "-qm", "base")
+    base = git(repository, "rev-parse", "HEAD")
+
+    for name in (
+        "app/loader.cjs",
+        "app/loader.mjs",
+        "app/loader.js",
+        "app/types.cts",
+        "app/types.mts",
+        "app/types.ts",
+    ):
+        write_file(repository, name, b"export const handler = 1;\n")
+    git(repository, "add", ".")
+    git(repository, "commit", "-qm", "change")
+    head = git(repository, "rev-parse", "HEAD")
+    output = tmp_path / "in_scope_files.txt"
+
+    result = run_inventory(
+        repository,
+        ".",
+        output,
+        arguments=["--diff-base", base, "--diff-head", head],
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output.read_text(encoding="utf-8").splitlines() == [
+        "app/loader.cjs",
+        "app/loader.js",
+        "app/loader.mjs",
+        "app/types.cts",
+        "app/types.mts",
+        "app/types.ts",
+    ]
+
+
 def test_diff_inventory_combines_staged_and_unstaged_changes(tmp_path: Path) -> None:
     repository = make_repository(tmp_path)
     git(repository, "add", ".")


### PR DESCRIPTION
## Summary

A diff scan of a commit that only changes `.cjs`, `.cts` or `.mts` files reviews
nothing. `generate_in_scope_files.py --diff-base ...` builds the changed-file
inventory by filtering on `TEXT_CODE_EXTENSIONS`, which already lists `.js`,
`.jsx`, `.mjs`, `.ts` and `.tsx` but not the three CommonJS/TypeScript module
extensions. Files with those names are dropped from the inventory silently, and
the diff-scan skill drives its review from exactly that list
(`prepare_codex_security_review_items` runs the same helper), so nothing reports
them as skipped.

Reproduced on `main` with a synthetic repository whose second commit adds five
JavaScript/TypeScript files, one of which contains an obvious command-injection
pattern:

```
$ git log --stat -1 --name-only --format=
helper.cts
helper.mjs
helper.mts
helper.ts
tool.cjs

$ python plugins/codex-security/scripts/generate_in_scope_files.py \
    --repo /tmp/diffrepo --scope . --out /tmp/inv.txt --diff-base HEAD~1
Recorded 2 in-scope files.
$ cat /tmp/inv.txt
helper.mjs
helper.ts
```

`tool.cjs`, which is the file holding
`require("child_process").execSync(process.argv[2])`, is not in the list.

The same constant also gates the repository rank input
(`generate_rank_input.py`), so files with these extensions were left out of
ranking for non-diff scans as well.

## Changes

- Add `.cjs`, `.cts` and `.mts` to `TEXT_CODE_EXTENSIONS`.
- Add the same three to `JAVASCRIPT_EXTENSIONS` so previews, comment/string
  masking and structural outlines use the JavaScript rules already applied to
  `.mjs` and `.ts` rather than the generic fallback. `BRACE_LANGUAGE_EXTENSIONS`
  picks them up through its existing spread.
- Regression test asserting the diff inventory keeps all six JavaScript and
  TypeScript module spellings.

## Testing

Before the change, the new test fails:

```
$ python -m pytest plugins/codex-security/tests/test_generate_in_scope_files.py -q -k javascript_module
E       AssertionError: assert ['app/loader....app/types.ts'] == ['app/loader....app/types.ts']
E         At index 0 diff: 'app/loader.js' != 'app/loader.cjs'
E         Right contains 3 more items, first extra item: 'app/types.cts'
1 failed, 23 deselected
```

After the change:

```
$ python -m pytest plugins/codex-security/tests/test_generate_in_scope_files.py -q -k javascript_module
1 passed, 23 deselected
```

Same command over the inventory, rank-input and preview suites, before and after
the change:

```
$ python -m pytest plugins/codex-security/tests/test_generate_in_scope_files.py \
    plugins/codex-security/tests/test_generate_rank_input.py \
    plugins/codex-security/tests/test_rank_preview.py \
    plugins/codex-security/tests/test_finding_preview.py -q
before: 13 failed, 127 passed, 4 skipped
after:  13 failed, 128 passed, 4 skipped
```

The thirteen failures are identical before and after and are local environment
limits on this Windows host: eight need `rg` on `PATH`, and five need
`symlink()`, which requires elevation or Developer Mode.

Portable source checks from `AGENTS.md`, all clean after the change:

```
python -m ruff check  --config plugins/codex-security/pyproject.toml plugins/codex-security   # All checks passed!
python -m ruff format --check --config plugins/codex-security/pyproject.toml plugins/codex-security   # 137 files already formatted
pnpm --dir sdk/typescript run build:ci
node .github/scripts/check_plugin_source_compatibility.mjs   # Plugin source compatibility checks passed.
node --test .github/scripts/test_check_plugin_source_compatibility.mjs   # 8 pass, 0 fail, 1 skip
```

Re-running the reproduction above after the change records all five files:

```
Recorded 5 in-scope files.
helper.cts
helper.mjs
helper.mts
helper.ts
tool.cjs
```

## Risk and rollout

Additive only: three extensions join a set that is used to decide which files
are eligible for review, so scans see strictly more source than before and no
previously reviewed file changes classification. Diff scans over repositories
that use these extensions will now list more changed files, which is the point.
Adding them to `JAVASCRIPT_EXTENSIONS` only affects how their previews are
summarized; no other extension's behavior changes. No public CLI surface change.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
