### PR TITLE
fix(deep): resume without historical worker prompts

### DIFF
--- a/plugins/codex-security/mcp-app/src/deep-scan/coordinator.ts
+++ b/plugins/codex-security/mcp-app/src/deep-scan/coordinator.ts
@@ -11,16 +11,12 @@ import {
   type ScanDraftInput
 } from "../artifact-scan-draft.js";
 import type { DeepScanArtifacts } from "./artifacts.js";
-import {
-  DeepScanWorkerRunner,
-  sha256
-} from "./worker-runner.js";
+import { DeepScanWorkerRunner } from "./worker-runner.js";
 import type {
   AcceptedDiscovery,
   DedupOutcome,
   DiscoveryOutcome,
-  SuccessfulDedupOutcome,
-  WorkerExecutionAudit
+  SuccessfulDedupOutcome
 } from "./worker-runner.js";
 import {
   boundedDeepScanErrorPair,
@@ -61,16 +57,6 @@ interface SchedulerResult {
 }
 
 type CoordinatorPhase = "setup" | "discovery" | "terminal";
-
-interface SchedulerAudit {
-  accepted: AcceptedDiscovery[];
-  mergedWorkerIds: string[];
-  omittedWorkerIds: string[];
-  canceledWorkerIds: string[];
-  bufferedWorkerIds: string[];
-  reducers: AcceptedReducer[];
-  executions: WorkerExecutionAudit[];
-}
 
 export interface CoordinatorOptions {
   run: DeepScanRunState;
@@ -124,15 +110,6 @@ export class DeepScanCoordinator {
   private externallyFailed = false;
   private phase: CoordinatorPhase = "setup";
   private discoveryDeadlineReached = false;
-  private readonly audit: SchedulerAudit = {
-    accepted: [],
-    mergedWorkerIds: [],
-    omittedWorkerIds: [],
-    canceledWorkerIds: [],
-    bufferedWorkerIds: [],
-    reducers: [],
-    executions: []
-  };
   private state: DeepScanRunState;
 
   constructor(private readonly options: CoordinatorOptions) {
@@ -149,10 +126,7 @@ export class DeepScanCoordinator {
       clock: this.clock,
       random: options.random ?? Math.random,
       log: this.log,
-      retryDelaysMs: options.retryDelaysMs ?? RETRY_DELAYS_MS,
-      recordExecution: (execution) => {
-        this.audit.executions.push(execution);
-      }
+      retryDelaysMs: options.retryDelaysMs ?? RETRY_DELAYS_MS
     } satisfies Omit<ConstructorParameters<typeof DeepScanWorkerRunner>[0], "signal">;
     this.workers = new DeepScanWorkerRunner({
       ...workerOptions,
@@ -610,10 +584,6 @@ export class DeepScanCoordinator {
       .filter((worker) => worker.kind === "discovery" && worker.status === "canceled")
       .map((worker) => worker.id);
     const omittedWorkerIds: string[] = [];
-    this.audit.accepted = [...accepted];
-    this.audit.mergedWorkerIds = mergedDiscoveries.map((worker) => worker.id);
-    this.audit.canceledWorkerIds = [...canceledWorkerIds];
-    this.audit.executions = await this.recoverPersistedExecutions();
     const recoveredReducers = await this.recoverCompletedReducers(recovered);
     const reducerOutcomes = recoveredReducers.reducers;
     let latestResult = recoveredReducers.result;
@@ -636,8 +606,6 @@ export class DeepScanCoordinator {
     let stopReason: DeepScanTerminalReason | undefined;
     let lastReplaceableFailure: Extract<DiscoveryOutcome, { status: "failed" }> | undefined;
 
-    this.audit.bufferedWorkerIds = buffer.map((worker) => worker.id);
-    this.audit.reducers = [...reducerOutcomes];
     const errorLimit = config.stopAfterConsecutiveErrors ?? config.stopAfterNoNew;
     let reducerFailures = persistedReducerFailureStreak(this.state.persistedWorkers ?? []);
     if (this.state.consecutiveErrors >= errorLimit) {
@@ -733,10 +701,6 @@ export class DeepScanCoordinator {
           canceledWorkerIds.push(outcome.workerId);
         }
       }
-      this.audit.accepted = [...accepted];
-      this.audit.omittedWorkerIds = unique(omittedWorkerIds);
-      this.audit.canceledWorkerIds = unique(canceledWorkerIds);
-      this.audit.bufferedWorkerIds = buffer.map((worker) => worker.id);
       return firstFailure;
     };
     const reconcileReducerSettlement = async (): Promise<unknown | undefined> => {
@@ -750,7 +714,6 @@ export class DeepScanCoordinator {
       const outcome = result.value;
       if ("status" in outcome) {
         buffer = [...outcome.consumed, ...buffer].sort(compareCompletionSequence);
-        this.audit.bufferedWorkerIds = buffer.map((worker) => worker.id);
         return outcome.error;
       }
       this.state = outcome.run;
@@ -759,9 +722,6 @@ export class DeepScanCoordinator {
       const { result: acceptedResult, ...metadata } = outcome;
       latestResult = acceptedResult;
       reducerOutcomes.push(metadata);
-      this.audit.reducers = [...reducerOutcomes];
-      this.audit.mergedWorkerIds = unique(mergedDiscoveries.map((worker) => worker.id));
-      this.audit.bufferedWorkerIds = buffer.map((worker) => worker.id);
       return undefined;
     };
 
@@ -847,7 +807,6 @@ export class DeepScanCoordinator {
               ?? (this.state.consecutiveErrors ?? 0) + 1;
             this.state = { ...this.state, consecutiveErrors };
             canceledWorkerIds.push(outcome.workerId);
-            this.audit.canceledWorkerIds = unique(canceledWorkerIds);
             this.log({
               event: "discovery_worker_replaced",
               scanId: this.state.scanId,
@@ -875,7 +834,6 @@ export class DeepScanCoordinator {
         }
         if (outcome.status === "canceled") {
           canceledWorkerIds.push(outcome.workerId);
-          this.audit.canceledWorkerIds = unique(canceledWorkerIds);
           if (
             !this.abortController.signal.aborted
             && !this.discoveryAbortController.signal.aborted
@@ -887,8 +845,6 @@ export class DeepScanCoordinator {
         accepted.push(outcome.worker);
         this.state = { ...this.state, consecutiveErrors: 0 };
         buffer.push(outcome.worker);
-        this.audit.accepted = [...accepted];
-        this.audit.bufferedWorkerIds = buffer.map((worker) => worker.id);
         this.logProgress(accepted.length);
         continue;
       }
@@ -896,7 +852,6 @@ export class DeepScanCoordinator {
       reducer = undefined;
       if ("status" in outcome) {
         buffer = [...outcome.consumed, ...buffer].sort(compareCompletionSequence);
-        this.audit.bufferedWorkerIds = buffer.map((worker) => worker.id);
         reducerFailures += 1;
         this.log({
           event: "dedup_worker_replaced",
@@ -923,9 +878,6 @@ export class DeepScanCoordinator {
       const { result: acceptedResult, ...metadata } = outcome;
       latestResult = acceptedResult;
       reducerOutcomes.push(metadata);
-      this.audit.reducers = [...reducerOutcomes];
-      this.audit.mergedWorkerIds = unique(mergedDiscoveries.map((worker) => worker.id));
-      this.audit.bufferedWorkerIds = buffer.map((worker) => worker.id);
       if (
         !this.discoveryDeadlineReached
         && outcome.run.noNewStreak >= config.stopAfterNoNew
@@ -933,8 +885,6 @@ export class DeepScanCoordinator {
       ) {
         stopReason = "saturated";
         canceledWorkerIds.push(...active.keys());
-        this.audit.canceledWorkerIds = unique(canceledWorkerIds);
-        this.audit.bufferedWorkerIds = [];
         this.abortController.abort("deep_scan_saturated");
       }
     }
@@ -942,12 +892,6 @@ export class DeepScanCoordinator {
     // Convergence cancels active workers, but their promises must settle before
     // the manifest records which results completed and which were canceled.
     const lateFailure = await reconcileRemainingDiscoveries("omitted");
-
-    this.audit.accepted = [...accepted];
-    this.audit.mergedWorkerIds = unique(mergedDiscoveries.map((worker) => worker.id));
-    this.audit.omittedWorkerIds = unique(omittedWorkerIds);
-    this.audit.canceledWorkerIds = unique(canceledWorkerIds);
-    this.audit.bufferedWorkerIds = buffer.map((worker) => worker.id);
 
     // Once Deep reaches saturation, late worker errors cannot fail the scan.
     if (lateFailure && stopReason !== "saturated") throw lateFailure;
@@ -981,7 +925,6 @@ export class DeepScanCoordinator {
         worker.resultManifestPath,
         this.state.scanId
       );
-      const evidence = await persistedWorkerEvidence(worker);
       recovered.push({
         id: worker.id,
         label: basename(dirname(worker.promptPath)),
@@ -989,8 +932,7 @@ export class DeepScanCoordinator {
         resultPath: worker.resultManifestPath,
         completionSequence: worker.completionSequence,
         attempt: worker.attempt,
-        ...(worker.threadId ? { threadId: worker.threadId } : {}),
-        ...evidence
+        ...(worker.threadId ? { threadId: worker.threadId } : {})
       });
     }
     return recovered.sort(compareCompletionSequence);
@@ -1031,7 +973,6 @@ export class DeepScanCoordinator {
       }, this.state.scanId);
       latestResult = result;
       noNewStreak = newFindings > 0 ? 0 : noNewStreak + accepted.length;
-      const evidence = await persistedWorkerEvidence(worker);
       outcomes.push({
         type: "dedup",
         id: worker.id,
@@ -1040,45 +981,10 @@ export class DeepScanCoordinator {
         newFindings,
         attempt: worker.attempt,
         ...(worker.threadId ? { threadId: worker.threadId } : {}),
-        ...evidence,
         run: { ...this.state, noNewStreak }
       });
     }
     return { reducers: outcomes, result: latestResult };
-  }
-
-  private async recoverPersistedExecutions(): Promise<WorkerExecutionAudit[]> {
-    const executions: WorkerExecutionAudit[] = [];
-    for (const worker of this.state.persistedWorkers ?? []) {
-      if (
-        worker.kind === "setup"
-        || worker.status === "queued"
-        || worker.status === "running"
-        || (worker.status === "canceled" && worker.attempt === 0)
-      ) {
-        continue;
-      }
-      const replaceableFailure = persistedReplaceableFailure(worker);
-      const status = replaceableFailure || worker.status === "failed"
-        ? "failed"
-        : worker.status;
-      executions.push({
-        id: worker.id,
-        label: basename(dirname(worker.promptPath)),
-        kind: worker.kind,
-        status,
-        attempt: worker.attempt,
-        ...(worker.threadId ? { threadId: worker.threadId } : {}),
-        promptPath: worker.promptPath,
-        artifactDir: worker.artifactDir,
-        ...await persistedWorkerEvidence(worker),
-        ...(status === "failed" && worker.error
-          ? { error: replaceableFailure?.message ?? worker.error }
-          : {}),
-        ...(replaceableFailure ? { failureKind: replaceableFailure.kind } : {})
-      });
-    }
-    return executions;
   }
 
   private reducerReady(
@@ -1236,30 +1142,6 @@ function persistedReplaceableFailure(
     }
   }
   return undefined;
-}
-
-async function persistedWorkerEvidence(worker: PersistedDeepScanWorker): Promise<{
-  basePromptSha256: string;
-  attemptPromptPaths: string[];
-}> {
-  const attemptPromptPaths = [worker.promptPath];
-  for (let attempt = 2; attempt <= worker.attempt; attempt += 1) {
-    const promptPath = join(
-      dirname(worker.promptPath),
-      "prompts",
-      `attempt-${String(attempt).padStart(2, "0")}.md`
-    );
-    try {
-      await fs.access(promptPath);
-      attemptPromptPaths.push(promptPath);
-    } catch {
-      // Transient execution retries reuse the original prompt.
-    }
-  }
-  return {
-    basePromptSha256: sha256(await fs.readFile(worker.promptPath, "utf8")),
-    attemptPromptPaths
-  };
 }
 
 function discoveryErrorLimitError(

--- a/plugins/codex-security/mcp-app/src/deep-scan/worker-runner.ts
+++ b/plugins/codex-security/mcp-app/src/deep-scan/worker-runner.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { dirname, join } from "node:path";
 import { getCodexSecurityDeepReducerInputs } from "../artifact-deep-reducer.js";
@@ -41,8 +40,6 @@ export interface AcceptedDiscovery {
   completionSequence: number;
   attempt: number;
   threadId?: string;
-  basePromptSha256: string;
-  attemptPromptPaths: string[];
 }
 
 export type DiscoveryOutcome =
@@ -66,8 +63,6 @@ export interface SuccessfulDedupOutcome {
   newFindings: number;
   attempt: number;
   threadId?: string;
-  basePromptSha256: string;
-  attemptPromptPaths: string[];
   run: DeepScanRunState;
 }
 
@@ -80,22 +75,6 @@ export interface FailedDedupOutcome {
 }
 
 export type DedupOutcome = SuccessfulDedupOutcome | FailedDedupOutcome;
-
-/** Audit evidence for every logical SDK execution, including failures and cancellation. */
-export interface WorkerExecutionAudit {
-  id: string;
-  label: string;
-  kind: DeepScanWorkerKind;
-  status: "succeeded" | "failed" | "canceled";
-  attempt: number;
-  threadId?: string;
-  promptPath: string;
-  artifactDir: string;
-  basePromptSha256: string;
-  attemptPromptPaths: string[];
-  error?: string;
-  failureKind?: DeepScanReplaceableFailureKind;
-}
 
 export interface ReducerRequest {
   id: string;
@@ -115,13 +94,11 @@ export interface DeepScanWorkerRunnerOptions {
   log: DeepScanLogger;
   retryDelaysMs: readonly number[];
   signal: AbortSignal;
-  recordExecution?: (execution: WorkerExecutionAudit) => void;
 }
 
 interface WorkerAttemptEvidence {
   attempt: number;
   threadId?: string;
-  attemptPromptPaths: string[];
 }
 
 type WorkerAttemptOutcome =
@@ -207,15 +184,6 @@ export class DeepScanWorkerRunner {
     if (!discoveryValidated) {
       await fs.rm(files.resultPath, { force: true });
     }
-    const basePromptSha256 = sha256(basePrompt);
-    this.recordExecution({
-      id: workerId,
-      label: workerLabel,
-      kind: "discovery",
-      promptPath,
-      artifactDir,
-      basePromptSha256
-    }, outcome);
     if (outcome.status === "failed") {
       return {
         type: "discovery",
@@ -283,9 +251,7 @@ export class DeepScanWorkerRunner {
         resultPath: files.resultPath,
         completionSequence: persisted.completionSequence,
         attempt: outcome.attempt,
-        threadId: outcome.threadId,
-        basePromptSha256,
-        attemptPromptPaths: outcome.attemptPromptPaths
+        threadId: outcome.threadId
       }
     };
   }
@@ -377,15 +343,6 @@ export class DeepScanWorkerRunner {
       }, outcome.attempt, outcome.threadId);
       outcome = { ...outcome, status: "canceled" };
     }
-    const basePromptSha256 = sha256(basePrompt);
-    this.recordExecution({
-      id: reducerId,
-      label: reducerLabel,
-      kind: "dedup",
-      promptPath,
-      artifactDir,
-      basePromptSha256
-    }, outcome);
     if (outcome.status === "failed") {
       if (outcome.error instanceof DeepScanNonRetryableError) throw outcome.error;
       return {
@@ -447,8 +404,6 @@ export class DeepScanWorkerRunner {
       newFindings: reducerValidation.newFindings,
       attempt: outcome.attempt,
       threadId: outcome.threadId,
-      basePromptSha256,
-      attemptPromptPaths: outcome.attemptPromptPaths,
       run: committed
     };
   }
@@ -470,10 +425,9 @@ export class DeepScanWorkerRunner {
     let continuationPrompt: string | undefined;
     let lastThreadId: string | undefined;
     let executionPromptPath = input.promptPath;
-    const attemptPromptPaths = [input.promptPath];
     for (let attempt = 1; attempt <= maximumAttempts; attempt += 1) {
       if (signal.aborted) {
-        return await this.cancelAttempt(input, attempt, lastThreadId, attemptPromptPaths);
+        return await this.cancelAttempt(input, attempt, lastThreadId);
       }
       let validationStarted = false;
       let validationCompleted = false;
@@ -527,7 +481,7 @@ export class DeepScanWorkerRunner {
           }
         });
         if (signal.aborted) {
-          return await this.cancelAttempt(input, attempt, activeThreadId, attemptPromptPaths);
+          return await this.cancelAttempt(input, attempt, activeThreadId);
         }
         validationStarted = true;
         try {
@@ -537,7 +491,7 @@ export class DeepScanWorkerRunner {
         }
         validationCompleted = true;
         if (signal.aborted) {
-          return await this.cancelAttempt(input, attempt, activeThreadId, attemptPromptPaths);
+          return await this.cancelAttempt(input, attempt, activeThreadId);
         }
         this.options.log({
           event: "worker_succeeded",
@@ -549,12 +503,11 @@ export class DeepScanWorkerRunner {
         return {
           status: "succeeded",
           attempt,
-          threadId: result.threadId ?? activeThreadId,
-          attemptPromptPaths: [...attemptPromptPaths]
+          threadId: result.threadId ?? activeThreadId
         };
       } catch (error) {
         if (signal.aborted) {
-          return await this.cancelAttempt(input, attempt, activeThreadId, attemptPromptPaths);
+          return await this.cancelAttempt(input, attempt, activeThreadId);
         }
         const normalized = asError(error);
         const policyRefusal = input.kind === "discovery"
@@ -588,8 +541,7 @@ export class DeepScanWorkerRunner {
               ? {}
               : { consecutiveErrors: persistedFailure.consecutiveErrors }),
             attempt,
-            threadId: activeThreadId,
-            attemptPromptPaths: [...attemptPromptPaths]
+            threadId: activeThreadId
           };
         }
         await this.options.store.updateWorker({
@@ -627,7 +579,6 @@ export class DeepScanWorkerRunner {
               failedAttempt: attempt,
               error: normalized
             });
-            attemptPromptPaths.push(executionPromptPath);
           }
         }
         const delayMs = Math.ceil(
@@ -645,7 +596,7 @@ export class DeepScanWorkerRunner {
           await this.options.clock.sleep(delayMs, signal);
         } catch (sleepError) {
           if (signal.aborted) {
-            return await this.cancelAttempt(input, attempt, activeThreadId, attemptPromptPaths);
+            return await this.cancelAttempt(input, attempt, activeThreadId);
           }
           throw sleepError;
         }
@@ -714,35 +665,14 @@ export class DeepScanWorkerRunner {
       artifactDir: string;
     },
     attempt: number,
-    threadId: string | undefined,
-    attemptPromptPaths: string[]
+    threadId: string | undefined
   ): Promise<WorkerAttemptOutcome> {
     await this.persistWorkerCancellation(input, attempt, threadId);
     return {
       status: "canceled",
       attempt,
-      threadId,
-      attemptPromptPaths: [...attemptPromptPaths]
+      threadId
     };
-  }
-
-  private recordExecution(
-    input: Omit<WorkerExecutionAudit, "status" | "attempt" | "threadId" | "attemptPromptPaths" | "error">,
-    outcome: WorkerAttemptOutcome
-  ): void {
-    this.options.recordExecution?.({
-      ...input,
-      status: outcome.status,
-      attempt: outcome.attempt,
-      ...(outcome.threadId ? { threadId: outcome.threadId } : {}),
-      attemptPromptPaths: [...outcome.attemptPromptPaths],
-      ...(outcome.status === "failed" ? {
-        error: outcome.error.message,
-        ...(outcome.replaceableFailureKind
-          ? { failureKind: outcome.replaceableFailureKind }
-          : {})
-      } : {})
-    });
   }
 }
 
@@ -878,10 +808,6 @@ function validationErrorData(error: Error, message: string): Record<string, unkn
     ...(typeof value.expected === "string" ? { expected: value.expected } : {}),
     message
   };
-}
-
-export function sha256(value: string): string {
-  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
 }
 
 function asError(error: unknown): Error {

--- a/plugins/codex-security/mcp-app/tests/test_deep_scan_coordinator.mjs
+++ b/plugins/codex-security/mcp-app/tests/test_deep_scan_coordinator.mjs
@@ -2910,6 +2910,8 @@ async function testPausedDiscoverySurvivesCoordinatorRestart() {
   store.heartbeatCoordinator = async () => structuredClone(store.run);
   const replacementExecutor = new FakeExecutor({ dedupNewFindings: [0] });
   const acceptedResult = await readFile(accepted.resultManifestPath, "utf8");
+  const acceptedWorkerId = await workerIdFromPrompt(accepted.promptPath);
+  await Promise.all(persistedWorkers.map((worker) => rm(worker.promptPath, { force: true })));
   const resumed = await startOrJoinDeepScanCoordinator({
     begin: { run: structuredClone(store.run), shouldStart: false },
     registry: new DeepScanCoordinatorRegistry(),
@@ -2926,11 +2928,11 @@ async function testPausedDiscoverySurvivesCoordinatorRestart() {
 
   assert.equal(continuationClaims.length, 1);
   assert.equal(continuationClaims[0].handoffClaimToken, handoffClaimToken);
-  assert.equal(terminal?.status, "succeeded");
+  assert.equal(terminal?.status, "succeeded", terminal?.error);
   assert.equal(store.failCalls, 0);
   assert.equal(replacementExecutor.logicalDiscoveryWorkers.size, 1);
   assert.equal(
-    replacementExecutor.logicalDiscoveryWorkers.has(await workerIdFromPrompt(accepted.promptPath)),
+    replacementExecutor.logicalDiscoveryWorkers.has(acceptedWorkerId),
     false
   );
   assert.equal(store.dedupClaims.length, 1);


### PR DESCRIPTION
## Summary

Deep Scan resume can fail when historical worker prompts are missing even though accepted results remain intact. Recovery now reads the accepted artifacts and ordered merge inputs it needs to continue.

## Changes

- Remove unused scheduler history, prompt hashes, callbacks and attempt-path reconstruction.
- Return the latest validated reducer result directly instead of rebuilding unused audit records.
- Preserve discovery and reducer recovery, original settings and deadlines, accepted findings, and ordered merge inputs.
- The latest cleanup (`5f09d59a`) removes 52 net production lines with no test changes.

## Testing

On `5f09d59a`:

- Deep coordinator, store and real-store integration tests passed.
- MCP typecheck and all five portable source checks passed: Ruff lint/format, SDK build, plugin source compatibility, and compatibility tests.
- Three independent reviews of `cb039309..5f09d59a` reported no findings; a separate verifier checked the complete outputs and source.
- [Exact-head CI](https://github.com/openai/codex-security/actions/runs/35176407716) succeeded: 42 jobs passed and two were skipped, including Linux, macOS, Windows and installed-package checks.
- Hosted Codex code and security reviews completed on this head; the code review reported no major issues.
- Source and caller review against main `02c5137f` found no interacting changes. A clean merge-tree check preserves the exact cleanup diff. This is not an end-to-end comparison.

<details>
<summary>Earlier qualification and preserved failures</summary>

The recovery regression set has eight expected failures and seven passing controls on its unchanged baseline; the implementation passes all 15 cases. The previous public head, `cb039309`, passed CI including Linux, macOS, Windows and installed-package checks. Those results do not qualify the new cleanup head.

The earlier CI run was canceled; its canceled jobs and downstream failures remain recorded. The nonblocking dependency-audit failure is also retained and is not a passing audit.

The latest real-store integration test initially failed under the sandbox's filesystem ownership mapping, then passed on the normal host without changing product guards. Initial offline dependency installation failures are retained; the frozen-lockfile install passed using the existing package store. Native reviewers' attempted coordinator test commands failed before execution because their source-only checkouts lacked `esbuild`; these attempts are not counted as passing tests.

</details>

## Risk and rollout

Accepted-artifact validation, persisted worker records, retries, scheduling and public results keep their existing owners. No schema or public CLI change. Local cleanup checks ran on Linux; the exact-head hosted results above cover the configured platform and package checks. This change does not merge or release the PR.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
