### PR TITLE
feat(build): support host native plugin builds

### DIFF
--- a/plugins/codex-security/mcp-app/TESTING.md
+++ b/plugins/codex-security/mcp-app/TESTING.md
@@ -11,3 +11,19 @@ node --test --test-concurrency=1 "tests/test_*.mjs"
 ```
 
 Use the existing injected clocks for retry policy tests. Keep real timers, subprocesses, SQLite files, and isolated temporary directories in the lifecycle, locking, permissions, and stdio tests. Do not share writable fixtures between test files or rebuild the bundled plugin while another test is reading it.
+
+## Build for the local host
+
+For a local or CI plugin that only runs on the build host, install the MCP app dependencies and the toolchain declared in `../native/rust-toolchain.toml`. Windows also requires the MSVC C++ build tools. From this directory:
+
+```sh
+pnpm install --frozen-lockfile
+pnpm run build:native
+node scripts/build_mcp_app.mjs --output .preview/mcp --native host
+```
+
+`build:native` compiles the native TypeScript tools with this package's existing dependencies, runs the locked Cargo build, and prepares dependency notices. It does not require the SDK source tree. Native outputs stay in ignored `../native/dist` and `../native/target` directories; `CARGO_TARGET_DIR` can select another Cargo cache.
+
+`--native host` copies the current OS, CPU, and Linux libc target from `native/dist`, together with all shared notices. It requires a fresh `build:native` run after native source changes and fails if the host binary is missing. Build again on each execution platform; a host build is not a portable release artifact.
+
+The default, `--native universal`, still requires the complete verified `native/prebuilt` payload. Package and release validation keep checking every supported platform. For distributing GNU Linux binaries, retain the glibc 2.28 build environment and the compatibility checks described in the [native README](../native/README.md).

--- a/plugins/codex-security/mcp-app/package.json
+++ b/plugins/codex-security/mcp-app/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "build": "tsc --noEmit",
+    "build:native": "node scripts/build_native.mjs",
     "build:mcp": "node scripts/build_mcp_app.mjs --output .preview/mcp",
     "test:mcp": "node --test --test-concurrency=2 --test-reporter=./scripts/test_reporter.mjs \"tests/test_*.mjs\"",
     "typecheck": "tsc --noEmit"

--- a/plugins/codex-security/mcp-app/scripts/build_mcp_app.mjs
+++ b/plugins/codex-security/mcp-app/scripts/build_mcp_app.mjs
@@ -4,13 +4,20 @@ import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { brotliCompressSync, constants as zlibConstants } from "node:zlib";
 import { execFileSync } from "node:child_process";
+import { parseArgs } from "node:util";
 import { build } from "esbuild";
 
 const root = resolve(import.meta.dirname, "..");
 const maxChunkBytes = 140_000;
 
-export async function buildMcpApp({ output }) {
+export async function buildMcpApp({ output, native = "universal" }) {
+  if (native !== "universal" && native !== "host") {
+    throw new Error("Native packaging must be universal or host.");
+  }
   const mcpDir = resolve(output);
+  const nativeTarget = native === "host"
+    ? (await import("../../native/platform.mjs")).nativeTarget
+    : undefined;
 
   execFileSync(process.execPath, ["--run", "build"], {
     cwd: root,
@@ -21,11 +28,18 @@ export async function buildMcpApp({ output }) {
 
   await writeRuntime("server", "main.ts");
   const contract = JSON.parse(await readFile(join(root, "../plugin-files.json"), "utf8"));
-  for (const file of contract.shippedExact.filter((path) => path.startsWith("mcp/native/"))) {
+  const nativeFiles = contract.shippedExact.filter((path) => path.startsWith("mcp/native/"));
+  if (nativeTarget !== undefined && !nativeFiles.some((path) => path.startsWith(`mcp/native/${nativeTarget}/`))) {
+    throw new Error(`Unsupported native target: ${nativeTarget}`);
+  }
+  for (const file of nativeFiles) {
+    if (nativeTarget !== undefined && file.endsWith(".node") && !file.startsWith(`mcp/native/${nativeTarget}/`)) {
+      continue;
+    }
     const path = file.slice("mcp/native/".length);
     const destination = join(mcpDir, "native", path);
     await mkdir(dirname(destination), { recursive: true });
-    await copyFile(join(root, "../native/prebuilt", path), destination);
+    await copyFile(join(root, "../native", native === "host" ? "dist" : "prebuilt", path), destination);
   }
   await writeRuntime("helpers", "helpers-main.ts");
 
@@ -71,15 +85,20 @@ if (
   invokedPath !== undefined
   && pathToFileURL(resolve(invokedPath)).href === import.meta.url
 ) {
-  const args = process.argv.slice(2);
-  if (args.length !== 2 || args[0] !== "--output") {
-    console.error("Usage: node scripts/build_mcp_app.mjs --output <directory>");
-    process.exitCode = 1;
-  } else {
-    buildMcpApp({ output: args[1] }).catch((error) => {
-      console.error(error instanceof Error ? error.message : error);
-      process.exitCode = 1;
+  try {
+    const { values } = parseArgs({
+      options: {
+        output: { type: "string" },
+        native: { type: "string", default: "universal" }
+      }
     });
+    if (!values.output) {
+      throw new Error("Usage: node scripts/build_mcp_app.mjs --output <directory> [--native universal|host]");
+    }
+    await buildMcpApp(values);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
   }
 }
 

--- a/plugins/codex-security/mcp-app/scripts/build_native.mjs
+++ b/plugins/codex-security/mcp-app/scripts/build_native.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { join, resolve } from "node:path";
+
+const app = resolve(import.meta.dirname, "..");
+const native = join(app, "../native");
+
+execFileSync(
+  process.execPath,
+  [
+    join(app, "node_modules/typescript/bin/tsc"),
+    "--project",
+    join(app, "tsconfig.native.json"),
+  ],
+  { cwd: app, stdio: "inherit" },
+);
+
+execFileSync(process.execPath, ["build.mjs"], {
+  cwd: native,
+  stdio: "inherit",
+});
+// Notices include every locked dependency, including those for other targets.
+execFileSync("cargo", ["fetch", "--locked"], { cwd: native, stdio: "inherit" });
+execFileSync(process.execPath, ["notices.mjs"], {
+  cwd: native,
+  stdio: "inherit",
+});

--- a/plugins/codex-security/mcp-app/tests/test_build_mcp_app.mjs
+++ b/plugins/codex-security/mcp-app/tests/test_build_mcp_app.mjs
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { transform } from "esbuild";
+
+const app = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const contract = JSON.parse(
+  await readFile(join(app, "../plugin-files.json"), "utf8"),
+);
+const nativeFiles = contract.shippedExact
+  .filter((path) => path.startsWith("mcp/native/"))
+  .map((path) => path.slice("mcp/native/".length));
+const platform = await transform(
+  await readFile(join(app, "../native/platform.mts"), "utf8"),
+  {
+    loader: "ts",
+    format: "esm",
+  },
+);
+const { nativeTarget } = await import(
+  `data:text/javascript,${encodeURIComponent(platform.code)}`
+);
+const hostBinary = nativeFiles.find((path) =>
+  path.startsWith(`${nativeTarget}/`),
+);
+assert.ok(hostBinary);
+const foreignBinary = nativeFiles.find(
+  (path) => path.endsWith(".node") && path !== hostBinary,
+);
+const notices = nativeFiles.filter((path) => !path.endsWith(".node"));
+
+async function fixture(t) {
+  const root = await realpath(
+    await mkdtemp(join(tmpdir(), "native-package-test-")),
+  );
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const mcp = join(root, "mcp-app");
+  await mkdir(join(mcp, "scripts"), { recursive: true });
+  await symlink(
+    join(app, "node_modules"),
+    join(mcp, "node_modules"),
+    "junction",
+  );
+  await copyFile(
+    join(app, "scripts/build_mcp_app.mjs"),
+    join(mcp, "scripts/build_mcp_app.mjs"),
+  );
+  await writeFile(
+    join(mcp, "package.json"),
+    JSON.stringify({
+      type: "module",
+      scripts: { build: "tsc --noEmit" },
+    }),
+  );
+  await writeFile(
+    join(mcp, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: { skipLibCheck: true },
+      include: ["*.ts"],
+    }),
+  );
+  await writeFile(join(mcp, "main.ts"), 'console.log("server fixture");\n');
+  await writeFile(
+    join(mcp, "helpers-main.ts"),
+    'console.log("helper fixture");\n',
+  );
+  await writeFile(join(root, "plugin-files.json"), JSON.stringify(contract));
+  for (const [directory, files] of [
+    ["prebuilt", nativeFiles],
+    ["dist", [...notices, hostBinary]],
+  ]) {
+    for (const path of files) {
+      const destination = join(root, "native", directory, path);
+      await mkdir(dirname(destination), { recursive: true });
+      await writeFile(destination, `${directory}:${path}`);
+    }
+  }
+  await writeFile(join(root, "native/platform.mjs"), platform.code);
+  const output = join(root, "output");
+  return {
+    root,
+    output,
+    build: (...args) =>
+      spawnSync(
+        process.execPath,
+        [join(mcp, "scripts/build_mcp_app.mjs"), "--output", output, ...args],
+        { encoding: "utf8" },
+      ),
+  };
+}
+
+test("host packaging uses only the source-built target and shared notices", async (t) => {
+  const { root, output, build } = await fixture(t);
+  await rm(join(root, "native/prebuilt"), { recursive: true });
+  const result = build("--native", "host");
+  assert.equal(result.status, 0, result.stderr);
+  const files = (
+    await readdir(join(output, "native"), {
+      recursive: true,
+      withFileTypes: true,
+    })
+  ).filter((entry) => entry.isFile());
+  assert.equal(files.length, notices.length + 1);
+  for (const path of [...notices, hostBinary]) {
+    assert.equal(
+      await readFile(join(output, "native", path), "utf8"),
+      `dist:${path}`,
+    );
+  }
+  assert.equal(
+    spawnSync(process.execPath, [join(output, "server.mjs")], {
+      encoding: "utf8",
+    }).stdout,
+    "server fixture\n",
+  );
+  assert.equal(
+    spawnSync(process.execPath, [join(output, "helpers.mjs")], {
+      encoding: "utf8",
+    }).stdout,
+    "helper fixture\n",
+  );
+});
+
+test("default packaging retains every verified prebuilt target", async (t) => {
+  const { output, build } = await fixture(t);
+  const result = build();
+  assert.equal(result.status, 0, result.stderr);
+  for (const path of nativeFiles) {
+    assert.equal(
+      await readFile(join(output, "native", path), "utf8"),
+      `prebuilt:${path}`,
+    );
+  }
+});
+
+test("host packaging rejects a missing host build even when prebuilt artifacts exist", async (t) => {
+  const { root, build } = await fixture(t);
+  await rm(join(root, "native/dist", hostBinary));
+  const result = build("--native", "host");
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /ENOENT/);
+});
+
+test("universal packaging still rejects a missing foreign target", async (t) => {
+  const { root, build } = await fixture(t);
+  await rm(join(root, "native/prebuilt", foreignBinary));
+  const result = build();
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /ENOENT/);
+});

--- a/plugins/codex-security/mcp-app/tsconfig.native.json
+++ b/plugins/codex-security/mcp-app/tsconfig.native.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": false,
+    "noEmitOnError": true,
+    "rootDir": "../native",
+    "typeRoots": ["./node_modules/@types"]
+  },
+  "include": ["../native/*.mts"]
+}


### PR DESCRIPTION
## Summary

Local and CI plugin builds currently require native artifacts for every supported platform. Add an explicit host packaging mode so those builds can compile the checked-out native source and package only the current target, with its notices.

## Changes

- Add `pnpm run build:native` in the MCP app to compile native TypeScript tools, run the locked Cargo build, and generate notices using the existing plugin dependencies.
- Add `build_mcp_app.mjs --output <directory> --native host`. The default remains `--native universal`, using every verified prebuilt target.
- Document setup and add packaging regressions for host output, universal output, and missing binaries.

## Testing

- Four packaging tests passed, including the host case that failed before the change.
- Built the native binding and host MCP payload on macOS ARM64 with Node 22.23.2 and the declared Rust 1.97.1 toolchain.
- Native compatibility/private-path checks and the Unix native proof with an empty PATH passed. MCP smoke and Deep Scan executor integration tests passed against a detached single-target plugin.
- SDK `build:ci`, plugin source compatibility, all nine compatibility tests, and the plugin's pinned Ruff checks passed. Compatibility tests ran with the local proxy agent's unrelated warning suppressed in child processes.

## Risk and rollout

This changes build tooling only. Universal package and release consumers retain their complete native payload requirement. Host mode requires `build:native` after native source changes and is intended for the build host; it does not replace portable distribution artifacts. Actual Windows and Linux host-build integration was not executed locally.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.

<!-- explain-pr:impact:start -->
## Change impact

The MCP app can compile one native target and package it without a universal artifact.

```mermaid
flowchart LR
  subgraph column_0["Inputs"]
    direction TB
    node_0["MCP app dependencies"]
    node_3["Prebuilt native files"]
  end
  subgraph column_1["Build tools"]
    direction TB
    node_1["Compile host native"]
    node_4["Select native payload"]
  end
  subgraph column_2["Payload"]
    direction TB
    node_2["Host binary and notices"]
    node_5["MCP output"]
  end
  node_0 -->|"compiles tools"| node_1
  node_1 -->|"builds and prepares"| node_2
  node_2 -->|"supplies host mode"| node_4
  node_3 -->|"supplies default mode"| node_4
  node_4 -->|"copies declared files"| node_5
  class node_0 context
  class node_1 changed
  class node_2 affected
  class node_3 context
  class node_4 changed
  class node_5 affected
  classDef changed fill:#d7f5e5,stroke:#237a4b,color:#111
  classDef affected fill:#e6f0ff,stroke:#3569a8,color:#111
  classDef context fill:#f2f3f5,stroke:#6e7781,color:#111
