### PR TITLE
fix(reports): retain distinct source remediations

### DIFF
--- a/plugins/codex-security/scripts/report_projection.py
+++ b/plugins/codex-security/scripts/report_projection.py
@@ -523,6 +523,41 @@ def _surface_notes(surface: dict[str, Any]) -> str:
     return _cell(f"{notes} Evidence: {evidence}")
 
 
+def _remediation_section(finding: dict[str, Any]) -> list[str]:
+    remediation = _text(finding.get("remediation"), "No canonical remediation was recorded.")
+    lines = ["", "#### Remediation", "", remediation]
+    seen = {remediation}
+    sources = finding.get("provenance", {}).get("sourceFindings", [])
+    originals = (
+        [
+            source
+            for source in sources
+            if isinstance(source, dict) and isinstance(source.get("finding"), dict)
+        ]
+        if isinstance(sources, list)
+        else []
+    )
+    for source in originals:
+        text = _text(source["finding"].get("remediation"), "")
+        if text and text not in seen:
+            seen.add(text)
+            lines.extend(["", f"Source {_text(source.get('id'), 'finding')}: {text}"])
+    for field, label in (
+        ("remediationTests", "Tests"),
+        ("preventiveControls", "Preventive controls"),
+    ):
+        values = list(
+            dict.fromkeys(
+                value
+                for original in [finding, *(source["finding"] for source in originals)]
+                for value in _strings(original.get(field))
+            )
+        )
+        if values:
+            lines.extend(["", f"{label}:", *_bullets(values, "None recorded.")])
+    return lines
+
+
 def _finding_section(number: int, finding: dict[str, Any]) -> list[str]:
     validation = finding.get("validation") if isinstance(finding.get("validation"), dict) else {}
     _, raw_root_cause = merged_root_cause(finding)
@@ -616,8 +651,6 @@ def _finding_section(number: int, finding: dict[str, Any]) -> list[str]:
         severity.get("changeConditions"),
         "Additional runtime or deployment evidence could raise or lower this severity.",
     )
-    remediation_tests = _strings(finding.get("remediationTests"))
-    preventive_controls = _strings(finding.get("preventiveControls"))
     attack_steps = _strings(attack_path.get("steps"))
     cwes = ", ".join(finding["taxonomy"]["cwe"]) or "none"
     title = _text(finding["title"], "Untitled finding")
@@ -736,18 +769,7 @@ def _finding_section(number: int, finding: dict[str, Any]) -> list[str]:
             lines.extend(
                 ["", f"{label} assessment:", *(f"- **{name}:** {value}" for name, value in details)]
             )
-    lines.extend(
-        [
-            "",
-            "#### Remediation",
-            "",
-            _text(finding["remediation"], "No canonical remediation was recorded."),
-        ]
-    )
-    if remediation_tests:
-        lines.extend(["", "Tests:", *_bullets(remediation_tests, "No tests recorded.")])
-    if preventive_controls:
-        lines.extend(["", "Preventive controls:", *_bullets(preventive_controls, "None recorded.")])
+    lines.extend(_remediation_section(finding))
     return lines
 
 
@@ -769,8 +791,12 @@ def _linked_finding_section(number: int, finding: dict[str, Any], report_path: s
         f"| CWE | {_cell(cwes)} |",
         f"| Affected lines | {_cell(_locations(finding))} |",
     ]
-    for heading in ("Summary", "Validation", "Dataflow", "Reachability", "Severity", "Remediation"):
+    for heading in ("Summary", "Validation", "Dataflow", "Reachability", "Severity"):
         lines.extend(["", f"#### {heading}", "", f"See the {link}."])
+    if finding.get("provenance", {}).get("sourceFindings"):
+        lines.extend(_remediation_section(finding))
+    else:
+        lines.extend(["", "#### Remediation", "", f"See the {link}."])
     return lines
 
 

--- a/plugins/codex-security/tests/test_deep_scan_successful_publication.py
+++ b/plugins/codex-security/tests/test_deep_scan_successful_publication.py
@@ -173,6 +173,38 @@ def assert_published_aggregate(scan):
     assert (scan.scan_dir / "report.md").is_file()
 
 
