### PR TITLE
fix(scan): report a failed ignored-but-tracked file listing

### DIFF
--- a/plugins/codex-security/scripts/generate_in_scope_files.py
+++ b/plugins/codex-security/scripts/generate_in_scope_files.py
@@ -128,17 +128,24 @@ def generate_in_scope_files(repository: Path, scope: str, output: Path) -> int:
                     ],
                     cwd=repository,
                     stdout=subprocess.PIPE,
-                    stderr=subprocess.DEVNULL,
+                    stderr=subprocess.PIPE,
                     check=False,
                 )
-            except OSError:
-                tracked = None
-            if tracked is not None and tracked.returncode == 0:
-                prefix = b"./" if scope == "." or scope.startswith("./") else b""
-                for path in tracked.stdout.split(b"\0"):
-                    candidate = repository / os.fsdecode(path)
-                    if path and candidate.is_file() and not candidate.is_symlink():
-                        inventory.write(prefix + path + b"\n")
+            except OSError as error:
+                raise InventoryError(f"could not run git ls-files: {error}") from error
+
+            if tracked.returncode != 0:
+                detail = tracked.stderr.decode("utf-8", errors="replace").strip()
+                message = f"git ls-files exited with status {tracked.returncode}"
+                if detail:
+                    message = f"{message}: {detail}"
+                raise InventoryError(message)
+
+            prefix = b"./" if scope == "." or scope.startswith("./") else b""
+            for path in tracked.stdout.split(b"\0"):
+                candidate = repository / os.fsdecode(path)
+                if path and candidate.is_file() and not candidate.is_symlink():
+                    inventory.write(prefix + path + b"\n")
 
         inventory.seek(0)
         rows = sorted(inventory)

--- a/plugins/codex-security/tests/test_generate_in_scope_files.py
+++ b/plugins/codex-security/tests/test_generate_in_scope_files.py
@@ -148,6 +148,21 @@ def test_inventory_keeps_ignored_tracked_files_without_ignored_untracked_files(
     assert "./app/ignored.skip" not in paths
 
 
+def test_inventory_reports_a_failed_ignored_tracked_listing(tmp_path: Path) -> None:
+    repository = make_repository(tmp_path)
+    write_file(repository, "ignored/tracked.py")
+    git(repository, "add", "--force", "--", "ignored/tracked.py")
+    git(repository, "config", "core.repositoryformatversion", "1")
+    git(repository, "config", "extensions.exampleUnsupported", "true")
+    output = tmp_path / "in_scope_files.txt"
+
+    result = run_inventory(repository, ".", output)
+
+    assert result.returncode == 2, result.stdout
+    assert "git ls-files" in result.stderr
+    assert not output.exists()
+
+
 def test_diff_inventory_includes_power_shell_files(tmp_path: Path) -> None:
     repository = tmp_path / "repository"
     repository.mkdir()


### PR DESCRIPTION
## Summary

`generate_in_scope_files` builds the shared scan inventory from ripgrep, then adds the files that Git tracks but `.gitignore` excludes — ripgrep honours ignore rules, so without that step every committed-but-ignored file (vendored dependencies, checked-in build output, generated clients) would be missing from the audit. `plugins/codex-security/tests/test_generate_in_scope_files.py::test_inventory_keeps_ignored_tracked_files_without_ignored_untracked_files` pins that guarantee.

That `git ls-files` call sent its stderr to `DEVNULL` and treated **both** a spawn failure and **any** non-zero exit status as "this repository has no ignored-but-tracked files". So when the Git listing fails for a reason unrelated to the file set, the inventory is silently written short, the command exits `0`, and the scan proceeds over a smaller file list while reporting normal success. Nothing on stdout, stderr, or in the artifact records that anything was dropped.

The branch is only entered when `repository/.git` exists, so the code has already concluded it is looking at a Git repository. Real triggers that leave the index intact while `git ls-files` fails: a repository format extension the local Git does not support (`fatal: unknown repository extension found: ...`), `detected dubious ownership in repository at ...` on a checkout owned by another user, or a linked worktree whose `gitdir` target is gone.

The ripgrep call ten lines above already handles the identical two failure modes correctly — `raise InventoryError` on `OSError`, and `raise InventoryError` with the captured stderr on an unexpected exit status. This change makes the Git call match its sibling.

## Changes

- `plugins/codex-security/scripts/generate_in_scope_files.py`: capture `git ls-files` stderr instead of discarding it; raise `InventoryError` on a spawn failure and on a non-zero exit status, including Git's own message in the error. The success path is unchanged apart from losing one level of indentation.
- `plugins/codex-security/tests/test_generate_in_scope_files.py`: regression test that a failing ignored-but-tracked listing exits `2` and writes no inventory.

## Testing

Reproduced through the plugin's own inventory command before and after the change, on Windows. Fixture: a repository with `vendor/` in `.gitignore` and `vendor/lib.py` committed with `git add --force`; `git ls-files` broken with an unsupported repository extension.

Before, on unmodified `main`:

```
$ python plugins/codex-security/scripts/generate_in_scope_files.py --repo <fixture> --scope . --out inv.txt
Recorded 2 in-scope files.
exit=0
$ cat inv.txt
./.gitignore
./app.py
```

`./vendor/lib.py` is gone, the command succeeded, and nothing said so. The same fixture with a healthy `.git/config` records 3 files including `./vendor/lib.py`.

New test against unmodified `main`:

```
$ python -m pytest plugins/codex-security/tests/test_generate_in_scope_files.py -q -k ignored
.F
>       assert result.returncode == 2, result.stdout
E       AssertionError: Recorded 10 in-scope files.
E         assert 0 == 2
1 failed, 1 passed, 23 deselected
```

After the change, same command and fixture:

```
$ python plugins/codex-security/scripts/generate_in_scope_files.py --repo <fixture> --scope . --out inv.txt
generate_in_scope_files: git ls-files exited with status 128: fatal: unknown repository extension found:
        exampleunsupported
exit=2
```

Still accepted, confirmed after the change:

- healthy Git repository, same fixture: `Recorded 3 in-scope files.` including `./vendor/lib.py`
- directory with no `.git`: `Recorded 1 in-scope files.`

Checks run:

- `python -m pytest plugins/codex-security/tests/test_generate_in_scope_files.py -q` — 21 passed, 4 skipped. The 4 skips are host-capability gates on this machine (2 need symlink creation privilege, 2 need executable script shims that Windows cannot launch); they skip on `main` as well.
- `python -m ruff check --config plugins/codex-security/pyproject.toml plugins/codex-security` — All checks passed!
- `python -m ruff format --check --config plugins/codex-security/pyproject.toml plugins/codex-security` — 137 files already formatted
- `tsc -p sdk/typescript/tsconfig.ci.json` (`build:ci`) — clean
- `node .github/scripts/check_plugin_source_compatibility.mjs` — Plugin source compatibility checks passed.
- `node --test .github/scripts/test_check_plugin_source_compatibility.mjs` — 8 pass, 0 fail, 1 skipped

## Risk and rollout

No public CLI surface changes: no new command, flag, environment variable, or default. The only behaviour change is that an inventory which previously succeeded with a silently truncated file list now fails with exit status `2` and Git's own diagnostic, which is the same contract the ripgrep step in this function already has.

This turns one previously tolerated situation into a failure: `.git` exists but Git cannot list the index. That is deliberate — for a security scan, a partial inventory reported as a complete one is worse than a stop with an actionable message, and the message points straight at the fix (add `safe.directory`, upgrade Git, repair the worktree). A repository with no `.git` entry is untouched, and a healthy repository behaves exactly as before.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
