### PR TITLE
fix(config): reject owned plugin keys inside Codex profiles

### DIFF
--- a/sdk/typescript/src/config.ts
+++ b/sdk/typescript/src/config.ts
@@ -322,6 +322,11 @@ function validateOverrides(overrides: JsonObject): void {
         `Codex override profile ${name} must be a TOML table.`,
       );
     }
+    if ("plugins" in profile || "marketplaces" in profile) {
+      throw new ConfigurationError(
+        `Codex Security owns plugin loading configuration in profile ${name}.`,
+      );
+    }
     const profileFeatures = profile["features"];
     if (profileFeatures !== undefined && !isObject(profileFeatures)) {
       throw new ConfigurationError(

--- a/sdk/typescript/tests-ts/config.test.ts
+++ b/sdk/typescript/tests-ts/config.test.ts
@@ -748,6 +748,16 @@ describe("Codex configuration", () => {
         },
       }),
     ).rejects.toThrow("owns plugin loading configuration");
+    for (const owned of ["plugins", "marketplaces"] as const) {
+      await expect(
+        mergedCodexConfig({
+          codexOverrides: {
+            profile: "disabled",
+            profiles: { disabled: { [owned]: {} } },
+          },
+        }),
+      ).rejects.toThrow("owns plugin loading configuration");
+    }
     await expect(
       mergedCodexConfig({
         codexOverrides: {


### PR DESCRIPTION
## Summary

Codex override validation refuses `plugins` and `marketplaces` at the top level
and `features.plugins` both at the top level and inside a profile, but accepts a
`plugins` or `marketplaces` table inside a profile. The same key is therefore
rejected in one spelling and silently accepted in another:

```
$ codex-security scan . --dry-run --codex 'plugins={}'
codex-security: Codex Security owns plugin loading configuration.

$ codex-security scan . --dry-run --codex 'marketplaces={}'
codex-security: Codex Security owns plugin loading configuration.

$ codex-security scan . --dry-run --codex 'profile="x"' --codex 'profiles.x.features.plugins={}'
codex-security: Codex Security owns plugin loading configuration in profile x.

$ codex-security scan . --dry-run --codex 'profile="x"' --codex 'profiles.x.plugins={}'
model: gpt-5.6-sol            # accepted
$ codex-security scan . --dry-run --codex 'profile="x"' --codex 'profiles.x.marketplaces={}'
model: gpt-5.6-sol            # accepted
```

The accepted table is not inert. `writeCodexConfig` puts it in the Codex
`config.toml` under the selected profile, and `resolveCodexProfile` — which
`policyCodexConfig` uses — promotes it to exactly the top-level key the
validator refuses. Measured against `main` with
`{ profile: "custom", profiles: { custom: { plugins: { example: { enabled: true } } } } }`:

```
resolveCodexProfile(await mergedCodexConfig(...))["plugins"]
  -> {"example":{"enabled":true}}

writeCodexConfig(...) config.toml lines matching /plugin/i
  -> ["plugins = true", "[profiles.custom.plugins.example]"]
```

So the setting Codex Security means to own is reachable by moving it one table
deeper, with no diagnostic.

## Changes

- `validateOverrides` applies its existing profile message to a `plugins` or
  `marketplaces` table in each profile, matching the checks already made at the
  top level and for `features.plugins` in a profile.
- Extend the existing owned-key test to cover both keys inside a profile.

## Testing

Run from `sdk/typescript`.

Before the change, the extended test fails:

```
$ bun test --timeout 30000 ./tests-ts/config.test.ts
Expected promise that rejects
Received promise that resolved: Promise { <resolved> }
      at <anonymous> (.../tests-ts/config.test.ts:759:17)
(fail) Codex configuration > rejects owned plugin keys and incompatible v2 overrides
 21 pass, 1 skip, 4 fail
```

After the change, the file matches its baseline:

```
$ bun test --timeout 30000 ./tests-ts/config.test.ts
 22 pass, 1 skip, 3 fail       # unmodified main: 22 pass, 1 skip, 3 fail
```

The three failures are identical on unmodified `main` and are local environment
limits on this Windows host (credential-home ACL ancestry and the pinned Codex
CLI permission check).

Command-line behavior after the change, with a profile that sets an ordinary key
still working:

```
$ codex-security scan . --dry-run --codex 'profile="x"' --codex 'profiles.x.plugins={}'
codex-security: Codex Security owns plugin loading configuration in profile x.
$ codex-security scan . --dry-run --codex 'profile="x"' --codex 'profiles.x.marketplaces={}'
codex-security: Codex Security owns plugin loading configuration in profile x.
$ codex-security scan . --dry-run --codex 'profile="x"' --codex 'profiles.x.model="gpt-5.6-terra"'
model: gpt-5.6-terra
```

Also run: `pnpm run format` (clean) and `tsc --noEmit` (clean).

## Risk and rollout

The rejected input is the same input the validator already rejects at the top
level, in the same two keys, with the message the profile branch already uses.
Overrides reach this function from `--codex`, the SDK `codexOverrides` option
and a saved scan recipe replayed by `scans rerun`; the ambient Codex
configuration is not validated here, so an existing profile in a user's own
`~/.codex/config.toml` is unaffected. Every other profile key, including model,
reasoning effort, provider and approval policy, keeps working. No public CLI
surface change.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
