### PR TITLE
test(ci): diagnose Windows package install timeouts

### DIFF
--- a/.github/scripts/diagnose_package_install.mjs
+++ b/.github/scripts/diagnose_package_install.mjs
@@ -1,0 +1,259 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { closeSync, openSync } from "node:fs";
+import { cp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { packageSmokeTimeouts } from "../../sdk/typescript/scripts/package-smoke-timeouts.mjs";
+
+// Publish phase measurements without copying npm's URLs, configuration or argv.
+const phases = new Set([
+  "npm",
+  "npm:load",
+  "command:install",
+  "idealTree",
+  "idealTree:init",
+  "idealTree:inflate",
+  "idealTree:userRequests",
+  "idealTree:buildDeps",
+  "idealTree:fixDepFlags",
+  "reify",
+  "reify:loadTrees",
+  "reify:diffTrees",
+  "reify:retireShallow",
+  "reify:createSparse",
+  "reify:loadBundles",
+  "reify:unpack",
+  "reify:unretire",
+  "reify:build",
+  "reify:trash",
+  "reify:save",
+  "build",
+  "build:deps",
+  "build:queue",
+  "build:link",
+  "build:run:preinstall",
+  "build:run:install",
+  "build:run:postinstall",
+]);
+
+export function projectPhases(log) {
+  const events = [];
+  for (const line of log.split(/\r?\n/)) {
+    const timing = line.match(
+      /^(?:\d+|npm) timing (\S+) Completed in (\d+)ms$/,
+    );
+    if (timing && phases.has(timing[1])) {
+      events.push({ phase: timing[1], completedMs: Number(timing[2]) });
+    } else if (/^(?:\d+|npm) silly fetch manifest /.test(line)) {
+      events.push({ phase: "fetch-manifest" });
+    } else {
+      const fetch = line.match(
+        /^(?:\d+|npm) http fetch (GET|POST) (\d+) .* (\d+)ms(?: |$)/,
+      );
+      if (fetch)
+        events.push({
+          phase: "http-fetch",
+          method: fetch[1],
+          status: Number(fetch[2]),
+          durationMs: Number(fetch[3]),
+        });
+    }
+  }
+  return events;
+}
+
+export async function installPair({
+  archives,
+  cache,
+  root,
+  npmCli,
+  npmVersion,
+  environment = process.env,
+  timeoutMs = packageSmokeTimeouts().commandTimeoutMs,
+}) {
+  for (const archive of archives) {
+    const digest = createHash("sha256")
+      .update(await readFile(archive.path))
+      .digest("hex");
+    assert.equal(
+      digest,
+      archive.sha256,
+      `Unexpected ${archive.label} archive digest.`,
+    );
+  }
+  await mkdir(root);
+  const evidence = join(root, "evidence");
+  await mkdir(evidence);
+  const prepared = [];
+  // Complete both copies before either npm install can warm its cache.
+  for (const archive of archives) {
+    const arm = join(root, archive.label);
+    const consumer = join(arm, "consumer");
+    const logs = join(arm, "logs");
+    const cacheCopy = join(arm, "cache");
+    await mkdir(consumer, { recursive: true });
+    await mkdir(logs);
+    await cp(cache, cacheCopy, { recursive: true });
+    await writeFile(
+      join(consumer, "package.json"),
+      JSON.stringify({
+        name: "codex-security-package-smoke",
+        private: true,
+        type: "module",
+      }) + "\n",
+    );
+    prepared.push({ archive, consumer, logs, cacheCopy });
+  }
+  const comparison = {
+    node: process.version,
+    npm: npmVersion,
+    platform: process.platform,
+    arch: process.arch,
+    timeoutMs,
+    results: [],
+  };
+  for (const { archive, consumer, logs, cacheCopy } of prepared) {
+    const args = [
+      npmCli,
+      "install",
+      "--prefer-offline",
+      "--include=optional",
+      "--ignore-scripts",
+      "--package-lock=false",
+      "--no-audit",
+      "--no-fund",
+      resolve(archive.path),
+      "typescript@7.0.2",
+      "@types/node@26.4.1",
+    ];
+    const outputPath = join(logs, "process.log");
+    const fd = openSync(outputPath, "w");
+    const started = performance.now();
+    let result;
+    try {
+      result = spawnSync(process.execPath, args, {
+        cwd: consumer,
+        env: {
+          ...environment,
+          npm_config_cache: cacheCopy,
+          npm_config_logs_dir: logs,
+          npm_config_timing: "true",
+          npm_config_loglevel: "http",
+        },
+        stdio: ["ignore", fd, fd],
+        timeout: timeoutMs,
+        killSignal: "SIGKILL",
+        windowsHide: true,
+      });
+    } finally {
+      closeSync(fd);
+    }
+    const durationMs = Math.round(performance.now() - started);
+    const logFiles = (await readdir(logs))
+      .filter((name) => /-debug-\d+\.log$/.test(name))
+      .sort();
+    const inputs = logFiles.length ? logFiles : ["process.log"];
+    const events = [];
+    for (const name of inputs)
+      events.push(...projectPhases(await readFile(join(logs, name), "utf8")));
+    const row = {
+      label: archive.label,
+      archiveSha256: archive.sha256,
+      exitCode: result.status,
+      signal: result.signal,
+      errorCode: result.error?.code ?? null,
+      durationMs,
+      phaseEvidenceAvailable: events.length > 0,
+      events,
+    };
+    comparison.results.push(row);
+    await writeFile(
+      join(evidence, "comparison.json"),
+      JSON.stringify(comparison, null, 2) + "\n",
+    );
+    const { events: measuredPhases, ...summary } = row;
+    console.log(
+      JSON.stringify({ ...summary, phaseEvents: measuredPhases.length }),
+    );
+  }
+  // Both measurements survive cleanup failure; npm logs remain outside consumers.
+  for (const { consumer } of prepared) {
+    await rm(consumer, {
+      recursive: true,
+      force: true,
+      maxRetries: 10,
+      retryDelay: 100,
+    });
+  }
+  return comparison;
+}
+
+async function main() {
+  const npmCli =
+    process.platform === "win32"
+      ? join(
+          dirname(process.execPath),
+          "node_modules",
+          "npm",
+          "bin",
+          "npm-cli.js",
+        )
+      : resolve(
+          dirname(process.execPath),
+          "../lib/node_modules/npm/bin/npm-cli.js",
+        );
+  const npmVersion = JSON.parse(
+    await readFile(resolve(dirname(npmCli), "../package.json"), "utf8"),
+  ).version;
+  const cacheResult = spawnSync(
+    process.execPath,
+    [npmCli, "config", "get", "cache"],
+    { encoding: "utf8" },
+  );
+  assert.equal(
+    cacheResult.status,
+    0,
+    "Could not locate the restored npm cache.",
+  );
+  assert.ok(
+    process.env.RUNNER_TEMP,
+    "RUNNER_TEMP must identify the diagnostic runner's temporary directory.",
+  );
+  const comparison = await installPair({
+    archives: [
+      {
+        label: "baseline",
+        path: resolve("dist/package-baseline/openai-codex-security-0.1.27.tgz"),
+        sha256:
+          "b8a66d239bd4193734be7f3abedb1d180f94c4448caabe4b2c4641795a00eb3a",
+      },
+      {
+        label: "candidate",
+        path: resolve(
+          "dist/package-candidate/openai-codex-security-0.1.27.tgz",
+        ),
+        sha256:
+          "0938546920234729740f897bfe9fe89b219ee675546cadc7012881a350446be2",
+      },
+    ],
+    cache: cacheResult.stdout.trim(),
+    root: join(process.env.RUNNER_TEMP, "package-install-diagnostic"),
+    npmCli,
+    npmVersion,
+  });
+  if (
+    comparison.results.some(
+      (result) => result.exitCode !== 0 || result.errorCode !== null,
+    )
+  )
+    process.exitCode = 1;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  await main();
+}

--- a/.github/scripts/test_package_install_diagnostic.mjs
+++ b/.github/scripts/test_package_install_diagnostic.mjs
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { installPair, projectPhases } from "./diagnose_package_install.mjs";
+import { packageSmokeTimeouts } from "../../sdk/typescript/scripts/package-smoke-timeouts.mjs";
+
+test("retains phase timing without publishing npm URL, argv or configuration data", () => {
+  const events = projectPhases(
+    [
+      "3 timing idealTree:init Completed in 12ms",
+      "4 silly fetch manifest private-package@https://token@example.invalid/archive",
+      "5 http fetch GET 200 https://token@example.invalid/archive 37ms (cache miss)",
+      "6 verbose argv --registry=https://token@example.invalid",
+      "7 timing reifyNode:node_modules/private-package Completed in 8ms",
+      "8 timing reify:unpack Completed in 20ms",
+    ].join("\n"),
+  );
+  assert.deepEqual(events, [
+    { phase: "idealTree:init", completedMs: 12 },
+    { phase: "fetch-manifest" },
+    { phase: "http-fetch", method: "GET", status: 200, durationMs: 37 },
+    { phase: "reify:unpack", completedMs: 20 },
+  ]);
+});
+
+test("both child installs start from copied cache state and retain failures and logs after consumer cleanup", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "package diagnostic % "));
+  try {
+    const cache = join(directory, "restored-cache");
+    await mkdir(cache);
+    await writeFile(join(cache, "state"), "original");
+    const archives = [];
+    for (const label of ["baseline", "candidate"]) {
+      const path = join(directory, `${label}.tgz`);
+      await writeFile(path, label);
+      archives.push({
+        label,
+        path,
+        sha256: createHash("sha256").update(label).digest("hex"),
+      });
+    }
+    const npmCli = join(directory, "npm-cli.cjs");
+    await writeFile(
+      npmCli,
+      `
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const args = process.argv.slice(2);
+assert.deepEqual(args.slice(0, 7), ['install', '--prefer-offline', '--include=optional', '--ignore-scripts', '--package-lock=false', '--no-audit', '--no-fund']);
+assert.deepEqual(args.slice(8), ['typescript@7.0.2', '@types/node@26.4.1']);
+assert.equal(fs.readFileSync(path.join(process.env.npm_config_cache, 'state'), 'utf8'), 'original');
+assert.equal(process.env.DIAGNOSTIC_TEST_INHERITED, 'preserved');
+assert.equal(process.env.npm_config_timing, 'true');
+assert.equal(process.env.npm_config_loglevel, 'http');
+fs.writeFileSync(path.join(process.env.npm_config_cache, 'state'), 'changed');
+fs.writeFileSync(path.join(process.env.npm_config_logs_dir, 'fixture-debug-0.log'), '0 timing idealTree:init Completed in 9ms\\n1 verbose argv synthetic-secret\\n');
+console.log('synthetic-private-output');
+process.exit(path.basename(args[7]) === 'baseline.tgz' ? 7 : 0);
+`,
+    );
+    const root = join(directory, "diagnostic");
+    const comparison = await installPair({
+      archives,
+      cache,
+      root,
+      npmCli,
+      npmVersion: "fixture",
+      environment: { ...process.env, DIAGNOSTIC_TEST_INHERITED: "preserved" },
+    });
+    assert.equal(comparison.timeoutMs, packageSmokeTimeouts().commandTimeoutMs);
+    assert.deepEqual(
+      comparison.results.map((row) => row.exitCode),
+      [7, 0],
+    );
+    assert.equal(await readFile(join(cache, "state"), "utf8"), "original");
+    for (const { label } of archives) {
+      await assert.rejects(
+        readFile(join(root, label, "consumer", "package.json")),
+        { code: "ENOENT" },
+      );
+      assert.match(
+        await readFile(join(root, label, "logs", "process.log"), "utf8"),
+        /synthetic-private-output/,
+      );
+      assert.deepEqual(
+        comparison.results.find((row) => row.label === label).events,
+        [{ phase: "idealTree:init", completedMs: 9 }],
+      );
+    }
+    const published = await readFile(
+      join(root, "evidence", "comparison.json"),
+      "utf8",
+    );
+    assert.doesNotMatch(
+      published,
+      /synthetic-private-output|synthetic-secret|DIAGNOSTIC_TEST_INHERITED/,
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("a timed-out child retains its last phase and does not prevent the second arm", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "package timeout % "));
+  try {
+    const cache = join(directory, "cache");
+    await mkdir(cache);
+    const archives = [];
+    for (const label of ["baseline", "candidate"]) {
+      const path = join(directory, `${label}.tgz`);
+      await writeFile(path, label);
+      archives.push({
+        label,
+        path,
+        sha256: createHash("sha256").update(label).digest("hex"),
+      });
+    }
+    const npmCli = join(directory, "npm-cli.cjs");
+    await writeFile(
+      npmCli,
+      `
+const fs = require('node:fs');
+const path = require('node:path');
+fs.writeFileSync(path.join(process.env.npm_config_logs_dir, 'fixture-debug-0.log'), '0 timing idealTree:init Completed in 2ms\\n');
+if (path.basename(process.argv[9]) === 'baseline.tgz') setInterval(() => {}, 1000);
+`,
+    );
+    const comparison = await installPair({
+      archives,
+      cache,
+      root: join(directory, "diagnostic"),
+      npmCli,
+      npmVersion: "fixture",
+      timeoutMs: 2000,
+    });
+    assert.equal(comparison.results[0].errorCode, "ETIMEDOUT");
+    assert.equal(comparison.results[0].exitCode, null);
+    assert.deepEqual(comparison.results[0].events, [
+      { phase: "idealTree:init", completedMs: 2 },
+    ]);
+    assert.equal(comparison.results[1].exitCode, 0);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("rejects a different archive before either install starts", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "package digest % "));
+  try {
+    const path = join(directory, "archive.tgz");
+    await writeFile(path, "different archive");
+    const root = join(directory, "diagnostic");
+    await assert.rejects(
+      installPair({
+        archives: [{ label: "baseline", path, sha256: "0".repeat(64) }],
+        root,
+      }),
+      /Unexpected baseline archive digest/,
+    );
+    await assert.rejects(readFile(join(root, "evidence", "comparison.json")), {
+      code: "ENOENT",
+    });
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -583,11 +583,14 @@ jobs:
         run: bun test --timeout 120000 ./tests-ts/windows-machine-policy.test.ts
 
   windows-verify:
-    name: windows-latest / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }} / verify
+    name: windows-latest / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }} / ${{ matrix.node == '24' && 'install diagnostic' || 'verify' }}
     needs: [validate-title, package]
     if: needs.validate-title.outputs.ci-mode == 'full'
     runs-on: windows-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -600,18 +603,51 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: ${{ matrix.node }}
