### PR TITLE
fix: advance scan progress when saving drafts

### DIFF
--- a/plugins/codex-security/mcp-app/tests/test_compact_artifact_server.mjs
+++ b/plugins/codex-security/mcp-app/tests/test_compact_artifact_server.mjs
@@ -526,6 +526,38 @@ async function testSemanticScanDraftCompletion(bundle, runtimeLabel) {
       );
     }
 
+    const progress = async () => requireSuccessfulTool(await call(
+      "get_codex_security_scan_context", { scanId, handoffClaimToken }
+    )).scan.progress;
+    assert.equal((await progress()).phase, "preflight");
+    requireSuccessfulTool(await call("update_codex_security_scan_progress", {
+      scanId, handoffClaimToken, phaseItemsTotal: 1, phaseItemsCompleted: 1,
+      phaseProgressUnit: "checks"
+    }));
+    const checkpoint = {
+      scanId,
+      handoffClaimToken,
+      complete: false,
+      findings: [finding],
+      coverage: { ...coverage, completeness: "partial" }
+    };
+    requireSuccessfulTool(await call("record_codex_security_scan_draft", checkpoint));
+    const discovery = await progress();
+    assert.equal(discovery.status, "running");
+    assert.equal(discovery.phase, "discovery");
+    assert.deepEqual(discovery.phaseProgress, { completed: 0, total: 0, unit: null });
+
+    requireSuccessfulTool(await call("update_codex_security_scan_progress", {
+      scanId, handoffClaimToken, phase: "validation", phaseItemsTotal: 2,
+      phaseItemsCompleted: 1, phaseProgressUnit: "candidate_findings"
+    }));
+    requireSuccessfulTool(await call("record_codex_security_scan_draft", checkpoint));
+    const validation = await progress();
+    assert.equal(validation.phase, "validation");
+    assert.deepEqual(validation.phaseProgress, {
+      completed: 1, total: 2, unit: "candidate_findings"
+    });
+
     const drafted = requireSuccessfulTool(await call(
       "record_codex_security_scan_draft",
       {
@@ -542,6 +574,10 @@ async function testSemanticScanDraftCompletion(bundle, runtimeLabel) {
       operation: "replace",
       status: "draft_written"
     });
+    const reporting = await progress();
+    assert.equal(reporting.phase, "reporting");
+    assert.equal(reporting.status, "running");
+    assert.deepEqual(reporting.phaseProgress, { completed: 0, total: 0, unit: null });
 
     const completed = requireSuccessfulTool(await call(
       "complete_codex_security_scan",

--- a/plugins/codex-security/scripts/workbench_saved_results.py
+++ b/plugins/codex-security/scripts/workbench_saved_results.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import os
 import re
+import sqlite3
 import stat
 import sys
 from collections.abc import Callable, Iterator
@@ -34,6 +35,7 @@ from finalize_scan_contract import (
     open_scan_local_file_descriptor,
     write_scan_local_bytes,
 )
+from workbench_constants import PHASES
 from workbench_validation import path_within_scope
 
 _PUBLISHED_OUTPUTS = (
@@ -1405,6 +1407,29 @@ def write_scan_draft(db: Any, connection: Any, args: Any) -> dict[str, Any]:
                 filename,
                 (json.dumps(document, allow_nan=False, indent=2) + "\n").encode(),
             )
+        # Accepted Standard drafts are evidence of review or report assembly,
+        # even when the parent omitted its explicit progress call.
+        if scan["mode"] == "standard":
+            phase = "discovery" if manifest["scan"].get("complete") is False else "reporting"
+            earlier = PHASES[: PHASES.index(phase)]
+            placeholders = ",".join("?" for _ in earlier)
+            timestamp = db.now()
+            try:
+                with connection:
+                    changed = connection.execute(
+                        "UPDATE scans SET phase = ?, updated_at = ? "
+                        f"WHERE id = ? AND status = 'running' AND phase IN ({placeholders})",
+                        (phase, timestamp, scan_id, *earlier),
+                    )
+                    if changed.rowcount:
+                        connection.execute(
+                            "UPDATE scan_progress SET phase_items_total = 0, "
+                            "phase_items_completed = 0, phase_progress_unit = NULL, updated_at = ? "
+                            "WHERE scan_id = ?",
+                            (timestamp, scan_id),
+                        )
+            except sqlite3.Error as exc:
+                print(f"Could not save scan progress: {exc}", file=sys.stderr)
     return {"scanId": scan_id, "status": "draft_written"}
 
 

--- a/plugins/codex-security/skills/security-scan/references/desktop-scan.md
+++ b/plugins/codex-security/skills/security-scan/references/desktop-scan.md
@@ -12,7 +12,11 @@ Resolve the target, requested scope, and user-provided security context before s
 
 Use the returned `scanId`, `scanDir`, scope, and exact `userContext` throughout the parent workflow. Read `../../../references/desktop-config-preflight.md` and run capability preflight only after this authoritative context exists.
 
-Use the existing desktop phase labels for work that actually occurs: threat mapping, investigation, parent-led validation, attack-path assessment, and report assembly. Preserve the authoritative scan ID and handoff token. Increase the investigator total before dispatching each newly discovered assignment; the concurrently running baseline is independent and does not inflate that total. Capture each completed, source-backed investigation as a real coverage surface before advancing its `review_receipts` progress count. Do not create separate receipt files. Advance later phase counts only after the corresponding finding or report artifact exists, and never invent counts, phase workers, or coverage.
+## Publish Live Progress
+
+Call `update_codex_security_scan_progress({ scanId, handoffClaimToken, phase })` when entering each real phase. After publishing a ready preflight result, set `phase: "threat_model"` before mapping security boundaries. Set `discovery` before dispatching investigation packets, `validation` before parent validation, `attack_path` before assessing reachability, and `reporting` before assembling the final report inputs. Preserve the current phase when work overlaps; never move backward or repeat completed work. Use the returned `scan.userContext` for the new phase and its workers.
+
+Publish meaningful completed-review batches through the same tool. Increase the investigator total before dispatching each newly discovered assignment; the concurrently running baseline is independent and does not inflate that total. Capture each completed, source-backed investigation as a real coverage surface before advancing its `review_receipts` progress count. Do not create separate receipt files. Advance later phase counts only after the corresponding finding or report artifact exists, and never invent counts, phase workers, or coverage. Accepted checkpoints also advance a Standard scan to at least `discovery`, and the final draft advances it to `reporting`; publish earlier phase transitions as they happen instead of waiting for a checkpoint.
 
 ## Complete The Same Scan
 


### PR DESCRIPTION
## Summary

A Standard scan can save valid review results while its displayed phase stays at the initial step. Saving a draft did not update progress, so the display depended on separate progress calls from the scan task.

This change advances the phase when a valid draft is saved. A partial checkpoint advances the scan to at least discovery. A final draft advances it to reporting. The scan remains running until normal completion succeeds.

## Changes

- Update progress only after the draft passes validation and its files are saved.
- Preserve later phases and their counts when a late checkpoint arrives. Reset phase counts only when the phase advances.
- Keep draft saving successful if the optional progress update fails.
- Make phase updates explicit in the desktop scan instructions.
- Extend the existing MCP integration test for source and bundled servers.

## Testing

The same controlled scan ran against the original and patched packaged MCP server, with no explicit progress calls. The original stayed in preflight after both a partial checkpoint and a final draft. The patch advanced to discovery and reporting while the scan was still running. Both runs completed. The regression test failed on the original code and passed with the patch.

Passed:

- All 23 MCP test files, including the source and bundled draft integration test.
- MCP TypeScript typecheck.
- Ruff lint and format checks for the full plugin with Ruff 0.16.1.
- `pnpm --dir sdk/typescript run build:ci`.
- `node .github/scripts/check_plugin_source_compatibility.mjs`.
- `node --test .github/scripts/test_check_plugin_source_compatibility.mjs` (9 tests).
- `git diff --check`.

Native desktop verification did not reach app launch. A Python CLI-help test failed to import a sibling module with Python safe-path mode enabled. The unchanged original helper reproduced the same failure. The full Python suite was stopped after that failure. No native UI or full model-driven scan is claimed as verified.

## Risk and rollout

The change applies to Standard scans. It does not change public commands, flags, schemas, or completion checks. Deep and diff scans retain their current behavior. Install the updated plugin to use the fix; an existing scan advances when it saves its next accepted checkpoint or receives an explicit progress update.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
