### PR TITLE
fix(scan): accept large saved post-scan prompts

### DIFF
--- a/plugins/codex-security/scripts/workbench_db.py
+++ b/plugins/codex-security/scripts/workbench_db.py
@@ -149,7 +149,6 @@ from workbench_validation import (
 FINDING_ARTIFACT_DIRECTORIES_LIMIT = 80
 FINDING_ARTIFACTS_LIMIT = 40
 FINDING_WRITEUP_REPORT_PATH = re.compile(r"^findings/([a-z0-9][a-z0-9._-]*)/\1\.md$")
-SCAN_RECIPE_MAX_BYTES = 256 * 1024
 
 
 def now() -> str:
@@ -1820,8 +1819,6 @@ def set_scan_cost_limit(connection: sqlite3.Connection, args: argparse.Namespace
 
 
 def parse_scan_recipe(value: str, repository: Path) -> dict[str, Any]:
-    if len(value.encode("utf-8")) > SCAN_RECIPE_MAX_BYTES:
-        raise SystemExit("Scan launch recipe must be no larger than 256 KiB.")
     try:
         recipe = json.loads(value, parse_constant=reject_non_finite_json)
     except (TypeError, UnicodeError, ValueError) as exc:

--- a/sdk/typescript/tests-ts/scan-recipe.test.ts
+++ b/sdk/typescript/tests-ts/scan-recipe.test.ts
@@ -1,0 +1,95 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, expect, test } from "bun:test";
+import { main } from "../src/cli.js";
+import { runWorkbench } from "../src/runtime.js";
+import { capture, dependencies } from "./cli-fixtures.js";
+import { PLUGIN_ROOT } from "./plugin-root.js";
+import { TestClient } from "./support/api-client.js";
+import {
+  createApiTestFixtures,
+  preparedRuntime,
+} from "./support/api-events.js";
+
+const { temporaryDirectory, cleanup } = createApiTestFixtures();
+afterEach(cleanup);
+
+test.each(["standard", "deep"])(
+  "%s scans save large post-scan prompts before starting Codex",
+  async (mode) => {
+    const root = await temporaryDirectory();
+    const repository = join(root, "repository");
+    const codexHome = join(root, "state", "codex-home");
+    await mkdir(repository);
+    await mkdir(codexHome, { recursive: true });
+    await writeFile(join(repository, "source.py"), "# synthetic source\n");
+    const promptFile = join(root, "post-scan.md");
+    const postScanPrompt =
+      "Review the completed scan and its evidence.\n".repeat(10_000);
+    expect(Buffer.byteLength(postScanPrompt)).toBeGreaterThan(256 * 1024);
+    await writeFile(promptFile, postScanPrompt);
+    const python = Bun.which("python3") ?? Bun.which("python");
+    if (python === null) throw new Error("Python is required for this test.");
+    const environment = {
+      PATH: process.env["PATH"],
+      SystemRoot: process.env["SystemRoot"],
+      TEMP: process.env["TEMP"],
+      TMP: process.env["TMP"],
+      CODEX_HOME: codexHome,
+      CODEX_SECURITY_STATE_DIR: join(root, "state"),
+      OPENAI_API_KEY: "synthetic-launch-key",
+    };
+    const command = (args: readonly string[], input?: string) =>
+      runWorkbench(
+        { python, pluginRoot: PLUGIN_ROOT, environment },
+        args,
+        input,
+      );
+    const stdout = capture();
+    const stderr = capture();
+    const code = await main(
+      [
+        "scan",
+        repository,
+        "--mode",
+        mode,
+        "--output-dir",
+        join(root, "scan"),
+        "--post-scan-prompt-file",
+        promptFile,
+        "--json",
+      ],
+      stdout.stream,
+      stderr.stream,
+      {
+        ...dependencies({ environment, currentDirectory: root }),
+        runWorkbench: command,
+        createSecurity: (config) =>
+          new TestClient(config, {
+            environment,
+            prepareRuntime: async () => preparedRuntime(codexHome),
+            resolvePluginPython: async () => python,
+            runWorkbench,
+            createCodex: () => {
+              throw new Error("Synthetic stop after registration");
+            },
+          }),
+      },
+    );
+    expect(code).toBe(2);
+    expect(stderr.text()).toContain("Synthetic stop after registration");
+    await rm(promptFile);
+    const scans = (await command(["list-scans", "--repository", repository]))[
+      "scans"
+    ] as Array<{ scanId: string }>;
+    expect(scans).toHaveLength(1);
+    const saved = await command([
+      "get-scan-recipe",
+      "--scan-id",
+      scans[0]!.scanId,
+    ]);
+    expect(saved["recipe"]).toMatchObject({ mode, postScanPrompt });
+    expect(JSON.stringify(saved)).not.toContain(promptFile);
+    expect(JSON.stringify(saved)).not.toContain("synthetic-launch-key");
+  },
+);


### PR DESCRIPTION
## Summary

Saving post-scan prompt contents in launch recipes made valid prompts above 256 KiB fail before Codex started. Remove the recipe byte cap so standard and Deep Scans can save those prompts and start normally.

## Changes

- Remove the fixed byte cap on locally supplied scan recipes while retaining the existing recipe and target validation.
- Add CLI regression coverage for standard and Deep Scans with prompts above 256 KiB, checking the complete saved contents after deleting the original prompt file.

## Testing

- Bun: `scan-recipe.test.ts` — 2 passed.
- Python workbench tests selected by `recipe or register_cli_scan` — 2 passed, 132 deselected.
- SDK `pnpm run types`, `pnpm run format`, and `pnpm run build:ci` — passed.
- Plugin Ruff check and format check — passed.
- `check_plugin_source_compatibility.mjs` and its 9 Node tests — passed.

## Risk and rollout

No new CLI options or storage format changes. Recipes can grow with user-supplied prompt contents; normal JSON and target validation still apply. Validation ran on macOS.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
