### PR TITLE
docs(scan-contract): drop canonical document size limits that do not exist

### DIFF
--- a/plugins/codex-security/references/scan-contract.md
+++ b/plugins/codex-security/references/scan-contract.md
@@ -10,7 +10,7 @@ A sealed terminal bundle contains these files under `<scan_dir>`:
 - `findings.json`: semantic finding records retained when the scan reached its terminal outcome
 - `coverage.json`: structured coverage summary with detailed receipt references
 
-Canonical UTF-8 document sizes are bounded consistently by the producer and SDK: `scan-manifest.json` is limited to 16 MiB, `findings.json` to 128 MiB, and `coverage.json` to 32 MiB. Finalization rejects oversized inputs or generated documents before sealing or changing scan outputs. Keep detailed evidence in scan-local artifacts and reference it from the canonical summaries.
+Keep detailed evidence in scan-local artifacts and reference it from the canonical summaries.
 
 Optional structured finding details used by rich consumers are documented in `finding-detail-fields.md`. They remain part of each semantic finding record, not a projection parsed from a readable report.
 

--- a/plugins/codex-security/references/scan-contract.md
+++ b/plugins/codex-security/references/scan-contract.md
@@ -28,11 +28,11 @@ A sealed manifest records the terminal timestamp and hashes for the canonical do
 
 `scan.status` records why the bundle was sealed:
 
-| Status | Meaning |
-| --- | --- |
-| `completed` | The requested scan reached normal completion. |
-| `failed` | The scan stopped after an unrecoverable failure; retained artifacts may be partial. |
-| `canceled` | The scan stopped after an explicit cancellation; retained artifacts may be partial. |
+| Status        | Meaning                                                                                                         |
+| ------------- | --------------------------------------------------------------------------------------------------------------- |
+| `completed`   | The requested scan reached normal completion.                                                                   |
+| `failed`      | The scan stopped after an unrecoverable failure; retained artifacts may be partial.                             |
+| `canceled`    | The scan stopped after an explicit cancellation; retained artifacts may be partial.                             |
 | `interrupted` | The scan stopped before normal completion because execution was interrupted; retained artifacts may be partial. |
 
 Only `completed` supports a completed-scan conclusion. For every stopped outcome, consumers must preserve retained findings and coverage while treating absence of findings as inconclusive.
@@ -56,12 +56,12 @@ For a workbench-backed scan, use the recorded target contract instead of inferri
 A clean Git checkout has `allowedKinds: ["git_revision"]`: use its recorded revision and omit `snapshotDigest`.
 A dirty checkout has `allowedKinds: ["git_worktree"]`: copy `requiredSnapshotDigest` exactly.
 
-| Kind | Required snapshot fields |
-| --- | --- |
-| `git_revision` | `revision` |
-| `git_worktree` | `revision` when available and `snapshotDigest` |
-| `git_diff` | `snapshotDigest`; include `baseRevision` and `headRevision` when available |
-| `directory_snapshot` | `snapshotDigest` |
+| Kind                 | Required snapshot fields                                                   |
+| -------------------- | -------------------------------------------------------------------------- |
+| `git_revision`       | `revision`                                                                 |
+| `git_worktree`       | `revision` when available and `snapshotDigest`                             |
+| `git_diff`           | `snapshotDigest`; include `baseRevision` and `headRevision` when available |
+| `directory_snapshot` | `snapshotDigest`                                                           |
 
 `targetId` identifies the stable repository or workspace. Prefer a digest of a sanitized canonical absolute remote URL when one exists. Otherwise use a digest of a stable local workspace identity. Never persist remote URL credentials, query parameters, fragments, or tokens.
 
@@ -122,39 +122,39 @@ For Standard and diff scans, record:
 
 `mode` records the requested scan workflow:
 
-| Mode | Meaning |
-| --- | --- |
-| `repository` | Repository-wide scan |
-| `scoped_path` | Scan limited to explicitly requested paths |
-| `diff` | Git-backed change-set scan when no more specific mode applies |
-| `commit` | Commit compared with its resolved baseline |
-| `branch_diff` | Branch or pull-request change set compared with its baseline |
-| `working_tree` | Staged or unstaged local changes |
-| `deep_repository` | Exhaustive repeated repository-wide scan |
+| Mode              | Meaning                                                       |
+| ----------------- | ------------------------------------------------------------- |
+| `repository`      | Repository-wide scan                                          |
+| `scoped_path`     | Scan limited to explicitly requested paths                    |
+| `diff`            | Git-backed change-set scan when no more specific mode applies |
+| `commit`          | Commit compared with its resolved baseline                    |
+| `branch_diff`     | Branch or pull-request change set compared with its baseline  |
+| `working_tree`    | Staged or unstaged local changes                              |
+| `deep_repository` | Exhaustive repeated repository-wide scan                      |
 
 `inventoryStrategy` records how the producer enumerated the reviewed content, independently of the requested scan workflow:
 
 For a whole-repository Deep scan, keep `inventoryStrategy` as `repository`; repeated discovery is workflow metadata, not a different inventory strategy.
 