```

> **Limits:** Host builds are for the build platform; portable releases still use universal artifacts. · Windows and Linux host-build integration was not executed locally.

<details>
<summary>Source evidence (4)</summary>

- [`plugins/codex-security/mcp-app/scripts/build_native.mjs:L8-L16`](https://github.com/openai/codex-security/blob/3c88f3ea2d2958528c31a4b48aa27ce85d402346/plugins/codex-security/mcp-app/scripts/build_native.mjs#L8-L16) — Compile native tools using the MCP app TypeScript dependency.
- [`plugins/codex-security/mcp-app/scripts/build_native.mjs:L18-L27`](https://github.com/openai/codex-security/blob/3c88f3ea2d2958528c31a4b48aa27ce85d402346/plugins/codex-security/mcp-app/scripts/build_native.mjs#L18-L27) — Run the existing locked native build and generate shared notices.
- [`plugins/codex-security/mcp-app/scripts/build_mcp_app.mjs:L13-L44`](https://github.com/openai/codex-security/blob/3c88f3ea2d2958528c31a4b48aa27ce85d402346/plugins/codex-security/mcp-app/scripts/build_mcp_app.mjs#L13-L44) — Host mode reads the current target from dist; the default copies every declared prebuilt file.
- [`plugins/codex-security/mcp-app/tsconfig.native.json:L1-L12`](https://github.com/openai/codex-security/blob/3c88f3ea2d2958528c31a4b48aa27ce85d402346/plugins/codex-security/mcp-app/tsconfig.native.json#L1-L12) — Emit the native tools without requiring the SDK TypeScript project.

</details>
<!-- explain-pr:impact:end -->