+def test_deep_publication_renders_each_source_remediation(
+    workbench_api, workbench_db, publication_scan
+):
+    scan = publication_scan()
+    finding = scan.findings[0]
+    first = copy.deepcopy(finding)
+    first.pop("provenance")
+    first["remediation"] = "Check the destination before writing the archive entry."
+    first["remediationTests"] = ["Reject an archive entry outside the destination."]
+    second = copy.deepcopy(first)
+    second["remediation"] = "Reject symbolic links before opening the destination."
+    second["remediationTests"] = ["Reject a symbolic link inside the destination."]
+    second["preventiveControls"] = ["Use a directory-relative file handle."]
+    finding["remediation"] = first["remediation"]
+    finding["remediationTests"] = first["remediationTests"]
+    finding["provenance"]["sourceFindings"] = [
+        {"id": "review-1:0", "finding": first},
+        {"id": "review-2:0", "finding": second},
+    ]
+    (scan.scan_dir / "findings.json").write_text(json.dumps({"findings": scan.findings}))
+
+    complete(workbench_api, workbench_db, scan)
+
+    assert_published_aggregate(scan)
+    report = (scan.scan_dir / "report.md").read_text()
+    for source in (first, second):
+        assert report.count(source["remediation"]) == 1
+        for test in source["remediationTests"]:
+            assert report.count(test) == 1
+    assert "Use a directory-relative file handle." in report
+
+
 @pytest.mark.parametrize("scope", [".", "subdir"], ids=["repository", "scoped"])
 def test_deep_publication_keeps_configured_scope_without_worker_observations(
     workbench_api, workbench_db, publication_scan, scope

--- a/plugins/codex-security/tests/test_report_projection.py
+++ b/plugins/codex-security/tests/test_report_projection.py
@@ -75,6 +75,26 @@ def test_projection_normalizes_multiline_and_block_structural_text() -> None:
     assert "Text: ## Injected remediation - unsafe instruction" in markdown
 
 
+def test_linked_writeup_retains_distinct_source_fixes() -> None:
+    manifest, findings, coverage = canonical_documents()
+    finding = findings["findings"][0]
+    finding["writeup"] = {"reportPath": "findings/parser/parser.md"}
+    finding["remediation"] = "Validate the record length."
+    finding["provenance"] = {
+        "sourceFindings": [
+            {"id": "review-1:0", "finding": {"remediation": "Validate the record length."}},
+            {"id": "review-2:0", "finding": {"remediation": "Reject duplicate record keys."}},
+            {"id": "review-3:0", "finding": {"remediation": "Reject duplicate record keys."}},
+        ]
+    }
+
+    markdown = PROJECTION.build_report_markdown(manifest, findings, coverage)
+
+    assert "findings/parser/parser.md" in markdown
+    assert markdown.count("Validate the record length.") == 1
+    assert markdown.count("Reject duplicate record keys.") == 1
+
+
 def test_projection_renders_inline_code_and_section_code_evidence() -> None:
     manifest, findings, coverage = canonical_documents()
     finding = findings["findings"][0]


### PR DESCRIPTION
## Summary

Standard completion and Deep reduction retain source findings whose fixes can disappear from the rendered report. Include distinct fixes, tests and preventive controls from saved previous findings and nested source provenance.

## Changes

- Traverse retained provenance in the existing standalone formatter for inline and linked reports.
- Preserve source order, deduplicate identical text and keep saved findings and linked writeups intact.
- Exercise actual Standard consolidation and nested Deep publication; separate fixture mutation from assertions.

## Testing

- Publication regression: parent `89ea5a87` has four expected failures and two passing controls; final `4d729e8a` passes all six cases.
- At runtime-identical `321e64e0`, affected report, finalization, publication and recovery suites pass 305 cases with two filesystem-specific skips. The final commit changes only test fixture setup.
- All five required portable checks pass at the final head, including nine source-compatibility tests.
- Three fresh native reviews and an independent verifier report no actionable findings against main `f5adb33a`.
- Original environment and setup failures remain recorded. The preceding head's CI passed after retrying a Docker Hub 502 before the container build; the final head’s CI passed, including Linux, macOS, Windows and installed-package checks.

## Risk and rollout

This change displays remediation already retained in accepted findings. It is limited to report rendering and preserves existing schemas, commands and scan execution behavior. Linked writeup contents remain intact.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
