### PR TITLE
test: make scan fixtures and assertions explicit

### DIFF
--- a/plugins/codex-security/mcp-app/tests/test_deep_scan_artifact_validation.mjs
+++ b/plugins/codex-security/mcp-app/tests/test_deep_scan_artifact_validation.mjs
@@ -202,7 +202,7 @@ async function testReducerValidation(root) {
     "worker-001",
     draft([firstFinding])
   );
-  const second = await createWorker(
+  await createWorker(
     artifacts,
     "discovery-0002",
     "worker-002",

--- a/plugins/codex-security/tests/test_deep_scan_successful_publication.py
+++ b/plugins/codex-security/tests/test_deep_scan_successful_publication.py
@@ -164,7 +164,8 @@ def assert_published_aggregate(scan):
     findings = json.loads((scan.scan_dir / "findings.json").read_text())["findings"]
     for finding in findings:
         for field in ("findingId", "occurrenceId", "fingerprints"):
-            assert finding.pop(field)
+            value = finding.pop(field)
+            assert value
     assert findings == scan.findings
     coverage = json.loads((scan.scan_dir / "coverage.json").read_text())
     for field in ("documentType", "schemaVersion", "scanId"):

--- a/plugins/codex-security/tests/test_workbench_db.py
+++ b/plugins/codex-security/tests/test_workbench_db.py
@@ -4060,10 +4060,7 @@ def test_completed_finding_projects_writeup_and_poc_artifact_paths(tmp_path: Pat
     (fixtures / "payload.txt").write_text("../outside\n")
     outside = tmp_path / "outside.txt"
     outside.write_text("must not be projected\n")
-    try:
-        (poc / "outside-link.txt").symlink_to(outside)
-    except OSError:
-        pass
+    (poc / "outside-link.txt").symlink_to(outside)
 
     completed = run_workbench(state_dir, "complete-scan", "--scan-id", scan_id)
     assert completed["scan"]["findings"][0]["artifactPaths"] == [
@@ -4176,7 +4173,6 @@ def test_workbench_preserves_dirty_git_scan_after_worktree_changes(tmp_path: Pat
     scan_id = str(started["results"]["scanId"])
     contract = started["results"]["contract"]["target"]
     assert contract["allowedKinds"] == ["git_worktree"]
-    snapshot_digest = str(contract["requiredSnapshotDigest"])
     write_completed_contract(
         Path(str(started["results"]["scanDir"])),
         scan_id,

--- a/sdk/typescript/tests-ts/mcp-launcher.test.ts
+++ b/sdk/typescript/tests-ts/mcp-launcher.test.ts
@@ -146,7 +146,7 @@ test.each(["server", "helper"] as const)(
         env_vars: string[];
       };
       expect(config.env_vars).toContain("CODEX_MCP_NODE_PATH");
-      let managedNode = node;
+      let managedNode: string;
       const marker = join(root, "managed-node-used");
       if (process.platform !== "win32") {
         managedNode = join(root, "managed node");


### PR DESCRIPTION
## Summary

The artifact projection test can pass without creating its symlink fixture. Require that fixture to be created, separate test-data normalization from assertions, and remove unused test bindings.

## Changes

- Let symlink fixture setup failures fail the artifact projection test.
- Remove generated finding metadata before asserting that its values are present.
- Drop unused worker and snapshot-digest bindings and an overwritten launcher initializer.

## Testing

Passed locally:

- Ruff lint and format checks for the plugin.
- TypeScript CI build.
- Portable plugin source compatibility checks and their Node tests.
- Plugin packaging, SDK types, and formatting.
- Focused launcher tests: 2 passed, 2 platform-specific tests skipped.
- Focused workbench, publication, stop-condition, and Windows-helper Python tests: 136 passed, 2 Windows-only tests skipped on macOS.
- Deep Scan artifact-validation tests.

GitHub CI passed all 52 checks on `2b413b5`, including Linux, macOS, Windows, installed-package verification, and native checks. Windows Node 24 package installation initially timed out; rerunning the failed jobs on the unchanged head passed. Codex code and security reviews completed on that head without findings.

The local SDK run with seed 12345 passed 2,993 tests and skipped 59. Its one failure was the sandbox denying `ps` in the existing process-group test; the hosted SDK suites passed.

## Risk and rollout

Test-only changes. The existing suite already requires symlink support; unexpected fixture creation failures now surface instead of silently omitting that scenario. The worker fixture creation call and later snapshot-digest checks remain in place.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
