### PR TITLE
test(cli): stabilize non-Git patch fixtures

### DIFF
--- a/sdk/typescript/tests-ts/cli-patch-results.test.ts
+++ b/sdk/typescript/tests-ts/cli-patch-results.test.ts
@@ -13,7 +13,7 @@ afterEach(async () => {
     await rm(directory, { recursive: true, force: true });
 });
 
-async function repositoryFixture() {
+async function repositoryFixture({ initializeGit = true } = {}) {
   const directory = await mkdtemp(join(tmpdir(), "patch-results-"));
   directories.push(directory);
   const runRepositoryCommand: NonNullable<
@@ -29,12 +29,14 @@ async function repositoryFixture() {
   };
   const git = (...args: string[]) =>
     runRepositoryCommand("git", args, directory);
-  git("init", "--initial-branch=main");
-  git("config", "user.name", "Synthetic User");
-  git("config", "user.email", "synthetic@example.test");
   await writeFile(join(directory, "app.ts"), "original\n");
-  git("add", ".");
-  git("commit", "-m", "Synthetic fixture");
+  if (initializeGit) {
+    git("init", "--initial-branch=main");
+    git("config", "user.name", "Synthetic User");
+    git("config", "user.email", "synthetic@example.test");
+    git("add", ".");
+    git("commit", "-m", "Synthetic fixture");
+  }
   return {
     directory,
     git,
@@ -180,11 +182,7 @@ lines.on("line", (line) => {
   test.each([false, true])(
     "checks patch changes outside a Git repository: %s",
     async (apply) => {
-      const fixture = await repositoryFixture();
-      await rm(join(fixture.directory, ".git"), {
-        recursive: true,
-        force: true,
-      });
+      const fixture = await repositoryFixture({ initializeGit: false });
       const outcome = await fixture.patch(["Synthetic issue"], {
         onCodex: async () => {
           if (apply)

--- a/sdk/typescript/tests-ts/cli-patch-results.test.ts
+++ b/sdk/typescript/tests-ts/cli-patch-results.test.ts
@@ -192,11 +192,15 @@ lines.on("line", (line) => {
           return 0;
         },
       });
-      expect(outcome.status).toBe(apply ? 0 : 2);
+      expect(outcome.status, outcome.stderr).toBe(apply ? 0 : 2);
       expect(outcome.result).toMatchObject({
         applied: apply,
         filesChanged: apply ? 1 : 0,
       });
+      if (!apply)
+        expect(outcome.result.error).toMatchObject({
+          code: "NO_PATCH_APPLIED",
+        });
     },
   );
 


### PR DESCRIPTION
## Summary

The non-Git patch test initialized and committed a repository, then deleted `.git`. On macOS CI, the case intermittently reached Git snapshotting and failed with `git read-tree HEAD` instead of exercising directory snapshots. Its no-op assertion could also accept that setup failure.

## Changes

- Create the non-Git cases as plain directories without initializing a repository or deleting Git metadata.
- Keep real Git detection and the existing successful-patch and no-op assertions.
- Require `NO_PATCH_APPLIED` for the no-op case and include captured stderr in exit-code failures.

## Testing

- Focused patch-result tests using Bun 1.3.14, Git 2.55.0, and the failing CI seed `1183541649`: 9 passed.
- Repeated the two non-Git cases 200 times each with the same tool versions and seed: 400 passed.
- `pnpm run types`: passed.
- `pnpm run format`: passed.
- `git diff --check`: passed.
- Previously injected a synthetic Git inspection failure: the original no-op assertion passed incorrectly, while the strengthened assertion rejected `PATCH_FAILED`. The injection is not part of this change.

## Risk and rollout

Test-only change with no runtime or public CLI changes. The CI log confirms that the intended non-Git case entered Git snapshotting; the underlying create/delete failure did not reproduce locally. Starting with a plain directory removes that unnecessary setup while preserving real command execution and strict outcome checks.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
