### PR TITLE
fix(test): keep parameterized JUnit names unique

### DIFF
--- a/sdk/typescript/tests-ts/cli-authentication.test.ts
+++ b/sdk/typescript/tests-ts/cli-authentication.test.ts
@@ -1268,7 +1268,7 @@ describe("skill authentication", () => {
     ["auto", false, "synthetic"],
     ["api-key", false, "synthetic"],
   ] as const)(
-    "patch uses %s auth without replacing a saved login (failure: %s, provider: %s)",
+    "patch uses %s auth without replacing a saved login (failure: %p, provider: %s)",
     async (auth, loginFailure, provider) => {
       const repository = join(stateDirectory, "repository");
       await mkdir(repository);

--- a/sdk/typescript/tests-ts/multiscan.test.ts
+++ b/sdk/typescript/tests-ts/multiscan.test.ts
@@ -373,7 +373,7 @@ describe("multiscan", () => {
   });
 
   test.each([false, true])(
-    "recovery records the original attempt and preserves it after resume failure=%s",
+    "recovery records the original attempt and preserves it after resume failure=%p",
     async (failure) => {
       const paths = await fixture();
       const source = await repository(paths.root, "retained");

--- a/sdk/typescript/tests-ts/release-pr.test.ts
+++ b/sdk/typescript/tests-ts/release-pr.test.ts
@@ -951,7 +951,7 @@ describe("human note ownership", () => {
 
 describe("rolling release reconciliation", () => {
   test.each([true, false])(
-    "leaves an empty release cycle unchanged with dryRun=%s",
+    "leaves an empty release cycle unchanged with dryRun=%p",
     async (dryRun) => {
       const fixture = new Fixture();
       const result = await fixture.run(dryRun);
@@ -1485,7 +1485,7 @@ describe("release proposal pauses", () => {
   });
 
   test.each([false, true])(
-    "updates an existing proposal with draft=%s",
+    "updates an existing proposal with draft=%p",
     async (draft) => {
       const fixture = new Fixture();
       fixture.merge("feat: initial feature");

--- a/sdk/typescript/tests-ts/scan-resume.test.ts
+++ b/sdk/typescript/tests-ts/scan-resume.test.ts
@@ -461,7 +461,7 @@ test.each([
   [false, true],
   [true, true],
 ])(
-  "resumed CLI seals the original scan (coordinator finished: %s, bulk: %s)",
+  "resumed CLI seals the original scan (coordinator finished: %p, bulk: %p)",
   async (alreadyFinished, bulk) => {
     const f = await interruptedScan("deep", bulk);
     if (alreadyFinished) await finishDiscovery(f);
@@ -791,7 +791,7 @@ test("CLI saves launch settings before execution without depending on the prompt
 });
 
 test.each([false, true])(
-  "resume restores saved launch settings (bulk: %s)",
+  "resume restores saved launch settings (bulk: %p)",
   async (bulk) => {
     const settings = {
       safetyIdentifier: "synthetic-original-user",


### PR DESCRIPTION
## Summary

Bun 1.3.13 leaves boolean `%s` parameters uninterpolated in JUnit test names. Six test tables therefore produce duplicate identities that the cross-runner report comparison rejects even when the tests pass.

## Changes

Use `%p` for the boolean parameters in scan recovery, campaign recovery, release proposal, and authentication tests so each case has a distinct JUnit identity.

## Testing

- Bun 1.3.13: `scan-resume.test.ts` and `multiscan.test.ts` with JUnit output — 85 passed, 1 Windows-only skip.
- Bun 1.3.13 full-inventory check across 132 files, filtered to the affected release and authentication cases — 14 passed, 2,852 filtered out.
- `compare-test-reports.mjs` accepted the full-inventory report, with 2,866 distinct identities and no duplicates. The focused report before the follow-up fix contained four duplicate identities.
- SDK `pnpm run types` and `pnpm run format` — passed.

## Risk and rollout

Only test display names change. Assertions and production behavior are unchanged. The filtered local report checks every registered test identity; it does not claim to execute every assertion. Cross-platform validation runs in CI.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
