### PR TITLE
docs(examples): add GitHub Actions workflow for Bedrock scans

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,10 @@
 
 Examples and templates for using Codex Security:
 
+- [GitHub Actions with Amazon Bedrock](github-actions/README.md): a copyable
+  workflow for PR-diff and full-repository scans with AWS OIDC authentication,
+  SARIF uploads, and downloadable reports.
+
 - [Findings CSV template](findings.csv): a header-only template for
   `codex-security publish scan --to cloud --csv PATH`. Copy it, add one finding
   per row, and validate the file before publishing:

--- a/examples/github-actions/README.md
+++ b/examples/github-actions/README.md
@@ -1,0 +1,136 @@
+# GitHub Actions with Amazon Bedrock
+
+Run Codex Security in a GitHub.com repository using short-lived AWS credentials.
+The [workflow](codex-security.yml) scans pull-request changes, supports manual
+full-repository scans, and uploads completed findings to GitHub Code Scanning
+as SARIF. It does not install a GitHub App or post PR review comments.
+
+The workflow stays in this example directory until you copy it into a repository's
+`.github/workflows/` directory. It does not enable scanning in this repository.
+
+## Setup
+
+1. Configure GitHub's OIDC identity provider in AWS and create a role that can
+   invoke your approved Bedrock model. Scope the role's permissions to the
+   required model or inference profile and region, including streaming invocation
+   when required. Follow the
+   [AWS credentials action's OIDC setup](https://github.com/aws-actions/configure-aws-credentials#oidc-recommended)
+   and [GitHub's AWS OIDC guidance](https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws).
+2. Restrict the role trust policy to your repository. Without a GitHub environment,
+   the default OIDC subjects differ by trigger:
+   - PR scans: `repo:OWNER/REPOSITORY:pull_request`.
+   - Manual and scheduled scans on `main`: `repo:OWNER/REPOSITORY:ref:refs/heads/main`.
+     Replace `main` with your default branch. Authorize other branches only if you
+     intend to run manual scans there. Require the `sts.amazonaws.com` audience.
+3. Add repository Actions variables under **Settings → Secrets and variables →
+   Actions → Variables**:
+
+   | Variable           | Value                                                                  |
+   | ------------------ | ---------------------------------------------------------------------- |
+   | `AWS_ROLE_ARN`     | ARN of the role created above                                          |
+   | `AWS_REGION`       | Region where that role can invoke the model                            |
+   | `BEDROCK_MODEL_ID` | Exact model or inference-profile identifier approved for this workflow |
+
+   No long-lived AWS access key or OpenAI API key is needed. Bedrock access and
+   any required model approvals must already be in place.
+
+4. Confirm GitHub Code Scanning is available for the repository. Private
+   repositories need the appropriate GitHub Code Security entitlement. If you
+   only want downloadable reports, remove the SARIF upload step and the
+   `security-events: write` and `actions: read` permissions.
+5. Copy `codex-security.yml` to
+   `.github/workflows/codex-security.yml` in the repository you want to scan.
+   Review its configuration and merge it into the default branch.
+6. In **Actions → Codex Security (Amazon Bedrock) → Run workflow**, select the
+   default branch and run a baseline scan. Inspect both the result and coverage
+   before relying on the findings. Then open a same-repository test PR to verify
+   the diff scan.
+
+GitHub documents the supported repositories and upload permissions in
+[Uploading a SARIF file](https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/integrate-with-existing-tools/upload-sarif-file).
+
+## Scan behavior
+
+- **Pull requests:** scans GitHub's checked-out PR merge commit against the
+  event's immutable base SHA. Full Git history is fetched, and checkout does not
+  retain a GitHub credential. Superseded runs are cancelled. Draft, fork, and
+  Dependabot-triggered PRs are skipped.
+- **Manual runs:** scans the entire selected ref. The role's OIDC trust policy
+  must allow that ref.
+- **Scheduled runs:** uncomment the schedule after the baseline works to scan
+  the default branch weekly. Scans consume Bedrock inference usage.
+- **Reasoning:** uses standard mode with high reasoning effort. The explicit
+  `model_reasoning_summary="none"` override supports Bedrock models that reject
+  reasoning summaries; it does not reduce reasoning effort. Do not combine
+  `--mode deep` with `--diff`.
+- **Versions:** pins the published CLI to `0.1.27` and actions to commit SHAs.
+  Review and test version updates before changing the pins. The Codex runtime is
+  supplied by the CLI package; its version is separate from the wrapper version.
+- **Duration:** the job and AWS role session are both limited to one hour.
+  Adjust both, and the IAM role's maximum session duration, for longer scans.
+
+See the [CLI documentation](../../sdk/typescript/README.md#scan-options-and-output)
+for scan settings and the
+[Bedrock configuration](../../sdk/typescript/README.md#authentication)
+for provider details.
+
+## Results and failure handling
+
+The scan is report-only by default: findings alone do not fail the job. Set
+`FAIL_ON_SEVERITY: "high"` to fail when a completed scan finds high or critical
+issues. To enforce that result before merging, configure the corresponding
+required check in your repository's rules.
+
+| CLI exit code | Workflow result                                                                                           |
+| ------------- | --------------------------------------------------------------------------------------------------------- |
+| `0`           | Completed scan; export and upload SARIF                                                                   |
+| `1`           | Completed scan with a configured severity-policy violation; upload SARIF and keep the job failed          |
+| `2`           | Invalid input, incomplete coverage, or runtime error; keep the job failed and do not upload partial SARIF |
+| Other nonzero | Keep the job failed; do not upload SARIF                                                                  |
+
+The result JSON and any available report, coverage, findings, and SARIF files
+are saved as a seven-day workflow artifact, even after a failed scan or SARIF
+upload. Cancelled jobs may not save artifacts. The workflow does not upload the
+entire scan directory, local authentication state, or raw agent transcripts.
+Reports can still contain sensitive source snippets and vulnerability details;
+review repository access and artifact retention accordingly.
+
+Completed SARIF appears under **Security → Code scanning**. Full and diff scans
+use separate analysis categories so a partial diff does not replace a full scan.
+Use a completed full scan to reassess the full-repository baseline. During setup,
+check alert locations, repeat-scan deduplication, and fixed-alert behavior in the
+destination repository. Source-root fingerprints help GitHub identify repeated
+findings; see [SARIF support](https://docs.github.com/en/code-security/reference/code-scanning/sarif-files/sarif-support).
+
+## Trust boundary
+
+This example is for trusted contributors on GitHub-hosted Linux runners. A
+same-repository PR can modify workflow code and receives model-invocation
+credentials when the scan runs. Skipping forks is not a substitute for reviewing
+who can push branches. For a wider contributor set, use a protected GitHub
+environment with required reviewers and update the OIDC subject to that
+environment before enabling this workflow.
+
+Do not change the trigger to `pull_request_target` to scan untrusted PR code with
+credentials. Do not add dependency installation, builds, or other PR-controlled
+commands to the scanner job. The workflow installs the CLI outside the checkout
+before checkout and scopes AWS credential environment variables to the scan step.
+It does not give the scanner a `GH_TOKEN` or `GITHUB_TOKEN`.
+
+Only scan code you are authorized to submit to the configured inference provider.
+If you supply additional scanner configuration, keep it maintainer-controlled;
+do not load native Codex configuration from an untrusted PR.
+
+## Troubleshooting
+
+- **OIDC role assumption fails:** compare the run's trigger/ref with the role's
+  allowed subject and audience. A protected environment changes the subject.
+- **Bedrock denies the request:** verify model access, model ID, region, and IAM
+  permissions. Do not paste credentials into workflow logs or issues.
+- **The scan exits with `2`:** inspect the log, result JSON, and coverage report.
+  Missing or partial coverage is not a clean security result.
+- **SARIF upload fails:** check Code Security entitlement and job permissions.
+  The report artifact remains available, but uploading it successfully is a
+  separate setup check from completing a scan.
+- **A PR run is skipped:** fork, Dependabot, and draft PRs are intentionally
+  excluded. Review your trust model before enabling additional contributors.

--- a/examples/github-actions/README.md
+++ b/examples/github-actions/README.md
@@ -1,136 +1,94 @@
 # GitHub Actions with Amazon Bedrock
 
-Run Codex Security in a GitHub.com repository using short-lived AWS credentials.
-The [workflow](codex-security.yml) scans pull-request changes, supports manual
-full-repository scans, and uploads completed findings to GitHub Code Scanning
-as SARIF. It does not install a GitHub App or post PR review comments.
-
-The workflow stays in this example directory until you copy it into a repository's
-`.github/workflows/` directory. It does not enable scanning in this repository.
+The [workflow](codex-security.yml) scans PR changes or, on manual and scheduled
+runs, the full repository. It uses short-lived AWS credentials and uploads
+completed findings to GitHub Code Scanning as SARIF. It does not install a GitHub
+App or post PR comments.
 
 ## Setup
 
-1. Configure GitHub's OIDC identity provider in AWS and create a role that can
-   invoke your approved Bedrock model. Scope the role's permissions to the
-   required model or inference profile and region, including streaming invocation
-   when required. Follow the
-   [AWS credentials action's OIDC setup](https://github.com/aws-actions/configure-aws-credentials#oidc-recommended)
-   and [GitHub's AWS OIDC guidance](https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws).
-2. Restrict the role trust policy to your repository. Without a GitHub environment,
-   the default OIDC subjects differ by trigger:
-   - PR scans: `repo:OWNER/REPOSITORY:pull_request`.
-   - Manual and scheduled scans on `main`: `repo:OWNER/REPOSITORY:ref:refs/heads/main`.
-     Replace `main` with your default branch. Authorize other branches only if you
-     intend to run manual scans there. Require the `sts.amazonaws.com` audience.
-3. Add repository Actions variables under **Settings → Secrets and variables →
+1. Configure [GitHub OIDC in AWS](https://github.com/aws-actions/configure-aws-credentials#oidc-recommended)
+   and create a role that can invoke your approved Bedrock model or inference
+   profile, including streaming invocation when required. Restrict its trust
+   policy to your repository and the `sts.amazonaws.com` audience. Without a
+   GitHub environment, the subjects are:
+   - PRs: `repo:OWNER/REPOSITORY:pull_request`.
+   - Manual and scheduled runs on `main`: `repo:OWNER/REPOSITORY:ref:refs/heads/main`.
+     Replace `main` with your default branch; allow other branches only if you
+     intend to run manual scans there.
+2. Add these repository variables under **Settings → Secrets and variables →
    Actions → Variables**:
 
-   | Variable           | Value                                                                  |
-   | ------------------ | ---------------------------------------------------------------------- |
-   | `AWS_ROLE_ARN`     | ARN of the role created above                                          |
-   | `AWS_REGION`       | Region where that role can invoke the model                            |
-   | `BEDROCK_MODEL_ID` | Exact model or inference-profile identifier approved for this workflow |
+   | Variable           | Value                                          |
+   | ------------------ | ---------------------------------------------- |
+   | `AWS_ROLE_ARN`     | ARN of the role created above                  |
+   | `AWS_REGION`       | Region where the role can invoke the model     |
+   | `BEDROCK_MODEL_ID` | Approved model or inference-profile identifier |
 
-   No long-lived AWS access key or OpenAI API key is needed. Bedrock access and
-   any required model approvals must already be in place.
+   Bedrock model access must already be enabled. No long-lived AWS access key or
+   OpenAI API key is needed.
 
-4. Confirm GitHub Code Scanning is available for the repository. Private
-   repositories need the appropriate GitHub Code Security entitlement. If you
-   only want downloadable reports, remove the SARIF upload step and the
-   `security-events: write` and `actions: read` permissions.
-5. Copy `codex-security.yml` to
-   `.github/workflows/codex-security.yml` in the repository you want to scan.
-   Review its configuration and merge it into the default branch.
-6. In **Actions → Codex Security (Amazon Bedrock) → Run workflow**, select the
-   default branch and run a baseline scan. Inspect both the result and coverage
-   before relying on the findings. Then open a same-repository test PR to verify
-   the diff scan.
+3. Confirm [GitHub Code Scanning and SARIF upload](https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/integrate-with-existing-tools/upload-sarif-file)
+   are available. Private repositories need the appropriate GitHub Code Security
+   entitlement. For downloadable reports only, remove the SARIF upload step and
+   the `security-events: write` and `actions: read` permissions.
+4. Copy `codex-security.yml` into the target repository's `.github/workflows/`
+   directory, review it, and merge it into the default branch. This example does
+   not enable scanning until copied.
+5. In **Actions → Codex Security (Amazon Bedrock) → Run workflow**, run a baseline
+   on the default branch, then open a same-repository test PR. Check coverage,
+   alert locations, deduplication, and fixed-alert behavior in the destination
+   repository before relying on the integration.
 
-GitHub documents the supported repositories and upload permissions in
-[Uploading a SARIF file](https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/integrate-with-existing-tools/upload-sarif-file).
+## Configuration
 
-## Scan behavior
+PR scans compare GitHub's default PR merge checkout against the event's immutable
+base SHA. Draft, fork, and Dependabot-triggered PRs are skipped; newer runs cancel
+older ones. Uncomment the schedule for weekly full scans after setup works.
+Scans consume Bedrock inference usage.
 
-- **Pull requests:** scans GitHub's checked-out PR merge commit against the
-  event's immutable base SHA. Full Git history is fetched, and checkout does not
-  retain a GitHub credential. Superseded runs are cancelled. Draft, fork, and
-  Dependabot-triggered PRs are skipped.
-- **Manual runs:** scans the entire selected ref. The role's OIDC trust policy
-  must allow that ref.
-- **Scheduled runs:** uncomment the schedule after the baseline works to scan
-  the default branch weekly. Scans consume Bedrock inference usage.
-- **Reasoning:** uses standard mode with high reasoning effort. The explicit
-  `model_reasoning_summary="none"` override supports Bedrock models that reject
-  reasoning summaries; it does not reduce reasoning effort. Do not combine
-  `--mode deep` with `--diff`.
-- **Versions:** pins the published CLI to `0.1.27` and actions to commit SHAs.
-  Review and test version updates before changing the pins. The Codex runtime is
-  supplied by the CLI package; its version is separate from the wrapper version.
-- **Duration:** the job and AWS role session are both limited to one hour.
-  Adjust both, and the IAM role's maximum session duration, for longer scans.
+The workflow uses standard mode with high reasoning effort. See
+[scan options](../../sdk/typescript/README.md#scan-options-and-output) and
+[Bedrock configuration](../../sdk/typescript/README.md#authentication) for details.
 
-See the [CLI documentation](../../sdk/typescript/README.md#scan-options-and-output)
-for scan settings and the
-[Bedrock configuration](../../sdk/typescript/README.md#authentication)
-for provider details.
+Actions are pinned to commit SHAs, and CLI and runtime versions are pinned in the
+workflow. Node.js uses the active LTS line.
+Review and test updates before changing pins. The job and AWS session each last
+at most one hour; for longer scans, adjust both and the IAM role's session limit.
 
-## Results and failure handling
+## Results
 
-The scan is report-only by default: findings alone do not fail the job. Set
-`FAIL_ON_SEVERITY: "high"` to fail when a completed scan finds high or critical
-issues. To enforce that result before merging, configure the corresponding
-required check in your repository's rules.
+Findings are report-only by default. Set `FAIL_ON_SEVERITY: "high"` to fail on
+high or critical findings, then make the check required in your repository rules
+if it should block merging.
 
-| CLI exit code | Workflow result                                                                                           |
-| ------------- | --------------------------------------------------------------------------------------------------------- |
-| `0`           | Completed scan; export and upload SARIF                                                                   |
-| `1`           | Completed scan with a configured severity-policy violation; upload SARIF and keep the job failed          |
-| `2`           | Invalid input, incomplete coverage, or runtime error; keep the job failed and do not upload partial SARIF |
-| Other nonzero | Keep the job failed; do not upload SARIF                                                                  |
+| CLI exit code | Workflow result                                                         |
+| ------------- | ----------------------------------------------------------------------- |
+| `0`           | Completed scan; export and upload SARIF                                 |
+| `1`           | Severity-policy violation; upload SARIF and keep the job failed         |
+| Other nonzero | Failed or incomplete scan; fail the job without uploading partial SARIF |
 
-The result JSON and any available report, coverage, findings, and SARIF files
-are saved as a seven-day workflow artifact, even after a failed scan or SARIF
-upload. Cancelled jobs may not save artifacts. The workflow does not upload the
-entire scan directory, local authentication state, or raw agent transcripts.
-Reports can still contain sensitive source snippets and vulnerability details;
-review repository access and artifact retention accordingly.
+For exit `2`, inspect the logs, result JSON, and coverage report: missing coverage
+is not a clean security result. Full and diff scans use separate SARIF categories
+so a diff does not replace the full-repository baseline.
 
-Completed SARIF appears under **Security → Code scanning**. Full and diff scans
-use separate analysis categories so a partial diff does not replace a full scan.
-Use a completed full scan to reassess the full-repository baseline. During setup,
-check alert locations, repeat-scan deduplication, and fixed-alert behavior in the
-destination repository. Source-root fingerprints help GitHub identify repeated
-findings; see [SARIF support](https://docs.github.com/en/code-security/reference/code-scanning/sarif-files/sarif-support).
+Reports are saved as seven-day artifacts even after a scan or SARIF upload fails
+(cancelled jobs may not save them). Only result JSON, report, coverage, findings,
+and SARIF files are uploaded—not authentication state or raw agent transcripts.
+Reports can contain sensitive source snippets and vulnerability details; review
+repository access and retention accordingly.
 
 ## Trust boundary
 
-This example is for trusted contributors on GitHub-hosted Linux runners. A
-same-repository PR can modify workflow code and receives model-invocation
-credentials when the scan runs. Skipping forks is not a substitute for reviewing
-who can push branches. For a wider contributor set, use a protected GitHub
-environment with required reviewers and update the OIDC subject to that
-environment before enabling this workflow.
+Use this example only for trusted contributors on GitHub-hosted Linux runners.
+A same-repository PR can change workflow code and receives model-invocation
+credentials. Skipping forks does not protect against someone who can push a
+branch. For a wider contributor set, require reviewers through a protected
+GitHub environment and [update the OIDC subject](https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws).
 
-Do not change the trigger to `pull_request_target` to scan untrusted PR code with
-credentials. Do not add dependency installation, builds, or other PR-controlled
-commands to the scanner job. The workflow installs the CLI outside the checkout
-before checkout and scopes AWS credential environment variables to the scan step.
-It does not give the scanner a `GH_TOKEN` or `GITHUB_TOKEN`.
-
-Only scan code you are authorized to submit to the configured inference provider.
-If you supply additional scanner configuration, keep it maintainer-controlled;
-do not load native Codex configuration from an untrusted PR.
-
-## Troubleshooting
-
-- **OIDC role assumption fails:** compare the run's trigger/ref with the role's
-  allowed subject and audience. A protected environment changes the subject.
-- **Bedrock denies the request:** verify model access, model ID, region, and IAM
-  permissions. Do not paste credentials into workflow logs or issues.
-- **The scan exits with `2`:** inspect the log, result JSON, and coverage report.
-  Missing or partial coverage is not a clean security result.
-- **SARIF upload fails:** check Code Security entitlement and job permissions.
-  The report artifact remains available, but uploading it successfully is a
-  separate setup check from completing a scan.
-- **A PR run is skipped:** fork, Dependabot, and draft PRs are intentionally
-  excluded. Review your trust model before enabling additional contributors.
+Do not use `pull_request_target` to scan untrusted PR code with credentials, or
+add PR-controlled dependency installs, builds, or commands to this job. The CLI
+is installed outside the checkout before checkout; AWS credentials are scoped
+to the scan step, and no `GH_TOKEN` or `GITHUB_TOKEN` is passed to the scanner.
+Keep any additional scanner configuration maintainer-controlled. Only scan code
+you are authorized to submit to the configured inference provider.

--- a/examples/github-actions/codex-security.yml
+++ b/examples/github-actions/codex-security.yml
@@ -39,14 +39,14 @@ jobs:
 
     steps:
       - name: Set up Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22.13.0"
+          node-version: "24.21.0"
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.12"
+          python-version: "3.14.7"
 
       # Install outside the checkout, before any repository content is present.
       - name: Install Codex Security
@@ -60,7 +60,7 @@ jobs:
           echo "$RUNNER_TEMP/codex-security-cli/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Check out the commit to scan
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -94,7 +94,6 @@ jobs:
             --model "$BEDROCK_MODEL_ID"
             --mode standard
             --effort high
-            --codex 'model_reasoning_summary="none"'
             --output-dir "$RUNNER_TEMP/codex-security-scan"
             --json
           )
@@ -123,7 +122,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Code Scanning
         if: ${{ !cancelled() && steps.sarif.outcome == 'success' }}
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/upload-sarif@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4.38.0
         with:
           sarif_file: ${{ runner.temp }}/codex-security.sarif
           category: codex-security/${{ github.event_name == 'pull_request' && 'diff' || 'full' }}

--- a/examples/github-actions/codex-security.yml
+++ b/examples/github-actions/codex-security.yml
@@ -1,0 +1,143 @@
+name: Codex Security (Amazon Bedrock)
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_dispatch:
+  # Uncomment after testing to scan the default branch weekly.
+  # schedule:
+  #   - cron: "17 3 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    # This job receives AWS credentials. Do not use pull_request_target or
+    # enable it for untrusted contributors; see the README's trust boundary.
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       github.actor != 'dependabot[bot]' &&
+       github.event.pull_request.draft == false)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      id-token: write
+      security-events: write
+      actions: read
+    env:
+      CODEX_SECURITY_VERSION: "0.1.27"
+      BEDROCK_MODEL_ID: ${{ vars.BEDROCK_MODEL_ID }}
+      # Report-only by default. Set to "high" to fail on high/critical findings.
+      FAIL_ON_SEVERITY: ""
+
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: "22.13.0"
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+
+      # Install outside the checkout, before any repository content is present.
+      - name: Install Codex Security
+        working-directory: ${{ runner.temp }}
+        shell: bash
+        run: |
+          npm install --prefix "$RUNNER_TEMP/codex-security-cli" \
+            --ignore-scripts --no-audit --no-fund \
+            --registry=https://registry.npmjs.org/ \
+            "@openai/codex-security@$CODEX_SECURITY_VERSION"
+          echo "$RUNNER_TEMP/codex-security-cli/node_modules/.bin" >> "$GITHUB_PATH"
+
+      - name: Check out the commit to scan
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          # On pull_request, the default checkout is GitHub's PR merge commit.
+
+      - name: Assume the Bedrock role with OIDC
+        id: aws
+        uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-session-name: codex-security-${{ github.run_id }}
+          role-duration-seconds: 3600
+          output-env-credentials: false
+          output-credentials: true
+
+      - name: Scan
+        id: scan
+        shell: bash
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ steps.aws.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws.outputs.aws-session-token }}
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          args=(
+            scan "$GITHUB_WORKSPACE"
+            --provider amazon-bedrock
+            --model "$BEDROCK_MODEL_ID"
+            --mode standard
+            --effort high
+            --codex 'model_reasoning_summary="none"'
+            --output-dir "$RUNNER_TEMP/codex-security-scan"
+            --json
+          )
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            args+=(--diff "$BASE_SHA")
+          fi
+          if [[ -n "$FAIL_ON_SEVERITY" ]]; then
+            args+=(--fail-on-severity "$FAIL_ON_SEVERITY")
+          fi
+          scan_status=0
+          codex-security "${args[@]}" > "$RUNNER_TEMP/codex-security-result.json" || scan_status=$?
+          echo "exit-code=$scan_status" >> "$GITHUB_OUTPUT"
+          exit "$scan_status"
+
+      # A policy violation (1) is still a completed scan. An incomplete/error
+      # result (2) must not replace code-scanning alerts with a partial report.
+      - name: Export completed findings as SARIF
+        id: sarif
+        if: ${{ !cancelled() && (steps.scan.outputs.exit-code == '0' || steps.scan.outputs.exit-code == '1') }}
+        shell: bash
+        run: |
+          codex-security export "$RUNNER_TEMP/codex-security-scan" \
+            --export-format sarif \
+            --source-root "$GITHUB_WORKSPACE" \
+            --output "$RUNNER_TEMP/codex-security.sarif"
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: ${{ !cancelled() && steps.sarif.outcome == 'success' }}
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        with:
+          sarif_file: ${{ runner.temp }}/codex-security.sarif
+          category: codex-security/${{ github.event_name == 'pull_request' && 'diff' || 'full' }}
+
+      - name: Save reports
+        if: ${{ !cancelled() && steps.scan.outputs.exit-code != '' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: codex-security-${{ github.run_id }}-${{ github.run_attempt }}
+          retention-days: 7
+          if-no-files-found: warn
+          path: |
+            ${{ runner.temp }}/codex-security-result.json
+            ${{ runner.temp }}/codex-security.sarif
+            ${{ runner.temp }}/codex-security-scan/report.md
+            ${{ runner.temp }}/codex-security-scan/coverage.json
+            ${{ runner.temp }}/codex-security-scan/findings.json

--- a/sdk/typescript/tests-ts/github-actions-example.test.ts
+++ b/sdk/typescript/tests-ts/github-actions-example.test.ts
@@ -1,0 +1,212 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, test } from "bun:test";
+import { parse } from "yaml";
+
+interface Step {
+  id?: string;
+  uses?: string;
+  if?: string;
+  run?: string;
+  env?: Record<string, string>;
+  with?: Record<string, unknown>;
+}
+
+const workflow = parse(
+  readFileSync(
+    new URL(
+      "../../../examples/github-actions/codex-security.yml",
+      import.meta.url,
+    ),
+    "utf8",
+  ),
+) as {
+  on: Record<string, unknown>;
+  jobs: {
+    scan: {
+      if: string;
+      env: Record<string, string>;
+      permissions: Record<string, string>;
+      steps: Step[];
+    };
+  };
+};
+const job = workflow.jobs.scan;
+const scan = job.steps.find((step) => step.id === "scan")!;
+const sarif = job.steps.find((step) => step.id === "sarif")!;
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function runStep(step: Step, overrides: Record<string, string> = {}) {
+  const directory = mkdtempSync(join(tmpdir(), "codex actions example "));
+  temporaryDirectories.push(directory);
+  // Git Bash accepts forward-slash drive paths on Windows.
+  const root = directory.replaceAll("\\", "/");
+  const bash =
+    process.platform === "win32"
+      ? join(
+          process.env["ProgramFiles"] ?? "C:/Program Files",
+          "Git/bin/bash.exe",
+        )
+      : "bash";
+  const result = spawnSync(
+    bash,
+    [
+      "--noprofile",
+      "--norc",
+      "-e",
+      "-o",
+      "pipefail",
+      "-c",
+      `codex-security() {
+  printf '%s\\0' "$@" > "$RUNNER_TEMP/arguments"
+  printf '{"mock":true}\\n'
+  return "$MOCK_EXIT_CODE"
+}
+${step.run}`,
+    ],
+    {
+      cwd: directory,
+      encoding: "utf8",
+      env: {
+        PATH: process.env["PATH"],
+        SYSTEMROOT: process.env["SYSTEMROOT"],
+        RUNNER_TEMP: root,
+        GITHUB_WORKSPACE: `${root}/repository with spaces`,
+        GITHUB_OUTPUT: `${root}/outputs`,
+        BEDROCK_MODEL_ID: "example.model",
+        EVENT_NAME: "workflow_dispatch",
+        BASE_SHA: "",
+        FAIL_ON_SEVERITY: "",
+        MOCK_EXIT_CODE: "0",
+        ...overrides,
+      },
+    },
+  );
+  if (result.error) throw result.error;
+  const args = readFileSync(join(directory, "arguments"), "utf8")
+    .split("\0")
+    .slice(0, -1);
+  return { ...result, directory, root, args };
+}
+
+test("scans PR changes at the default merge checkout with literal arguments", () => {
+  const base = "base; $(touch should-not-exist)";
+  const result = runStep(scan, {
+    EVENT_NAME: "pull_request",
+    BASE_SHA: base,
+  });
+  expect(result.status).toBe(0);
+  expect(result.args).toEqual([
+    "scan",
+    `${result.root}/repository with spaces`,
+    "--provider",
+    "amazon-bedrock",
+    "--model",
+    "example.model",
+    "--mode",
+    "standard",
+    "--effort",
+    "high",
+    "--codex",
+    'model_reasoning_summary="none"',
+    "--output-dir",
+    `${result.root}/codex-security-scan`,
+    "--json",
+    "--diff",
+    base,
+  ]);
+  const checkout = job.steps.find((step) =>
+    step.uses?.startsWith("actions/checkout@"),
+  )!;
+  expect(checkout.with?.["fetch-depth"]).toBe(0);
+  expect(checkout.with?.["persist-credentials"]).toBe(false);
+  expect(checkout.with?.["ref"]).toBeUndefined();
+});
+
+for (const event of ["workflow_dispatch", "schedule"]) {
+  test(`${event} scans the full repository without a severity gate by default`, () => {
+    const result = runStep(scan, { EVENT_NAME: event });
+    expect(result.status).toBe(0);
+    expect(result.args).not.toContain("--diff");
+    expect(result.args).not.toContain("--fail-on-severity");
+    expect(job.env["FAIL_ON_SEVERITY"]).toBe("");
+  });
+}
+
+for (const status of [0, 1, 2, 130]) {
+  test(`preserves scan exit ${status} and writes its result for later steps`, () => {
+    const result = runStep(scan, {
+      MOCK_EXIT_CODE: String(status),
+      FAIL_ON_SEVERITY: "high",
+    });
+    expect(result.status).toBe(status);
+    expect(result.args.slice(-2)).toEqual(["--fail-on-severity", "high"]);
+    expect(readFileSync(join(result.directory, "outputs"), "utf8")).toBe(
+      `exit-code=${status}\n`,
+    );
+    expect(
+      JSON.parse(
+        readFileSync(
+          join(result.directory, "codex-security-result.json"),
+          "utf8",
+        ),
+      ),
+    ).toEqual({ mock: true });
+  });
+}
+
+test("exports the completed scan with source-root fingerprints outside the checkout", () => {
+  const result = runStep(sarif);
+  expect(result.status).toBe(0);
+  expect(result.args).toEqual([
+    "export",
+    `${result.root}/codex-security-scan`,
+    "--export-format",
+    "sarif",
+    "--source-root",
+    `${result.root}/repository with spaces`,
+    "--output",
+    `${result.root}/codex-security.sarif`,
+  ]);
+  expect(sarif.if).toBe(
+    "${{ !cancelled() && (steps.scan.outputs.exit-code == '0' || steps.scan.outputs.exit-code == '1') }}",
+  );
+  const upload = job.steps.find((step) =>
+    step.uses?.startsWith("github/codeql-action/upload-sarif@"),
+  )!;
+  expect(upload.if).toBe(
+    "${{ !cancelled() && steps.sarif.outcome == 'success' }}",
+  );
+});
+
+test("keeps credentials scoped and skips untrusted PR workflows", () => {
+  expect(workflow.on).toHaveProperty("pull_request");
+  expect(workflow.on).not.toHaveProperty("pull_request_target");
+  expect(job.if).toContain(
+    "github.event.pull_request.head.repo.full_name == github.repository",
+  );
+  expect(job.if).toContain("github.actor != 'dependabot[bot]'");
+  expect(job.permissions).toEqual({
+    contents: "read",
+    "id-token": "write",
+    "security-events": "write",
+    actions: "read",
+  });
+  const aws = job.steps.find((step) => step.id === "aws")!;
+  expect(aws.with?.["output-env-credentials"]).toBe(false);
+  expect(aws.with?.["output-credentials"]).toBe(true);
+  expect(scan.env).toHaveProperty("AWS_SESSION_TOKEN");
+  for (const step of job.steps) {
+    expect(step.env ?? {}).not.toHaveProperty("GH_TOKEN");
+    expect(step.env ?? {}).not.toHaveProperty("GITHUB_TOKEN");
+    if (step.uses) expect(step.uses).toMatch(/@[a-f0-9]{40}$/);
+  }
+});

--- a/sdk/typescript/tests-ts/github-actions-example.test.ts
+++ b/sdk/typescript/tests-ts/github-actions-example.test.ts
@@ -28,7 +28,6 @@ const workflow = parse(
     scan: {
       if: string;
       env: Record<string, string>;
-      permissions: Record<string, string>;
       steps: Step[];
     };
   };
@@ -98,31 +97,17 @@ ${step.run}`,
 }
 
 test("scans PR changes at the default merge checkout with literal arguments", () => {
-  const base = "base; $(touch should-not-exist)";
+  const base = "a".repeat(40);
   const result = runStep(scan, {
     EVENT_NAME: "pull_request",
     BASE_SHA: base,
   });
   expect(result.status).toBe(0);
-  expect(result.args).toEqual([
+  expect(result.args.slice(0, 2)).toEqual([
     "scan",
     `${result.root}/repository with spaces`,
-    "--provider",
-    "amazon-bedrock",
-    "--model",
-    "example.model",
-    "--mode",
-    "standard",
-    "--effort",
-    "high",
-    "--codex",
-    'model_reasoning_summary="none"',
-    "--output-dir",
-    `${result.root}/codex-security-scan`,
-    "--json",
-    "--diff",
-    base,
   ]);
+  expect(result.args.slice(-2)).toEqual(["--diff", base]);
   const checkout = job.steps.find((step) =>
     step.uses?.startsWith("actions/checkout@"),
   )!;
@@ -194,12 +179,6 @@ test("keeps credentials scoped and skips untrusted PR workflows", () => {
     "github.event.pull_request.head.repo.full_name == github.repository",
   );
   expect(job.if).toContain("github.actor != 'dependabot[bot]'");
-  expect(job.permissions).toEqual({
-    contents: "read",
-    "id-token": "write",
-    "security-events": "write",
-    actions: "read",
-  });
   const aws = job.steps.find((step) => step.id === "aws")!;
   expect(aws.with?.["output-env-credentials"]).toBe(false);
   expect(aws.with?.["output-credentials"]).toBe(true);


### PR DESCRIPTION
## Summary

Add a copyable GitHub Actions example for running Codex Security through Amazon Bedrock. It connects existing diff-scan and SARIF-export commands to AWS OIDC, GitHub Code Scanning, and downloadable reports.

## Changes

- Add `examples/github-actions/codex-security.yml` for same-repository PR-diff scans and manual full scans, with an optional weekly schedule.
- Pin the latest stable actions verified on September 11, 2026: checkout 7.0.1, setup-node 7.0.0, setup-python 7.0.0, configure-aws-credentials 6.2.4, CodeQL upload-sarif 4.38.0, and upload-artifact 7.0.1. All actions use exact commit SHAs.
- Use published CLI 0.1.27, Node.js 24.21.0 (active LTS), and Python 3.14.7. Rely on the CLI's existing Bedrock reasoning-summary default.
- Install the CLI before checkout, scope short-lived AWS credentials to the scan step, and disable checkout credential persistence.
- Default to report-only scanning, support an optional severity gate, preserve failures, and upload SARIF only after a completed scan and successful export.
- Document setup, contributor trust, and result handling; link from the examples index. The simplification pass removes duplicated guidance and narrows test assertions to behavior rather than full configuration snapshots.

## Testing

- `actionlint examples/github-actions/codex-security.yml` passed, including ShellCheck.
- `bun test --timeout 30000 tests-ts/github-actions-example.test.ts tests-ts/mock-scan.test.ts tests-ts/targets.test.ts tests-ts/cli-export.test.ts tests-ts/sarif.test.ts tests-ts/config.test.ts` passed: 98 tests, 4 platform/sandbox-specific skips, no failures. This includes all 9 workflow regression tests.
- `pnpm --dir sdk/typescript run build:plugin` passed using this PR's verified native bundle.
- SDK `build`, `types`, and `format` passed, along with explicit Prettier checks of all changed files and `git diff --check`.
- Executed the workflow's scan/export shell blocks with the pinned published CLI on Node.js 24.21.0 and Python 3.14.7, adding only `--mock` to avoid inference. Full scans exited 0; severity-gated diff scans exited 1. Both exported valid SARIF 2.1.0 with synthetic findings.
- Confirmed the published CLI defaults Bedrock reasoning summaries to `none` while preserving high reasoning effort.
- Live AWS OIDC, Bedrock inference, and GitHub SARIF ingestion were not exercised; these require a configured destination repository and AWS role.

## Risk and rollout

The workflow is an example under `examples/`, not an active workflow in this repository. Adoption requires copying it into a destination repository and configuring its variables, AWS trust, and GitHub Code Scanning access. It is for trusted same-repository contributors and skips fork, draft, and Dependabot-triggered PRs; the README explains when protected-environment approval is needed.

No public CLI/API or shipped package changes. Reports may contain source snippets and vulnerability details, so adopters must review repository access and retention. The optional schedule remains commented out.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