+          node-version: ${{ matrix.node == '24' && '24.20.0' || matrix.node }}
           cache: npm
           cache-dependency-path: sdk/typescript/pnpm-lock.yaml
       - name: Download package for this commit
+        if: matrix.node != '24'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: package-${{ github.sha }}
           path: dist
       - name: Inspect installed package
+        if: matrix.node != '24'
         working-directory: sdk/typescript
         shell: bash
         run: node scripts/check-package.mjs ../../dist/*.tgz
+
+      - name: Test package install diagnostic
+        if: matrix.node == '24'
+        run: node --test .github/scripts/test_package_install_diagnostic.mjs
+      - name: Download baseline package
+        if: matrix.node == '24'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: package-4372b9c4bb2b099bf3b2a8b461f5eb4ee0abc538
+          run-id: 34668484160
+          github-token: ${{ github.token }}
+          path: dist/package-baseline
+      - name: Download comparison package
+        if: matrix.node == '24'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: package-0aab33cc319f1e85dd2ab72b3c8760d3dc21ac06
+          run-id: 34677084903
+          github-token: ${{ github.token }}
+          path: dist/package-candidate
+      - name: Compare package installs with persistent timing evidence
+        if: matrix.node == '24'
+        run: node .github/scripts/diagnose_package_install.mjs
+      - name: Upload package install phase evidence
+        if: always() && matrix.node == '24'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-node24-package-install-diagnostic-${{ github.run_attempt }}
+          overwrite: true
+          path: ${{ runner.temp }}/package-install-diagnostic/evidence/comparison.json
+          if-no-files-found: warn
 
   windows:
     name: windows-latest / node-${{ matrix.node == '22.13.0' && '22' || matrix.node }}


### PR DESCRIPTION
## Summary

Windows Node 24 package verification has twice timed out during npm installation before SDK assertions. Add a temporary paired install diagnostic using the preserved baseline and comparison archives to identify the last observed npm phase.

## Changes

- Use the existing Windows Node 24 matrix slot with Node 24.20.0 and the original 180-second install limit.
- Verify the two archive digests and prepare separate copies of the restored npm cache before either install.
- Preserve each arm's result and upload phase/timing evidence under an attempt-specific artifact name. Raw npm URLs, arguments, configuration and environment are not published.
- Keep Windows Node 22 verification unchanged. The Node 24 diagnostic checks installation only.

## Testing

- Four deterministic child-process tests passed, including timeout retention, second-arm execution and archive identity.
- Existing CI workflow tests: 301 passed.
- Both preserved archives installed successfully through the diagnostic on Linux Node 22.13.0/npm 10.9.2. Native Windows execution is pending this CI run.
- All five portable plugin source checks, Prettier and git diff checks passed.

## Risk and rollout

This is a temporary diagnostic branch. It does not change SDK runtime behavior, dependencies or public commands. The Node 24 job is explicitly an install diagnostic; its success does not qualify SDK behavior. Do not merge this temporary replacement as the production package gate. Preserve both earlier failures and use the new phase evidence before selecting a fix or further experiment.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
