### PR TITLE
refactor: simplify scan runtime bookkeeping

### DIFF
--- a/plugins/codex-security/mcp-app/src/deep-scan/coordinator.ts
+++ b/plugins/codex-security/mcp-app/src/deep-scan/coordinator.ts
@@ -959,7 +959,7 @@ export class DeepScanCoordinator {
       throw new Error("Deep Scan ended without a successfully reduced Standard scan.");
     }
     return {
-      reason: stopReason ?? "capped",
+      reason: stopReason,
       omittedWorkerIds: unique(omittedWorkerIds),
       canceledWorkerIds: unique(canceledWorkerIds),
       accepted,

--- a/plugins/codex-security/scripts/windows_scan_local_files.py
+++ b/plugins/codex-security/scripts/windows_scan_local_files.py
@@ -465,7 +465,7 @@ def open_read_fd(scan_dir: Path, relative_path: str, context: str) -> int:
                 flags=_FILE_FLAG_OPEN_REPARSE_POINT,
             )
             assert handle is not None and handle.value is not None
-            try:
+            with handle:
                 _verify_regular_file(handle.value, path)
                 raw_handle = handle.detach()
                 try:
@@ -474,8 +474,6 @@ def open_read_fd(scan_dir: Path, relative_path: str, context: str) -> int:
                 except BaseException:
                     _close_handle(raw_handle)
                     raise
-            finally:
-                handle.close()
     except WindowsScanLocalFileError as exc:
         raise WindowsScanLocalFileError(
             exc.errno,

--- a/plugins/codex-security/scripts/workbench_db.py
+++ b/plugins/codex-security/scripts/workbench_db.py
@@ -2486,7 +2486,7 @@ def require_reviewed_patch_applied(
             checkout = checkout_root
             copy_directory_excluding(target, checkout, excluded)
         else:
-            checkout = copy_git_worktree_files(target, checkout_root, excluded)
+            copy_git_worktree_files(target, checkout_root, excluded)
         arguments = ["apply", "--reverse", "--whitespace=nowarn"]
         if unversioned:
             arguments.append("--no-index")

--- a/plugins/codex-security/scripts/workbench_saved_results.py
+++ b/plugins/codex-security/scripts/workbench_saved_results.py
@@ -1260,7 +1260,6 @@ def preserve_scan_results_locked(
             for relative, digest in retained_sources.items()
         ):
             raise ContractError("Stopped scan source digests could not be frozen.")
-        frozen_source_digests = retained_sources
         with connection:
             connection.execute(
                 "UPDATE scans SET retained_source_digests_json = ? "

--- a/sdk/typescript/src/cli.ts
+++ b/sdk/typescript/src/cli.ts
@@ -8348,10 +8348,10 @@ async function executeScan(
           if (status.kind === "dispatch") {
             dashboard.setStage(scanPhase(status.phase));
           }
-          if (message !== null) dashboard.note(message);
+          dashboard.note(message);
           return;
         }
-        if (message === null || progress === null) return;
+        if (progress === null) return;
         progress.stopTimer();
         progress.stage(message);
         progress.startTimer(runningMessage());
@@ -9242,7 +9242,7 @@ export function parseCodexOverrides(
   return result;
 }
 
-function workerStatusMessage(status: ScanWorkerStatus): string | null {
+function workerStatusMessage(status: ScanWorkerStatus): string {
   if (status.kind === "preflight") {
     if (status.delegation === "unavailable") {
       return "Preflight: worker delegation unavailable; continuing without delegated workers.";


### PR DESCRIPTION
## Summary

Scan progress and result handling contain redundant state and unreachable fallback branches. Remove those branches and use the existing Windows handle context manager to keep resource ownership explicit.

## Changes

- Match the worker-status helper's return type to its string-only behavior and simplify its callers.
- Return the known scan stop reason and remove unused checkout and retained-digest bindings.
- Use the owned-handle context manager while preserving raw-handle transfer and failure cleanup.

## Testing

Passed locally:

- Ruff lint and format checks for the plugin.
- TypeScript CI build.
- Portable plugin source compatibility checks and their Node tests.
- Plugin packaging, SDK types, and formatting.
- Focused CLI suite: 154 passed.
- Focused workbench, publication, stop-condition, and Windows-helper Python tests: 136 passed, 2 Windows-only tests skipped on macOS.
- Deep Scan coordinator tests.

GitHub CI passed all 52 checks on `f03b984`, including Linux, macOS, Windows, installed-package verification, and native checks. Codex code and security reviews completed on that head without findings.

The local SDK run with seed 12345 passed 2,993 tests and skipped 59. Its one failure was the sandbox denying `ps` in the existing process-group test; that test passed when rerun with access to inspect its own child process.

## Risk and rollout

Mechanical refactor. Target and path checks, retained-source digest persistence, and stop conditions remain intact. Windows handle conversion still transfers ownership on success and closes the raw handle on failure.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
