### PR TITLE
fix(release): use versioned conventional commit titles

### DIFF
--- a/.github/workflows/node-release-labels.yml
+++ b/.github/workflows/node-release-labels.yml
@@ -32,7 +32,7 @@ jobs:
           set -euo pipefail
 
           release_note_label() {
-            local type="$1" breaking_marker="$2"
+            local type="$1" breaking_marker="$2" scope="$3"
             if [[ "$breaking_marker" == "!" ]]; then
               printf '%s\n' breaking-change
               return 0
@@ -50,6 +50,11 @@ jobs:
                 ;;
               release | test)
                 printf '%s\n' skip-release-notes
+                ;;
+              chore)
+                if [[ "$scope" == "(release)" ]]; then
+                  printf '%s\n' skip-release-notes
+                fi
                 ;;
               *)
                 return 0
@@ -78,8 +83,9 @@ jobs:
             exit 1
           fi
           type="${BASH_REMATCH[1]}"
+          scope="${BASH_REMATCH[2]:-}"
           breaking_marker="${BASH_REMATCH[3]:-}"
-          label="$(release_note_label "$type" "$breaking_marker")"
+          label="$(release_note_label "$type" "$breaking_marker" "$scope")"
           current_labels="$(
             gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" \
               --jq '.[].name'

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,18 +28,20 @@ feat(sdk)!: remove the legacy result field
 
 The title controls the generated release category:
 
-| Title             | Release category |
-| ----------------- | ---------------- |
-| Any type with `!` | Breaking changes |
-| `feat`            | Features         |
-| `fix`             | Fixes            |
-| `docs`            | Documentation    |
-| `release`, `test` | Excluded         |
-| Any other type    | Other changes    |
+| Title                               | Release category |
+| ----------------------------------- | ---------------- |
+| Any type with `!`                   | Breaking changes |
+| `feat`                              | Features         |
+| `fix`                               | Fixes            |
+| `docs`                              | Documentation    |
+| `chore(release)`, `release`, `test` | Excluded         |
+| Any other type                      | Other changes    |
 
-Use `release` and `test` only for changes that do not affect package users. A
-maintainer can apply `skip-release-notes` to exclude another internal change.
-That manual label takes precedence over the title category.
+Use `chore(release)` for release preparation and `test` for test-only changes.
+The legacy `release` type remains supported. Use these only for changes that
+do not affect package users. A maintainer can apply `skip-release-notes` to
+exclude another internal change. That manual label takes precedence over the
+title category.
 
 ## Version policy before 1.0
 
@@ -67,9 +69,12 @@ once a change reaches `main` after the current package version. It recomputes
 the proposal's version from all changes since that package version first
 reached `main`. Squash-merge release PRs, as required by this
 repository's enabled merge method, so the whole proposal lands as one
-release boundary commit. A later breaking change changes the version on the
-same PR. Each update incorporates the latest `main` and appends a commit;
-the updater never force-pushes. A concurrent commit causes it to reread and
+release boundary commit. Generated PR titles and commit subjects use
+`chore(release): X.Y.Z`, matching the proposed package version. Confirm the
+squash commit subject uses the current PR title when merging. A later breaking
+change updates the version and title on the same PR. Each update incorporates
+the latest `main` and appends a commit; the updater never force-pushes.
+A concurrent commit causes it to reread and
 retry. It requests Codex review when the proposal files change. Updates that
 only incorporate `main` keep CI current without repeating the same proposal
 review. New suggestions for human-owned notes still appear in a comment.
@@ -86,9 +91,10 @@ reach `main` before opening the next proposal. An empty release cycle returns
 `action: "unchanged"` without creating a branch or PR. Publication of the
 previous version still has to complete and pass the verification steps below.
 