-| Inventory strategy | Meaning |
-| --- | --- |
-| `repository` | Repository-wide tracked source-like file inventory |
-| `scoped_path` | Repository inventory constrained to requested paths |
-| `diff` | Files selected from the reviewed Git change set |
-| `directory` | Deterministic non-Git directory inventory |
-| `custom` | Producer-defined inventory described by detailed receipts |
+| Inventory strategy | Meaning                                                   |
+| ------------------ | --------------------------------------------------------- |
+| `repository`       | Repository-wide tracked source-like file inventory        |
+| `scoped_path`      | Repository inventory constrained to requested paths       |
+| `diff`             | Files selected from the reviewed Git change set           |
+| `directory`        | Deterministic non-Git directory inventory                 |
+| `custom`           | Producer-defined inventory described by detailed receipts |
 
 For Standard and diff scans, use `complete` when the requested scope was fully reviewed, `partial` when in-scope work was deferred, and `unknown` when the producer cannot establish enough coverage to make that distinction.
 
 Map detailed ledger closure into completed surface summaries in this order:
 
-| Completed surface condition | Disposition |
-| --- | --- |
-| At least one `reportable` row | `reported` |
-| Otherwise, at least one `deferred` row | `needs_follow_up` |
-| Otherwise, at least one `suppressed` row | `rejected` |
-| Otherwise, an applicable surface was checked and no candidate survived | `no_issue_found` |
-| Otherwise, the surface is not applicable | `not_applicable` |
+| Completed surface condition                                            | Disposition       |
+| ---------------------------------------------------------------------- | ----------------- |
+| At least one `reportable` row                                          | `reported`        |
+| Otherwise, at least one `deferred` row                                 | `needs_follow_up` |
+| Otherwise, at least one `suppressed` row                               | `rejected`        |
+| Otherwise, an applicable surface was checked and no candidate survived | `no_issue_found`  |
+| Otherwise, the surface is not applicable                               | `not_applicable`  |
 
 Record each explicit exclusion with a `pattern` and `reason`. Record each deferred unit with a stable `id`, a `reason`, and optional `paths` or `surfaceIds`.
 


### PR DESCRIPTION
## Summary

`plugins/codex-security/references/scan-contract.md` is loaded as scan guidance and states a contract that does not exist:

> Canonical UTF-8 document sizes are bounded consistently by the producer and SDK: `scan-manifest.json` is limited to 16 MiB, `findings.json` to 128 MiB, and `coverage.json` to 32 MiB. Finalization rejects oversized inputs or generated documents before sealing or changing scan outputs.

Neither side does any byte accounting. In the producer, `_contract_json_bytes` validates the JSON value and serializes it with no size check; in the SDK, `contract.ts` reads the document with `await file.readFile({ signal })` and never measures it. `grep -n "MiB\|1024 \* 1024"` over both files returns only read-chunk sizes.

This repository already asserts the opposite behaviour, in tests whose names say so:

- `plugins/codex-security/tests/test_finalize_scan_contract.py::test_finalizes_canonical_document_beyond_previous_size_limit` builds a manifest with a 16 MiB `metadata` field and asserts `finalize_scan` returns it.
- `…::test_reads_schema_beyond_previous_size_limit` reads a 4 MiB schema.

The identical sentence was removed from `sdk/typescript/README.md` in 38c0a302, "docs: remove outdated scan size limits" — which also removed the neighbouring 1 MiB cost-event and 64-item/1 MiB input limits. This copy in the plugin reference was left behind, so the two documents describing the same contract now disagree.

## Changes

- `plugins/codex-security/references/scan-contract.md`: remove the two sentences stating the per-document byte limits and the rejection guarantee. The guidance sentence that followed them — "Keep detailed evidence in scan-local artifacts and reference it from the canonical summaries." — is kept, and is the reason a reader would have been consulting that paragraph.

- Apply the existing Prettier table formatting required by the PR Markdown check.

No code changes.

## Testing

Measured the accepted sizes directly against unmodified `main`, by loading the finalizer module and calling the function that produces canonical document bytes:

```
$ python -c "<load finalize_scan_contract.py; call _contract_json_bytes>"
scan-manifest.json: documented limit 16 MiB, accepted 20971541 bytes (20.0 MiB)
coverage.json:      documented limit 32 MiB, accepted 41943061 bytes (40.0 MiB)
```

Existing tests that pin this behaviour, on unmodified `main`:

```
$ python -m pytest plugins/codex-security/tests/test_finalize_scan_contract.py -q \
    -k "size_limit or nesting_limit"
3 passed, 152 deselected
```

Portable checks from `AGENTS.md`, all run:

- `python -m ruff check --config plugins/codex-security/pyproject.toml plugins/codex-security` — All checks passed!
- `python -m ruff format --check --config plugins/codex-security/pyproject.toml plugins/codex-security` — 137 files already formatted
- `tsc -p sdk/typescript/tsconfig.ci.json` (`build:ci`) — clean
- `node .github/scripts/check_plugin_source_compatibility.mjs` — Plugin source compatibility checks passed.
- `node --test .github/scripts/test_check_plugin_source_compatibility.mjs` — 8 pass, 0 fail, 1 skipped

`pnpm run format` covers `plugins/codex-security/native/*.md` but not `references/*.md`, and reports "All matched files use Prettier code style!" before and after this change. The PR-specific Markdown check checks this file directly and also catches its pre-existing table formatting. The follow-up applies Prettier table alignment without changing any table cell content. The direct Markdown check now passes.

## Risk and rollout

Documentation only; no behaviour, schema, CLI surface or public API is affected. The removed text described a guarantee that was never enforced, so nothing that relied on the actual behaviour changes. If per-document limits are wanted, they would need to be implemented and the two tests above updated; this change only stops the reference from promising them today.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
