### PR TITLE
fix(deep): preserve checkpoint authority during recovery

### DIFF
--- a/plugins/codex-security/scripts/workbench_saved_results.py
+++ b/plugins/codex-security/scripts/workbench_saved_results.py
@@ -173,6 +173,46 @@ def _read_saved_result(
     return draft, _digest(draft)
 
 
+def _worker_checkpoint_head(scan_dir: Path, directory: str, scan_id: str) -> str | None:
+    relative = f"{directory}/checkpoint-head.json"
+    try:
+        (scan_dir / relative).lstat()
+    except FileNotFoundError:
+        return None
+    head = _read_scan_local_json(scan_dir, relative, "Saved worker checkpoint head")
+    name = head.get("checkpoint")
+    if not isinstance(name, str) or not re.fullmatch(r"[0-9a-f]{64}\.json", name):
+        raise ContractError("Saved worker checkpoint head is invalid.")
+    checkpoint = f"{directory}/checkpoints/{name}"
+    # A committed head precedes replacement of result.json. Do not fall back to
+    # that older result if the selected checkpoint cannot be read.
+    _read_saved_result(scan_dir, checkpoint, scan_id)
+    return checkpoint
+
+
+def _worker_checkpoint_heads(scan_dir: Path, workers: list[Any], scan_id: str) -> dict[str, str]:
+    heads: dict[str, str] = {}
+    for worker in workers:
+        if worker["kind"] != "discovery":
+            continue
+        try:
+            output = Path(worker["artifact_dir"]).relative_to(scan_dir)
+        except (TypeError, ValueError):
+            continue
+        attempts = (output.parent if output.name == "output" else output) / "attempts"
+        directories = [output] + [
+            attempts / name
+            for name in _children(scan_dir, attempts.as_posix())
+            if re.fullmatch(r"attempt-\d+", name)
+        ]
+        for directory in directories:
+            relative = directory.as_posix()
+            head = _worker_checkpoint_head(scan_dir, relative, scan_id)
+            if head is not None:
+                heads[relative] = head
+    return heads
+
+
 def _read_saved_parent_result(
     scan_dir: Path, scan_id: str
 ) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -254,6 +294,10 @@ def _saved_results_changed(db: Any, connection: Any, scan: Any) -> bool:
         published_sources = _source_digests(
             manifest_scan.get("preservedSources", {}), "Published scan"
         )
+        if _worker_checkpoint_heads(scan_dir, workers, scan["id"]) != manifest_scan.get(
+            "preservedCheckpointHeads", {}
+        ):
+            return True
         current_sources = dict(published_sources)
         for path in paths:
             try:
@@ -267,7 +311,9 @@ def _saved_results_changed(db: Any, connection: Any, scan: Any) -> bool:
         return False
 
 
-def _recovery_source_digests(db: Any, connection: Any, scan: Any) -> tuple[dict[str, str], bool]:
+def _recovery_source_digests(
+    db: Any, connection: Any, scan: Any
+) -> tuple[dict[str, str], bool, dict[str, str]]:
     scan_dir = db.require_canonical_scan_directory(Path(scan["scan_dir"]))
     frozen_sources: dict[str, str] | None = None
     include_parent = True
@@ -310,6 +356,7 @@ def _recovery_source_digests(db: Any, connection: Any, scan: Any) -> tuple[dict[
         "FROM deep_scan_workers WHERE scan_id = ?",
         (scan["id"],),
     ).fetchall()
+    checkpoint_heads = _worker_checkpoint_heads(scan_dir, workers, scan["id"])
     paths = dict(_saved_result_paths(scan_dir, workers))
     recovery_sources = dict(frozen_sources or {})
     for relative, expected_digest in recovery_sources.items():
@@ -327,7 +374,7 @@ def _recovery_source_digests(db: Any, connection: Any, scan: Any) -> tuple[dict[
             )
         except (ContractError, OSError, ValueError):
             continue
-    return recovery_sources, include_parent
+    return recovery_sources, include_parent, checkpoint_heads
 
 
 def scan_results_recovery_needed(db: Any, connection: Any, scan: Any) -> bool:
@@ -469,10 +516,13 @@ def merge_saved_results(
     stopped: bool,
     reason: str,
     frozen_source_digests: dict[str, str] | None = None,
+    checkpoint_heads: dict[str, str] | None = None,
     allow_frozen_legacy_parent: bool = False,
 ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]] | None:
     """Read only bound parent/worker files; return an unsealed loss-preserving union."""
     initial_warnings = set(warnings)
+    if checkpoint_heads is None:
+        checkpoint_heads = _worker_checkpoint_heads(scan_dir, workers, scan_id)
     parent: dict[str, Any] | None = None
     parent_manifest: dict[str, Any] | None = None
     if frozen_source_digests is None or allow_frozen_legacy_parent:
@@ -560,22 +610,40 @@ def merge_saved_results(
             continue
         if worker["kind"] != "discovery":
             continue
+        head = checkpoint_heads.get(output)
+        if head is not None:
+            paths[head] = worker["id"]
+            current_results.add(head)
         paths[f"{output}/result.json"] = worker["id"]
-        current_results.add(f"{output}/result.json")
+        if head is None:
+            current_results.add(f"{output}/result.json")
         checkpoints(f"{output}/checkpoints", worker["id"])
         attempts = (
             Path(output).parent if Path(output).name == "output" else Path(output)
         ) / "attempts"
-        for name in _children(scan_dir, attempts.as_posix()):
-            if re.fullmatch(r"attempt-\d+", name):
-                archived = (attempts / name).as_posix()
-                paths[f"{archived}/result.json"] = worker["id"]
-                checkpoints(f"{archived}/checkpoints", worker["id"])
+        archived_attempts = sorted(
+            (
+                name
+                for name in _children(scan_dir, attempts.as_posix())
+                if re.fullmatch(r"attempt-\d+", name)
+            ),
+            key=lambda name: int(name.removeprefix("attempt-")),
+            reverse=True,
+        )
+        for name in archived_attempts:
+            archived = (attempts / name).as_posix()
+            archived_head = checkpoint_heads.get(archived)
+            if archived_head is not None:
+                paths[archived_head] = worker["id"]
+                current_results.add(archived_head)
+            paths[f"{archived}/result.json"] = worker["id"]
+            checkpoints(f"{archived}/checkpoints", worker["id"])
         if worker["result_manifest_path"]:
             try:
                 current_path = Path(worker["result_manifest_path"]).relative_to(scan_dir).as_posix()
                 paths[current_path] = worker["id"]
-                current_results.add(current_path)
+                if head is None:
+                    current_results.add(current_path)
             except ValueError:
                 warnings.append("Skipped a worker result outside the scan directory.")
 
@@ -637,6 +705,7 @@ def merge_saved_results(
         and parent_manifest["scan"].get("sealedAt")
         and parent_manifest["scan"].get("status") == binding["status"]
         and parent_manifest["scan"].get("preservedSources") == source_digests
+        and parent_manifest["scan"].get("preservedCheckpointHeads", {}) == checkpoint_heads
         and all(warning in initial_warnings for warning in warnings)
     ):
         return None
@@ -668,6 +737,7 @@ def merge_saved_results(
     for key in ("sealedAt", "artifacts"):
         manifest["scan"].pop(key, None)
     manifest["scan"]["preservedSources"] = source_digests
+    manifest["scan"]["preservedCheckpointHeads"] = checkpoint_heads
     coverage = (
         copy.deepcopy(parent["coverage"])
         if parent and parent["coverage"]
@@ -1100,6 +1170,7 @@ def preserve_scan_results_locked(
     scan_id: str,
     *,
     recovery_source_digests: dict[str, str] | None = None,
+    recovery_checkpoint_heads: dict[str, str] | None = None,
     include_parent_with_recovery: bool = False,
 ) -> bool:
     """Publish or verify retained terminal results through the workbench host."""
@@ -1107,6 +1178,7 @@ def preserve_scan_results_locked(
     if scan["status"] != "failed":
         return False
     frozen_source_digests: dict[str, str] | None = None
+    checkpoint_heads = recovery_checkpoint_heads
     raw_frozen_sources = scan["retained_source_digests_json"]
     if recovery_source_digests is not None:
         frozen_source_digests = recovery_source_digests
@@ -1114,6 +1186,7 @@ def preserve_scan_results_locked(
         frozen_source_digests = _source_digests(
             json.loads(raw_frozen_sources), "Saved stopped-scan"
         )
+        checkpoint_heads = json.loads(scan["retained_checkpoint_heads_json"] or "{}")
     scan_dir = db.require_canonical_scan_directory(Path(scan["scan_dir"]))
     deep_run = connection.execute(
         "SELECT status FROM deep_scan_runs WHERE scan_id = ?", (scan_id,)
@@ -1167,11 +1240,15 @@ def preserve_scan_results_locked(
             db.index_findings(connection, scan_id, findings, scan["completed_at"])
             connection.execute(
                 "UPDATE scans SET seal_manifest_digest = ?, retained_source_digests_json = ?, "
+                "retained_checkpoint_heads_json = ?, "
                 "completion_warnings_json = ?, "
                 "updated_at = ? WHERE id = ? AND status = 'failed'",
                 (
                     digest,
                     json.dumps(retained_sources, sort_keys=True),
+                    json.dumps(
+                        manifest["scan"].get("preservedCheckpointHeads", {}), sort_keys=True
+                    ),
                     json.dumps(list(dict.fromkeys(warnings))),
                     timestamp,
                     scan_id,
@@ -1198,6 +1275,7 @@ def preserve_scan_results_locked(
         db.verify_manifest_binding(scan, existing)
         if existing_scan.get("status") == outcome:
             existing_sources = existing_scan.get("preservedSources")
+            existing_heads = existing_scan.get("preservedCheckpointHeads", {})
             if frozen_source_digests is None:
                 if not isinstance(existing_sources, dict) or not all(
                     isinstance(relative, str) and isinstance(digest, str)
@@ -1205,7 +1283,8 @@ def preserve_scan_results_locked(
                 ):
                     raise ContractError("Stopped scan source digests could not be frozen.")
                 frozen_source_digests = existing_sources
-            if existing_sources == frozen_source_digests:
+                checkpoint_heads = existing_heads
+            if existing_sources == frozen_source_digests and existing_heads == checkpoint_heads:
                 if (
                     raw_frozen_sources is not None
                     and scan["seal_manifest_digest"] is not None
@@ -1232,6 +1311,7 @@ def preserve_scan_results_locked(
             f"{scan['failure_message'] or ''}"
         ).strip(),
         frozen_source_digests=frozen_source_digests,
+        checkpoint_heads=checkpoint_heads,
         allow_frozen_legacy_parent=(
             include_parent_with_recovery
             or (
@@ -1263,9 +1343,16 @@ def preserve_scan_results_locked(
         frozen_source_digests = retained_sources
         with connection:
             connection.execute(
-                "UPDATE scans SET retained_source_digests_json = ? "
+                "UPDATE scans SET retained_source_digests_json = ?, "
+                "retained_checkpoint_heads_json = ? "
                 "WHERE id = ? AND retained_source_digests_json IS NULL",
-                (json.dumps(retained_sources, sort_keys=True), scan_id),
+                (
+                    json.dumps(retained_sources, sort_keys=True),
+                    json.dumps(
+                        documents[0]["scan"].get("preservedCheckpointHeads", {}), sort_keys=True
+                    ),
+                    scan_id,
+                ),
             )
     prepared = _prepare_scan_finalization(
         scan_dir,
@@ -1293,12 +1380,15 @@ def recover_scan_results(db: Any, connection: Any, args: Any) -> dict[str, Any]:
             raise SystemExit("Only a stopped scan can recover terminal results.")
         if scan["canceled_at"] is not None:
             raise SystemExit("Canceled scans cannot recover terminal results.")
-        recovery_source_digests, include_parent = _recovery_source_digests(db, connection, scan)
+        recovery_source_digests, include_parent, checkpoint_heads = _recovery_source_digests(
+            db, connection, scan
+        )
         if not preserve_scan_results_locked(
             db,
             connection,
             scan_id,
             recovery_source_digests=recovery_source_digests,
+            recovery_checkpoint_heads=checkpoint_heads,
             include_parent_with_recovery=include_parent,
         ):
             raise SystemExit("No saved stopped-scan results were available to recover.")

--- a/plugins/codex-security/scripts/workbench_schema.py
+++ b/plugins/codex-security/scripts/workbench_schema.py
@@ -867,6 +867,13 @@ MIGRATIONS = (
         );
         """,
     ),
+    (
+        47,
+        "freeze stopped scan checkpoint selections",
+        """
+        ALTER TABLE scans ADD COLUMN retained_checkpoint_heads_json TEXT;
+        """,
+    ),
 )
 
 

--- a/plugins/codex-security/tests/test_checkpoint_publication_authority.py
+++ b/plugins/codex-security/tests/test_checkpoint_publication_authority.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+import copy
+import json
+import uuid
+from argparse import Namespace
+
+import pytest
+from test_deep_scan_successful_publication import add_worker
+from test_deep_scan_successful_publication import publication_scan as publication_scan
+from test_workbench_standard_deep_results import deep_scan_fixture, worker_paths
+from workbench_test_support import run_workbench, write_checkpoint, write_completed_contract
+
+
+def test_public_stop_retains_accepted_partial_evidence_and_newer_rejection(tmp_path):
+    state, home, target, scan_dir, scan_id = deep_scan_fixture(tmp_path, workers=2)
+    environment = {"CODEX_HOME": str(home)}
+    contract = tmp_path / "contract"
+    contract.mkdir()
+    write_completed_contract(contract, scan_id, target, relative_path="app.py")
+    finding = json.loads((contract / "findings.json").read_text())["findings"][0]
+    deferred = {
+        "candidateId": "pending-query",
+        "reason": "Validation is pending.",
+        "paths": ["app.py"],
+    }
+    coverage = {
+        "completeness": "partial",
+        "surfaces": [],
+        "explicitExclusions": [],
+        "deferred": [deferred],
+    }
+    workers = []
+    for accepted in (True, False):
+        name = "accepted" if accepted else "interrupted"
+        prompt, output, result = worker_paths(scan_dir, name)
+        worker_id = str(uuid.uuid4())
+        worker_args = (
+            "upsert-deep-scan-worker",
+            "--scan-id",
+            scan_id,
+            "--worker-id",
+            worker_id,
+            "--kind",
+            "discovery",
+            "--prompt-path",
+            str(prompt),
+            "--artifact-dir",
+            str(output),
+            "--attempt",
+            "1",
+        )
+        run_workbench(state, *worker_args, "--status", "running", environment=environment)
+        current = copy.deepcopy(finding)
+        current["identity"]["anchor"] = name
+        current["extensions"] = {"candidateId": name}
+        draft = {"scanId": scan_id, "complete": True, "findings": [current], "coverage": coverage}
+        result.write_text(json.dumps(draft))
+        write_checkpoint(output / "checkpoints", draft)
+        if accepted:
+            run_workbench(
+                state,
+                *worker_args,
+                "--status",
+                "succeeded",
+                "--result-manifest-path",
+                str(result),
+                environment=environment,
+            )
+        else:
+            rejected = {
+                **draft,
+                "complete": False,
+                "findings": [],
+                "coverage": {
+                    **coverage,
+                    "surfaces": [
+                        {
+                            "candidateId": name,
+                            "label": "Reviewed candidate",
+                            "disposition": "rejected",
+                            "receiptRefs": [],
+                        }
+                    ],
+                },
+            }
+            head = write_checkpoint(output / "checkpoints", rejected)
+            (output / "checkpoint-head.json").write_text(json.dumps({"checkpoint": head.name}))
+        workers.append(worker_id)
+
+    stopped = run_workbench(
+        state,
+        "fail-deep-scan",
+        "--scan-id",
+        scan_id,
+        "--message",
+        "Original worker failure.",
+        "--deep-status",
+        "interrupted",
+        environment=environment,
+    )["deepScan"]
+    assert stopped["status"] == "interrupted"
+    scan = run_workbench(state, "get-scan", "--scan-id", scan_id)["scan"]
+    assert scan["findingCount"] == 1
+    findings = json.loads((scan_dir / "findings.json").read_text())["findings"]
+    assert [item["identity"]["anchor"] for item in findings] == ["accepted"]
+    retained_coverage = json.loads((scan_dir / "coverage.json").read_text())
+    assert retained_coverage["completeness"] == "partial"
+    assert any(item.get("candidateId") == "pending-query" for item in retained_coverage["deferred"])
+    assert any(
+        item.get("candidateId") == "interrupted" and item["disposition"] == "rejected"
+        for item in retained_coverage["surfaces"]
+    )
+    assert scan["failureMessage"] == "Original worker failure."
+    assert {worker["id"]: worker["status"] for worker in stopped["workers"]} == {
+        workers[0]: "succeeded",
+        workers[1]: "canceled",
+    }
+
+
+@pytest.mark.parametrize("archived", [False, True], ids=["current", "archived"])
+@pytest.mark.parametrize("has_head", [True, False], ids=["committed-head", "legacy"])
+@pytest.mark.parametrize("complete", [False, True], ids=["checkpoint", "complete"])
+def test_recovery_honors_rejection_committed_before_result_replacement(
+    workbench_api, workbench_db, publication_scan, archived, has_head, complete
+):
+    scan = publication_scan()
+    provisional = copy.deepcopy(scan.findings[0])
+    provisional["extensions"] = {"candidateId": "candidate-rejected"}
+    retained = copy.deepcopy(scan.findings[0])
+    retained["identity"]["anchor"] = "independent-finding"
+    retained["extensions"] = {"candidateId": "candidate-retained"}
+    retained["locations"][0]["startLine"] = 20
+    retained["locations"][0]["endLine"] = 21
+    (scan.scan_dir / "findings.json").write_text(json.dumps({"findings": []}))
+    result_path = add_worker(workbench_db, scan, status="canceled")
+    if archived:
+        result_path = result_path.parent / "attempts" / "attempt-1" / "result.json"
+        result_path.parent.mkdir(parents=True)
+    previous = {
+        "scanId": scan.scan_id,
+        "complete": True,
+        "findings": [provisional, retained],
+        "coverage": scan.coverage,
+    }
+    result_path.write_text(json.dumps(previous))
+    old_checkpoint = write_checkpoint(result_path.parent / "checkpoints", previous)
+    rejected = {
+        **previous,
+        "complete": complete,
+        "findings": [retained],
+        "coverage": {
+            **scan.coverage,
+            "surfaces": [
+                {
+                    "candidateId": "candidate-rejected",
+                    "label": "Validated candidate disposition",
+                    "disposition": "rejected",
+                    "receiptRefs": [],
+                }
+            ],
+        },
+    }
+    checkpoint = write_checkpoint(result_path.parent / "checkpoints", rejected)
+    if has_head:
+        (result_path.parent / "checkpoint-head.json").write_text(
+            json.dumps({"checkpoint": checkpoint.name})
+        )
+    saved_bytes = {path: path.read_bytes() for path in (result_path, old_checkpoint, checkpoint)}
+
+    stopped = workbench_api["fail_scan"](
+        workbench_db,
+        Namespace(scan_id=scan.scan_id, claim_token=None, cost_json=None, message="Audit stopped."),
+    )["scan"]
+
+    findings = json.loads((scan.scan_dir / "findings.json").read_text())["findings"]
+    assert stopped["findingCount"] == len(findings) == (1 if has_head else 2)
+    assert any(finding["identity"]["anchor"] == "independent-finding" for finding in findings)
+    assert all(path.read_bytes() == contents for path, contents in saved_bytes.items())
+    if has_head:
+        coverage = json.loads((scan.scan_dir / "coverage.json").read_text())
+        assert any(
+            surface.get("candidateId") == "candidate-rejected"
+            and surface.get("disposition") == "rejected"
+            for surface in coverage["surfaces"]
+        )
+
+
+def save_disposition(scan, directory, disposition):
+    directory.mkdir(parents=True, exist_ok=True)
+    finding = copy.deepcopy(scan.findings[0])
+    finding["extensions"] = {"candidateId": "candidate-disposition"}
+    draft = {
+        "scanId": scan.scan_id,
+        "complete": True,
+        "findings": [finding] if disposition == "reported" else [],
+        "coverage": {
+            **scan.coverage,
+            "surfaces": [
+                {
+                    "candidateId": "candidate-disposition",
+                    "label": "Validated candidate disposition",
+                    "disposition": disposition,
+                    "receiptRefs": [],
+                }
+            ],
+        },
+    }
+    checkpoint = write_checkpoint(directory / "checkpoints", draft)
+    (directory / "checkpoint-head.json").write_text(json.dumps({"checkpoint": checkpoint.name}))
+    return draft
+
+
+@pytest.mark.parametrize("archived", [False, True], ids=["current-head", "newer-archive"])
+@pytest.mark.parametrize("disposition", ["reported", "rejected"])
+def test_newer_checkpoint_disposition_precedes_older_archived_head(
+    workbench_api, workbench_db, publication_scan, archived, disposition
+):
+    scan = publication_scan()
+    (scan.scan_dir / "findings.json").write_text(json.dumps({"findings": []}))
+    result = add_worker(workbench_db, scan, status="canceled")
+    old = result.parent / "attempts" / "attempt-2"
+    save_disposition(scan, old, "rejected" if disposition == "reported" else "reported")
+    current = result.parent / "attempts" / "attempt-10" if archived else result.parent
+    draft = save_disposition(scan, current, disposition)
+    (current / "result.json").write_text(json.dumps(draft))
+
+    stopped = workbench_api["fail_scan"](
+        workbench_db,
+        Namespace(scan_id=scan.scan_id, claim_token=None, cost_json=None, message="Audit stopped."),
+    )["scan"]
+
+    assert stopped["findingCount"] == (1 if disposition == "reported" else 0)
+
+
+@pytest.mark.parametrize("head_change", ["replaced", "removed", "missing-checkpoint"])
+def test_frozen_stopped_replay_ignores_later_worker_head_changes(
+    workbench_api, workbench_db, publication_scan, monkeypatch, head_change
+):
+    import finalize_scan_contract
+
+    scan = publication_scan()
+    (scan.scan_dir / "findings.json").write_text(json.dumps({"findings": []}))
+    result = add_worker(workbench_db, scan, status="canceled")
+    previous = save_disposition(scan, result.parent, "reported")
+    result.write_text(json.dumps(previous))
+    save_disposition(scan, result.parent, "rejected")
+    checkpoint_name = json.loads((result.parent / "checkpoint-head.json").read_text())["checkpoint"]
+    directory = result.parent.relative_to(scan.scan_dir).as_posix()
+    expected_heads = {directory: f"{directory}/checkpoints/{checkpoint_name}"}
+    original_outputs = {
+        name: (scan.scan_dir / name).read_bytes()
+        for name in ("findings.json", "coverage.json", "scan-manifest.json")
+    }
+    write_bytes = finalize_scan_contract.write_scan_local_bytes
+    failed_writes = []
+
+    def fail_coverage_write(directory, relative, payload, **kwargs):
+        if relative != "coverage.json" or failed_writes:
+            return write_bytes(directory, relative, payload, **kwargs)
+        # Exercise the real writer after findings have reached disk. Remove the
+        # temporary obstruction before the publisher restores its old outputs.
+        failed_writes.append(json.loads((directory / "findings.json").read_text()))
+        path = directory / relative
+        previous_bytes = path.read_bytes()
+        path.unlink()
+        path.mkdir()
+        try:
+            return write_bytes(directory, relative, payload, **kwargs)
+        finally:
+            path.rmdir()
+            path.write_bytes(previous_bytes)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(finalize_scan_contract, "write_scan_local_bytes", fail_coverage_write)
+        workbench_api["fail_scan"](
+            workbench_db,
+            Namespace(
+                scan_id=scan.scan_id, claim_token=None, cost_json=None, message="Audit stopped."
+            ),
+        )
+    row = workbench_db.execute("SELECT * FROM scans WHERE id = ?", (scan.scan_id,)).fetchone()
+    assert len(failed_writes) == 1
+    assert "scanId" in failed_writes[0]
+    assert row["status"] == "failed"
+    assert row["failure_message"] == "Audit stopped."
+    assert row["retained_source_digests_json"]
+    assert row["seal_manifest_digest"] is None
+    assert all(
+        (scan.scan_dir / name).read_bytes() == contents
+        for name, contents in original_outputs.items()
+    )
+    original_sources = row["retained_source_digests_json"]
+    original_run = dict(
+        workbench_db.execute(
+            "SELECT * FROM deep_scan_runs WHERE scan_id = ?", (scan.scan_id,)
+        ).fetchone()
+    )
+    head = result.parent / "checkpoint-head.json"
+    if head_change == "replaced":
+        save_disposition(scan, result.parent, "reported")
+    elif head_change == "removed":
+        head.unlink()
+    else:
+        head.write_text(json.dumps({"checkpoint": "a" * 64 + ".json"}))
+
+    replayed = workbench_api["preserve_scan_results"](
+        workbench_db,
+        Namespace(
+            scan_id=scan.scan_id, claim_token=None, thread_id=None, coordinator_generation=None
+        ),
+    )["scan"]
+
+    assert replayed["findingCount"] == 0
+    assert json.loads((scan.scan_dir / "findings.json").read_text())["findings"] == []
+    assert json.loads(result.read_text()) == previous
+    row = workbench_db.execute("SELECT * FROM scans WHERE id = ?", (scan.scan_id,)).fetchone()
+    assert row["failure_message"] == "Audit stopped."
+    assert row["retained_source_digests_json"] == original_sources
+    assert json.loads(row["retained_checkpoint_heads_json"]) == expected_heads
+    assert row["seal_manifest_digest"]
+    manifest = json.loads((scan.scan_dir / "scan-manifest.json").read_text())
+    assert manifest["scan"]["preservedCheckpointHeads"] == expected_heads
+    assert (
+        dict(
+            workbench_db.execute(
+                "SELECT * FROM deep_scan_runs WHERE scan_id = ?", (scan.scan_id,)
+            ).fetchone()
+        )
+        == original_run
+    )
+
+
+def test_explicit_recovery_observes_head_change_between_existing_checkpoints(
+    workbench_api, workbench_db, publication_scan
+):
+    scan = publication_scan()
+    (scan.scan_dir / "findings.json").write_text(json.dumps({"findings": []}))
+    result = add_worker(workbench_db, scan, status="canceled")
+    previous = save_disposition(scan, result.parent, "reported")
+    result.write_text(json.dumps(previous))
+    save_disposition(scan, result.parent, "rejected")
+    stopped = workbench_api["fail_scan"](
+        workbench_db,
+        Namespace(scan_id=scan.scan_id, claim_token=None, cost_json=None, message="Audit stopped."),
+    )["scan"]
+    assert stopped["findingCount"] == 0
+
+    save_disposition(scan, result.parent, "reported")
+
+    context = workbench_api["scan_context"](workbench_db, scan.scan_id)["scan"]
+    assert context["resultsRecoveryNeeded"] is True
+    recovered = workbench_api["recover_scan_results"](
+        workbench_db, Namespace(scan_id=scan.scan_id)
+    )["scan"]
+    assert recovered["findingCount"] == 1
+    assert recovered["resultsRecoveryNeeded"] is False
+
+
+def test_legacy_frozen_publication_keeps_result_fallback_without_saved_heads(
+    workbench_api, workbench_db, publication_scan, monkeypatch
+):
+    scan = publication_scan()
+    (scan.scan_dir / "findings.json").write_text(json.dumps({"findings": []}))
+    result = add_worker(workbench_db, scan, status="canceled")
+    previous = save_disposition(scan, result.parent, "reported")
+    result.write_text(json.dumps(previous))
+    save_disposition(scan, result.parent, "rejected")
+    (result.parent / "checkpoint-head.json").unlink()
+
+    def fail_before_publication(*args, **kwargs):
+        raise OSError("Synthetic publication interruption")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(
+            workbench_api["saved_results"],
+            "_write_prepared_scan_finalization",
+            fail_before_publication,
+        )
+        workbench_api["fail_scan"](
+            workbench_db,
+            Namespace(
+                scan_id=scan.scan_id, claim_token=None, cost_json=None, message="Audit stopped."
+            ),
+        )
+    with workbench_db:
+        workbench_db.execute(
+            "UPDATE scans SET retained_checkpoint_heads_json = NULL WHERE id = ?", (scan.scan_id,)
+        )
+    save_disposition(scan, result.parent, "rejected")
+
+    replayed = workbench_api["preserve_scan_results"](
+        workbench_db,
+        Namespace(
+            scan_id=scan.scan_id, claim_token=None, thread_id=None, coordinator_generation=None
+        ),
+    )["scan"]
+
+    assert replayed["findingCount"] == 1

--- a/plugins/codex-security/tests/test_checkpoint_schema.py
+++ b/plugins/codex-security/tests/test_checkpoint_schema.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import closing
+
+import pytest
+
+
+@pytest.mark.parametrize("upgrade", [False, True], ids=["fresh", "upgrade"])
+def test_frozen_checkpoint_head_migration_preserves_scan_state(workbench_api, upgrade):
+    migrations = workbench_api["MIGRATIONS"]
+    timestamp = "2026-07-01T00:00:00Z"
+
+    def migrate(connection, selected):
+        workbench_api["apply_schema_migrations"](
+            connection, selected, lambda: timestamp, workbench_api["backfill_security_targets"]
+        )
+
+    with closing(sqlite3.connect(":memory:")) as connection:
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys = ON")
+        migrate(
+            connection,
+            tuple(item for item in migrations if item[0] != 47) if upgrade else migrations,
+        )
+        connection.execute(
+            "INSERT INTO workspaces (id, created_at, updated_at) VALUES (?, ?, ?)",
+            ("workspace", timestamp, timestamp),
+        )
+        for status in ("running", "failed"):
+            connection.execute(
+                "INSERT INTO scans (id, workspace_id, target_path, target_revision, scope, "
+                "mode, scan_dir, status, phase, started_at, created_at, updated_at, "
+                "failure_message, retained_source_digests_json) "
+                "VALUES (?, 'workspace', 'target', 'revision', '.', 'deep', ?, ?, "
+                "'discovery', ?, ?, ?, ?, ?)",
+                (
+                    status,
+                    f"scans/{status}",
+                    status,
+                    timestamp,
+                    timestamp,
+                    timestamp,
+                    "Original stop reason." if status == "failed" else None,
+                    json.dumps({"workers/review/result.json": "b" * 64})
+                    if status == "failed"
+                    else None,
+                ),
+            )
+        before = [dict(row) for row in connection.execute("SELECT * FROM scans ORDER BY id")]
+        migrate(connection, migrations)
+        after = [dict(row) for row in connection.execute("SELECT * FROM scans ORDER BY id")]
+        for original, updated in zip(before, after, strict=True):
+            assert updated.pop("retained_checkpoint_heads_json") is None
+            original.pop("retained_checkpoint_heads_json", None)
+            assert updated == original
+
+        heads = json.dumps({"workers/review": "workers/review/checkpoints/" + "a" * 64 + ".json"})
+        connection.execute(
+            "UPDATE scans SET retained_checkpoint_heads_json = ? WHERE id = 'failed'", (heads,)
+        )
+        migrate(connection, migrations)
+        assert (
+            connection.execute(
+                "SELECT retained_checkpoint_heads_json FROM scans WHERE id = 'failed'"
+            ).fetchone()[0]
+            == heads
+        )
+        assert (
+            connection.execute(
+                "SELECT retained_checkpoint_heads_json FROM scans WHERE id = 'running'"
+            ).fetchone()[0]
+            is None
+        )
+        assert [
+            tuple(row)
+            for row in connection.execute(
+                "SELECT version, name FROM schema_migrations WHERE version = 47"
+            )
+        ] == [(47, "freeze stopped scan checkpoint selections")]
+        assert connection.execute("PRAGMA foreign_key_check").fetchall() == []

--- a/plugins/codex-security/tests/test_workbench_db.py
+++ b/plugins/codex-security/tests/test_workbench_db.py
@@ -1042,7 +1042,7 @@ def test_workbench_persists_progress_and_indexes_completed_findings(tmp_path: Pa
             )
         }
         assert tables == EXPECTED_TABLES
-        assert connection.execute("SELECT COUNT(*) FROM schema_migrations").fetchone() == (41,)
+        assert connection.execute("SELECT COUNT(*) FROM schema_migrations").fetchone() == (42,)
         assert connection.execute("SELECT COUNT(*) FROM findings").fetchone() == (1,)
         assert connection.execute("SELECT COUNT(*) FROM finding_locations").fetchone() == (1,)
 

--- a/plugins/codex-security/tests/test_workbench_deep_scan.py
+++ b/plugins/codex-security/tests/test_workbench_deep_scan.py
@@ -279,7 +279,7 @@ def test_existing_generation_safely_claims_and_reclaims_without_schema_migration
         return claim_deep_scan_coordinator(state_dir, codex_home, scan_id)
 
     with sqlite3.connect(state_dir / "workbench.sqlite3") as connection:
-        assert connection.execute("SELECT MAX(version) FROM schema_migrations").fetchone() == (41,)
+        assert connection.execute("SELECT MAX(version) FROM schema_migrations").fetchone() == (47,)
     assert claim()["deepScan"]["coordinatorGeneration"] == 2
     assert claim()["coordinatorDisposition"] == "observing"
     expire_deep_scan_coordinator(state_dir, scan_id)

--- a/plugins/codex-security/tests/test_workbench_setup_and_migrations.py
+++ b/plugins/codex-security/tests/test_workbench_setup_and_migrations.py
@@ -405,7 +405,7 @@ def test_workbench_serializes_concurrent_first_run_migrations(tmp_path: Path) ->
         {"databasePath": str(state_dir / "workbench.sqlite3")},
     ]
     with sqlite3.connect(state_dir / "workbench.sqlite3") as connection:
-        assert connection.execute("SELECT COUNT(*) FROM schema_migrations").fetchone() == (41,)
+        assert connection.execute("SELECT COUNT(*) FROM schema_migrations").fetchone() == (42,)
 
 
 @pytest.mark.parametrize("previous_history", ["main", "comparison-preview"])
@@ -867,6 +867,7 @@ def test_workbench_creates_single_final_schema(tmp_path: Path) -> None:
             (39, "store dedupe checkpoint bindings in columns"),
             (40, "index finding identity and comparison history"),
             (41, "checkpoint finding severity assessments"),
+            (47, "freeze stopped scan checkpoint selections"),
         ]
         assert {row[1] for row in connection.execute("PRAGMA table_info(workspaces)")} >= {
             "diff_target_kind",
@@ -969,7 +970,7 @@ def test_workbench_upgrades_preexisting_database(tmp_path: Path) -> None:
         connection.execute("ALTER TABLE scans DROP COLUMN handoff_claim_token")
     run_workbench(state_dir, "database-info")
     with sqlite3.connect(database) as connection:
-        assert connection.execute("SELECT MAX(version) FROM schema_migrations").fetchone() == (41,)
+        assert connection.execute("SELECT MAX(version) FROM schema_migrations").fetchone() == (47,)
         assert {row[1] for row in connection.execute("PRAGMA table_info(scans)")} >= {
             "handoff_claimed_at",
             "handoff_claim_token",
@@ -1996,6 +1997,7 @@ def test_workbench_upgrades_released_database_schema(tmp_path: Path) -> None:
             (39, "store dedupe checkpoint bindings in columns"),
             (40, "index finding identity and comparison history"),
             (41, "checkpoint finding severity assessments"),
+            (47, "freeze stopped scan checkpoint selections"),
         ]
         assert "capability_preflight_json" in {
             row[1] for row in connection.execute("PRAGMA table_info(workspaces)")
@@ -2079,6 +2081,7 @@ def test_workbench_upgrades_pre_release_phase_progress_migration(tmp_path: Path)
             (39, "store dedupe checkpoint bindings in columns"),
             (40, "index finding identity and comparison history"),
             (41, "checkpoint finding severity assessments"),
+            (47, "freeze stopped scan checkpoint selections"),
         ]
         assert "continuation_thread_id" in {
             row[1] for row in connection.execute("PRAGMA table_info(scans)")
@@ -2170,6 +2173,7 @@ def test_workbench_upgrades_pre_release_preflight_progress_migration(tmp_path: P
             (39, "store dedupe checkpoint bindings in columns"),
             (40, "index finding identity and comparison history"),
             (41, "checkpoint finding severity assessments"),
+            (47, "freeze stopped scan checkpoint selections"),
         ]
         assert "continuation_thread_id" in {
             row[1] for row in connection.execute("PRAGMA table_info(scans)")


### PR DESCRIPTION
## Summary

Stopped Deep scans can resurrect a rejected candidate by reading an older result file, or change their recovery input after a publication write fails. Read the committed checkpoint head and freeze that selection so replay preserves the accepted evidence and latest disposition.

## Changes

- Prefer the committed discovery checkpoint over older current and archived results; order archived attempts numerically.
- Freeze selected checkpoint paths alongside existing retained source digests before publication. Explicit recovery can adopt a later head; ordinary replay uses the frozen selection.
- Preserve accepted partial evidence, original failure state and legacy results without checkpoint-head metadata.
- Add migration 47 for the nullable frozen-head mapping; existing migrations remain unchanged. No public CLI change.

## Testing

On `bd70d41478d06331f297decd171d0d11d7fd439f`:

- The schema-capable parent has 10 regression failures and 10 passing controls; the same tests pass all 20 cases after the correction.
- Affected Python suites: 552 passed, two skips and 55 subtests. Four affected SDK suites: 82 passed, 584 assertions. Four affected MCP suites passed.
- Installed SDK and physically detached plugin: 20 cases passed, including five new-process replays and public contract reads.
- All five required portable checks passed: Ruff lint/format, SDK `build:ci`, plugin source compatibility and its tests. SDK/plugin builds passed.
- Tests exercise real output-write failure after findings reach disk, restoration of prior outputs, changed or missing heads, newer rejection, partial evidence and explicit recovery.
- Independent composition with the publication fence passes 44 targeted cases; a second verification passes 45 with one additional existing control. Current-main source composition is clean. Native platform CI remains pending.

## Risk and rollout

This PR contains both compatible readers and the frozen-head writer. Establish a reader-capable rollback artifact before enabling new writes; the schema-only commit is insufficient. Coordinate migration 47 with other open migration work and keep its identity unchanged.

The change preserves original stopped state and source digests. Legacy records without frozen-head metadata retain their existing fallback. Keep this PR unmerged until reader-first ordering and platform acceptance are complete.

## Public disclosure review

- [x] No customer, partner, prospect, or user identities, data, or identifying details are included.
- [x] No credentials, personal data, private source, scan findings, or nonpublic links or tickets are included.
- [x] I reviewed the branch name, title, description, commits, changes, comments, logs, screenshots, attachments, and links for public disclosure.