-The updater leaves another open `release:` PR targeting `main`, including a
-manually prepared release, untouched and does not open a duplicate. Finish
-or close that PR before enabling the new flow. Closing an automated proposal
+The updater leaves another open `chore(release):` or legacy `release:` PR
+targeting `main`, including a manually prepared release, untouched and does not
+open a duplicate. Finish or close that PR before enabling the new flow.
+Closing an automated proposal
 pauses its cycle; reopen it to resume. Retargeting it away from `main` also
 pauses updates; restore its `main` base before resuming. Both ready proposals
 and existing drafts receive updates. Existing drafts can be marked ready
@@ -177,7 +183,7 @@ Generated PRs leave the disclosure attestations unchecked for maintainer review.
    compatibility work, link relevant public documentation, and leave the
    pull-request inventory to the generated section.
 4. Open a pull request with a strict Conventional Commit title such as
-   `release: bump Codex Security to 0.2.0`.
+   `chore(release): 0.2.0`.
 5. Run the checks required by the changed files and record the results in the
    pull request. Do not merge until required CI, review, and public disclosure
    checks pass on the current commit.

--- a/sdk/typescript/scripts/release-pr.mjs
+++ b/sdk/typescript/scripts/release-pr.mjs
@@ -551,12 +551,13 @@ export async function reconcileReleasePullRequest({
         dryRun,
         plan,
       };
-    const changed =
+    const branchChanged =
       !headSha ||
       previous.mergeBase !== mainSha ||
       Object.entries(plan.files).some(
         ([path, content]) => repo.readFile(headSha, path) !== content,
       );
+    const changed = branchChanged || pull?.title !== plan.title;
     if (dryRun)
       return {
         action: !pull ? "would-create" : changed ? "would-update" : "unchanged",
@@ -566,7 +567,7 @@ export async function reconcileReleasePullRequest({
 
     let commitSha = headSha;
     let currentPulls;
-    if (changed) {
+    if (branchChanged) {
       if ((await branchHead(github, "main")) !== mainSha) continue;
       const tree = await github.request("POST", "git/trees", {
         base_tree: repo.git("rev-parse", `${mainSha}^{tree}`).trim(),

--- a/sdk/typescript/scripts/release-pr.mjs
+++ b/sdk/typescript/scripts/release-pr.mjs
@@ -11,18 +11,22 @@ export const statePath = ".github/release-pr-state.json";
 const templatePath = ".github/PULL_REQUEST_TEMPLATE.md";
 const sectionIds = ["highlights", "upgrades"];
 const releaseBranchPrefix = "release/next-";
-const conventionalTitle = /^([a-z][a-z0-9-]*)(?:\([^)]*\))?(!)?: (.+)$/u;
+const conventionalTitle = /^([a-z][a-z0-9-]*)(?:\(([^)]*)\))?(!)?: (.+)$/u;
+
+function isReleaseTitle(title) {
+  const [, type, scope] = conventionalTitle.exec(title) ?? [];
+  return type === "release" || (type === "chore" && scope === "release");
+}
 
 function isReleasePull(pull) {
   return (
-    conventionalTitle.exec(pull.title)?.[1] === "release" ||
-    pull.head.ref.startsWith(releaseBranchPrefix)
+    isReleaseTitle(pull.title) || pull.head.ref.startsWith(releaseBranchPrefix)
   );
 }
 
 export function isBreakingChange(change) {
   return (
-    conventionalTitle.exec(change.title)?.[2] === "!" ||
+    conventionalTitle.exec(change.title)?.[3] === "!" ||
     /^(?:BREAKING CHANGE|BREAKING-CHANGE):\s+\S/mu.test(change.body ?? "") ||
     (change.labels ?? []).includes("breaking-change")
   );
@@ -47,7 +51,7 @@ function markdownText(value) {
 }
 
 function changeLine(change) {
-  const description = conventionalTitle.exec(change.title)?.[3] ?? change.title;
+  const description = conventionalTitle.exec(change.title)?.[4] ?? change.title;
   const reference = change.number
     ? `#${change.number}`
     : change.sha.slice(0, 7);
@@ -59,7 +63,7 @@ function visibleChanges(changes) {
     const type = conventionalTitle.exec(change.title)?.[1];
     return (
       !(change.labels ?? []).includes("skip-release-notes") &&
-      (change.breaking || !["release", "test"].includes(type))
+      (change.breaking || (type !== "test" && !isReleaseTitle(change.title)))
     );
   });
 }
@@ -206,10 +210,7 @@ export function createReleasePlan(history, previous = null) {
     mainSha,
     version,
     branch: `${releaseBranchPrefix}${baseVersion}`,
-    title:
-      changes.length > 0
-        ? `release: bump Codex Security to ${version}`
-        : "release: prepare the next Codex Security release",
+    title: `chore(release): ${version}`,
     changes,
     generated,
     humanOwned: sectionIds.filter((id) => sections[id].humanOwned),

--- a/sdk/typescript/tests-ts/release-automation.test.ts
+++ b/sdk/typescript/tests-ts/release-automation.test.ts
@@ -3862,7 +3862,7 @@ describe("GitHub release workflow safeguards", () => {
       'gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER"',
     );
     expect(releaseLabelsWorkflow).toContain(
-      'label="$(release_note_label "$type" "$breaking_marker")"',
+      'label="$(release_note_label "$type" "$breaking_marker" "$scope")"',
     );
     expect(releaseLabelsWorkflow).toContain(
       "breaking-change | enhancement | bug | documentation | skip-release-notes)",
@@ -4510,6 +4510,7 @@ describe("GitHub release workflow safeguards", () => {
     { title: "fix: publish a customer fix", label: "bug" },
     { title: "docs: publish customer documentation", label: "documentation" },
     { title: "chore: stop excluding an internal change", label: null },
+    { title: "chore(deps): upgrade a dependency", label: null },
     { title: "security: publish a security fix", label: null },
     { title: "deps: upgrade a dependency", label: null },
   ])(
@@ -4583,6 +4584,7 @@ describe("GitHub release workflow safeguards", () => {
     { title: "fix!: breaking fix", label: "breaking-change" },
     { title: "fix(api)!: breaking fix", label: "breaking-change" },
     { title: "docs!: breaking documentation", label: "breaking-change" },
+    { title: "chore(release)!: require migration", label: "breaking-change" },
     {
       title: "docs(api)!: breaking documentation",
       label: "breaking-change",
@@ -4638,56 +4640,64 @@ describe("GitHub release workflow safeguards", () => {
     expect(result.stdout).toContain(`labels[]=${label}`);
   });
 
-  test("executes and recovers from concurrent skip-label creation", async () => {
-    const script = workflowStepShell(
-      releaseLabelsWorkflow,
-      "Categorize pull request without checking out its code",
-    );
-    const mock = [
-      "skip_label_exists=0",
-      "gh() {",
-      '  if [[ "$1" != "api" ]]; then return 64; fi',
-      "  shift",
-      "  local method=GET",
-      '  if [[ "${1:-}" == "--method" ]]; then',
-      '    method="$2"',
-      "    shift 2",
-      "  fi",
-      '  local endpoint="$1"',
-      '  case "$method $endpoint" in',
-      '    "GET repos/test/codex-security/issues/17")',
-      "      printf '%s' 'release: automate published notes' | base64",
-      "      ;;",
-      '    "GET repos/test/codex-security/issues/17/labels")',
-      "      return 0",
-      "      ;;",
-      '    "GET repos/test/codex-security/labels/skip-release-notes")',
-      '      [[ "$skip_label_exists" == 1 ]]',
-      "      ;;",
-      '    "POST repos/test/codex-security/labels")',
-      "      skip_label_exists=1",
-      "      return 1",
-      "      ;;",
-      '    "POST repos/test/codex-security/issues/17/labels")',
-      '      if [[ "$skip_label_exists" != 1 ]]; then return 65; fi',
-      "      printf '%s\\n' 'applied skip-release-notes'",
-      "      ;;",
-      "    *) return 66 ;;",
-      "  esac",
-      "}",
-    ].join("\n");
-    const result = await runCommand(bash, ["-c", `${mock}\n${script}`], {
-      env: {
-        ...process.env,
-        GITHUB_REPOSITORY: "test/codex-security",
-        PR_NUMBER: "17",
-      },
-      timeout: 10_000,
-    });
+  test.each([
+    "chore(release): 0.1.24",
+    "release: automate published notes",
+    "test: extend coverage",
+  ])(
+    "excludes %s and recovers from concurrent skip-label creation",
+    async (title) => {
+      const script = workflowStepShell(
+        releaseLabelsWorkflow,
+        "Categorize pull request without checking out its code",
+      );
+      const mock = [
+        "skip_label_exists=0",
+        "gh() {",
+        '  if [[ "$1" != "api" ]]; then return 64; fi',
+        "  shift",
+        "  local method=GET",
+        '  if [[ "${1:-}" == "--method" ]]; then',
+        '    method="$2"',
+        "    shift 2",
+        "  fi",
+        '  local endpoint="$1"',
+        '  case "$method $endpoint" in',
+        '    "GET repos/test/codex-security/issues/17")',
+        "      printf '%s' \"$MOCK_PR_TITLE\" | base64",
+        "      ;;",
+        '    "GET repos/test/codex-security/issues/17/labels")',
+        "      return 0",
+        "      ;;",
+        '    "GET repos/test/codex-security/labels/skip-release-notes")',
+        '      [[ "$skip_label_exists" == 1 ]]',
+        "      ;;",
+        '    "POST repos/test/codex-security/labels")',
+        "      skip_label_exists=1",
+        "      return 1",
+        "      ;;",
+        '    "POST repos/test/codex-security/issues/17/labels")',
+        '      if [[ "$skip_label_exists" != 1 ]]; then return 65; fi',
+        "      printf '%s\\n' 'applied skip-release-notes'",
+        "      ;;",
+        "    *) return 66 ;;",
+        "  esac",
+        "}",
+      ].join("\n");
+      const result = await runCommand(bash, ["-c", `${mock}\n${script}`], {
+        env: {
+          ...process.env,
+          GITHUB_REPOSITORY: "test/codex-security",
+          MOCK_PR_TITLE: title,
+          PR_NUMBER: "17",
+        },
+        timeout: 10_000,
+      });
 
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain("applied skip-release-notes");
-  });
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("applied skip-release-notes");
+    },
+  );
 
   test("documents JSON stdin for every verification command", async () => {
     const result = await runCommand(

--- a/sdk/typescript/tests-ts/release-pr.test.ts
+++ b/sdk/typescript/tests-ts/release-pr.test.ts
@@ -783,6 +783,28 @@ describe("pre-1.0 release policy", () => {
     ).toThrow("policy");
   });
 
+  test("excludes release preparation while preserving visible and breaking changes", () => {
+    const plan = createReleasePlan(
+      history([
+        change("chore(release): 0.1.24", 1),
+        change("release: prepare legacy release", 2),
+        change("test: extend coverage", 3),
+        change("chore(deps): update dependencies", 4),
+        change("docs(release): explain publishing", 5),
+        change("chore(release)!: require migration", 6),
+      ]),
+    );
+    expect(plan.version).toBe("0.2.0");
+    expect(plan.title).toBe("chore(release): 0.2.0");
+    expect(plan.generated.highlights).not.toContain("0.1.24");
+    expect(plan.generated.highlights).not.toContain("prepare legacy release");
+    expect(plan.generated.highlights).not.toContain("extend coverage");
+    expect(plan.generated.highlights).toContain("update dependencies");
+    expect(plan.generated.highlights).toContain("explain publishing");
+    expect(plan.generated.highlights).toContain("require migration");
+    expect(plan.generated.upgrades).toContain("require migration");
+  });
+
   test.each([
     { format: "compact", indent: undefined },
     { format: "indented", indent: 2 },
@@ -973,6 +995,7 @@ describe("rolling release reconciliation", () => {
     const preview = await fixture.run(true);
     expect(preview.action).toBe("would-create");
     expect(preview.plan.version).toBe("0.1.24");
+    expect(preview.plan.title).toBe("chore(release): 0.1.24");
     expect(fixture.github.writes).toHaveLength(0);
     const first = await fixture.run();
     expect(first.action).toBe("created");
@@ -981,6 +1004,10 @@ describe("rolling release reconciliation", () => {
       (candidate) => candidate.number === first.pull,
     )!;
     expect(pull.draft).toBe(false);
+    expect(pull.title).toBe("chore(release): 0.1.24");
+    expect(
+      fixture.git("show", "-s", "--format=%s", first.headSha!).trim(),
+    ).toBe("chore(release): 0.1.24");
     expect(pull.body).toContain("- [ ]");
     pull.body += "\nMaintainer review and test results.\n";
     const humanBody = pull.body;
@@ -991,6 +1018,10 @@ describe("rolling release reconciliation", () => {
     expect(second.action).toBe("updated");
     expect(second.pull).toBe(first.pull);
     expect(second.plan.version).toBe("0.2.0");
+    expect(pull.title).toBe("chore(release): 0.2.0");
+    expect(
+      fixture.git("show", "-s", "--format=%s", second.headSha!).trim(),
+    ).toBe("chore(release): 0.2.0");
     expect(second.plan.branch).toBe(first.plan.branch);
     expect(pull.body).toBe(humanBody);
     expect(
@@ -1011,6 +1042,29 @@ describe("rolling release reconciliation", () => {
     const writes = fixture.github.writes.length;
     expect((await fixture.run()).action).toBe("unchanged");
     expect(fixture.github.writes).toHaveLength(writes);
+  });
+
+  test("retitles an existing release PR without changing an up-to-date branch", async () => {
+    const fixture = new Fixture();
+    fixture.merge("fix: initial fix");
+    const first = await fixture.run();
+    const pull = fixture.github.pulls.find(
+      (candidate) => candidate.number === first.pull,
+    )!;
+    pull.title = "release: prepare the next Codex Security release";
+    const body = pull.body;
+    const writes = fixture.github.writes.length;
+    const updated = await fixture.run();
+    expect(updated.headSha).toBe(first.headSha);
+    expect(pull.title).toBe("chore(release): 0.1.24");
+    expect(pull.body).toBe(body);
+    expect(fixture.github.writes.slice(writes)).toEqual([
+      {
+        method: "PATCH",
+        path: `pulls/${pull.number}`,
+        body: { title: "chore(release): 0.1.24" },
+      },
+    ]);
   });
 
   test("incorporates main-only changes without another proposal review or repeated commits", async () => {
@@ -1251,30 +1305,33 @@ describe("rolling release reconciliation", () => {
     ).toBe(false);
   });
 
-  test("does not touch another release PR or recreate an intentionally closed proposal", async () => {
-    const fixture = new Fixture();
-    fixture.merge("feat: initial feature");
-    const manual = fixture.github.addPull(
-      "manual-release",
-      "release: prepare a release",
-      fixture.head()!,
-    );
-    const held = await fixture.run();
-    expect(held.action).toBe("held");
-    expect(held.reason).toContain(`#${manual.number}`);
-    expect(fixture.github.writes).toHaveLength(0);
-    manual.state = "closed";
-    const created = await fixture.run();
-    const pull = fixture.github.pulls.find(
-      (candidate) => candidate.number === created.pull,
-    )!;
-    pull.state = "closed";
-    const writes = fixture.github.writes.length;
-    expect((await fixture.run()).action).toBe("held");
-    expect(fixture.github.writes).toHaveLength(writes);
-    pull.state = "open";
-    expect((await fixture.run()).pull).toBe(pull.number);
-  });
+  test.each(["chore(release): 0.1.24", "release: prepare a release"])(
+    "does not touch another %s PR or recreate an intentionally closed proposal",
+    async (title) => {
+      const fixture = new Fixture();
+      fixture.merge("feat: initial feature");
+      const manual = fixture.github.addPull(
+        "manual-release",
+        title,
+        fixture.head()!,
+      );
+      const held = await fixture.run();
+      expect(held.action).toBe("held");
+      expect(held.reason).toContain(`#${manual.number}`);
+      expect(fixture.github.writes).toHaveLength(0);
+      manual.state = "closed";
+      const created = await fixture.run();
+      const pull = fixture.github.pulls.find(
+        (candidate) => candidate.number === created.pull,
+      )!;
+      pull.state = "closed";
+      const writes = fixture.github.writes.length;
+      expect((await fixture.run()).action).toBe("held");
+      expect(fixture.github.writes).toHaveLength(writes);
+      pull.state = "open";
+      expect((await fixture.run()).pull).toBe(pull.number);
+    },
+  );
 
   test("does not create a duplicate when a manual release PR opens during preparation", async () => {
     const fixture = new Fixture();

--- a/sdk/typescript/tests-ts/release-pr.test.ts
+++ b/sdk/typescript/tests-ts/release-pr.test.ts
@@ -1054,7 +1054,11 @@ describe("rolling release reconciliation", () => {
     pull.title = "release: prepare the next Codex Security release";
     const body = pull.body;
     const writes = fixture.github.writes.length;
+    const preview = await fixture.run(true);
+    expect(preview.action).toBe("would-update");
+    expect(fixture.github.writes).toHaveLength(writes);
     const updated = await fixture.run();
+    expect(updated.action).toBe("updated");
     expect(updated.headSha).toBe(first.headSha);
     expect(pull.title).toBe("chore(release): 0.1.24");
     expect(pull.body).toBe(body);


### PR DESCRIPTION
<!-- Use a Conventional Commit title: <type>[optional scope][!]: <description>. See RELEASING.md. -->

## Summary

Release proposals and their bot commits now use `chore(release): X.Y.Z`, with the proposed package version in the title. This removes the generic next-release placeholder from generated titles.

## Changes

- Use the same versioned Conventional Commit title when creating or updating release PRs and commits. Report title-only changes as updates in previews and write results without creating an extra commit.
- Recognize `chore(release)` alongside legacy `release` titles for duplicate release detection and release-note exclusions, while preserving breaking-change handling.
- Document the title format and checking the current squash commit subject at merge time.

## Testing

- [Hosted CI on the final commit](https://github.com/openai/codex-security/actions/runs/34549674878): **42 jobs passed, 2 skipped**, including the full platform test suites.
- Focused release tests: **362 passed**; all **73 release-updater tests passed again** after the title-only status fix.
- `pnpm run types`, `pnpm run format`, Prettier on the changed workflow and release documentation, `actionlint`, and `git diff --check`: passed.
- Local fixed-seed suite across three shards: **2,814 passed, 57 skipped, 2 sandbox failures**. The affected publication cases passed with isolated temporary state and process-inspection access.
- Stopped the additional local randomized run after hosted CI passed. Two existing fixtures timed out during local runs; both passed individually, including the end-to-end scan fixture on the final commit.

## Risk and rollout

Takes effect after merge when the release updater next runs. Existing nonempty proposals receive the new title on reconciliation. Legacy release titles remain supported. No CLI, package-version, permission, or publication-gate changes; existing merged commit subjects are not rewritten.

## Public disclosure review

<!-- Review every public artifact before checking all three attestations. -->

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
