### PR TITLE
fix(publish): detect a Linear URL contradiction over plain HTTP

### DIFF
--- a/sdk/typescript/src/publication-events.ts
+++ b/sdk/typescript/src/publication-events.ts
@@ -314,7 +314,12 @@ function linearIssueReferenceFromUrl(
   } catch {
     return undefined;
   }
-  if (url.protocol !== "https:" || url.hostname !== "linear.app") {
+  // Recognize every scheme linearIssueReference parses, so a plain HTTP URL
+  // still resolves to the issue it names instead of an unrecognized claim.
+  if (
+    (url.protocol !== "https:" && url.protocol !== "http:") ||
+    url.hostname !== "linear.app"
+  ) {
     return undefined;
   }
   try {

--- a/sdk/typescript/src/publication-events.ts
+++ b/sdk/typescript/src/publication-events.ts
@@ -200,11 +200,14 @@ export function resolveClaims(
   if (identifiers.size === 0) {
     return { state: "absent", claims: retained };
   }
+  const url =
+    [...urls].find((value) => /^https:\/\//iu.test(value)) ??
+    urls.values().next().value;
   return {
     state: "resolved",
     claims: retained,
     issueIdentifier: identifiers.values().next().value!,
-    ...(urls.size === 0 ? {} : { url: urls.values().next().value! }),
+    ...(url === undefined ? {} : { url }),
   };
 }
 

--- a/sdk/typescript/tests-ts/publication-events.test.ts
+++ b/sdk/typescript/tests-ts/publication-events.test.ts
@@ -223,6 +223,23 @@ describe("Linear publication claim resolution", () => {
       },
     ],
     [
+      "plain HTTP URL and human key contradiction",
+      {
+        issueIdentifier: "SYNTH-502",
+        url: `http://linear.app/example/issue/${identifier}`,
+      },
+      {
+        state: "conflicting",
+        claims: [
+          { kind: "identifier", value: "SYNTH-502" },
+          {
+            kind: "url",
+            value: `http://linear.app/example/issue/${identifier}`,
+          },
+        ],
+      },
+    ],
+    [
       "opaque entity relabeled as a human key",
       {
         id: "synthetic-opaque-entity",

--- a/sdk/typescript/tests-ts/publication-events.test.ts
+++ b/sdk/typescript/tests-ts/publication-events.test.ts
@@ -171,16 +171,18 @@ describe("Linear publication claim resolution", () => {
       ),
     ],
     [
-      "equivalent Linear URL spellings",
+      "equivalent Linear URL spellings retain HTTPS",
       {
         identifier,
         url,
         structured_content: { url: `${url}/` },
+        structuredContent: { url: url.replace("https:", "http:") },
         issue: { url: `${url}/synthetic-title/` },
       },
       resolved(
         [
           { kind: "identifier", value: identifier },
+          { kind: "url", value: url.replace("https:", "http:") },
           { kind: "url", value: url },
           { kind: "url", value: `${url}/` },
           { kind: "url", value: `${url}/synthetic-title/` },


### PR DESCRIPTION
## Summary

Publication validation could accept an issue identifier and an HTTP Linear URL that named different issues. It also treated HTTP and HTTPS URLs for the same issue as conflicting.

## Changes

- Recognize both URL schemes accepted by the existing Linear issue parser.
- Retain the HTTPS URL when equivalent HTTP and HTTPS claims coexist, preserving the issue link in command output.
- Cover HTTP contradictions and HTTPS selection in the existing claim-resolution tests.

## Testing

- Reproduced both identity errors against the base commit through the publication flow with mocked connector and storage dependencies; verified the corrected results.
- Reproduced selection of HTTP over an available HTTPS URL before the follow-up fix; the regression test now passes.
- 84 focused tests passed across publication claims, Linear intake, publication preflight, preparation, and evidence reconciliation.
- TypeScript `tsc --noEmit`, formatting checks for both changed files, and `git diff --check` passed.

## Risk and rollout

This changes publication-result interpretation without adding CLI arguments or settings. Existing HTTP Linear URLs participate in identity checks, and equivalent claims retain an available HTTPS URL. The command's URL display rules remain unchanged.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
