### PR TITLE
fix(plugin): pin native Rust formatting edition

### DIFF
--- a/plugins/codex-security/native/rustfmt.toml
+++ b/plugins/codex-security/native/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2021"
+style_edition = "2021"


### PR DESCRIPTION
## Summary

Native Rust formatting can inherit a conflicting style edition when the plugin source is embedded beneath another checkout. Pin the native crate's existing 2021 parsing and formatting editions locally.

## Changes

- Add `plugins/codex-security/native/rustfmt.toml` with `edition = "2021"` and `style_edition = "2021"`.
- Preserve the existing Rust source and formatting behavior in standalone checkouts.

## Testing

- Reproduced the import-order failure for all five native Rust files beneath a synthetic parent configured for the 2024 style; the new local configuration passes without modifying those files.
- `cargo +1.97.1 fmt --manifest-path plugins/codex-security/native/Cargo.toml --check` passed.
- Plugin Ruff lint and formatting checks passed (137 files).
- SDK `build:ci` and the plugin source compatibility check passed.
- All nine source compatibility tests passed with the local Node `UNDICI-EHPA` experimental warning disabled; the initial run's stderr assertions were affected by that warning.

## Risk and rollout

Formatting configuration only; no runtime code, dependencies, payload entries, or release versions change. Embedded checkouts pick up the configuration when they import the source.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.

<!-- explain-pr:impact:start -->
## Change impact

The native crate declares its existing formatting edition so embedded checkouts keep the same source style.

```mermaid
flowchart LR
  subgraph column_0["Crate policy"]
    direction TB
    node_0["Rust 2021 crate"]
  end
  subgraph column_1["Local configuration"]
    direction TB
    node_1["Native rustfmt settings"]
  end
  subgraph column_2["Native source"]
    direction TB
    node_2["Existing import ordering"]
  end
  node_0 -->|"matches edition"| node_1
  node_1 -->|"sets formatting style"| node_2
  class node_0 context
  class node_1 changed
  class node_2 affected
  classDef changed fill:#d7f5e5,stroke:#237a4b,color:#111
  classDef affected fill:#e6f0ff,stroke:#3569a8,color:#111
  classDef context fill:#f2f3f5,stroke:#6e7781,color:#111
```

> **Limits:** Local checks passed. Hosted CI results remain available in the PR checks.

<details>
<summary>Source evidence (3)</summary>

- [`plugins/codex-security/native/rustfmt.toml:L1-L2`](https://github.com/openai/codex-security/blob/c99cff7a8c22ee918ef4a74df52ee51b1a6e0631/plugins/codex-security/native/rustfmt.toml#L1-L2) — The native directory explicitly selects Rust 2021 parsing and formatting.
- [`plugins/codex-security/native/Cargo.toml:L1-L5`](https://github.com/openai/codex-security/blob/c99cff7a8c22ee918ef4a74df52ee51b1a6e0631/plugins/codex-security/native/Cargo.toml#L1-L5) — The crate already declares the Rust 2021 edition.
- [`plugins/codex-security/native/src/windows.rs:L1-L21`](https://github.com/openai/codex-security/blob/c99cff7a8c22ee918ef4a74df52ee51b1a6e0631/plugins/codex-security/native/src/windows.rs#L1-L21) — Existing imports retain their order when checked beneath a differently configured parent.

</details>
<!-- explain-pr:impact:end -->
